### PR TITLE
feat(webapp): improve webspeech handling and deploys

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -48,6 +48,15 @@ jobs:
               - '.editorconfig'
             deploy_frontend:
               - 'apps/webapp/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.base.json'
+              - 'eslint.config.js'
+              - 'prettier.config.js'
+              - 'vitest.config.ts'
+              - 'vitest.shared.ts'
+              - '.npmrc'
+              - '.editorconfig'
             backend_node:
               - 'apps/session-manager/**'
               - 'libs/**'
@@ -363,6 +372,58 @@ jobs:
           dockerfile: "./apps/webapp/Dockerfile"
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+  deploy-webapp:
+    needs:
+      - changes
+      - check-formatting-node
+      - run-linter-node
+      - run-build-node
+    if: needs.changes.outputs.deploy_frontend == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Build webapp
+        working-directory: "apps/webapp"
+        run: npm run build
+
+      - name: Validate deploy configuration
+        env:
+          WEBAPP_SSH_KEY: ${{ secrets.WEBAPP_SSH_KEY }}
+          WEBAPP_SSH_USER: ${{ secrets.WEBAPP_SSH_USER }}
+          WEBAPP_DEPLOY_PATH: ${{ secrets.WEBAPP_DEPLOY_PATH }}
+        run: |
+          missing=0
+          for secret_name in WEBAPP_SSH_KEY WEBAPP_SSH_USER WEBAPP_DEPLOY_PATH; do
+            if [ -z "${!secret_name}" ]; then
+              echo "::error::Missing required secret: $secret_name"
+              missing=1
+            fi
+          done
+          exit $missing
+
+      - name: Configure SSH
+        shell: bash
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.WEBAPP_SSH_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          if [ -n "${{ secrets.WEBAPP_SSH_KNOWN_HOSTS }}" ]; then
+            printf '%s\n' "${{ secrets.WEBAPP_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+            chmod 600 ~/.ssh/known_hosts
+          fi
+
+      - name: Deploy webapp
+        env:
+          DEPLOY_HOST: scribear.illinois.edu
+          DEPLOY_USER: ${{ secrets.WEBAPP_SSH_USER }}
+          DEPLOY_PATH: ${{ secrets.WEBAPP_DEPLOY_PATH }}
+        run: |
+          rsync -az --delete -e "ssh -o StrictHostKeyChecking=accept-new" apps/webapp/dist/ "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/"
 
   release-webapp:
     needs:

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -16,6 +16,7 @@
     "format:fix": "prettier --write ./src",
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
+    "test": "vitest run",
     "test:dev": "vitest --ui --coverage"
   },
   "dependencies": {

--- a/apps/webapp/src/features/transcription-providers/services/providers/webspeech/components/webspeech-modal.tsx
+++ b/apps/webapp/src/features/transcription-providers/services/providers/webspeech/components/webspeech-modal.tsx
@@ -9,6 +9,7 @@ import { selectProviderStatus } from '#src/features/transcription-providers/stor
 import { useAppDispatch, useAppSelector } from '#src/stores/use-redux';
 
 import { ProviderId } from '../../provider-registry';
+import { getLastWebspeechErrorDetail } from '../services/webspeech-provider';
 import { WebspeechStatus } from '../types/webspeech-status';
 
 export const WebspeechModal = () => {
@@ -18,6 +19,7 @@ export const WebspeechModal = () => {
   const webspeechStatus = useAppSelector((state) =>
     selectProviderStatus(state, ProviderId.WEBSPEECH),
   );
+  const errorDetail = getLastWebspeechErrorDetail();
 
   const cancelModal = () => {
     dispatch(setPreferredProviderId(null));
@@ -51,7 +53,11 @@ export const WebspeechModal = () => {
   const error = (
     <ChoiceModal
       isOpen={webspeechStatus === WebspeechStatus.ERROR}
-      message={`${displayName} encountered an unexpected error`}
+      message={
+        errorDetail
+          ? `${displayName} failed (${errorDetail}). Check browser microphone/speech permissions, then retry.`
+          : `${displayName} encountered an unexpected error`
+      }
       rightAction="Retry"
       onRightAction={retryActivation}
       onCancel={cancelModal}

--- a/apps/webapp/src/features/transcription-providers/services/providers/webspeech/services/webspeech-provider.ts
+++ b/apps/webapp/src/features/transcription-providers/services/providers/webspeech/services/webspeech-provider.ts
@@ -2,9 +2,61 @@ import { BaseProviderInterface } from '../../base-provider-interface';
 import type { ProviderInterface } from '../../provider-interface';
 import {
   INITIAL_WEBSPEECH_STATUS,
+  languageTags,
   type WebspeechConfig,
 } from '../config/webspeech-config';
 import { WebspeechStatus } from '../types/webspeech-status';
+
+let lastWebspeechErrorDetail: string | null = null;
+
+export const getLastWebspeechErrorDetail = () => {
+  return lastWebspeechErrorDetail;
+};
+
+const resolveSupportedLanguageTag = (tag: string): string | null => {
+  if (tag in languageTags) return tag;
+
+  try {
+    const locale = new Intl.Locale(tag).maximize();
+    const maximizedTag =
+      locale.region !== undefined
+        ? `${locale.language}-${locale.region}`
+        : locale.language;
+
+    if (maximizedTag in languageTags) {
+      return maximizedTag;
+    }
+
+    const matchedTag = Object.keys(languageTags).find((supportedTag) =>
+      supportedTag.startsWith(`${locale.language}-`),
+    );
+    if (matchedTag) return matchedTag;
+  } catch {
+    const [baseLanguage] = tag.split('-');
+    if (!baseLanguage) return null;
+
+    const matchedTag = Object.keys(languageTags).find((supportedTag) =>
+      supportedTag.startsWith(`${baseLanguage}-`),
+    );
+    if (matchedTag) return matchedTag;
+  }
+
+  return null;
+};
+
+const resolveAutoLanguageTag = (): string | null => {
+  const candidates = [
+    ...(navigator.languages ?? []),
+    navigator.language,
+  ].filter((tag): tag is string => tag !== '');
+
+  for (const tag of candidates) {
+    const resolvedTag = resolveSupportedLanguageTag(tag);
+    if (resolvedTag !== null) return resolvedTag;
+  }
+
+  return null;
+};
 
 export class WebspeechProvider
   extends BaseProviderInterface<WebspeechStatus>
@@ -54,6 +106,23 @@ export class WebspeechProvider
       return;
     }
 
+    // Can happen during intentional stop/restart cycles.
+    if (event.error === 'aborted') {
+      if (
+        this._muted ||
+        this.status === WebspeechStatus.INACTIVE ||
+        this.status === WebspeechStatus.ACTIVE_MUTE
+      ) {
+        return;
+      }
+    }
+
+    const errorDetail =
+      event.message !== ''
+        ? `${event.error}: ${event.message}`
+        : `${event.error}`;
+    lastWebspeechErrorDetail = errorDetail;
+
     console.error('Webspeech encountered unexpected error', event);
     this._setStatus(WebspeechStatus.ERROR);
   }
@@ -86,10 +155,14 @@ export class WebspeechProvider
 
     recognition.continuous = true;
     recognition.interimResults = true;
-    recognition.lang = config.languageTag;
+    const resolvedLanguageTag =
+      config.languageTag !== '' ? config.languageTag : resolveAutoLanguageTag();
+    if (resolvedLanguageTag !== null) {
+      recognition.lang = resolvedLanguageTag;
+    }
 
     recognition.onresult = this._handleResult.bind(this);
-    recognition.onerror = this._handleEnd.bind(this);
+    recognition.onerror = this._handleError.bind(this);
     recognition.onend = this._handleEnd.bind(this);
 
     return recognition;
@@ -119,7 +192,18 @@ export class WebspeechProvider
     this._setStatus(WebspeechStatus.ACTIVE_MUTE);
   }
 
+  private _stopProvider() {
+    if (this._recognition && this._providerIsStarted) {
+      this._recognition.stop();
+    }
+
+    this._providerIsStarted = false;
+    this._finalizedResultCount = 0;
+    this._setStatus(WebspeechStatus.INACTIVE);
+  }
+
   activateProvider(config: WebspeechConfig) {
+    lastWebspeechErrorDetail = null;
     this._setStatus(WebspeechStatus.ACTIVATING);
 
     try {
@@ -143,8 +227,7 @@ export class WebspeechProvider
   }
 
   deactivateProvider() {
-    this._setStatus(WebspeechStatus.INACTIVE);
-    this._pauseProvider();
+    this._stopProvider();
     this._recognition = null;
   }
 


### PR DESCRIPTION
add a `deploy-webapp` GitHub Actions job that builds the webapp and deploys `apps/webapp/dist` to `scribear.illinois.edu` on pushes to main.
and npm test for webapp workspace

auto-resolving a supported browser language (when no one is set)
show the detailed browser speech-recognition errors in the modal