### PR TITLE
fix: Node changes github action incorrect change detection

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -4,7 +4,6 @@ description: >
   Walks tsconfig project references to include transitive dependents of changed
   workspaces. If any global config file (package-lock.json, eslint.config.js,
   etc.) changed, all workspaces are returned.
-  Requires: git checkout with fetch-depth: 0 and node already set up by caller.
 
 outputs:
   workspaces:
@@ -17,6 +16,14 @@ outputs:
 runs:
   using: composite
   steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '24.10.0'
+
     - name: Compute affected workspaces
       id: compute
       shell: bash

--- a/.github/workflows/node-cd.yml
+++ b/.github/workflows/node-cd.yml
@@ -18,13 +18,8 @@ jobs:
       workspaces: ${{ steps.changes.outputs.workspaces }}
       has_changes: ${{ steps.changes.outputs.has_changes }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-
-      - id: changes
+      - name: Detect Changed Workspaces
+        id: changes
         uses: ./.github/actions/detect-changes
 
   docker-build:

--- a/.github/workflows/node-cd.yml
+++ b/.github/workflows/node-cd.yml
@@ -18,6 +18,8 @@ jobs:
       workspaces: ${{ steps.changes.outputs.workspaces }}
       has_changes: ${{ steps.changes.outputs.has_changes }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Detect Changed Workspaces
         id: changes
         uses: ./.github/actions/detect-changes

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -19,10 +19,7 @@ jobs:
       workspaces: ${{ steps.changes.outputs.workspaces }}
       has_changes: ${{ steps.changes.outputs.has_changes }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-
-      - name: Detech Changed Workspaces
+      - name: Detect Changed Workspaces
         id: changes
         uses: ./.github/actions/detect-changes
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -19,6 +19,8 @@ jobs:
       workspaces: ${{ steps.changes.outputs.workspaces }}
       has_changes: ${{ steps.changes.outputs.has_changes }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Detect Changed Workspaces
         id: changes
         uses: ./.github/actions/detect-changes


### PR DESCRIPTION
The changes action currently fails to correct detect changes because the repository was cloned without full git history. Thus, the action falls back to marking all workspaces as changed. Fixes #86 

Fix:
- Include full git history
- Merge fetch and node setup steps into changes action instead of relying on workflow job to correctly set up repository