### PR TITLE
finish webspeech network debug

### DIFF
--- a/apps/standalone-webapp/src/features/transcription-providers/services/providers/provider-interface.ts
+++ b/apps/standalone-webapp/src/features/transcription-providers/services/providers/provider-interface.ts
@@ -21,9 +21,8 @@ export interface ProviderEvents<StatusType> {
  * with the standard provider events and exposes lifecycle methods for activation,
  * deactivation, and microphone mute/unmute control.
  */
-export interface ProviderInterface<ConfigType, StatusType> extends EventEmitter<
-  ProviderEvents<StatusType>
-> {
+export interface ProviderInterface<ConfigType, StatusType>
+  extends EventEmitter<ProviderEvents<StatusType>> {
   get status(): StatusType;
 
   activateProvider(config: ConfigType): Promise<void> | void;

--- a/apps/standalone-webapp/src/features/transcription-providers/services/providers/webspeech/components/webspeech-modal.tsx
+++ b/apps/standalone-webapp/src/features/transcription-providers/services/providers/webspeech/components/webspeech-modal.tsx
@@ -68,9 +68,22 @@ export const WebspeechModal = () => {
     />
   );
 
+  const reconnecting = (
+    <CancelableInfoModal
+      isOpen={webspeechStatus === WebspeechStatus.NETWORK_RETRYING}
+      message={`${displayName} network error detected. Reconnecting...`}
+      onCancel={cancelModal}
+    >
+      <Stack direction="row" justifyContent="space-around">
+        <CircularProgress />
+      </Stack>
+    </CancelableInfoModal>
+  );
+
   return (
     <>
       {activating}
+      {reconnecting}
       {unsupported}
       {error}
     </>

--- a/apps/standalone-webapp/src/features/transcription-providers/services/providers/webspeech/components/webspeech-status-icon.tsx
+++ b/apps/standalone-webapp/src/features/transcription-providers/services/providers/webspeech/components/webspeech-status-icon.tsx
@@ -40,6 +40,9 @@ export const WebspeechStatusIcon = () => {
   } else if (webspeechStatus === WebspeechStatus.ERROR) {
     icon = <NotInterestedIcon />;
     tooltip = `${displayName} encountered an unexpected error`;
+  } else if (webspeechStatus === WebspeechStatus.NETWORK_RETRYING) {
+    icon = <HourglassTopIcon />;
+    tooltip = `${displayName} lost network, reconnecting`;
   }
 
   return (

--- a/apps/standalone-webapp/src/features/transcription-providers/services/providers/webspeech/services/webspeech-provider.ts
+++ b/apps/standalone-webapp/src/features/transcription-providers/services/providers/webspeech/services/webspeech-provider.ts
@@ -1,5 +1,4 @@
-import type { MicrophoneService } from '@scribear/microphone-store';
-
+// import type { MicrophoneService } from '@scribear/microphone-store';
 import { BaseProviderInterface } from '../../base-provider-interface';
 import type { ProviderInterface } from '../../provider-interface';
 import {
@@ -7,6 +6,10 @@ import {
   type WebspeechConfig,
 } from '../config/webspeech-config';
 import { WebspeechStatus } from '../types/webspeech-status';
+
+interface MicrophoneServiceLike {
+  activateMicrophone: () => void | Promise<void>;
+}
 
 /**
  * Transcription provider implementation built on the browser's Web Speech API
@@ -22,11 +25,21 @@ export class WebspeechProvider
   private _recognition: SpeechRecognition | null = null;
   private _finalizedResultCount = 0;
   private _providerIsStarted = false;
-  private readonly _microphoneService: MicrophoneService;
+  // private readonly _microphoneService: MicrophoneService;
+  private _networkRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly _NETWORK_RETRY_MS = 3000;
 
-  constructor(microphoneService: MicrophoneService) {
+  private readonly _microphoneService: MicrophoneServiceLike;
+  constructor(microphoneService: MicrophoneServiceLike) {
     super(INITIAL_WEBSPEECH_STATUS);
     this._microphoneService = microphoneService;
+  }
+
+  private _clearNetworkRetryTimer() {
+    if (this._networkRetryTimer) {
+      clearTimeout(this._networkRetryTimer);
+      this._networkRetryTimer = null;
+    }
   }
 
   private _handleResult(event: SpeechRecognitionEvent) {
@@ -58,6 +71,26 @@ export class WebspeechProvider
   private _handleError(event: SpeechRecognitionErrorEvent) {
     if (event.error === 'no-speech') {
       this._commitParagraphBreak();
+      return;
+    }
+
+    if (event.error === 'network') {
+      console.warn('Webspeech network error, reconnecting...', event);
+      this._setStatus(WebspeechStatus.NETWORK_RETRYING);
+      this._clearNetworkRetryTimer();
+      this._networkRetryTimer = setTimeout(() => {
+        this._networkRetryTimer = null;
+        if (!this._recognition || this._muted) return;
+        if (this.status !== WebspeechStatus.NETWORK_RETRYING) return;
+        try {
+          this._recognition.start();
+          this._providerIsStarted = true;
+          this._setStatus(WebspeechStatus.ACTIVE);
+        } catch (error) {
+          console.error('Failed to restart after network error', error);
+          this._setStatus(WebspeechStatus.ERROR);
+        }
+      }, WebspeechProvider._NETWORK_RETRY_MS);
       return;
     }
 
@@ -104,6 +137,7 @@ export class WebspeechProvider
 
   private _startProvider() {
     if (!this._recognition) return;
+    this._clearNetworkRetryTimer();
 
     try {
       this._recognition.start();
@@ -161,6 +195,7 @@ export class WebspeechProvider
    * Stops recognition, resets status to `INACTIVE`, and releases the recognition object.
    */
   deactivateProvider() {
+    this._clearNetworkRetryTimer();
     this._setStatus(WebspeechStatus.INACTIVE);
     if (this._recognition) {
       // Detach handlers before stopping so the async `onend` does not

--- a/apps/standalone-webapp/src/features/transcription-providers/services/providers/webspeech/services/webspeech-provider.ts
+++ b/apps/standalone-webapp/src/features/transcription-providers/services/providers/webspeech/services/webspeech-provider.ts
@@ -25,11 +25,10 @@ export class WebspeechProvider
   private _recognition: SpeechRecognition | null = null;
   private _finalizedResultCount = 0;
   private _providerIsStarted = false;
-  // private readonly _microphoneService: MicrophoneService;
+  private readonly _microphoneService: MicrophoneServiceLike;
   private _networkRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private static readonly _NETWORK_RETRY_MS = 3000;
 
-  private readonly _microphoneService: MicrophoneServiceLike;
   constructor(microphoneService: MicrophoneServiceLike) {
     super(INITIAL_WEBSPEECH_STATUS);
     this._microphoneService = microphoneService;

--- a/apps/standalone-webapp/src/features/transcription-providers/services/providers/webspeech/types/webspeech-status.ts
+++ b/apps/standalone-webapp/src/features/transcription-providers/services/providers/webspeech/types/webspeech-status.ts
@@ -13,6 +13,8 @@ export enum WebspeechStatus {
   ACTIVE = 'ACTIVE',
   // Provider is initialized but microphone is muted; recognition is paused.
   ACTIVE_MUTE = 'ACTIVE_MUTE',
+  // When there exist network error, we will reconnect the webspeech
+  NETWORK_RETRYING = 'NETWORK_RETRYING',
   // Provider encountered an unrecoverable error.
   ERROR = 'ERROR',
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -450,6 +450,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1128,6 +1129,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1171,6 +1173,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2890,6 +2893,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.8.tgz",
       "integrity": "sha512-QKd1RhDXE1hf2sQDNayA9ic9jGkEgvZOf0tTkJxlBPG8ns8aS4rS8WwYURw2x5y3739p0HauUXX9WbH7UufFLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@mui/core-downloads-tracker": "^7.3.8",
@@ -3951,6 +3955,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4297,6 +4302,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4852,6 +4858,7 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -4907,6 +4914,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5139,6 +5147,7 @@
       "resolved": "https://registry.npmjs.org/awilix/-/awilix-13.0.0.tgz",
       "integrity": "sha512-kVpYTF+hFM3KD1EeMZvdRBbhY2UufBk1DAony89CeywsNGn8IaofSK4h9rnm8FehnptYk6iY8eVDlRNRHB4vdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-glob": "^3.3.3"
       },
@@ -5463,6 +5472,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6391,6 +6401,7 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7099,6 +7110,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fastify/ajv-compiler": "^4.0.5",
         "@fastify/error": "^4.0.0",
@@ -8069,6 +8081,7 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.11.tgz",
       "integrity": "sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -8951,6 +8964,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.19.0.tgz",
       "integrity": "sha512-QIcLGi508BAHkQ3pJNptsFz5WQMlpGbuBGBaIaXsWK8mel2kQ/rThYI+DbgjUvZrIr7MiuEuc9LcChJoEZK1xQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.12.0",
@@ -9232,6 +9246,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9432,6 +9447,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9441,6 +9457,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9639,7 +9656,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-remember": {
       "version": "6.0.2",
@@ -10495,6 +10513,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10709,7 +10728,8 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.5.tgz",
       "integrity": "sha512-TBdiM4mSppvWdmRDK5PoocxrMOqGIU9TxmS9zdHH+k8S/+2SIaNlPfMlx3f6hISxma14t2yX7SRySg7+TYYT9w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -10717,6 +10737,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11054,6 +11075,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11162,6 +11184,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11175,6 +11198,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -11429,6 +11453,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11571,6 +11596,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
This pr potentially solves the problem of network error bug and add reconnecting feature after network error happens in standalone-webapp.

## Modifications
### Error handling
* Network errors are now handled explicitly in the WebSpeech error handler.
* A reconnect process is triggered when a network error occurs.

### Updated WebSpeech UI:
* Modal now shows a reconnecting state during network retry.
* Status icon/tooltip now reflects network reconnecting status.

## Potential Reason of the bug
Previously, network errors could push the provider into a generic error experience without clear retry-state feedback.
Now users are informed of reconnecting progress and transient network issues recover automatically.

## Scope
apps/standalone-webapp WebSpeech provider + related status UI only.
No backend/API contract changes.