### PR TITLE
fix: set max age for cookie so it doesn't get treated as a session cookie

### DIFF
--- a/apps/session-manager/src/server/features/device-management/device-management.controller.ts
+++ b/apps/session-manager/src/server/features/device-management/device-management.controller.ts
@@ -61,6 +61,7 @@ export class DeviceManagementController {
       path: '/',
       secure: this._useSecureCookie,
       sameSite: 'strict',
+      maxAge: 60 * 60 * 24 * 365,
     });
     res
       .code(200)


### PR DESCRIPTION
Without a max age, browsers treat cookie as a session cookie and deletes it after the session ends (browser closed).