### PR TITLE
Make submenu text clickable

### DIFF
--- a/libs/ui/core-ui/src/components/drawer-menu-group.tsx
+++ b/libs/ui/core-ui/src/components/drawer-menu-group.tsx
@@ -1,13 +1,13 @@
 import type React from 'react';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
 import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
 import Collapse from '@mui/material/Collapse';
 import Divider from '@mui/material/Divider';
 import Icon from '@mui/material/Icon';
-import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 
@@ -35,32 +35,43 @@ export const DrawerMenuGroup = ({
   summary,
   children,
 }: DrawerMenuGroupProps) => {
+  const contentId = useId();
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <Box>
-      <Stack
-        direction="row"
-        alignItems="center"
-        justifyContent="space-between"
-        sx={{ p: 2 }}
+      <ButtonBase
+        component="button"
+        type="button"
+        onClick={() => {
+          setIsOpen((currentIsOpen) => !currentIsOpen);
+        }}
+        aria-expanded={isOpen}
+        aria-controls={contentId}
+        sx={{
+          width: '100%',
+          p: 2,
+          color: 'inherit',
+          justifyContent: 'space-between',
+          textAlign: 'left',
+        }}
       >
-        <Stack direction="row" alignItems="center">
-          <Stack sx={{ p: 1 }}>
+        <Stack component="span" direction="row" alignItems="center">
+          <Stack component="span" sx={{ p: 1 }}>
             <Icon color="inherit">{icon}</Icon>
           </Stack>
-          <Typography>{summary}</Typography>
+          <Typography component="span">{summary}</Typography>
         </Stack>
 
-        <IconButton
-          onClick={() => {
-            setIsOpen(!isOpen);
-          }}
+        <Box
+          component="span"
+          aria-hidden="true"
+          sx={{ display: 'inline-flex', p: 1 }}
         >
           {isOpen ? <ExpandLess /> : <ExpandMore />}
-        </IconButton>
-      </Stack>
-      <Collapse in={isOpen}>
+        </Box>
+      </ButtonBase>
+      <Collapse id={contentId} in={isOpen}>
         <Stack sx={{ p: 2 }} direction="column" spacing={1}>
           {children}
         </Stack>


### PR DESCRIPTION
## Summary
- make the drawer submenu header a full-width toggle target
- keep the chevron as part of the same accessible button
- connect the toggle button to its collapsible panel with ARIA attributes

## Validation
- git diff --check
- esbuild TSX transform for drawer-menu-group.tsx

Note: the local TypeScript, ESLint, and Vite CLIs hung without diagnostics in this environment, so those checks were stopped cleanly.