### PR TITLE
Worker pool update

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           WORKSPACES: ${{ needs.changes.outputs.workspaces }}
         run: |
-          node -e "process.stdout.write(JSON.parse(process.env.WORKSPACES).join('\n'))" > /tmp/workspaces.txt
+          node -e "console.log(JSON.parse(process.env.WORKSPACES).join('\n'))" > /tmp/workspaces.txt
           while IFS= read -r ws; do
             echo "::group::$ws"
             npm run format --workspace "$ws"
@@ -58,7 +58,7 @@ jobs:
         env:
           WORKSPACES: ${{ needs.changes.outputs.workspaces }}
         run: |
-          node -e "process.stdout.write(JSON.parse(process.env.WORKSPACES).join('\n'))" > /tmp/workspaces.txt
+          node -e "console.log(JSON.parse(process.env.WORKSPACES).join('\n'))" > /tmp/workspaces.txt
           while IFS= read -r ws; do
             echo "::group::$ws"
             npm run lint --workspace "$ws"
@@ -78,7 +78,7 @@ jobs:
         env:
           WORKSPACES: ${{ needs.changes.outputs.workspaces }}
         run: |
-          node -e "process.stdout.write(JSON.parse(process.env.WORKSPACES).join('\n'))" > /tmp/workspaces.txt
+          node -e "console.log(JSON.parse(process.env.WORKSPACES).join('\n'))" > /tmp/workspaces.txt
           while IFS= read -r ws; do
             echo "::group::$ws"
             npm run build --workspace "$ws" --if-present
@@ -98,7 +98,7 @@ jobs:
         env:
           WORKSPACES: ${{ needs.changes.outputs.workspaces }}
         run: |
-          node -e "process.stdout.write(JSON.parse(process.env.WORKSPACES).join('\n'))" > /tmp/workspaces.txt
+          node -e "console.log(JSON.parse(process.env.WORKSPACES).join('\n'))" > /tmp/workspaces.txt
           while IFS= read -r ws; do
             echo "::group::$ws"
             npm run test:unit --workspace "$ws" --if-present

--- a/apps/node-server/tests/integration/global-setup.ts
+++ b/apps/node-server/tests/integration/global-setup.ts
@@ -151,15 +151,13 @@ export async function setup({
   // on the CPU image.
   const providerConfigJson = JSON.stringify({
     num_workers: 1,
-    rolling_utilization_window_sec: 600,
     contexts: [],
-    providers: [
-      {
-        provider_key: 'debug',
+    providers: {
+      debug: {
         provider_uid: 'debug',
         provider_config: { sample_rate: 48000, num_channels: 1 },
       },
-    ],
+    },
   });
 
   transcriptionContainer = await txImage

--- a/apps/session-manager/tests/unit/shared/services/session-token.service.test.ts
+++ b/apps/session-manager/tests/unit/shared/services/session-token.service.test.ts
@@ -69,7 +69,7 @@ describe('SessionTokenService', () => {
       const token = service.sign(PAYLOAD);
       const [encodedPayload, signature] = token.split('.');
       // Replace the signature with one that has the same length but is a
-      // valid base64url string of zeros — so the only thing that changes is
+      // valid base64url string of zeros - so the only thing that changes is
       // whether the HMAC validates.
       const fakeSig = 'A'.repeat(signature!.length);
       const forged = `${encodedPayload}.${fakeSig}`;
@@ -103,7 +103,7 @@ describe('SessionTokenService', () => {
       // calc we can drive, so reach in via the same algorithm: just sign a
       // valid payload and hand-craft.
       // Instead: feed a known-good token but flip a payload byte to break
-      // JSON parsing. The signature won't match — which is exactly the point;
+      // JSON parsing. The signature won't match - which is exactly the point;
       // verify() should reject before the JSON parse anyway.
       const token = `${garbage}.${'X'.repeat(43)}`;
 

--- a/transcription_service/provider_config.template.json
+++ b/transcription_service/provider_config.template.json
@@ -1,15 +1,10 @@
 {
-    "num_workers": 3,
-    "rolling_utilization_window_sec": 600,
+    "num_workers": 1,
     "contexts": [
         {
             "context_uid": "faster-whisper",
-            "max_instances": 3,
-            "tags": [
-                "whisper_cpu_context"
-            ],
-            "negative_affinity": null,
-            "creation_cost": 0.1,
+            "worker_ids": [0],
+            "tags": ["whisper_cpu_context"],
             "context_config": {
                 "model": "small",
                 "device": "cpu"
@@ -17,33 +12,28 @@
         },
         {
             "context_uid": "silero-vad",
-            "max_instances": 3,
-            "tags": [
-                "silero_vad"
-            ],
-            "negative_affinity": null,
-            "creation_cost": 0.05,
+            "worker_ids": [0],
+            "tags": ["silero_vad"],
             "context_config": {}
         }
     ],
-    "providers": [
-        {
-            "provider_key": "debug",
+    "providers": {
+        "debug": {
             "provider_uid": "debug",
             "provider_config": {
                 "sample_rate": 16000,
                 "num_channels": 1
             }
         },
-        {
-            "provider_key": "whisper",
+        "whisper": {
             "provider_uid": "whisper-streaming",
             "provider_config": {
-                "context_tag": "whisper_cpu_context",
+                "whisper_context_tag": "whisper_cpu_context",
+                "silero_context_tag": "silero_vad",
                 "job_period_ms": 5000,
                 "max_buffer_len_sec": 30,
                 "local_agree_dim": 2
             }
         }
-    ]
+    }
 }

--- a/transcription_service/src/shared/config/config.py
+++ b/transcription_service/src/shared/config/config.py
@@ -45,10 +45,8 @@ class JobContextConfigSchema(BaseModel):
     """
 
     context_uid: JobContextDefinitionUID
-    max_instances: int
+    worker_ids: list[int]
     tags: list[str]
-    negative_affinity: str | None
-    creation_cost: float
     context_config: Any
 
 
@@ -66,7 +64,6 @@ class TranscriptionProviderConfigSchema(BaseModel):
     Base config schema for a transcription provider
     """
 
-    provider_key: str = Field(max_length=32)
     provider_uid: TranscriptionProviderUID
     provider_config: Any
 
@@ -77,9 +74,8 @@ class ProviderConfigFileSchema(BaseModel):
     """
 
     num_workers: int
-    rolling_utilization_window_sec: float
     contexts: list[JobContextConfigSchema]
-    providers: list[TranscriptionProviderConfigSchema]
+    providers: dict[str, TranscriptionProviderConfigSchema]
 
 
 # pylint: disable=invalid-name

--- a/transcription_service/src/shared/utils/worker_pool/__init__.py
+++ b/transcription_service/src/shared/utils/worker_pool/__init__.py
@@ -5,5 +5,5 @@ Public exports for WorkerPool
 from .job_context_interface import JobContextInterface
 from .job_interface import JobInterface
 from .job_result import JobException, JobStatistics, JobSuccess
-from .worker_pool import WorkerPool
+from .worker_pool import ContextAssignment, WorkerPool
 from .worker_process_manager import JobHandle, WorkerProcessManager

--- a/transcription_service/src/shared/utils/worker_pool/job_context_interface.py
+++ b/transcription_service/src/shared/utils/worker_pool/job_context_interface.py
@@ -13,61 +13,26 @@ JobContextInstance = TypeVar("JobContextInstance")
 class JobContextInterface(ABC, Generic[JobContextInstance]):
     """
     Interface for defining job context
-    Used by WorkerPool to create and destroy context instances
+    Used by WorkerPool to create context instances at worker startup. Contexts
+    are pinned to specific workers via the pool's configuration and are created
+    eagerly when the worker process starts.
     """
-
-    @property
-    def max_instances(self) -> int:
-        """
-        Maximum number of worker processes that can instantiate this context
-        """
-        return self._max_instances
 
     @property
     def tags(self) -> set[str]:
         """
-        Set of tags that context is assigned
-        Used by WorkerPool to select context to be used for a job
+        Set of tags assigned to this context
+        Used by WorkerPool to route jobs requesting matching tags to workers
+        that own a context with at least one of those tags
         """
         return self._tags
 
-    @property
-    def negative_affinity(self) -> str | None:
-        """
-        Tag that context is has negative affinity with
-        Used by WorkerPool to select context to be used for a job
-        """
-        return self._negative_affinity
-
-    @property
-    def creation_cost(self) -> float:
-        """
-        Cost weight of creating a job, higher means slower creation
-        Used by WorkerPool to select context to be used for a job
-        """
-        return self._creation_cost
-
-    # pylint: disable=unused-argument
-    def __init__(
-        self,
-        context_config: object,
-        max_instances: int,
-        tags: list[str],
-        negative_affinity: str | None,
-        creation_cost: float,
-    ):
+    def __init__(self, tags: list[str]):
         """
         Args:
-            context_config      - JobContext implementation dependent config
-            max_instances       - Maximum instances configured for job context
-            tags                - List of tags configured for job context
-            negative_affinity   - Negative affinity tag configured for job context
-            creation_cost       - Cost weight of creating this context
+            tags    - Tags configured for job context
         """
-        self._max_instances = max_instances
         self._tags = set(tags)
-        self._negative_affinity = negative_affinity
-        self._creation_cost = creation_cost
 
     @abstractmethod
     def create(self, log: Logger) -> JobContextInstance:

--- a/transcription_service/src/shared/utils/worker_pool/job_interface.py
+++ b/transcription_service/src/shared/utils/worker_pool/job_interface.py
@@ -10,9 +10,10 @@ from src.shared.logger import Logger
 C = TypeVar("C", bound=tuple)
 D = TypeVar("D")
 R = TypeVar("R")
+Conf = TypeVar("Conf")
 
 
-class JobInterface(ABC, Generic[C, D, R]):
+class JobInterface(ABC, Generic[C, D, R, Conf]):
     """
     Interface for defining job
     """
@@ -33,3 +34,17 @@ class JobInterface(ABC, Generic[C, D, R]):
         Returns:
             Any job result
         """
+
+    @abstractmethod
+    def update_config(self, log: Logger, contexts: C, config: Conf) -> None:
+        """
+        Apply a config update mid-stream
+        Called by WorkerPool between process_batch calls when a config update
+        was queued via JobHandle.update_config.
+
+        Args:
+            log         - Application logger
+            contexts    - Context instances created by WorkerPool
+            config      - New config to apply
+        """
+        return

--- a/transcription_service/src/shared/utils/worker_pool/result.py
+++ b/transcription_service/src/shared/utils/worker_pool/result.py
@@ -25,9 +25,12 @@ class ResultType(IntEnum):
 @dataclass
 class InitializeWorkerResult:
     """
-    Result for when WorkerProcess is fully initialized
+    Result emitted by WorkerProcess once it has finished startup
+    error is set when context creation fails - main process should
+    raise to abort pool startup in that case
     """
 
+    error: str | None = None
     type: Literal[ResultType.INITIALIZE_WORKER] = ResultType.INITIALIZE_WORKER
 
 

--- a/transcription_service/src/shared/utils/worker_pool/task.py
+++ b/transcription_service/src/shared/utils/worker_pool/task.py
@@ -18,6 +18,7 @@ class TaskType(IntEnum):
     REGISTER_JOB = 1
     DEREGISTER_JOB = 2
     QUEUE_DATA = 3
+    UPDATE_JOB_CONFIG = 4
 
 
 @dataclass
@@ -38,7 +39,7 @@ class RegisterJobTask:
     job_id: int
     context_ids: tuple[int, ...]
     period_ms: int
-    job: JobInterface[Any, Any, Any]
+    job: JobInterface[Any, Any, Any, Any]
     type: Literal[TaskType.REGISTER_JOB] = TaskType.REGISTER_JOB
 
 
@@ -63,4 +64,21 @@ class QueueDataTask:
     type: Literal[TaskType.QUEUE_DATA] = TaskType.QUEUE_DATA
 
 
-type Task = TerminateWorkerTask | RegisterJobTask | DeregisterJobTask | QueueDataTask
+@dataclass
+class UpdateJobConfigTask:
+    """
+    Task to apply a config update between data batches for a job
+    """
+
+    job_id: int
+    config: Any
+    type: Literal[TaskType.UPDATE_JOB_CONFIG] = TaskType.UPDATE_JOB_CONFIG
+
+
+type Task = (
+    TerminateWorkerTask
+    | RegisterJobTask
+    | DeregisterJobTask
+    | QueueDataTask
+    | UpdateJobConfigTask
+)

--- a/transcription_service/src/shared/utils/worker_pool/worker_log_handler.py
+++ b/transcription_service/src/shared/utils/worker_pool/worker_log_handler.py
@@ -3,7 +3,8 @@ Defines WorkerLogHandler for pushing logs to result queue
 """
 
 import logging
-from queue import Queue
+
+from multiprocess.queues import Queue
 
 from .result import LoggingResult, Result
 

--- a/transcription_service/src/shared/utils/worker_pool/worker_pool.py
+++ b/transcription_service/src/shared/utils/worker_pool/worker_pool.py
@@ -2,11 +2,13 @@
 Defines WorkerPool for managing multiple WorkerProcessManagers
 """
 
+from dataclasses import dataclass
 from itertools import product
 from typing import Any, TypeVar, cast
 
 from src.shared.logger import Logger
 from src.shared.utils.worker_pool.worker_process_manager import (
+    ROLLING_UTILIZATION_WINDOW_NS,
     JobHandle,
     WorkerProcessManager,
 )
@@ -17,57 +19,59 @@ from .job_interface import JobInterface
 C = TypeVar("C", bound=tuple)
 D = TypeVar("D")
 R = TypeVar("R")
+Conf = TypeVar("Conf")
+
+
+@dataclass
+class ContextAssignment:
+    """
+    Assigns a context definition to a specific set of workers
+    Each listed worker will eagerly create an instance of this context at startup.
+    """
+
+    context_def: JobContextInterface[Any]
+    worker_ids: list[int]
 
 
 class WorkerPool:
     """
     Interface for managing multiple WorkerProcessManagers
-    Handles assigning jobs to processes
+    Assigns contexts to workers up front and routes jobs to workers that own
+    a matching context with lowest utilization.
 
     Usage
     ```
     class Context(JobContextInterface[int]):
         def __init__(self):
-            super().__init__(tags={"some_context"})
+            super().__init__(tags=["some_context"])
 
         def create(self, log: Logger) -> int:
             return 42
 
-        def destroy(self, log: ContextLogger, context: int) -> None:
+        def destroy(self, log: Logger, context: int) -> None:
             return
 
 
-    class Job(JobInterface[int, int, int]):
+    class Job(JobInterface[tuple[int], int, int]):
         def process_batch(
-            self, log: ContextLogger, context: int, batch: list[int]
+            self, log: Logger, contexts: tuple[int], batch: list[int]
         ) -> int:
-            return sum(batch) + context
+            return sum(batch) + contexts[0]
 
 
-    # Create WorkerPool
-    context_def: dict[int, JobContextInterface[Any]] = {0: Context()}
-    rolling_utilization_window_sec = 5 * 60
     pool = WorkerPool(
-        logger, 2, context_def, rolling_utilization_window_sec
+        logger,
+        num_workers=2,
+        contexts=[ContextAssignment(Context(), worker_ids=[0, 1])],
     )
 
-    # Register a job
-    period_ms = 100
-    handle = pool.register_job("some_context", period_ms, Job())
-
-    # Queue data for job to process
+    handle = pool.register_job(("some_context",), period_ms=100, job=Job())
     handle.queue_data([1, 2, 3])
-    handle.queue_data([4, 5, 6])
+    handle.on(handle.JobResultEvent, lambda result: print(result))
 
-    # Handle job results
-    handle.on(handle.JobResultEvent, lambda result: print(result))  # Prints 63
-
-    # Give job time to execute
-    await asyncio.sleep(1)
+    # ...
 
     handle.deregister()
-
-    # Shutdown pool
     pool.shutdown()
     ```
     """
@@ -76,64 +80,71 @@ class WorkerPool:
         self,
         logger: Logger,
         num_workers: int,
-        context_def: dict[int, JobContextInterface[Any]],
-        rolling_utilization_window_sec: float,
+        contexts: list[ContextAssignment],
+        rolling_utilization_window_ns: int = ROLLING_UTILIZATION_WINDOW_NS,
     ):
+        """
+        Args:
+            logger      - Application logger
+            num_workers - Number of worker processes to spawn
+            contexts    - Context assignments. Each context_def is created on
+                            every worker listed in its worker_ids. Position in
+                            the list determines the context_id.
+            rolling_utilization_window_ns - Override for the per-worker utilization
+                                              smoothing window (production should
+                                              use the default)
+
+        Raises:
+            ValueError      if num_workers is 0 or worker_ids reference an invalid worker
+            RuntimeError    if any worker fails to initialize a context
+        """
         if num_workers <= 0:
             raise ValueError("num_workers must be at least 1")
 
+        # Assign each context to its target workers (position in `contexts` is context_id)
+        per_worker_defs: list[dict[int, JobContextInterface[Any]]] = [
+            {} for _ in range(num_workers)
+        ]
+        for context_id, assignment in enumerate(contexts):
+            for worker_id in assignment.worker_ids:
+                if not 0 <= worker_id < num_workers:
+                    raise ValueError(
+                        f"Context {context_id} references invalid worker_id={worker_id}"
+                    )
+                per_worker_defs[worker_id][context_id] = assignment.context_def
+
+        self._contexts = contexts
         self._processes = [
             WorkerProcessManager(
-                logger, id, context_def, rolling_utilization_window_sec
+                logger,
+                worker_id,
+                per_worker_defs[worker_id],
+                rolling_utilization_window_ns,
             )
-            for id in range(num_workers)
+            for worker_id in range(num_workers)
         ]
 
-        self._context_def = context_def
+        # Pre-compute tag -> set of context_ids that have it for fast routing
+        self._tag_to_context_ids: dict[str, set[int]] = {}
+        for context_id, assignment in enumerate(contexts):
+            for tag in assignment.context_def.tags:
+                self._tag_to_context_ids.setdefault(tag, set()).add(context_id)
 
-    def get_context_ids_by_tag(self, tag: str):
+    def get_context_ids_by_tag(self, tag: str) -> set[int]:
         """
-        Gets set of context_ids that with the given tag
+        Gets set of context_ids that have the given tag
 
         Args:
-            tag         - Tag to select context definitions
+            tag     - Tag to look up
 
         Returns:
-            Set of context_id that have given tag
+            Set of context_ids that include this tag; empty if no match
         """
-        context_ids = set[int]()
-        for context_id in self._context_def:
-            if tag in self._context_def[context_id].tags:
-                context_ids.add(context_id)
-        return context_ids
-
-    def tagged_context_is_instance(self, tag: str, instances: list[Any]):
-        """
-        Checks that all context definitions matching given tag is an
-        instance of one of the given instances
-
-        Args:
-            tags        - Tag to select context definitions to check
-            instances   - List of instance definitions to check against
-
-        Returns:
-            True if all matching context definitions is an instance of
-            one of the given instances, False otherwise
-        """
-        context_ids = self.get_context_ids_by_tag(tag)
-        for context_id in context_ids:
-            matches_type = False
-            for inst in instances:
-                if isinstance(self._context_def[context_id], inst):
-                    matches_type = True
-                    break
-            if not matches_type:
-                return False
-        return True
+        return set(self._tag_to_context_ids.get(tag, set()))
 
     def _get_min_utilization(self):
         """
-        Gets the process id with minimum utilization
+        Gets the worker id with minimum utilization
         """
         min_util = None
         min_util_process = None
@@ -143,190 +154,76 @@ class WorkerPool:
                 min_util_process = process_id
         return cast(int, min_util_process)
 
-    def _context_max_active_reached(self, context_id: int):
+    def _workers_with_contexts(self, context_ids: tuple[int, ...]) -> set[int]:
         """
-        Determine if a given context_id has reached maximum active instances allowed
+        Find workers that own every context in the given group
 
         Args:
-            context_id      - Context id to check
+            context_ids     - Group of context_ids that must all live on the same worker
 
         Returns:
-            True if maximum is reached, False if not
+            Set of worker_ids that have all requested contexts initialized
         """
-        max_instances = self._context_def[context_id].max_instances
-        if max_instances == -1:
-            return False
+        unique = set(context_ids)
+        worker_ids = set(range(len(self._processes)))
+        for cid in unique:
+            worker_ids &= self._processes_with_context(cid)
+            if not worker_ids:
+                break
+        return worker_ids
 
-        count = 0
-        for process in self._processes:
-            if context_id in process.active_context_ids:
-                count += 1
-        return count >= max_instances
-
-    def _context_ids_are_compatible(self, context_ids: tuple[int, ...]):
+    def _processes_with_context(self, context_id: int) -> set[int]:
         """
-        Determines if group of context ids are compatible
-        As in none have negative affinity with another
-
-        Args:
-            context_ids     - Group of context ids to check
-
-        Returns:
-            True if context_ids are compatible, False if not
+        Set of worker_ids that have the given context_id pinned to them
         """
-        for context_id in context_ids:
-            other_tags = set[str]()
-            for other_id in context_ids:
-                if other_id != context_ids:
-                    other_tags.update(self._context_def[other_id].tags)
-
-            if self._context_def[context_id].negative_affinity in other_tags:
-                return False
-        return True
-
-    def _has_negative_affinity(self, context_id: int, process_id: int):
-        """
-        Determines if given context id has negative affinity with active contexts on process
-
-        Args:
-            context_id      - Context id to check
-            process_id      - Process id to to check
-
-        Returns:
-            True if context id has negative affinity with process, False if not
-        """
-        tags = self._context_def[context_id].tags
-        negative_affinity = self._context_def[context_id].negative_affinity
-
-        # Set of tags for currently active contexts on process
-        active_context_tags = set[str]()
-        # Set of negative affinities for active contexts on process
-        active_negative_affinity = set[str]()
-
-        for active_id in self._processes[process_id].active_context_ids:
-            if active_id is None:
-                continue
-            active_context_tags.update(self._context_def[active_id].tags)
-
-            active_neg_tag = self._context_def[active_id].negative_affinity
-            if active_neg_tag is not None:
-                active_negative_affinity.add(active_neg_tag)
-
-        # Ensure this context does not have negative affinity with the currently active contexts
-        if negative_affinity in active_context_tags:
-            return True
-        # Ensure this currently active contexts does not have negative affinity with this context
-        if not tags.isdisjoint(active_negative_affinity):
-            return True
-        return False
-
-    def _assignment_is_valid(
-        self, context_ids: tuple[int, ...], process_id: int
-    ):
-        """
-        Determinie if a given group of context ids can be assigned to a given process
-
-        Args:
-            context_ids     - Group of context ids to check
-            process_id      - Process id of process to check
-
-        Returns:
-            True if context ids can be assigned, False if not
-        """
-        # Process needs to support every context_id in group
-        for context_id in context_ids:
-            # context_id/process_id is disqualified if pair has negative affinity
-            if self._has_negative_affinity(context_id, process_id):
-                return False
-
-            # context_id/process_id id disqualified if it requires created new
-            # context instance when max instance count is already reached
-            if (
-                self._context_max_active_reached(context_id)
-                and context_id
-                not in self._processes[process_id].active_context_ids
-            ):
-                return False
-        return True
-
-    def _get_potential_assignments(
-        self, matched_contexts: tuple[set[int], ...]
-    ):
-        """
-        Determine potential valid assignments for job given set of context_id matches
-
-        Args:
-            matched_contexts    - Group of lists, with each list matching set of
-                                    context ids that matched corresponding context tag
-
-        Returns:
-            List of process_ids and tuples of context_ids that are valid assignments
-        """
-        potential_assignments: list[tuple[int, tuple[int, ...]]] = []
-        for context_ids in product(*matched_contexts):
-            if not self._context_ids_are_compatible(context_ids):
-                print(context_ids)
-                continue
-
-            for process_id in range(len(self._processes)):
-                if self._assignment_is_valid(context_ids, process_id):
-                    potential_assignments.append((process_id, context_ids))
-        return potential_assignments
+        return {
+            worker_id
+            for worker_id, process in enumerate(self._processes)
+            if context_id in process.context_ids
+        }
 
     def _assign_process(
         self, context_tags: tuple[str, ...]
     ) -> tuple[int, tuple[int, ...]]:
         """
-        Determine which process to assign a job with given context tags to
-        Considers all valid combinations of context_ids matching tags and processes
-        and selects the pair with best score.
+        Pick the worker for a job. Contexts are pinned so this just finds workers
+        that own every required tag and picks the one with lowest utilization.
 
         Args:
-            context_tags        - Group of tags corresponding to the requested context of the job
+            context_tags    - Tags the job's contexts must match (in order)
 
         Returns:
-            Process id and tuple of context_ids to assign to it
+            (worker_id, context_ids tuple matching context_tags order)
+
+        Raises:
+            KeyError        if any tag matches no configured context
+            RuntimeError    if no single worker holds a context for every tag
         """
-        # If no context is required, select process with minimum utilization
         if len(context_tags) == 0:
             return (self._get_min_utilization(), ())
 
-        # Map each context tag to set of context ids
-        matched_contexts = tuple(map(self.get_context_ids_by_tag, context_tags))
-        # If a tag doesn't match any ids, we cannot provide assign a worker
-        for i, context_ids in enumerate(matched_contexts):
-            if len(context_ids) == 0:
+        matched_per_tag: list[set[int]] = []
+        for tag in context_tags:
+            ids = self._tag_to_context_ids.get(tag, set())
+            if not ids:
                 raise KeyError(
-                    f"context tag: {context_tags[i]} matched 0 context definitions"
+                    f"context tag: {tag} matched 0 context definitions"
                 )
+            matched_per_tag.append(ids)
 
         best_score = None
         best_assignment = None
-        for process_id, context_ids in self._get_potential_assignments(
-            matched_contexts
-        ):
-            # Compute the cost of creating contexts on process
-            creation_cost = 0
-            # Only use unique context ids to compute cost
-            for context_id in set(context_ids):
-                is_active_context = (
-                    context_id in self._processes[process_id].active_context_ids
-                )
-                if not is_active_context:
-                    creation_cost += self._context_def[context_id].creation_cost
-
-            utilization = self._processes[process_id].utilization
-
-            score = 1 - utilization
-            score -= creation_cost
-
-            if best_score is None or score > best_score:
-                best_score = score
-                best_assignment = (process_id, context_ids)
+        for context_ids in product(*matched_per_tag):
+            worker_ids = self._workers_with_contexts(context_ids)
+            for wid in worker_ids:
+                score = 1 - self._processes[wid].utilization
+                if best_score is None or score > best_score:
+                    best_score = score
+                    best_assignment = (wid, context_ids)
 
         if best_assignment is None:
             raise RuntimeError(
-                f"No valid assignment cound be found for context tags: {context_tags}"
+                f"No worker has a context for every tag in: {context_tags}"
             )
         return best_assignment
 
@@ -334,13 +231,13 @@ class WorkerPool:
         self,
         context_tags: tuple[str, ...],
         period_ms: int,
-        job: JobInterface[C, D, R],
-    ) -> JobHandle[D, R]:
+        job: JobInterface[C, D, R, Conf],
+    ) -> JobHandle[D, R, Conf]:
         """
         Registers a new job with WorkerPool
 
         Args:
-            context_tags    - Context tags of context instances to provide to Job, can be empty
+            context_tags    - Tags identifying which contexts the job needs, can be empty
             period_ms       - Frequency at which job should be run
             job             - Definition of job to register
 
@@ -348,17 +245,17 @@ class WorkerPool:
             JobHandle for registered job
 
         Raises:
-            KeyError if invalid context id is provided
-            RuntimeError if job could not be assigned to a worker
+            KeyError        if any context_tag matches no configured context
+            RuntimeError    if no worker has all required contexts together
         """
-        process_id, context_id = self._assign_process(context_tags)
+        process_id, context_ids = self._assign_process(context_tags)
         return self._processes[process_id].register_job(
-            context_id, period_ms, job
+            context_ids, period_ms, job
         )
 
     def shutdown(self):
         """
-        Shuts down all WorkerProcessses
+        Shuts down all WorkerProcesses
         Blocks while waiting for worker processes to exit before returning
         """
         for process in self._processes:

--- a/transcription_service/src/shared/utils/worker_pool/worker_process.py
+++ b/transcription_service/src/shared/utils/worker_pool/worker_process.py
@@ -5,8 +5,10 @@ Defines WorkerProcess which handles worker process execution
 import time
 from dataclasses import dataclass
 from enum import IntEnum
-from queue import Empty, Queue
+from queue import Empty
 from typing import Any
+
+from multiprocess.queues import Queue
 
 from src.shared.logger import Logger
 
@@ -45,6 +47,21 @@ class _JobState(IntEnum):
 
 
 @dataclass
+class _BufferSegment:
+    """
+    A contiguous batch of data optionally followed by a config update
+
+    The job's process_batch is called with `data`, then if `trailing_config`
+    is not None, job.update_config is called with it before the next segment
+    is processed.
+    """
+
+    data: list[Any]
+    trailing_config: Any = None
+    has_trailing_config: bool = False
+
+
+@dataclass
 class _JobEntry:
     """
     Holds relevant information about a job when assigned to worker process
@@ -56,70 +73,10 @@ class _JobEntry:
     # Beginning of next period based on time.perf_counter_ns()
     period_start_ns: int
     context_ids: tuple[int, ...]
-    buffer: list[Any]
-    job: JobInterface[Any, Any, Any]
-
-
-class _JobContextTable:
-    """
-    Helper class for managing context instances
-    Automatically creates context instances when fetched if instance isn't already created
-    """
-
-    def __init__(
-        self, logger: Logger, context_def: dict[int, JobContextInterface[Any]]
-    ):
-        """
-        Args:
-            context_def - Mapping from context_id (int) to context definitions
-                            implementing JobContextInterface
-        """
-        self._log = logger
-        self._context_def = context_def
-        self._instance_table: dict[int, Any] = {}
-
-    def get(self, context_id: int | None):
-        """
-        Fetches the corresponding context_id, creating context instance if not already created
-
-        Args:
-            context_id  - context_id to fetch, None if no context is needed
-
-        Returns:
-            ContextInstance of corresponding context_id
-
-        Raises:
-            KeyError if context_id is not found in context_def map
-        """
-        if context_id is None:
-            return None
-        if context_id not in self._context_def:
-            raise KeyError("Invalid Context Id")
-
-        log = self._log.child({"context_id": context_id})
-        if context_id in self._instance_table:
-            return self._instance_table[context_id]
-
-        instance = self._context_def[context_id].create(log)
-        self._instance_table[context_id] = instance
-        return instance
-
-    def destroy_unused(self, active_context_ids: set[int]):
-        """
-        Destroys context instances that are not in use.
-
-        Args:
-            active_context_ids  - Set of in use context_ids that should be kept
-        """
-        for context_id in list(self._instance_table.keys()):
-            if context_id in active_context_ids:
-                continue
-
-            log = self._log.child({"context_id": context_id})
-
-            instance = self._instance_table[context_id]
-            self._context_def[context_id].destroy(log, instance)
-            del self._instance_table[context_id]
+    buffer: list[_BufferSegment]
+    job: JobInterface[Any, Any, Any, Any]
+    # Cached child logger to avoid rebuilding every batch
+    log: Logger
 
 
 class WorkerProcess:
@@ -132,27 +89,57 @@ class WorkerProcess:
         logger: Logger,
         task_queue: Queue[Task],
         result_queue: Queue[Result],
-        context_def: dict[int, JobContextInterface[Any]],
+        context_defs: dict[int, JobContextInterface[Any]],
     ):
         """
         Args:
             logger          - Application logger
             task_queue      - Read only queue for fetching admin tasks from main process
             result_queue    - Write only queue for pushing results to main process
-            context_def     - Mapping from context id to context definitions
+            context_defs    - Mapping from context id to context definitions assigned
+                                to this worker. All contexts are created at startup.
         """
         self._log = logger
 
         self._last_state_change = time.perf_counter_ns()
-        self._state = WorkerState.ADMIN
+        self._state = WorkerState.BUSY
 
         self._task_queue = task_queue
         self._result_queue = result_queue
 
-        self._context_table = _JobContextTable(logger, context_def)
+        self._context_defs = context_defs
+        self._contexts: dict[int, Any] = {}
         self._job_entries: dict[int, _JobEntry] = {}
 
         self._should_exit = False
+
+    def _initialize_contexts(self):
+        """
+        Eagerly create every context assigned to this worker before the
+        execution loop accepts any jobs. Errors are returned to the caller
+        so it can report them to the main process and abort startup.
+
+        Returns:
+            None on success, error string describing the failed context on failure
+        """
+        for context_id, context_def in self._context_defs.items():
+            log = self._log.child({"context_id": context_id})
+            try:
+                self._contexts[context_id] = context_def.create(log)
+            # pylint: disable=broad-exception-caught
+            except Exception as error:
+                return f"context_id={context_id}: {error}"
+        return None
+
+    def _destroy_contexts(self):
+        """
+        Destroy every context instance owned by this worker
+        Called once during shutdown - context lifetime matches worker lifetime
+        """
+        for context_id, instance in self._contexts.items():
+            log = self._log.child({"context_id": context_id})
+            self._context_defs[context_id].destroy(log, instance)
+        self._contexts.clear()
 
     def _set_state(self, state: WorkerState):
         """
@@ -192,6 +179,41 @@ class WorkerProcess:
         except Empty:
             return None
 
+    def _append_data(self, job_id: int, data: list[Any]):
+        """
+        Append data to the job's buffer, extending the open segment or
+        starting a new one if the last segment has been closed by a config update
+
+        Args:
+            job_id  - Job id of job to append data to
+            data    - Data to append
+        """
+        buffer = self._job_entries[job_id].buffer
+        if not buffer or buffer[-1].has_trailing_config:
+            buffer.append(_BufferSegment(data=list(data)))
+        else:
+            buffer[-1].data.extend(data)
+
+    def _append_config_update(self, job_id: int, config: Any):
+        """
+        Mark the job's open segment as closed by a config update, or start
+        a new segment with that trailing config if the last is already closed
+
+        Args:
+            job_id  - Job id of job to append config update to
+            config  - New config to apply after the open segment
+        """
+        buffer = self._job_entries[job_id].buffer
+        if not buffer or buffer[-1].has_trailing_config:
+            buffer.append(
+                _BufferSegment(
+                    data=[], trailing_config=config, has_trailing_config=True
+                )
+            )
+        else:
+            buffer[-1].trailing_config = config
+            buffer[-1].has_trailing_config = True
+
     def _execute_admin_task(self, task: Task):
         """
         Determines the type of task provided and executes it
@@ -201,10 +223,12 @@ class WorkerProcess:
         """
         if task.type == TaskType.TERMINATE_WORKER:
             self._log.info("Terminating worker")
-            self._context_table.destroy_unused(set())
+            self._destroy_contexts()
             self._should_exit = True
         elif task.type == TaskType.QUEUE_DATA:
-            self._job_entries[task.job_id].buffer.extend(task.data)
+            self._append_data(task.job_id, task.data)
+        elif task.type == TaskType.UPDATE_JOB_CONFIG:
+            self._append_config_update(task.job_id, task.config)
         elif task.type == TaskType.DEREGISTER_JOB:
             self._log.info(f"Deregistering job: {task.job_id}")
             del self._job_entries[task.job_id]
@@ -220,22 +244,17 @@ class WorkerProcess:
                 context_ids=task.context_ids,
                 buffer=[],
                 job=task.job,
+                log=self._log.child({"job_id": task.job_id}),
             )
-
-    def _cleanup_unused_context(self):
-        """
-        Destroys all context instances that aren't in use by a job
-        """
-        self._log.debug("Cleaning up unused context")
-        active_context_ids = set[int]()
-        for entry in self._job_entries.values():
-            active_context_ids.update(entry.context_ids)
-
-        self._context_table.destroy_unused(active_context_ids)
 
     def _execute_job(self, job_id: int):
         """
         Executes the given job
+
+        Walks the job's buffer segment-by-segment, calling process_batch on each
+        segment's data and update_config between segments where a trailing config
+        update was queued. Each process_batch call emits its own JobExecutionResult;
+        update_config emits only on error.
 
         Args:
             job_id  - Job id of job to execture
@@ -243,33 +262,34 @@ class WorkerProcess:
         job_scheduled_time_ns = time.perf_counter_ns()
 
         entry = self._job_entries[job_id]
-        logger = self._log.child({"job_id": job_id})
+        log = entry.log
 
-        # Initialize job contexts
-        try:
-            contexts = tuple(map(self._context_table.get, entry.context_ids))
-        # Worker should catch all exceptions and push to main process to be handled
-        # pylint: disable=broad-exception-caught
-        except Exception as error:
-            stats = JobStatistics(
-                period_start_ns=entry.period_start_ns,
-                job_scheduled_time_ns=job_scheduled_time_ns,
-                start_execute_time_ns=time.perf_counter_ns(),
-                complete_time_ns=time.perf_counter_ns(),
-            )
-            self._result_queue.put(
-                JobExecutionResult(job_id, JobException(error, stats))
-            )
-            entry.state = _JobState.ERRORED
-            return
+        # Contexts are pre-initialized at worker startup so this is just a lookup
+        contexts = tuple(self._contexts[cid] for cid in entry.context_ids)
 
-        # Execute job
-        start_execute_time_ns = time.perf_counter_ns()
-        try:
-            batch = entry.buffer
-            entry.buffer = []
+        # Snapshot and clear the buffer. If empty, run a single empty batch to
+        # preserve existing semantics: process_batch is called every period even
+        # when no data has been queued.
+        segments = entry.buffer if entry.buffer else [_BufferSegment(data=[])]
+        entry.buffer = []
 
-            result = entry.job.process_batch(logger, contexts, batch)
+        for seg in segments:
+            start_execute_time_ns = time.perf_counter_ns()
+            try:
+                result = entry.job.process_batch(log, contexts, seg.data)
+            # pylint: disable=broad-exception-caught
+            except Exception as error:
+                stats = JobStatistics(
+                    period_start_ns=entry.period_start_ns,
+                    job_scheduled_time_ns=job_scheduled_time_ns,
+                    start_execute_time_ns=start_execute_time_ns,
+                    complete_time_ns=time.perf_counter_ns(),
+                )
+                self._result_queue.put(
+                    JobExecutionResult(job_id, JobException(error, stats))
+                )
+                entry.state = _JobState.ERRORED
+                return
 
             stats = JobStatistics(
                 period_start_ns=entry.period_start_ns,
@@ -280,20 +300,27 @@ class WorkerProcess:
             self._result_queue.put(
                 JobExecutionResult(job_id, JobSuccess(result, stats))
             )
-        # Worker should catch all exceptions and push to main process to be handled
-        # pylint: disable=broad-exception-caught
-        except Exception as error:
-            stats = JobStatistics(
-                period_start_ns=entry.period_start_ns,
-                job_scheduled_time_ns=job_scheduled_time_ns,
-                start_execute_time_ns=start_execute_time_ns,
-                complete_time_ns=time.perf_counter_ns(),
-            )
-            self._result_queue.put(
-                JobExecutionResult(job_id, JobException(error, stats))
-            )
-            entry.state = _JobState.ERRORED
-            return
+
+            if not seg.has_trailing_config:
+                continue
+
+            # Apply trailing config update between segments
+            start_config_time_ns = time.perf_counter_ns()
+            try:
+                entry.job.update_config(log, contexts, seg.trailing_config)
+            # pylint: disable=broad-exception-caught
+            except Exception as error:
+                stats = JobStatistics(
+                    period_start_ns=entry.period_start_ns,
+                    job_scheduled_time_ns=job_scheduled_time_ns,
+                    start_execute_time_ns=start_config_time_ns,
+                    complete_time_ns=time.perf_counter_ns(),
+                )
+                self._result_queue.put(
+                    JobExecutionResult(job_id, JobException(error, stats))
+                )
+                entry.state = _JobState.ERRORED
+                return
 
         # Update job state
         entry.state = _JobState.SLEEPING
@@ -362,38 +389,39 @@ class WorkerProcess:
     def execution_loop(self):
         """
         Main execution loop for worker process
-        Continuously fetches admin tasks, schedules jobs, and executes jobs
-        Returns when TerminateWorker task is received and currently executing job finishes
+        Eagerly creates every assigned context, then enters the scheduling loop.
+        Returns when TerminateWorker task is received and currently executing job finishes.
+        Returns early without entering the loop if context initialization fails.
         """
+        init_error = self._initialize_contexts()
+        if init_error is not None:
+            self._log.error(
+                f"Worker context initialization failed: {init_error}"
+            )
+            self._result_queue.put(InitializeWorkerResult(error=init_error))
+            return
+
         self._result_queue.put(InitializeWorkerResult())
 
         while True:
-            self._set_state(WorkerState.ADMIN)
-            # Perform all queued admin tasks
-            self._log.debug("Performing admin tasks")
-            while True:
-                if self._should_exit:
-                    return
+            if self._should_exit:
+                return
 
+            while True:
                 task = self._get_admin_task(block=False, timeout=None)
                 if task is None:
                     break
-
                 self._execute_admin_task(task)
+                if self._should_exit:
+                    return
 
-            # Cleaning up unused context is also an admin task
-            self._cleanup_unused_context()
-
-            # Determine next job to run or how long to idle for
             job_id, idle_time = self._scheduler()
 
             if job_id is not None:
-                self._log.info(f"Executing job_id: {job_id}")
                 self._set_state(WorkerState.BUSY)
                 self._execute_job(job_id)
             else:
                 self._set_state(WorkerState.IDLE)
-                self._log.debug(f"Idling for {idle_time} seconds")
 
                 # Idle by blocking on task queue since only new admin
                 # tasks would wake worker from idle
@@ -401,5 +429,5 @@ class WorkerProcess:
 
                 # Execute this admin task here so it isn't lost
                 if task is not None:
-                    self._set_state(WorkerState.ADMIN)
+                    self._set_state(WorkerState.BUSY)
                     self._execute_admin_task(task)

--- a/transcription_service/src/shared/utils/worker_pool/worker_process_manager.py
+++ b/transcription_service/src/shared/utils/worker_pool/worker_process_manager.py
@@ -5,10 +5,11 @@ Defines WorkerProcessManager that manages main process communication with Worker
 import asyncio
 import logging
 from collections import deque
-from queue import Queue
-from typing import Any, Callable, Generic, TypeVar
+from queue import Empty
+from typing import Any, Callable, Generic, TypeVar, cast
 
 import multiprocess as mp
+from multiprocess.queues import Queue
 
 from src.shared.logger import ContextLogger, Logger
 from src.shared.utils.event_emitter import Event, EventEmitter
@@ -23,6 +24,7 @@ from .task import (
     RegisterJobTask,
     Task,
     TerminateWorkerTask,
+    UpdateJobConfigTask,
 )
 from .worker_log_handler import WorkerLogHandler
 from .worker_process import WorkerProcess
@@ -30,12 +32,16 @@ from .worker_state import WorkerState
 
 NS_PER_SEC = 1000000000
 
+# Rolling window over which a worker's busy/idle ratio is averaged.
+ROLLING_UTILIZATION_WINDOW_NS = 10 * 60 * NS_PER_SEC
+
 C = TypeVar("C", bound=tuple)
 D = TypeVar("D")
 R = TypeVar("R")
+Conf = TypeVar("Conf")
 
 
-class JobHandle(Generic[D, R], EventEmitter):
+class JobHandle(Generic[D, R, Conf], EventEmitter):
     """
     Handle to a job registered to WorkerProcessManager
     """
@@ -61,14 +67,16 @@ class JobHandle(Generic[D, R], EventEmitter):
         worker_id: int,
         job_id: int,
         queue_data: Callable[[list[D]], None],
+        update_config: Callable[[Conf], None],
         deregister: Callable[..., None],
     ):
         """
         Args:
-            worker_id   - Worker id of worker that job is registered to
-            job_id      - Registered job id
-            queue_data  - Callback function to queue data to be processed
-            deregister  - Callback function to deregister job
+            worker_id     - Worker id of worker that job is registered to
+            job_id        - Registered job id
+            queue_data    - Callback function to queue data to be processed
+            update_config - Callback function to queue a config update
+            deregister    - Callback function to deregister job
         """
         super().__init__()
 
@@ -76,6 +84,7 @@ class JobHandle(Generic[D, R], EventEmitter):
         self._job_id = job_id
 
         self._queue_data = queue_data
+        self._update_config = update_config
         self._deregister = deregister
 
     def queue_data(self, data: list[D]) -> None:
@@ -90,6 +99,21 @@ class JobHandle(Generic[D, R], EventEmitter):
             return
         self._queue_data(data)
 
+    def update_config(self, config: Conf) -> None:
+        """
+        Queue a config update to be applied between data batches by the job
+        Splits the current data buffer at the time of this call so that data
+        queued before this update is processed under the old config and data
+        queued after is processed under the new one.
+        Does nothing if job has been deregistered
+
+        Args:
+            config  - New config to apply
+        """
+        if not self._update_config:
+            return
+        self._update_config(config)
+
     def deregister(self) -> None:
         """
         Deregisters job from worker
@@ -100,6 +124,7 @@ class JobHandle(Generic[D, R], EventEmitter):
         self._deregister()
 
         self._queue_data = None
+        self._update_config = None
         self._deregister = None
 
 
@@ -123,7 +148,6 @@ class _RollingUtilization:
         Args:
             rolling_window_ns   - Length of rolling window in nanoseconds
         """
-        self._admin_time_ns = 0
         self._idle_time_ns = 0
         self._busy_time_ns = 0
 
@@ -167,9 +191,7 @@ class _RollingUtilization:
             increment_ns    - Time in nanoseconds to change counter by
         """
         self._total_time_ns += increment_ns
-        if state == WorkerState.ADMIN:
-            self._admin_time_ns += increment_ns
-        elif state == WorkerState.IDLE:
+        if state == WorkerState.IDLE:
             self._idle_time_ns += increment_ns
         elif state == WorkerState.BUSY:
             self._busy_time_ns += increment_ns
@@ -234,7 +256,7 @@ class WorkerProcessManager:
     def _worker_function(
         task_queue: Queue[Task],
         result_queue: Queue[Result],
-        context_def: dict[int, JobContextInterface[Any]],
+        context_defs: dict[int, JobContextInterface[Any]],
         log_level: int,
         logger_context: dict[str, Any],
     ):
@@ -245,7 +267,8 @@ class WorkerProcessManager:
         Args:
             task_queue      - Read only queue for fetching admin tasks from main process
             result_queue    - Write only queue for pushing results to main process
-            context_def     - Mapping from context id to context definitions
+            context_defs    - Mapping from context id to context definitions assigned
+                                to this worker. Eagerly created at startup.
             log_level       - Application log level
             logger_context  - Context to initialize worker's application logger with
         """
@@ -259,9 +282,19 @@ class WorkerProcessManager:
 
         log = ContextLogger(logger, logger_context)
 
-        return WorkerProcess(
-            log, task_queue, result_queue, context_def
-        ).execution_loop()
+        try:
+            return WorkerProcess(
+                log, task_queue, result_queue, context_defs
+            ).execution_loop()
+        finally:
+            # Flush pending result writes before releasing the queue, then
+            # cancel the task queue feeder (worker only reads from it) so
+            # process exit doesn't leave the resource_tracker holding stale
+            # semaphore references.
+            result_queue.close()
+            result_queue.join_thread()
+            task_queue.cancel_join_thread()
+            task_queue.close()
 
     @property
     def utilization(self):
@@ -271,65 +304,79 @@ class WorkerProcessManager:
         return self._rolling_utilization.utilization
 
     @property
-    def active_context_ids(self) -> set[int]:
+    def context_ids(self) -> set[int]:
         """
-        Gets set of context_ids that are actively used by jobs
+        Gets set of context_ids this worker has initialized
         """
-        active_ids = set[int]()
-        for context_ids in self._job_context_ids.values():
-            active_ids.update(context_ids)
-        return active_ids
+        return set(self._context_defs.keys())
 
     def __init__(
         self,
         logger: Logger,
         worker_id: int,
-        context_def: dict[int, JobContextInterface[Any]],
-        rolling_utilization_window_sec: float,
+        context_defs: dict[int, JobContextInterface[Any]],
+        rolling_utilization_window_ns: int = ROLLING_UTILIZATION_WINDOW_NS,
     ):
         """
+        Constructor blocks until the worker process has finished creating all
+        assigned contexts. Raises RuntimeError if context initialization fails
+        so the pool startup can abort before any job is accepted.
+
         Args:
-            logger                          - Application logger
-            worker_id                       - Unique identifier for worker
-            context_def                     - Mapping from context id to context definitions
-            rolling_utilization_window_sec  - Length of rolling utilization window in seconds
+            logger          - Application logger
+            worker_id       - Unique identifier for worker
+            context_defs    - Mapping from context id to context definitions to
+                                initialize on this worker
+            rolling_utilization_window_ns - Override for utilization smoothing window
+                                              (production should use the default)
         """
         self._log = logger.child({"worker_id": worker_id})
         self._worker_id = worker_id
 
         self._rolling_utilization = _RollingUtilization(
-            int(rolling_utilization_window_sec * NS_PER_SEC)
+            rolling_utilization_window_ns
         )
 
         self._next_job_id = 0
-        self._context_def = context_def
-        self._registered_job_handles: dict[int, JobHandle[Any, Any]] = {}
-        self._job_context_ids: dict[int, tuple[int, ...]] = {}
+        self._context_defs = context_defs
+        self._registered_job_handles: dict[int, JobHandle[Any, Any, Any]] = {}
 
         # False positive
         # pylint: disable=no-member
         ctx = mp.get_context("spawn")
 
-        self._manager = ctx.Manager()
-        self._task_queue: Queue[Task] = self._manager.Queue()
-        self._result_queue: Queue[Result] = self._manager.Queue()
+        self._task_queue = cast(Queue[Task], ctx.Queue())
+        self._result_queue = cast(Queue[Result], ctx.Queue())
 
         self._process = ctx.Process(
             target=WorkerProcessManager._worker_function,
             args=(
                 self._task_queue,
                 self._result_queue,
-                context_def,
+                context_defs,
                 self._log.logger.level,
                 self._log.context,
             ),
         )
         self._process.start()
 
-        # Wait for initialization result that indicates worker is ready to accept jobs
-        result = self._result_queue.get(block=True)
-        if result.type != ResultType.INITIALIZE_WORKER:
-            raise RuntimeError("Failed to start worker process")
+        # Block until worker confirms it has created every assigned context.
+        # Drain log records that may arrive before the init result.
+        while True:
+            result = self._result_queue.get(block=True)
+            if result.type == ResultType.LOGGING:
+                self._log.logger.handle(result.record)
+                continue
+            if result.type != ResultType.INITIALIZE_WORKER:
+                raise RuntimeError(
+                    f"Unexpected result during worker init: {result.type}"
+                )
+            if result.error is not None:
+                self._process.join()
+                raise RuntimeError(
+                    f"Worker {worker_id} failed to initialize: {result.error}"
+                )
+            break
 
         # Start the asyncio task that polls for results from the workers
         self._result_poller_task = asyncio.create_task(self._poll_results())
@@ -362,8 +409,8 @@ class WorkerProcessManager:
         self,
         context_ids: tuple[int, ...],
         period_ms: int,
-        job: JobInterface[C, D, R],
-    ) -> JobHandle[D, R]:
+        job: JobInterface[C, D, R, Conf],
+    ) -> JobHandle[D, R, Conf]:
         """
         Registers a new job with WorkerProcess
 
@@ -379,13 +426,12 @@ class WorkerProcessManager:
             KeyError if invalid context id is provided
         """
         for context_id in context_ids:
-            if context_id not in self._context_def:
+            if context_id not in self._context_defs:
                 raise KeyError("Invalid Context Id")
 
         job_id = self._next_job_id
         self._next_job_id += 1
 
-        self._job_context_ids[job_id] = context_ids
         self._task_queue.put(
             RegisterJobTask(job_id, context_ids, period_ms, job)
         )
@@ -393,14 +439,15 @@ class WorkerProcessManager:
         def _queue_data(data: list[D]):
             self._task_queue.put(QueueDataTask(job_id, data))
 
+        def _update_config(config: Conf):
+            self._task_queue.put(UpdateJobConfigTask(job_id, config))
+
         def _deregister():
             self._task_queue.put(DeregisterJobTask(job_id))
-
             del self._registered_job_handles[job_id]
-            del self._job_context_ids[job_id]
 
-        job_handle = JobHandle[D, R](
-            self._worker_id, job_id, _queue_data, _deregister
+        job_handle = JobHandle[D, R, Conf](
+            self._worker_id, job_id, _queue_data, _update_config, _deregister
         )
         self._registered_job_handles[job_id] = job_handle
         return job_handle
@@ -412,9 +459,6 @@ class WorkerProcessManager:
         Does not wait for process to exit
         Call wait_shutdown() after send_terminate() to wait for process to exit
         """
-        # Stop the result polling task
-        self._result_poller_task.cancel()
-
         self._task_queue.put(TerminateWorkerTask())
 
     def wait_shutdown(self):
@@ -423,4 +467,19 @@ class WorkerProcessManager:
         Should call send_terminate() before wait_shutdown()
         """
         self._process.join()
-        self._manager.shutdown()
+
+        # Cancel the async poller and drain any results the worker emitted
+        # during shutdown (e.g. destroy logs) so callers see them.
+        self._result_poller_task.cancel()
+        while True:
+            try:
+                result = self._result_queue.get_nowait()
+            except Empty:
+                break
+            if result.type == ResultType.LOGGING:
+                self._log.logger.handle(result.record)
+
+        self._task_queue.close()
+        self._result_queue.close()
+        self._task_queue.join_thread()
+        self._result_queue.join_thread()

--- a/transcription_service/src/shared/utils/worker_pool/worker_state.py
+++ b/transcription_service/src/shared/utils/worker_pool/worker_state.py
@@ -9,11 +9,9 @@ class WorkerState(IntEnum):
     """
     Represents the current state of the worker process
 
-    ADMIN - Working on admin tasks (registering/deregistering jobs, queueing data, scheduling, etc.)
-    IDLE  - No ready jobs and no admin tasks
-    BUSY  - Actively executing job (could include initializing context)
+    IDLE  - No ready jobs and no pending admin tasks
+    BUSY  - Actively executing job, draining admin tasks, or scheduling
     """
 
-    ADMIN = 0
     IDLE = 1
     BUSY = 2

--- a/transcription_service/src/transcription_contexts/faster_whisper_context/faster_whisper_context.py
+++ b/transcription_service/src/transcription_contexts/faster_whisper_context/faster_whisper_context.py
@@ -30,21 +30,8 @@ class FasterWhisperContext(JobContextInterface[WhisperModel]):
     Job context definition for using faster whisper in WorkerProcess and WorkerPool
     """
 
-    def __init__(
-        self,
-        context_config: Any,
-        max_instances: int,
-        tags: list[str],
-        negative_affinity: str | None,
-        creation_cost: float,
-    ):
-        super().__init__(
-            context_config,
-            max_instances,
-            tags,
-            negative_affinity,
-            creation_cost,
-        )
+    def __init__(self, context_config: Any, tags: list[str]):
+        super().__init__(tags)
         self._config = faster_whisper_context_config_adapter.validate_python(
             context_config
         )

--- a/transcription_service/src/transcription_contexts/silero_vad_context/silero_vad_context.py
+++ b/transcription_service/src/transcription_contexts/silero_vad_context/silero_vad_context.py
@@ -67,22 +67,8 @@ class SileroVadContext(JobContextInterface[SileroVadModelType]):
     Job context definition for managing Silero VAD model lifecycle
     """
 
-    # pylint: disable=duplicate-code
-    def __init__(
-        self,
-        context_config: Any,
-        max_instances: int,
-        tags: list[str],
-        negative_affinity: str | None,
-        creation_cost: float,
-    ):
-        super().__init__(
-            context_config,
-            max_instances,
-            tags,
-            negative_affinity,
-            creation_cost,
-        )
+    def __init__(self, context_config: Any, tags: list[str]):
+        super().__init__(tags)
         self._config = silero_vad_context_config_adapter.validate_python(
             context_config
         )

--- a/transcription_service/src/transcription_providers/debug_provider/debug_provider_job.py
+++ b/transcription_service/src/transcription_providers/debug_provider/debug_provider_job.py
@@ -10,7 +10,7 @@ from src.transcription_provider_interface import TranscriptionClientError
 from .debug_session_config import DebugSessionConfig
 
 
-class DebugProviderJob(JobInterface[tuple, bytes, float]):
+class DebugProviderJob(JobInterface[tuple, bytes, float, None]):
     """
     WorkerPool job definition for DebugProvider
     Decodes audio chunks and returns number of seconds of audio received
@@ -37,3 +37,6 @@ class DebugProviderJob(JobInterface[tuple, bytes, float]):
             samples_decoded += len(segments)
 
         return samples_decoded / self._sample_rate
+
+    def update_config(self, log: Logger, contexts: tuple, config: None) -> None:
+        raise TranscriptionClientError("On the fly config update not supported")

--- a/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_config.py
+++ b/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_config.py
@@ -12,8 +12,8 @@ class WhisperStreamingProviderConfig(BaseModel):
     Provider configuration format for WhisperStreamingProvider
     """
 
-    context_tag: str
-    vad_context_tag: str = "silero_vad"
+    whisper_context_tag: str
+    silero_context_tag: str
     job_period_ms: int
     max_buffer_len_sec: float
     local_agree_dim: int

--- a/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_job.py
+++ b/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_job.py
@@ -26,7 +26,10 @@ NUM_CHANNELS = 1
 
 class WhisperStreamingProviderJob(
     JobInterface[
-        tuple[WhisperModel, SileroVadModelType], bytes, TranscriptionResult
+        tuple[WhisperModel, SileroVadModelType],
+        bytes,
+        TranscriptionResult,
+        None,
     ]
 ):
     """
@@ -257,3 +260,6 @@ class WhisperStreamingProviderJob(
             )
 
         return TranscriptionResult(in_progress=in_progress, final=final)
+
+    def update_config(self, log: Logger, contexts: tuple, config: None) -> None:
+        raise TranscriptionClientError("On the fly config update not supported")

--- a/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_provider.py
+++ b/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_provider.py
@@ -6,9 +6,6 @@ from dataclasses import asdict
 
 from src.shared.logger import Logger
 from src.shared.utils.worker_pool import JobException, JobSuccess, WorkerPool
-from src.transcription_contexts.faster_whisper_context import (
-    FasterWhisperContext,
-)
 from src.transcription_provider_interface import (
     TranscriptionProviderInterface,
     TranscriptionResult,
@@ -57,8 +54,8 @@ class WhisperStreamingProvider(TranscriptionProviderInterface):
 
             self._job = provider.worker_pool.register_job(
                 (
-                    self._provider.config.context_tag,
-                    self._provider.config.vad_context_tag,
+                    self._provider.config.whisper_context_tag,
+                    self._provider.config.silero_context_tag,
                 ),
                 self._provider.config.job_period_ms,
                 WhisperStreamingProviderJob(self._provider.config),
@@ -104,21 +101,6 @@ class WhisperStreamingProvider(TranscriptionProviderInterface):
         self.config = whisper_streaming_config_adapter.validate_python(
             provider_config
         )
-
-        # Check that configured worker context provides a Whisper model
-        worker_pool.tagged_context_is_instance(
-            self.config.context_tag, [FasterWhisperContext]
-        )
-        try:
-            assert worker_pool.tagged_context_is_instance(
-                self.config.context_tag, [FasterWhisperContext]
-            ), f"Context tag '{self.config.context_tag}' is not an instance of FasterWhisperContext"
-        except AssertionError as e:
-            self._log.error(
-                f"Context '{self.config.context_tag}' not found or invalid: {e}"
-            )
-            raise
-
         self.worker_pool = worker_pool
 
     def create_session(self, session_config: object, logger: Logger):

--- a/transcription_service/src/webserver/shared/transcription_service/transcription_service.py
+++ b/transcription_service/src/webserver/shared/transcription_service/transcription_service.py
@@ -14,7 +14,7 @@ from src.shared.config import (
     TranscriptionProviderUID,
 )
 from src.shared.logger import Logger
-from src.shared.utils.worker_pool import JobContextInterface, WorkerPool
+from src.shared.utils.worker_pool import ContextAssignment, WorkerPool
 from src.transcription_provider_interface import (
     TranscriptionClientError,
     TranscriptionProviderInterface,
@@ -33,45 +33,38 @@ class TranscriptionService:
             config      - Application config
             logger      - Application logger
         """
-        context_def = self._load_context_def(config.provider_config.contexts)
+        contexts = self._load_contexts(config.provider_config.contexts)
 
         self._worker_pool = WorkerPool(
-            logger,
-            config.provider_config.num_workers,
-            context_def,
-            config.provider_config.rolling_utilization_window_sec,
+            logger, config.provider_config.num_workers, contexts
         )
 
         self._providers = self._load_providers(
             logger, self._worker_pool, config.provider_config.providers
         )
 
-    def _load_context_def(
+    def _load_contexts(
         self, context_configurations: list[JobContextConfigSchema]
-    ):
+    ) -> list[ContextAssignment]:
         """
-        Imports definitions for all of the configured context definitions
+        Build ContextAssignment list from the configured context entries
 
         Args:
             context_configurations  - List of context configurations to load
 
         Returns
-            Context definition dictionary for WorkerPool to use
+            List of ContextAssignments preserving the order of the config
         """
-        context_def: dict[int, JobContextInterface[Any]] = {}
-        for i, config in enumerate(context_configurations):
+        assignments: list[ContextAssignment] = []
+        for config in context_configurations:
             match config.context_uid:
                 case JobContextDefinitionUID.FASTER_WHISPER:
                     from src.transcription_contexts.faster_whisper_context import (
                         FasterWhisperContext,
                     )
 
-                    context = FasterWhisperContext(
-                        config.context_config,
-                        config.max_instances,
-                        config.tags,
-                        config.negative_affinity,
-                        config.creation_cost,
+                    context: Any = FasterWhisperContext(
+                        config.context_config, config.tags
                     )
                 case JobContextDefinitionUID.SILERO_VAD:
                     from src.transcription_contexts.silero_vad_context import (
@@ -79,21 +72,21 @@ class TranscriptionService:
                     )
 
                     context = SileroVadContext(
-                        config.context_config,
-                        config.max_instances,
-                        config.tags,
-                        config.negative_affinity,
-                        config.creation_cost,
+                        config.context_config, config.tags
                     )
 
-            context_def[i] = context
-        return context_def
+            assignments.append(
+                ContextAssignment(
+                    context_def=context, worker_ids=config.worker_ids
+                )
+            )
+        return assignments
 
     def _load_providers(
         self,
         logger: Logger,
         worker_pool: WorkerPool,
-        configured_providers: list[TranscriptionProviderConfigSchema],
+        configured_providers: dict[str, TranscriptionProviderConfigSchema],
     ):
         """
         Imports transcription providers for all of the configured providers
@@ -101,14 +94,14 @@ class TranscriptionService:
         Args:
             logger                  - Logger to provide to providers
             worker_pool             - Worker pool to provide to providers
-            configured_providers    - List of provider configurations to load
+            configured_providers    - Mapping from provider_key to provider config
 
         Returns
             Provider instance dictionary
         """
         providers: dict[str, TranscriptionProviderInterface] = {}
-        for config in configured_providers:
-            child_logger = logger.child({"provider_key": config.provider_key})
+        for provider_key, config in configured_providers.items():
+            child_logger = logger.child({"provider_key": provider_key})
 
             match config.provider_uid:
                 case TranscriptionProviderUID.DEBUG:
@@ -128,7 +121,7 @@ class TranscriptionService:
                         config.provider_config, child_logger, worker_pool
                     )
 
-            providers[config.provider_key] = provider
+            providers[provider_key] = provider
         return providers
 
     def create_session(

--- a/transcription_service/tests/integration/transcription_stream/transcription_stream_test.py
+++ b/transcription_service/tests/integration/transcription_stream/transcription_stream_test.py
@@ -52,8 +52,7 @@ def mock_config():
     mock.provider_config.contexts = []
     mock.provider_config.providers = {
         "debug": TranscriptionProviderConfigSchema(
-            provider_uid=TranscriptionProviderUID.DEBUG,
-            provider_config=None,
+            provider_uid=TranscriptionProviderUID.DEBUG, provider_config=None
         )
     }
     return mock

--- a/transcription_service/tests/integration/transcription_stream/transcription_stream_test.py
+++ b/transcription_service/tests/integration/transcription_stream/transcription_stream_test.py
@@ -49,13 +49,13 @@ def mock_config():
     mock.api_key = API_KEY
     mock.ws_init_timeout_sec = TIMEOUT_SEC
     mock.provider_config.num_workers = 2
-    mock.provider_config.providers = [
-        TranscriptionProviderConfigSchema(
-            provider_key="debug",
+    mock.provider_config.contexts = []
+    mock.provider_config.providers = {
+        "debug": TranscriptionProviderConfigSchema(
             provider_uid=TranscriptionProviderUID.DEBUG,
             provider_config=None,
         )
-    ]
+    }
     return mock
 
 

--- a/transcription_service/tests/unit/shared/config/config_test.py
+++ b/transcription_service/tests/unit/shared/config/config_test.py
@@ -38,32 +38,25 @@ PROVIDER_CONFIG_PATH={provider_config_path}
 )
 
 NUM_WORKERS = 2
-ROLLING_UTILIZATION_WINDOW_SEC = 600
 CONTEXT_0 = JobContextConfigSchema(
     context_uid=JobContextDefinitionUID.FASTER_WHISPER,
-    max_instances=2,
+    worker_ids=[0, 1],
     tags=["tag0", "tag1"],
-    negative_affinity="tag2",
     context_config={"some_key": "some_value"},
-    creation_cost=0.1,
 )
 CONTEXT_1 = JobContextConfigSchema(
     context_uid=JobContextDefinitionUID.FASTER_WHISPER,
-    max_instances=1,
+    worker_ids=[1],
     tags=["tag2"],
-    negative_affinity=None,
     context_config={"some_key": "other_value"},
-    creation_cost=0,
 )
 
 
 PROVIDER_0 = TranscriptionProviderConfigSchema(
-    provider_key="provider0",
     provider_uid=TranscriptionProviderUID.DEBUG,
     provider_config={"some_key": "some_value"},
 )
 PROVIDER_1 = TranscriptionProviderConfigSchema(
-    provider_key="provider1",
     provider_uid=TranscriptionProviderUID.DEBUG,
     provider_config={"some_key": "other_value"},
 )
@@ -71,15 +64,14 @@ PROVIDER_1 = TranscriptionProviderConfigSchema(
 VALID_PROVIDER_CONFIG_JSON = f"""
 {{
     "num_workers": {str(NUM_WORKERS)},
-    "rolling_utilization_window_sec": {str(ROLLING_UTILIZATION_WINDOW_SEC)},
     "contexts": [
         {CONTEXT_0.model_dump_json()},
         {CONTEXT_1.model_dump_json()}
     ],
-    "providers": [
-        {PROVIDER_0.model_dump_json()},
-        {PROVIDER_1.model_dump_json()}
-    ]
+    "providers": {{
+        "provider0": {PROVIDER_0.model_dump_json()},
+        "provider1": {PROVIDER_1.model_dump_json()}
+    }}
 }}"""
 
 
@@ -121,16 +113,12 @@ def test_config_load_valid_config(clean_os_environ: None, tmp_path: Path):
     assert config.ws_init_timeout_sec == WS_INIT_TIMEOUT_SEC
 
     assert config.provider_config.num_workers == NUM_WORKERS
-    assert (
-        config.provider_config.rolling_utilization_window_sec
-        == ROLLING_UTILIZATION_WINDOW_SEC
-    )
     assert len(config.provider_config.contexts) == 2
     assert config.provider_config.contexts[0] == CONTEXT_0
     assert config.provider_config.contexts[1] == CONTEXT_1
     assert len(config.provider_config.providers) == 2
-    assert config.provider_config.providers[0] == PROVIDER_0
-    assert config.provider_config.providers[1] == PROVIDER_1
+    assert config.provider_config.providers["provider0"] == PROVIDER_0
+    assert config.provider_config.providers["provider1"] == PROVIDER_1
 
 
 def test_config_invalid_transcription_file(

--- a/transcription_service/tests/unit/shared/utils/worker_pool/config_update_test.py
+++ b/transcription_service/tests/unit/shared/utils/worker_pool/config_update_test.py
@@ -1,0 +1,173 @@
+"""
+Unit tests for on-the-fly config updates queued via JobHandle.update_config
+"""
+
+import asyncio
+
+import pytest
+
+from src.shared.utils.worker_pool import (
+    JobException,
+    JobSuccess,
+    WorkerProcessManager,
+)
+
+from .jobs import ConfigBatchResult, ConfigErrorJob, ConfigJob
+
+pytestmark = pytest.mark.timeout(2)
+
+
+@pytest.mark.asyncio
+async def test_config_update_splits_batch(wpm: WorkerProcessManager):
+    """
+    Test that an update_config queued between two queue_data calls produces
+    two process_batch invocations with the old and new config values
+    """
+    # Arrange
+    results: list[JobSuccess[ConfigBatchResult] | JobException] = []
+    job = wpm.register_job((), 200, ConfigJob(initial_config=10))
+    job.on(job.JobResultEvent, results.append)
+
+    # Act
+    job.queue_data([1, 2])
+    job.update_config(20)
+    job.queue_data([3, 4])
+    await asyncio.sleep(0.2 + 0.1)
+
+    # Assert
+    assert len(results) == 2
+    assert results[0].has_exception is False
+    assert results[0].value == ConfigBatchResult(config=10, batch=[1, 2])
+    assert results[1].has_exception is False
+    assert results[1].value == ConfigBatchResult(config=20, batch=[3, 4])
+
+
+@pytest.mark.asyncio
+async def test_multiple_config_updates_in_one_period(wpm: WorkerProcessManager):
+    """
+    Test that multiple update_config calls within a period produce one
+    process_batch per segment, each with its corresponding config value
+    """
+    # Arrange
+    results: list[JobSuccess[ConfigBatchResult] | JobException] = []
+    job = wpm.register_job((), 200, ConfigJob(initial_config=1))
+    job.on(job.JobResultEvent, results.append)
+
+    # Act
+    job.queue_data([10])
+    job.update_config(2)
+    job.queue_data([20])
+    job.update_config(3)
+    job.queue_data([30])
+    await asyncio.sleep(0.2 + 0.1)
+
+    # Assert
+    assert len(results) == 3
+    assert results[0].value == ConfigBatchResult(config=1, batch=[10])
+    assert results[1].value == ConfigBatchResult(config=2, batch=[20])
+    assert results[2].value == ConfigBatchResult(config=3, batch=[30])
+
+
+@pytest.mark.asyncio
+async def test_consecutive_config_updates_preserve_order(
+    wpm: WorkerProcessManager,
+):
+    """
+    Test that two consecutive update_config calls (no data between them)
+    both apply in order, producing empty-batch process_batch calls at the
+    segment boundaries
+    """
+    # Arrange
+    results: list[JobSuccess[ConfigBatchResult] | JobException] = []
+    job = wpm.register_job((), 200, ConfigJob(initial_config=1))
+    job.on(job.JobResultEvent, results.append)
+
+    # Act
+    job.queue_data([100])
+    job.update_config(2)
+    job.update_config(3)
+    job.queue_data([200])
+    await asyncio.sleep(0.2 + 0.1)
+
+    # Assert
+    assert len(results) == 3
+    assert results[0].value == ConfigBatchResult(config=1, batch=[100])
+    assert results[1].value == ConfigBatchResult(config=2, batch=[])
+    assert results[2].value == ConfigBatchResult(config=3, batch=[200])
+
+
+@pytest.mark.asyncio
+async def test_config_update_with_no_preceding_data(wpm: WorkerProcessManager):
+    """
+    Test that update_config queued before any data produces an empty
+    process_batch under the old config followed by data under the new config
+    """
+    # Arrange
+    results: list[JobSuccess[ConfigBatchResult] | JobException] = []
+    job = wpm.register_job((), 200, ConfigJob(initial_config=1))
+    job.on(job.JobResultEvent, results.append)
+
+    # Act
+    job.update_config(2)
+    job.queue_data([5])
+    await asyncio.sleep(0.2 + 0.1)
+
+    # Assert
+    assert len(results) == 2
+    assert results[0].value == ConfigBatchResult(config=1, batch=[])
+    assert results[1].value == ConfigBatchResult(config=2, batch=[5])
+
+
+@pytest.mark.asyncio
+async def test_config_update_persists_across_periods(wpm: WorkerProcessManager):
+    """
+    Test that a config update applied in one period stays in effect for
+    subsequent periods where no further updates are queued
+    """
+    # Arrange
+    results: list[JobSuccess[ConfigBatchResult] | JobException] = []
+    job = wpm.register_job((), 200, ConfigJob(initial_config=1))
+    job.on(job.JobResultEvent, results.append)
+
+    # Act
+    job.queue_data([10])
+    job.update_config(2)
+    job.queue_data([20])
+    await asyncio.sleep(0.2 + 0.1)
+
+    job.queue_data([30])
+    await asyncio.sleep(0.2)
+
+    # Assert
+    assert len(results) == 3
+    assert results[0].value == ConfigBatchResult(config=1, batch=[10])
+    assert results[1].value == ConfigBatchResult(config=2, batch=[20])
+    assert results[2].value == ConfigBatchResult(config=2, batch=[30])
+
+
+@pytest.mark.asyncio
+async def test_config_update_error_returns_exception_and_stops_job(
+    wpm: WorkerProcessManager,
+):
+    """
+    Test that an exception raised by update_config emits a JobException and
+    prevents further scheduling of the job (same as process_batch errors)
+    """
+    # Arrange
+    results: list[JobSuccess[int] | JobException] = []
+    job = wpm.register_job((), 200, ConfigErrorJob())
+    job.on(job.JobResultEvent, results.append)
+
+    # Act
+    job.queue_data([1, 2])
+    job.update_config(99)
+    job.queue_data([3, 4])
+    await asyncio.sleep(0.2 + 0.1)
+    await asyncio.sleep(0.4)
+
+    # Assert
+    assert len(results) == 2
+    assert results[0].has_exception is False
+    assert results[0].value == 3
+    assert results[1].has_exception is True
+    assert isinstance(results[1].value, RuntimeError)

--- a/transcription_service/tests/unit/shared/utils/worker_pool/conftest.py
+++ b/transcription_service/tests/unit/shared/utils/worker_pool/conftest.py
@@ -1,0 +1,61 @@
+"""
+Shared pytest fixtures for worker_pool test modules
+"""
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+
+from src.shared.logger import ContextLogger
+from src.shared.utils.worker_pool import (
+    JobContextInterface,
+    WorkerProcessManager,
+)
+
+NS_PER_SEC = 10**9
+TEST_WORKER_ID = 0
+# Shrunk for tests so utilization assertions don't have to wait minutes
+TEST_ROLLING_UTILIZATION_WINDOW_NS = 3 * NS_PER_SEC
+
+
+@pytest.fixture
+def mock_underlying_logger():
+    """
+    Create a mocked logger instance for tests
+    """
+    logger = MagicMock(spec=logging.Logger)
+    logger.level = 10
+    return logger
+
+
+@pytest.fixture
+def context_defs() -> dict[int, JobContextInterface[Any]]:
+    """
+    Default empty context_defs used by WorkerProcessManager fixture.
+    Override in a test module to pre-initialize specific contexts on the worker.
+    """
+    return {}
+
+
+@pytest_asyncio.fixture
+async def wpm(
+    mock_underlying_logger: logging.Logger,
+    context_defs: dict[int, JobContextInterface[Any]],
+):
+    """
+    Create a fresh WorkerProcessManager for each test and handle teardown
+    """
+    wpm = WorkerProcessManager(
+        ContextLogger(mock_underlying_logger),
+        TEST_WORKER_ID,
+        context_defs,
+        rolling_utilization_window_ns=TEST_ROLLING_UTILIZATION_WINDOW_NS,
+    )
+
+    yield wpm
+
+    wpm.send_terminate()
+    wpm.wait_shutdown()

--- a/transcription_service/tests/unit/shared/utils/worker_pool/context_definitions.py
+++ b/transcription_service/tests/unit/shared/utils/worker_pool/context_definitions.py
@@ -25,12 +25,13 @@ class Context(JobContextInterface[ContextInstance]):
     Definition for context that reports the number of times it is created/destroyed for testing
     """
 
-    def __init__(self, context_id: int):
+    def __init__(self, context_id: int, tags: list[str] | None = None):
         """
         Args:
             context_id  - Identifier for created context instance
+            tags        - Optional tags override; defaults to a generic "context" tag
         """
-        super().__init__(None, 2, ["context", "no_error"], None, 0)
+        super().__init__(tags or ["context"])
         self._context_id = context_id
         self._create_count = 0
         self._destroy_count = 0
@@ -55,7 +56,7 @@ class ErrorContext(JobContextInterface[None]):
     """
 
     def __init__(self):
-        super().__init__(None, -1, ["error"], None, 0)
+        super().__init__(["error"])
 
     def create(self, log: Logger) -> None:
         raise RuntimeError("Failed Create Context")
@@ -70,9 +71,7 @@ class LoggerContext(JobContextInterface[None]):
     """
 
     def __init__(self):
-        super().__init__(
-            None, -1, ["no_error", "none_context", "log_context"], None, 0.1
-        )
+        super().__init__(["log_context"])
 
     def create(self, log: Logger) -> None:
         log.info("Create Context")
@@ -91,13 +90,7 @@ class SlowContext(JobContextInterface[int]):
         Args:
             work_time_ns    - Nanoseconds slow context should take to create
         """
-        super().__init__(
-            None,
-            2,
-            ["slow_context", "no_error", "none_context"],
-            "log_context",
-            0.1,
-        )
+        super().__init__(["slow_context"])
         self._work_time_ns = work_time_ns
 
     def create(self, log: Logger) -> int:

--- a/transcription_service/tests/unit/shared/utils/worker_pool/jobs.py
+++ b/transcription_service/tests/unit/shared/utils/worker_pool/jobs.py
@@ -3,6 +3,7 @@ Test job definitions
 """
 
 import time
+from dataclasses import dataclass
 
 from src.shared.logger import Logger
 from src.shared.utils.worker_pool import JobInterface
@@ -10,7 +11,7 @@ from src.shared.utils.worker_pool import JobInterface
 from .context_definitions import ContextInstance
 
 
-class SumJob(JobInterface[tuple[()], int, int]):
+class SumJob(JobInterface[tuple[()], int, int, None]):
     """
     Definition for job that sums batch elements for testing
     """
@@ -20,8 +21,62 @@ class SumJob(JobInterface[tuple[()], int, int]):
     ) -> int:
         return sum(batch)
 
+    def update_config(self, log: Logger, contexts: tuple, config: None) -> None:
+        return
 
-class ErrorJob(JobInterface[tuple[()], None, None]):
+
+@dataclass
+class ConfigBatchResult:
+    """
+    Result emitted by ConfigJob containing the config active at process_batch time
+    and the batch that was processed
+    """
+
+    config: int
+    batch: list[int]
+
+
+class ConfigJob(JobInterface[tuple[()], int, ConfigBatchResult, int]):
+    """
+    Definition for job that reports the active config alongside each batch
+    Used to verify that config updates split batches correctly
+    """
+
+    def __init__(self, initial_config: int):
+        """
+        Args:
+            initial_config  - Config value to start with
+        """
+        self._config = initial_config
+
+    def process_batch(
+        self, log: Logger, contexts: tuple[()], batch: list[int]
+    ) -> ConfigBatchResult:
+        return ConfigBatchResult(config=self._config, batch=list(batch))
+
+    def update_config(
+        self, log: Logger, contexts: tuple[()], config: int
+    ) -> None:
+        self._config = config
+
+
+class ConfigErrorJob(JobInterface[tuple[()], int, int, int]):
+    """
+    Definition for job whose update_config raises an exception for testing
+    """
+
+    def process_batch(
+        self, log: Logger, contexts: tuple[()], batch: list[int]
+    ) -> int:
+        return sum(batch)
+
+    def update_config(
+        self, log: Logger, contexts: tuple[()], config: int
+    ) -> None:
+        raise RuntimeError(f"update_config failed for config: {config}")
+
+
+class ErrorJob(JobInterface[tuple[()], None, None, None]):
     """
     Definition for job that raises exception for testing
     """
@@ -31,8 +86,13 @@ class ErrorJob(JobInterface[tuple[()], None, None]):
     ) -> None:
         raise RuntimeError("Failed Process Batch")
 
+    def update_config(self, log: Logger, contexts: tuple, config: None) -> None:
+        return
 
-class ContextJob(JobInterface[tuple[ContextInstance], None, ContextInstance]):
+
+class ContextJob(
+    JobInterface[tuple[ContextInstance], None, ContextInstance, None]
+):
     """
     Definition for job that returns context for testing
     """
@@ -42,8 +102,11 @@ class ContextJob(JobInterface[tuple[ContextInstance], None, ContextInstance]):
     ) -> ContextInstance:
         return contexts[0]
 
+    def update_config(self, log: Logger, contexts: tuple, config: None) -> None:
+        return
 
-class LoggerJob(JobInterface[tuple[()], None, None]):
+
+class LoggerJob(JobInterface[tuple[()], None, None, None]):
     """
     Definition for job that uses logger for testing
     """
@@ -53,8 +116,11 @@ class LoggerJob(JobInterface[tuple[()], None, None]):
     ) -> None:
         log.info("Process Batch")
 
+    def update_config(self, log: Logger, contexts: tuple, config: None) -> None:
+        return
 
-class SlowJob(JobInterface[tuple[()], None, None]):
+
+class SlowJob(JobInterface[tuple[()], None, None, None]):
     """
     Definition for slow job for testing
     """
@@ -72,3 +138,6 @@ class SlowJob(JobInterface[tuple[()], None, None]):
         end_time = time.perf_counter_ns() + self._work_time_ns
         while time.perf_counter_ns() < end_time:
             pass
+
+    def update_config(self, log: Logger, contexts: tuple, config: None) -> None:
+        return

--- a/transcription_service/tests/unit/shared/utils/worker_pool/worker_pool_test.py
+++ b/transcription_service/tests/unit/shared/utils/worker_pool/worker_pool_test.py
@@ -3,7 +3,7 @@ Unit tests for WorkerPool
 """
 
 from typing import Any
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
@@ -11,53 +11,45 @@ from pytest_mock import MockerFixture, MockType
 
 from src.shared.logger import Logger
 from src.shared.utils.worker_pool import (
-    JobContextInterface,
+    ContextAssignment,
     JobInterface,
     WorkerPool,
     WorkerProcessManager,
 )
 
-from .context_definitions import (
-    Context,
-    ErrorContext,
-    LoggerContext,
-    SlowContext,
-)
+from .context_definitions import Context, LoggerContext, SlowContext
 
-TEST_CONTEXT_ID = 1
-TEST_LOGGER_CONTEXT = 2
-TEST_ERROR_CONTEXT = 3
-TEST_SLOW_CONTEXT = 4
-
-ROLLING_UTILIZATION_WINDOW_SEC = 3
+# Context IDs (positions in the contexts list)
+CTX_CONTEXT = 0
+CTX_LOGGER = 1
+CTX_SLOW = 2
 
 
 @pytest.fixture
 def mock_logger():
     """
-    Create a mocked logger instance for tests
+    Placeholder logger; WorkerPool just forwards it to WorkerProcessManagers (mocked)
     """
-    return
+    return None
 
 
 @pytest.fixture
 def mock_wpm_instances(mocker: MockerFixture):
     """
-    Creates set of mock WorkerProcessManager instances for WorkerPool to use
+    Three mock WorkerProcessManager instances. Tests override .utilization and
+    .context_ids per test to drive routing behavior.
     """
-    mock_wpm_instances = [
-        mocker.MagicMock(spec=WorkerProcessManager),
-        mocker.MagicMock(spec=WorkerProcessManager),
-        mocker.MagicMock(spec=WorkerProcessManager),
-    ]
-
-    return mock_wpm_instances
+    instances = [mocker.MagicMock(spec=WorkerProcessManager) for _ in range(3)]
+    for inst in instances:
+        inst.context_ids = set()
+        inst.utilization = 0.0
+    return instances
 
 
 @pytest.fixture
 def mock_wpm_class(mocker: MockerFixture, mock_wpm_instances: list[MagicMock]):
     """
-    Patches WorkerPool's WorkerProcessManager import to use mocked instances
+    Patch WorkerPool's WorkerProcessManager symbol so construction yields mocks
     """
     return mocker.patch(
         "src.shared.utils.worker_pool.worker_pool.WorkerProcessManager",
@@ -66,16 +58,37 @@ def mock_wpm_class(mocker: MockerFixture, mock_wpm_instances: list[MagicMock]):
 
 
 @pytest.fixture
-def context_def():
+def contexts() -> list[ContextAssignment]:
     """
-    Defines mapping from context ids to context definition
+    Default context assignments
+        0: Context "context" tag, on all workers
+        1: LoggerContext "log_context" tag, on all workers
+        2: SlowContext "slow_context" tag, on all workers
+    Tests that need different pinning can override.
     """
-    return {
-        TEST_CONTEXT_ID: Context(TEST_CONTEXT_ID),
-        TEST_LOGGER_CONTEXT: LoggerContext(),
-        TEST_ERROR_CONTEXT: ErrorContext(),
-        TEST_SLOW_CONTEXT: SlowContext(0),
-    }
+    return [
+        ContextAssignment(
+            context_def=Context(CTX_CONTEXT), worker_ids=[0, 1, 2]
+        ),
+        ContextAssignment(context_def=LoggerContext(), worker_ids=[0, 1, 2]),
+        ContextAssignment(context_def=SlowContext(0), worker_ids=[0, 1, 2]),
+    ]
+
+
+def _set_context_ids_from(
+    mock_wpm_instances: list[MagicMock], contexts: list[ContextAssignment]
+):
+    """
+    Compute the per-worker context_id sets from the assignment list and apply
+    them to the mocks so the pool's routing sees the same state it would in
+    production.
+    """
+    per_worker: list[set[int]] = [set() for _ in mock_wpm_instances]
+    for context_id, assignment in enumerate(contexts):
+        for worker_id in assignment.worker_ids:
+            per_worker[worker_id].add(context_id)
+    for worker_id, inst in enumerate(mock_wpm_instances):
+        inst.context_ids = per_worker[worker_id]
 
 
 # pylint: disable=unused-argument
@@ -83,18 +96,14 @@ def context_def():
 async def pool(
     mock_wpm_class: MockType,
     mock_wpm_instances: list[MagicMock],
-    context_def: dict[int, JobContextInterface[Any]],
+    contexts: list[ContextAssignment],
     mock_logger: Logger,
 ):
     """
-    Create a fresh instance of WorkerPool for each test and handle teardown
+    Create a fresh WorkerPool with mocked WorkerProcessManagers and handle teardown
     """
-    pool = WorkerPool(
-        mock_logger,
-        len(mock_wpm_instances),
-        context_def,
-        ROLLING_UTILIZATION_WINDOW_SEC,
-    )
+    _set_context_ids_from(mock_wpm_instances, contexts)
+    pool = WorkerPool(mock_logger, len(mock_wpm_instances), contexts)
 
     yield pool
 
@@ -102,22 +111,17 @@ async def pool(
 
 
 # pylint: disable=unused-argument
-def test_worker_pool_correctly_shutdown_processes(
+def test_worker_pool_correctly_shuts_down_processes(
     mock_logger: MagicMock,
     mock_wpm_class: MockType,
     mock_wpm_instances: list[MagicMock],
-    context_def: dict[int, JobContextInterface[Any]],
+    contexts: list[ContextAssignment],
 ):
     """
     Test that worker pool correctly shuts down processes when pool is shutdown
     """
     # Arrange / Act
-    pool = WorkerPool(
-        mock_logger,
-        len(mock_wpm_instances),
-        context_def,
-        ROLLING_UTILIZATION_WINDOW_SEC,
-    )
+    pool = WorkerPool(mock_logger, len(mock_wpm_instances), contexts)
     pool.shutdown()
 
     # Assert
@@ -127,108 +131,102 @@ def test_worker_pool_correctly_shutdown_processes(
 
 
 # pylint: disable=unused-argument
-def test_worker_pool_correctly_instantiates_processes(
+def test_worker_pool_instantiates_processes_with_assigned_contexts(
     mock_logger: MagicMock,
     mock_wpm_class: MockType,
     mock_wpm_instances: list[MagicMock],
-    context_def: dict[int, JobContextInterface[Any]],
+    contexts: list[ContextAssignment],
     pool: WorkerPool,
 ):
     """
-    Test that worker pool creates processes with unique ids and correct configuration
+    Test that each WorkerProcessManager is instantiated with exactly the
+    context_defs assigned to it via worker_ids
     """
     # Arrange / Act
     num_workers = len(mock_wpm_instances)
-    expected_calls = [
-        call(mock_logger, id, context_def, ROLLING_UTILIZATION_WINDOW_SEC)
-        for id in range(num_workers)
-    ]
+    expected_per_worker: list[dict[int, Any]] = [{} for _ in range(num_workers)]
+    for context_id, assignment in enumerate(contexts):
+        for worker_id in assignment.worker_ids:
+            expected_per_worker[worker_id][context_id] = assignment.context_def
 
-    # Assert
+    # Assert each worker got its expected context_defs as the 3rd positional arg
     assert mock_wpm_class.call_count == num_workers
-    mock_wpm_class.assert_has_calls(expected_calls)
+    for worker_id in range(num_workers):
+        args, _ = mock_wpm_class.call_args_list[worker_id]
+        assert args[0] is mock_logger
+        assert args[1] == worker_id
+        assert args[2] == expected_per_worker[worker_id]
+
+
+def test_worker_pool_raises_on_invalid_worker_id(
+    mock_logger: MagicMock,
+    # pylint: disable=unused-argument
+    mock_wpm_class: MockType,
+):
+    """
+    Test that worker_ids pointing outside [0, num_workers) raise at construction
+    """
+    # Arrange / Act / Assert
+    with pytest.raises(ValueError, match="invalid worker_id"):
+        WorkerPool(
+            mock_logger,
+            2,
+            [
+                ContextAssignment(
+                    context_def=Context(CTX_CONTEXT), worker_ids=[5]
+                )
+            ],
+        )
+
+
+def test_worker_pool_raises_on_zero_workers(
+    mock_logger: MagicMock,
+    # pylint: disable=unused-argument
+    mock_wpm_class: MockType,
+):
+    """
+    Test that constructing with num_workers <= 0 raises
+    """
+    # Arrange / Act / Assert
+    with pytest.raises(ValueError, match="at least 1"):
+        WorkerPool(mock_logger, 0, [])
 
 
 def test_fetch_single_context_by_tag(pool: WorkerPool):
     """
-    Test that fetching a single context by tags returns single matching context id
+    Test fetching context_ids for a tag that matches one context
     """
     # Arrange / Act
-    context_ids = pool.get_context_ids_by_tag("error")
+    context_ids = pool.get_context_ids_by_tag("log_context")
 
     # Assert
-    assert context_ids == set([TEST_ERROR_CONTEXT])
+    assert context_ids == {CTX_LOGGER}
 
 
-def test_fetch_multiple_context_by_tag(pool: WorkerPool):
+def test_fetch_unknown_tag_returns_empty(pool: WorkerPool):
     """
-    Test that fetching a multiple contexts by tags returns all matching context ids
+    Test that fetching by an unknown tag returns an empty set
     """
     # Arrange / Act
-    context_ids = pool.get_context_ids_by_tag("no_error")
+    context_ids = pool.get_context_ids_by_tag("does_not_exist")
 
     # Assert
-    assert context_ids == set(
-        [TEST_CONTEXT_ID, TEST_LOGGER_CONTEXT, TEST_SLOW_CONTEXT]
-    )
+    assert context_ids == set()
 
 
-def test_tagged_context_is_instance_valid_single_definition(pool: WorkerPool):
-    """
-    Test checking context instances where tagged context definitions are the same
-    """
-    # Arrange / Act / Assert
-    assert pool.tagged_context_is_instance("context", [Context])
-
-
-def test_tagged_context_is_instance_invalid_single_definition(pool: WorkerPool):
-    """
-    Test checking context instances where tagged context definitions don't match given definition
-    """
-    # Arrange / Act / Assert
-    assert pool.tagged_context_is_instance("no_error", [ErrorContext]) is False
-
-
-def test_tagged_context_is_instance_valid_multiple_definitions(
-    pool: WorkerPool,
-):
-    """
-    Test checking context instances where tagged context definitions are not the same
-    """
-    # Arrange / Act / Assert
-    assert pool.tagged_context_is_instance(
-        "none_context", [LoggerContext, SlowContext]
-    )
-
-
-def test_tagged_context_is_instance_invalid_multiple_definitions(
-    pool: WorkerPool,
-):
-    """
-    Test checking context instances where tagged context definitions
-    are not the same and don't match given definition
-    """
-    # Arrange / Act / Assert
-    assert (
-        pool.tagged_context_is_instance(
-            "no_error", [LoggerContext, SlowContext]
-        )
-        is False
-    )
-
-
-def test_register_job_no_context(
+def test_register_job_no_context_picks_lowest_utilization(
     pool: WorkerPool, mock_wpm_instances: list[MagicMock]
 ):
     """
-    Test that registering a job with no context selects the process with lowest utilization
+    Test that registering a job with no context tag picks the worker with
+    lowest utilization
     """
     # Arrange
     period_ms = 1000
     job = MagicMock(spec=JobInterface)
 
     mock_wpm_instances[0].utilization = 0.5
-    mock_wpm_instances[1].utilization = 0
+    mock_wpm_instances[1].utilization = 0.0
     mock_wpm_instances[2].utilization = 0.25
 
     # Act
@@ -242,52 +240,28 @@ def test_register_job_no_context(
     mock_wpm_instances[2].register_job.assert_not_called()
 
 
-def test_register_job_with_context_single_tag_match_no_active(
-    pool: WorkerPool, mock_wpm_instances: list[MagicMock]
+def test_register_job_routes_to_worker_owning_required_tag(
+    mock_logger: MagicMock,
+    # pylint: disable=unused-argument
+    mock_wpm_class: MockType,
+    mock_wpm_instances: list[MagicMock],
 ):
     """
-    Test that registering a job with context tag that matches a single definition
-    with no active instance assigns job to lowest utilization process
+    Test that a job requesting a tag is routed only to workers that own a
+    matching context - workers without that context are skipped even if they
+    have lower utilization
     """
-    # Arrange
+    # Arrange - only worker 2 has the slow_context, context_id 0 in this list
+    contexts = [ContextAssignment(context_def=SlowContext(0), worker_ids=[2])]
+    _set_context_ids_from(mock_wpm_instances, contexts)
+    pool = WorkerPool(mock_logger, len(mock_wpm_instances), contexts)
+
+    mock_wpm_instances[0].utilization = 0.0  # lowest utilization but no context
+    mock_wpm_instances[1].utilization = 0.1
+    mock_wpm_instances[2].utilization = 0.5
+
     period_ms = 1000
     job = MagicMock(spec=JobInterface)
-
-    mock_wpm_instances[0].utilization = 0.1
-    mock_wpm_instances[1].utilization = 0.5
-    mock_wpm_instances[2].utilization = 0.25
-
-    # Act
-    pool.register_job(("log_context",), period_ms, job)
-
-    # Assert
-    mock_wpm_instances[0].register_job.assert_called_once_with(
-        (TEST_LOGGER_CONTEXT,), period_ms, job
-    )
-    mock_wpm_instances[1].register_job.assert_not_called()
-    mock_wpm_instances[2].register_job.assert_not_called()
-
-
-def test_register_job_prefers_active_context_over_lower_utilization(
-    pool: WorkerPool, mock_wpm_instances: list[MagicMock]
-):
-    """
-    Test that the job scheduler prefers a process that already has the
-    context active, even if another process has slightly lower utilization,
-    due to the creation_cost of a context.
-    """
-    # Arrange
-    period_ms = 1000
-    job = MagicMock(spec=JobInterface)
-
-    mock_wpm_instances[0].utilization = 0.1
-    mock_wpm_instances[0].active_context_ids = set()
-
-    mock_wpm_instances[1].utilization = 0.5
-    mock_wpm_instances[1].active_context_ids = set()
-
-    mock_wpm_instances[2].utilization = 0.15
-    mock_wpm_instances[2].active_context_ids = {TEST_SLOW_CONTEXT}
 
     # Act
     pool.register_job(("slow_context",), period_ms, job)
@@ -296,163 +270,104 @@ def test_register_job_prefers_active_context_over_lower_utilization(
     mock_wpm_instances[0].register_job.assert_not_called()
     mock_wpm_instances[1].register_job.assert_not_called()
     mock_wpm_instances[2].register_job.assert_called_once_with(
-        (TEST_SLOW_CONTEXT,), period_ms, job
+        (0,), period_ms, job
     )
 
 
-def test_register_job_prefers_create_context_over_high_utilization_active_context(
+def test_register_job_picks_lowest_utilization_among_owning_workers(
     pool: WorkerPool, mock_wpm_instances: list[MagicMock]
 ):
     """
-    Test that the job scheduler prefers a process that doesn't have
-    active context over one with active context when utilization
-    on active context exceeds creation_cost
+    Test that when multiple workers own the requested context, the one with
+    lowest utilization is picked
     """
     # Arrange
     period_ms = 1000
     job = MagicMock(spec=JobInterface)
 
-    mock_wpm_instances[0].utilization = 0.2
-    mock_wpm_instances[0].active_context_ids = set()
-
+    mock_wpm_instances[0].utilization = 0.5
     mock_wpm_instances[1].utilization = 0.1
-    mock_wpm_instances[1].active_context_ids = set()
-
-    mock_wpm_instances[2].utilization = 0.5
-    mock_wpm_instances[2].active_context_ids = {TEST_SLOW_CONTEXT}
-
-    # Act
-    pool.register_job(("slow_context",), period_ms, job)
-
-    # Assert
-    mock_wpm_instances[0].register_job.assert_not_called()
-    mock_wpm_instances[1].register_job.assert_called_once_with(
-        (TEST_SLOW_CONTEXT,), period_ms, job
-    )
-    mock_wpm_instances[2].register_job.assert_not_called()
-
-
-def test_register_job_respects_max_instances(
-    pool: WorkerPool, mock_wpm_instances: list[MagicMock]
-):
-    """
-    Test that if a context's max_instances is reached, a new job for
-    that context can only be assigned to a process already running it.
-    """
-    # Arrange
-    period_ms = 1000
-    job = MagicMock(spec=JobInterface)
-
-    mock_wpm_instances[0].utilization = 0.3
-    mock_wpm_instances[0].active_context_ids = {TEST_SLOW_CONTEXT}
-
-    mock_wpm_instances[1].utilization = 0.5
-    mock_wpm_instances[1].active_context_ids = {TEST_SLOW_CONTEXT}
-
-    mock_wpm_instances[2].utilization = 0.1
-    mock_wpm_instances[2].active_context_ids = set()
-
-    # Act
-    pool.register_job(("slow_context",), period_ms, job)
-
-    # Assert
-    mock_wpm_instances[0].register_job.assert_called_once_with(
-        (TEST_SLOW_CONTEXT,), period_ms, job
-    )
-    mock_wpm_instances[1].register_job.assert_not_called()
-    mock_wpm_instances[2].register_job.assert_not_called()
-
-
-def test_register_job_avoids_context_own_negative_affinity(
-    pool: WorkerPool, mock_wpm_instances: list[MagicMock]
-):
-    """
-    Test that a job is not assigned to a process if its context has
-    negative affinity with a context already active on that process.
-    """
-    # Arrange
-    period_ms = 1000
-    job = MagicMock(spec=JobInterface)
-
-    mock_wpm_instances[0].utilization = 0.1
-    mock_wpm_instances[0].active_context_ids = {TEST_LOGGER_CONTEXT}
-
-    mock_wpm_instances[1].utilization = 0.2
-    mock_wpm_instances[1].active_context_ids = set()
-
     mock_wpm_instances[2].utilization = 0.3
-    mock_wpm_instances[2].active_context_ids = set()
-
-    # Act
-    pool.register_job(("slow_context",), period_ms, job)
-
-    # Assert
-    mock_wpm_instances[0].register_job.assert_not_called()
-    mock_wpm_instances[1].register_job.assert_called_once_with(
-        (TEST_SLOW_CONTEXT,), period_ms, job
-    )
-    mock_wpm_instances[2].register_job.assert_not_called()
-
-
-def test_register_job_avoids_active_context_negative_affinity(
-    pool: WorkerPool, mock_wpm_instances: list[MagicMock]
-):
-    """
-    Test that a job is not assigned to a process if a process has active context
-    that has negative affinity with requested context
-    """
-    # Arrange
-    period_ms = 1000
-    job = MagicMock(spec=JobInterface)
-
-    mock_wpm_instances[0].utilization = 0.2
-    mock_wpm_instances[0].active_context_ids = set()
-
-    mock_wpm_instances[1].utilization = 0.5
-    mock_wpm_instances[1].active_context_ids = set()
-
-    mock_wpm_instances[2].utilization = 0.1
-    mock_wpm_instances[2].active_context_ids = {TEST_SLOW_CONTEXT}
 
     # Act
     pool.register_job(("log_context",), period_ms, job)
 
     # Assert
-    mock_wpm_instances[0].register_job.assert_called_once_with(
-        (TEST_LOGGER_CONTEXT,), period_ms, job
+    mock_wpm_instances[0].register_job.assert_not_called()
+    mock_wpm_instances[1].register_job.assert_called_once_with(
+        (CTX_LOGGER,), period_ms, job
     )
-    mock_wpm_instances[1].register_job.assert_not_called()
     mock_wpm_instances[2].register_job.assert_not_called()
 
 
-def test_register_job_raises_runtime_error_if_no_valid_assignment(
-    pool: WorkerPool, mock_wpm_instances: list[MagicMock]
+def test_register_job_with_multiple_tags_needs_all_on_same_worker(
+    mock_logger: MagicMock,
+    # pylint: disable=unused-argument
+    mock_wpm_class: MockType,
+    mock_wpm_instances: list[MagicMock],
 ):
     """
-    Test that a RuntimeError is raised if all processes are disqualified
-    (e.g., by negative affinity or max_instances).
+    Test that registering a job with multiple tags requires a single worker
+    to own a context for every tag - partial coverage doesn't qualify
     """
     # Arrange
+    # worker 0 owns CTX_CONTEXT only
+    # worker 1 owns CTX_LOGGER only
+    # worker 2 owns both - should be picked
+    contexts = [
+        ContextAssignment(context_def=Context(CTX_CONTEXT), worker_ids=[0, 2]),
+        ContextAssignment(context_def=LoggerContext(), worker_ids=[1, 2]),
+    ]
+    _set_context_ids_from(mock_wpm_instances, contexts)
+    pool = WorkerPool(mock_logger, len(mock_wpm_instances), contexts)
+
+    mock_wpm_instances[0].utilization = 0.0
+    mock_wpm_instances[1].utilization = 0.0
+    mock_wpm_instances[2].utilization = 0.5
+
     period_ms = 1000
     job = MagicMock(spec=JobInterface)
 
-    mock_wpm_instances[0].utilization = 0.1
-    mock_wpm_instances[0].active_context_ids = {TEST_LOGGER_CONTEXT}
+    # Act
+    pool.register_job(("context", "log_context"), period_ms, job)
 
-    mock_wpm_instances[1].utilization = 0.1
-    mock_wpm_instances[1].active_context_ids = {TEST_LOGGER_CONTEXT}
+    # Assert
+    mock_wpm_instances[0].register_job.assert_not_called()
+    mock_wpm_instances[1].register_job.assert_not_called()
+    mock_wpm_instances[2].register_job.assert_called_once_with(
+        (CTX_CONTEXT, CTX_LOGGER), period_ms, job
+    )
 
-    mock_wpm_instances[2].utilization = 0.1
-    mock_wpm_instances[2].active_context_ids = {TEST_LOGGER_CONTEXT}
+
+def test_register_job_raises_runtime_error_if_no_worker_owns_all_tags(
+    mock_logger: MagicMock,
+    # pylint: disable=unused-argument
+    mock_wpm_class: MockType,
+    mock_wpm_instances: list[MagicMock],
+):
+    """
+    Test that RuntimeError is raised when no single worker owns a context for
+    every requested tag, even if the tags individually exist
+    """
+    # Arrange - disjoint coverage
+    contexts = [
+        ContextAssignment(context_def=Context(CTX_CONTEXT), worker_ids=[0]),
+        ContextAssignment(context_def=LoggerContext(), worker_ids=[1]),
+    ]
+    _set_context_ids_from(mock_wpm_instances, contexts)
+    pool = WorkerPool(mock_logger, len(mock_wpm_instances), contexts)
+
+    period_ms = 1000
+    job = MagicMock(spec=JobInterface)
 
     # Act / Assert
     with pytest.raises(RuntimeError):
-        pool.register_job(("slow_context",), period_ms, job)
+        pool.register_job(("context", "log_context"), period_ms, job)
 
 
 def test_register_job_raises_key_error_for_invalid_tag(pool: WorkerPool):
     """
-    Test that a KeyError is raised if the context_tag matches no definitions.
+    Test that a KeyError is raised if the context_tag matches no definitions
     """
     # Arrange
     period_ms = 1000
@@ -464,134 +379,3 @@ def test_register_job_raises_key_error_for_invalid_tag(pool: WorkerPool):
         match="context tag: non_existent_tag matched 0 context definitions",
     ):
         pool.register_job(("non_existent_tag",), period_ms, job)
-
-
-def test_register_job_with_multiple_context_no_active(
-    pool: WorkerPool, mock_wpm_instances: list[MagicMock]
-):
-    """
-    Test that registering a job with multiple contexts with no active contexts
-    selects process with lowest utilization
-    """
-    # Arrange
-    period_ms = 1000
-    job = MagicMock(spec=JobInterface)
-
-    mock_wpm_instances[0].utilization = 0.1
-    mock_wpm_instances[1].utilization = 0.3
-    mock_wpm_instances[2].utilization = 0.5
-
-    # Act
-    pool.register_job(("context", "log_context"), period_ms, job)
-
-    # Assert
-    mock_wpm_instances[0].register_job.assert_called_once_with(
-        (TEST_CONTEXT_ID, TEST_LOGGER_CONTEXT), period_ms, job
-    )
-    mock_wpm_instances[1].register_job.assert_not_called()
-    mock_wpm_instances[2].register_job.assert_not_called()
-
-
-def test_register_job_with_multiple_context_lowest_creation_cost(
-    pool: WorkerPool, mock_wpm_instances: list[MagicMock]
-):
-    """
-    Test that registering a job with multiple contexts with no active contexts
-    selects process with lowest utilization and lowest creation cost
-    """
-    # Arrange
-    period_ms = 1000
-    job = MagicMock(spec=JobInterface)
-
-    mock_wpm_instances[0].utilization = 0.1
-    mock_wpm_instances[1].utilization = 0.3
-    mock_wpm_instances[2].utilization = 0.5
-
-    # Act
-    pool.register_job(("no_error", "error"), period_ms, job)
-
-    # Assert
-    mock_wpm_instances[0].register_job.assert_called_once_with(
-        (TEST_CONTEXT_ID, TEST_ERROR_CONTEXT), period_ms, job
-    )
-    mock_wpm_instances[1].register_job.assert_not_called()
-    mock_wpm_instances[2].register_job.assert_not_called()
-
-
-def test_register_job_with_multiple_context_negative_affinity(
-    pool: WorkerPool, mock_wpm_instances: list[MagicMock]
-):
-    """
-    Test that registering a job with multiple contexts with negative affinity
-    to active context is assigned to a different process
-    """
-    # Arrange
-    period_ms = 1000
-    job = MagicMock(spec=JobInterface)
-
-    mock_wpm_instances[0].utilization = 0.1
-    mock_wpm_instances[0].active_context_ids = {TEST_LOGGER_CONTEXT}
-
-    mock_wpm_instances[1].utilization = 0.3
-    mock_wpm_instances[1].active_context_ids = {TEST_LOGGER_CONTEXT}
-
-    mock_wpm_instances[2].utilization = 0.5
-    mock_wpm_instances[2].active_context_ids = set()
-
-    # Act
-    pool.register_job(("context", "slow_context"), period_ms, job)
-
-    # Assert
-    mock_wpm_instances[0].register_job.assert_not_called()
-    mock_wpm_instances[1].register_job.assert_not_called()
-    mock_wpm_instances[2].register_job.assert_called_once_with(
-        (TEST_CONTEXT_ID, TEST_SLOW_CONTEXT), period_ms, job
-    )
-
-
-def test_register_job_with_multiple_context_active_negative_affinity(
-    pool: WorkerPool, mock_wpm_instances: list[MagicMock]
-):
-    """
-    Test that registering a job with multiple contexts with active contexts
-    that have negative affinity with requested context is assigned to a
-    different process
-    """
-    # Arrange
-    period_ms = 1000
-    job = MagicMock(spec=JobInterface)
-
-    mock_wpm_instances[0].utilization = 0.1
-    mock_wpm_instances[0].active_context_ids = {TEST_SLOW_CONTEXT}
-
-    mock_wpm_instances[1].utilization = 0.3
-    mock_wpm_instances[1].active_context_ids = {TEST_SLOW_CONTEXT}
-
-    mock_wpm_instances[2].utilization = 0.5
-    mock_wpm_instances[2].active_context_ids = set()
-
-    # Act
-    pool.register_job(("context", "log_context"), period_ms, job)
-
-    # Assert
-    mock_wpm_instances[0].register_job.assert_not_called()
-    mock_wpm_instances[1].register_job.assert_not_called()
-    mock_wpm_instances[2].register_job.assert_called_once_with(
-        (TEST_CONTEXT_ID, TEST_LOGGER_CONTEXT), period_ms, job
-    )
-
-
-def test_register_job_with_invalid_multiple_context_raises_runtime_error(
-    pool: WorkerPool,
-):
-    """
-    Test that registering a job with multiple contexts that have negative affinity
-    with each other raises RuntimeError
-    """
-    # Arrange
-    period_ms = 1000
-    job = MagicMock(spec=JobInterface)
-
-    # Act / Assert
-    with pytest.raises(RuntimeError):
-        pool.register_job(("slow_context", "log_context"), period_ms, job)

--- a/transcription_service/tests/unit/shared/utils/worker_pool/worker_process_manager_test.py
+++ b/transcription_service/tests/unit/shared/utils/worker_pool/worker_process_manager_test.py
@@ -3,12 +3,10 @@ Unit tests for WorkerProcessManager
 """
 
 import asyncio
-import logging
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
-import pytest_asyncio
 
 from src.shared.logger import ContextLogger
 from src.shared.utils.worker_pool import (
@@ -18,12 +16,12 @@ from src.shared.utils.worker_pool import (
     WorkerProcessManager,
 )
 
+from .conftest import TEST_ROLLING_UTILIZATION_WINDOW_NS, TEST_WORKER_ID
 from .context_definitions import (
     Context,
     ContextInstance,
     ErrorContext,
     LoggerContext,
-    SlowContext,
 )
 from .jobs import ContextJob, ErrorJob, LoggerJob, SlowJob, SumJob
 
@@ -32,17 +30,9 @@ pytestmark = pytest.mark.timeout(2)
 
 NS_PER_SEC = 10**9
 
-TEST_WORKER_ID = 0
-
 TEST_CONTEXT_ID_0 = 0
 TEST_CONTEXT_ID_1 = 1
 TEST_LOGGER_CONTEXT = 2
-TEST_ERROR_CONTEXT = 3
-TEST_SLOW_CONTEXT = 4
-# Time slow context takes to create
-TEST_SLOW_CONTEXT_TIME_NS = NS_PER_SEC
-
-ROLLING_UTILIZATION_WINDOW_SEC = 3
 
 
 def assert_logger_was_called_with(
@@ -69,7 +59,7 @@ def assert_logger_was_called_with(
     assert logged
 
 
-def assert_rel_error(measured: int, expected: int, rtol: float = 1.5e-2):
+def assert_rel_error(measured: int, expected: int, rtol: float = 1e-3):
     """
     Asserts that relative error is below tolerance
 
@@ -83,42 +73,20 @@ def assert_instant_time(measured_ns: int):
     """
     Asserts that timestamp in nanoseconds is basically 0
     """
-    assert 0 < measured_ns < 1.5e-2 * NS_PER_SEC
+    assert 0 < measured_ns < 1e-3 * NS_PER_SEC
 
 
 @pytest.fixture
-def mock_underlying_logger():
+def context_defs() -> dict[int, JobContextInterface[Any]]:
     """
-    Create a mocked logger instance for tests
+    Pre-initialized contexts the WorkerProcessManager fixture starts with.
+    ErrorContext is intentionally excluded - including it would fail worker init.
     """
-    logger = MagicMock(spec=logging.Logger)
-    logger.level = 10
-    return logger
-
-
-@pytest_asyncio.fixture
-async def wpm(mock_underlying_logger: logging.Logger):
-    """
-    Create a fresh instance of WorkerProcessManager for each test and handle teardown
-    """
-    context_def: dict[int, JobContextInterface[Any]] = {
+    return {
         TEST_CONTEXT_ID_0: Context(TEST_CONTEXT_ID_0),
         TEST_CONTEXT_ID_1: Context(TEST_CONTEXT_ID_1),
         TEST_LOGGER_CONTEXT: LoggerContext(),
-        TEST_ERROR_CONTEXT: ErrorContext(),
-        TEST_SLOW_CONTEXT: SlowContext(TEST_SLOW_CONTEXT_TIME_NS),
     }
-    wpm = WorkerProcessManager(
-        ContextLogger(mock_underlying_logger),
-        TEST_WORKER_ID,
-        context_def,
-        ROLLING_UTILIZATION_WINDOW_SEC,
-    )
-
-    yield wpm
-
-    wpm.send_terminate()
-    wpm.wait_shutdown()
 
 
 @pytest.mark.asyncio
@@ -411,34 +379,12 @@ async def test_deregister_single_job_while_running_multiple_registered(
 
 
 @pytest.mark.asyncio
-async def test_creates_context_instance_on_new_request_single_job(
+async def test_reuses_pre_initialized_context_instance(
     wpm: WorkerProcessManager,
 ):
     """
-    Test that registering a job with new context id creates corresponding context instance
-    """
-    # Arrange
-    results: list[JobSuccess[ContextInstance] | JobException] = []
-
-    job = wpm.register_job((TEST_CONTEXT_ID_0,), 200, ContextJob())
-    job.on(job.JobResultEvent, results.append)
-
-    # Act
-    await asyncio.sleep(0.2 + 0.1)
-
-    # Assert
-    assert len(results) == 1
-    assert results[0].value == ContextInstance(
-        TEST_CONTEXT_ID_0, create_count=1, destroy_count=0
-    )
-
-
-@pytest.mark.asyncio
-async def test_reuses_context_instance_on_repeat_request_multiple_jobs(
-    wpm: WorkerProcessManager,
-):
-    """
-    Test that registering a job with repeat context id reuses existing context instance
+    Test that all jobs using the same context_id receive the single context
+    instance created at worker startup (no per-job creation)
     """
     # Arrange
     results0: list[JobSuccess[ContextInstance] | JobException] = []
@@ -464,12 +410,12 @@ async def test_reuses_context_instance_on_repeat_request_multiple_jobs(
 
 
 @pytest.mark.asyncio
-async def test_creates_context_instance_on_new_request_multiple_jobs(
+async def test_distinct_context_ids_yield_distinct_instances(
     wpm: WorkerProcessManager,
 ):
     """
-    Test that registering a multiple jobs with new context ids
-    create corresponding context instances
+    Test that jobs requesting different context_ids each receive their own
+    pre-initialized instance
     """
     # Arrange
     results0: list[JobSuccess[ContextInstance] | JobException] = []
@@ -495,169 +441,38 @@ async def test_creates_context_instance_on_new_request_multiple_jobs(
 
 
 @pytest.mark.asyncio
-async def test_does_not_destroy_active_context_instance_on_deregister_single_context(
-    wpm: WorkerProcessManager,
-):
+async def test_reports_pinned_context_ids(wpm: WorkerProcessManager):
     """
-    Test that deregistering a job does not destroy active context instance
+    Test that the manager reports the set of context_ids it has initialized
     """
-    # Arrange
-    results2: list[JobSuccess[ContextInstance] | JobException] = []
-
-    job0 = wpm.register_job((TEST_CONTEXT_ID_0,), 200, ContextJob())
-    # Second job to keep context active
-    wpm.register_job((TEST_CONTEXT_ID_0,), 200, ContextJob())
-
-    # Act
-    await asyncio.sleep(0.2 + 0.1)
-    job0.deregister()
-    await asyncio.sleep(0.1)
-
-    # Register job to capture context state
-    job2 = wpm.register_job((TEST_CONTEXT_ID_0,), 200, ContextJob())
-    job2.on(job2.JobResultEvent, results2.append)
-    await asyncio.sleep(0.2 + 0.1)
-
-    # Assert
-    assert len(results2) == 1
-    assert results2[0].value == ContextInstance(
-        TEST_CONTEXT_ID_0, create_count=1, destroy_count=0
-    )
+    # Arrange / Act / Assert
+    assert wpm.context_ids == {
+        TEST_CONTEXT_ID_0,
+        TEST_CONTEXT_ID_1,
+        TEST_LOGGER_CONTEXT,
+    }
 
 
 @pytest.mark.asyncio
-async def test_destroys_unused_context_instance_on_deregister_single_context(
-    wpm: WorkerProcessManager,
+async def test_worker_init_raises_when_context_creation_fails(
+    mock_underlying_logger: MagicMock,
 ):
     """
-    Test that deregistering a job does destroy unused context instances
+    Test that constructing WorkerProcessManager raises if any assigned context
+    fails to create on the worker. The pool should not silently advance into
+    job acceptance when a context is broken.
     """
     # Arrange
-    results1: list[JobSuccess[ContextInstance] | JobException] = []
+    failing_defs: dict[int, JobContextInterface[Any]] = {0: ErrorContext()}
 
-    job0 = wpm.register_job((TEST_CONTEXT_ID_0,), 200, ContextJob())
-
-    # Act
-    await asyncio.sleep(0.2 + 0.1)
-    job0.deregister()
-    await asyncio.sleep(0.1)
-
-    # Register job to capture context state
-    job1 = wpm.register_job((TEST_CONTEXT_ID_0,), 200, ContextJob())
-    job1.on(job1.JobResultEvent, results1.append)
-    await asyncio.sleep(0.2 + 0.1)
-
-    # Assert
-    assert len(results1) == 1
-    assert results1[0].value == ContextInstance(
-        TEST_CONTEXT_ID_0, create_count=2, destroy_count=1
-    )
-
-
-@pytest.mark.asyncio
-async def test_does_not_destroy_active_context_instance_on_deregister_multiple_context(
-    wpm: WorkerProcessManager,
-):
-    """
-    Test that deregistering a job does not destroy active context
-    instances while also destroying unused context instances
-    """
-    # Arrange
-    results2: list[JobSuccess[ContextInstance] | JobException] = []
-    results3: list[JobSuccess[ContextInstance] | JobException] = []
-
-    job0 = wpm.register_job((TEST_CONTEXT_ID_0,), 200, ContextJob())
-    # Context 1 stays active, context 0 gets deregistered
-    wpm.register_job((TEST_CONTEXT_ID_1,), 200, ContextJob())
-
-    # Act
-    await asyncio.sleep(0.2 + 0.1)
-    job0.deregister()
-    await asyncio.sleep(0.1)
-
-    # Register job to capture context state
-    job2 = wpm.register_job((TEST_CONTEXT_ID_0,), 200, ContextJob())
-    job2.on(job2.JobResultEvent, results2.append)
-    job3 = wpm.register_job((TEST_CONTEXT_ID_1,), 200, ContextJob())
-    job3.on(job3.JobResultEvent, results3.append)
-    await asyncio.sleep(0.2 + 0.1)
-
-    # Assert
-    assert len(results2) == 1
-    assert results2[0].value == ContextInstance(
-        TEST_CONTEXT_ID_0, create_count=2, destroy_count=1
-    )
-    assert len(results3) == 1
-    assert results3[0].value == ContextInstance(
-        TEST_CONTEXT_ID_1, create_count=1, destroy_count=0
-    )
-
-
-@pytest.mark.asyncio
-async def test_reports_active_context_ids_after_register(
-    wpm: WorkerProcessManager,
-):
-    """
-    Test that WorkerProcessManager reports currently active context ids after registering jobs
-    """
-    # Arrange
-    wpm.register_job((TEST_CONTEXT_ID_0,), 200, ContextJob())
-    wpm.register_job((TEST_CONTEXT_ID_1,), 200, ContextJob())
-    wpm.register_job((TEST_LOGGER_CONTEXT,), 200, ContextJob())
-
-    # Act
-    await asyncio.sleep(0.2 + 0.1)
-
-    # Assert
-    assert wpm.active_context_ids == set(
-        [TEST_CONTEXT_ID_0, TEST_CONTEXT_ID_1, TEST_LOGGER_CONTEXT]
-    )
-
-
-@pytest.mark.asyncio
-async def test_reports_active_context_ids_after_deregister(
-    wpm: WorkerProcessManager,
-):
-    """
-    Test that WorkerProcessManager reports currently active context ids after deregistering jobs
-    """
-    # Arrange
-    wpm.register_job((TEST_CONTEXT_ID_0,), 200, ContextJob())
-    wpm.register_job((TEST_CONTEXT_ID_0,), 200, ContextJob())
-    wpm.register_job((TEST_LOGGER_CONTEXT,), 200, ContextJob())
-    job3 = wpm.register_job((TEST_CONTEXT_ID_1,), 200, ContextJob())
-
-    # Act
-    await asyncio.sleep(0.2 + 0.1)
-    job3.deregister()
-    await asyncio.sleep(0.1)
-
-    # Assert
-    assert wpm.active_context_ids == set(
-        [TEST_CONTEXT_ID_0, TEST_LOGGER_CONTEXT]
-    )
-
-
-@pytest.mark.asyncio
-async def test_returns_error_result_on_create_context_error(
-    wpm: WorkerProcessManager,
-):
-    """
-    Test that context creation that raises an exception returns error result
-    """
-    # Arrange
-    results: list[JobSuccess[int] | JobException] = []
-
-    job = wpm.register_job((TEST_ERROR_CONTEXT,), 200, SumJob())
-    job.on(job.JobResultEvent, results.append)
-
-    # Act
-    await asyncio.sleep(0.2 + 0.1)
-
-    # Assert
-    assert len(results) == 1
-    assert results[0].has_exception
-    assert isinstance(results[0].value, RuntimeError)
+    # Act / Assert
+    with pytest.raises(RuntimeError, match="failed to initialize"):
+        WorkerProcessManager(
+            ContextLogger(mock_underlying_logger),
+            TEST_WORKER_ID,
+            failing_defs,
+            rolling_utilization_window_ns=TEST_ROLLING_UTILIZATION_WINDOW_NS,
+        )
 
 
 # Logging
@@ -684,16 +499,16 @@ async def test_job_logger_logs_messages(
 
 @pytest.mark.asyncio
 async def test_context_create_logger_logs_messages(
-    mock_underlying_logger: MagicMock, wpm: WorkerProcessManager
+    mock_underlying_logger: MagicMock,
+    # pylint: disable=unused-argument
+    wpm: WorkerProcessManager,
 ):
     """
-    Test that logger provided to context create correctly logs messages
+    Test that logger provided to context create is invoked at worker startup
+    (the wpm fixture already constructed the worker, which created the context)
     """
-    # Arrange
-    wpm.register_job((TEST_LOGGER_CONTEXT,), 200, SumJob())
-
-    # Act
-    await asyncio.sleep(0.2 + 0.1)
+    # Arrange / Act
+    await asyncio.sleep(0.05)
 
     # Assert
     assert_logger_was_called_with(
@@ -705,18 +520,27 @@ async def test_context_create_logger_logs_messages(
 
 @pytest.mark.asyncio
 async def test_context_destroy_logger_logs_messages(
-    mock_underlying_logger: MagicMock, wpm: WorkerProcessManager
+    mock_underlying_logger: MagicMock,
+    context_defs: dict[int, JobContextInterface[Any]],
 ):
     """
-    Test that logger provided to context destroy correctly logs messages
+    Test that logger provided to context destroy is invoked at worker shutdown.
+    Build and tear down a manager manually so we can assert the destroy log
+    after shutdown completes (wait_shutdown drains any pending log records).
     """
-    # Arrange
-    job = wpm.register_job((TEST_LOGGER_CONTEXT,), 200, SumJob())
+    # Arrange - async context required because WorkerProcessManager spins up
+    # an asyncio task internally
+    # pylint: disable=duplicate-code
+    wpm = WorkerProcessManager(
+        ContextLogger(mock_underlying_logger),
+        TEST_WORKER_ID,
+        context_defs,
+        rolling_utilization_window_ns=TEST_ROLLING_UTILIZATION_WINDOW_NS,
+    )
 
     # Act
-    await asyncio.sleep(0.2 + 0.1)
-    job.deregister()
-    await asyncio.sleep(0.1)
+    wpm.send_terminate()
+    wpm.wait_shutdown()
 
     # Assert
     assert_logger_was_called_with(
@@ -748,36 +572,6 @@ async def test_reports_jobs_stats_single_slow_job(wpm: WorkerProcessManager):
     assert_instant_time(job_stats.context_initialization_time_ns)
     assert_rel_error(job_stats.execution_time_ns, slow_worker_time)
     assert_rel_error(job_stats.total_time_ns, slow_worker_time)
-
-
-@pytest.mark.timeout(3)
-@pytest.mark.asyncio
-async def test_reports_jobs_stats_single_slow_job_slow_context(
-    wpm: WorkerProcessManager,
-):
-    """
-    Test statistics are correctly reported for single slow job with slow context creation
-    """
-    # Arrange
-    slow_worker_time = NS_PER_SEC
-
-    results: list[JobSuccess[None] | JobException] = []
-    job = wpm.register_job((TEST_SLOW_CONTEXT,), 200, SlowJob(NS_PER_SEC))
-    job.on(job.JobResultEvent, results.append)
-
-    # Act
-    await asyncio.sleep(2 + 0.2 + 0.1)
-
-    # Assert
-    job_stats = results[0].stats
-    assert_instant_time(job_stats.scheduling_delay_ns)
-    assert_rel_error(
-        job_stats.context_initialization_time_ns, TEST_SLOW_CONTEXT_TIME_NS
-    )
-    assert_rel_error(job_stats.execution_time_ns, slow_worker_time)
-    assert_rel_error(
-        job_stats.total_time_ns, slow_worker_time + TEST_SLOW_CONTEXT_TIME_NS
-    )
 
 
 @pytest.mark.timeout(4)
@@ -839,20 +633,18 @@ async def test_utilization_report_single_job(wpm: WorkerProcessManager):
     """
     # Arrange
     target_utilization = 0.25
+    window_sec = TEST_ROLLING_UTILIZATION_WINDOW_NS / NS_PER_SEC
     wpm.register_job(
         (),
-        ROLLING_UTILIZATION_WINDOW_SEC * 1000,
-        SlowJob(
-            int(
-                target_utilization * ROLLING_UTILIZATION_WINDOW_SEC * NS_PER_SEC
-            )
-        ),
-    )  # Act
+        int(window_sec * 1000),
+        SlowJob(int(target_utilization * window_sec * NS_PER_SEC)),
+    )
 
-    await asyncio.sleep(ROLLING_UTILIZATION_WINDOW_SEC * 2)
+    # Act
+    await asyncio.sleep(window_sec * 2)
 
     # Assert
-    assert abs(wpm.utilization - target_utilization) < 0.15
+    assert abs(wpm.utilization - target_utilization) < 0.1
 
 
 @pytest.mark.timeout(10)
@@ -864,22 +656,18 @@ async def test_utilization_report_multiple_jobs(wpm: WorkerProcessManager):
     # Arrange
     target_utilization = 0.25
     num_jobs = 2
+    window_sec = TEST_ROLLING_UTILIZATION_WINDOW_NS / NS_PER_SEC
     for _ in range(num_jobs):
         wpm.register_job(
             (),
-            ROLLING_UTILIZATION_WINDOW_SEC * 1000,
+            int(window_sec * 1000),
             SlowJob(
-                int(
-                    target_utilization
-                    * ROLLING_UTILIZATION_WINDOW_SEC
-                    * NS_PER_SEC
-                    / num_jobs
-                )
+                int(target_utilization * window_sec * NS_PER_SEC / num_jobs)
             ),
         )
 
     # Act
-    await asyncio.sleep(ROLLING_UTILIZATION_WINDOW_SEC * 2)
+    await asyncio.sleep(window_sec * 2)
 
     # Assert
-    assert abs(wpm.utilization - target_utilization) < 0.15
+    assert abs(wpm.utilization - target_utilization) < 0.1

--- a/transcription_service/tests/unit/transcription_providers/debug_provider/debug_provider_test.py
+++ b/transcription_service/tests/unit/transcription_providers/debug_provider/debug_provider_test.py
@@ -40,7 +40,7 @@ async def debug_provider_session():
     logger = MagicMock(spec=logging.Logger)
     logger.level = 10
 
-    worker_pool = WorkerPool(ContextLogger(logger), 1, {}, 1)
+    worker_pool = WorkerPool(ContextLogger(logger), 1, [])
     provider = DebugProvider(None, MagicMock(spec=Logger), worker_pool)
     session = provider.create_session(SESSION_CONFIG, MagicMock(spec=Logger))
 

--- a/transcription_service/tests/unit/webserver/shared/transcription_service/transcription_service_test.py
+++ b/transcription_service/tests/unit/webserver/shared/transcription_service/transcription_service_test.py
@@ -16,7 +16,11 @@ from src.shared.config import (
     TranscriptionProviderUID,
 )
 from src.shared.logger import Logger
-from src.shared.utils.worker_pool import JobContextInterface, WorkerPool
+from src.shared.utils.worker_pool import (
+    ContextAssignment,
+    JobContextInterface,
+    WorkerPool,
+)
 from src.transcription_provider_interface import (
     TranscriptionClientError,
     TranscriptionProviderInterface,
@@ -24,7 +28,6 @@ from src.transcription_provider_interface import (
 from src.webserver.shared.transcription_service import TranscriptionService
 
 NUM_WORKERS = 2
-ROLLING_UTILIZATION_WINDOW_SEC = 5
 
 
 @pytest.fixture
@@ -37,38 +40,31 @@ def mock_config():
     context_configs: list[JobContextConfigSchema] = [
         JobContextConfigSchema(
             context_uid=JobContextDefinitionUID.FASTER_WHISPER,
-            max_instances=1,
+            worker_ids=[0],
             tags=["tag0", "tag1"],
-            negative_affinity=None,
             context_config="config:faster_0",
-            creation_cost=0.1,
         ),
         JobContextConfigSchema(
             context_uid=JobContextDefinitionUID.FASTER_WHISPER,
-            max_instances=2,
+            worker_ids=[0, 1],
             tags=["tag1"],
-            negative_affinity="tag0",
             context_config="config:faster_1",
-            creation_cost=0,
         ),
     ]
 
-    provider_configs: list[TranscriptionProviderConfigSchema] = [
-        TranscriptionProviderConfigSchema(
-            provider_key="debug_0",
+    provider_configs: dict[str, TranscriptionProviderConfigSchema] = {
+        "debug_0": TranscriptionProviderConfigSchema(
             provider_uid=TranscriptionProviderUID.DEBUG,
             provider_config="config:debug_0",
         ),
-        TranscriptionProviderConfigSchema(
-            provider_key="debug_1",
+        "debug_1": TranscriptionProviderConfigSchema(
             provider_uid=TranscriptionProviderUID.DEBUG,
             provider_config="config:debug_1",
         ),
-    ]
+    }
 
     mock.provider_config = ProviderConfigFileSchema(
         num_workers=NUM_WORKERS,
-        rolling_utilization_window_sec=ROLLING_UTILIZATION_WINDOW_SEC,
         contexts=context_configs,
         providers=provider_configs,
     )
@@ -141,7 +137,7 @@ def mock_worker_pool_import(
 @pytest.fixture
 def mock_provider_instances(mocker: MockerFixture):
     """
-    Patches import for worker pool
+    Mock provider instances for the two debug providers
     """
     return [
         mocker.MagicMock(spec=TranscriptionProviderInterface),
@@ -156,13 +152,11 @@ def mock_provider_import(
     """
     Patches imports for providers
     """
-    # For dynamic imports, we need to mock the module before it's imported
     mock_debug_module = mocker.MagicMock()
     mock_debug_module.DebugProvider = mocker.MagicMock(
         side_effect=[mock_provider_instances[0], mock_provider_instances[1]]
     )
 
-    # Patch sys.modules to inject our mock
     mocker.patch.dict(
         "sys.modules",
         {"src.transcription_providers.debug_provider": mock_debug_module},
@@ -193,7 +187,7 @@ def test_loads_context(
     transcription_service: TranscriptionService,
 ):
     """
-    Test that transcription service imports job context with correct config
+    Test that transcription service imports job context with correct config and tags
     """
     # Arrange / Act / Assert
     mock_context_import[
@@ -202,17 +196,11 @@ def test_loads_context(
         [
             call(
                 mock_config.provider_config.contexts[0].context_config,
-                mock_config.provider_config.contexts[0].max_instances,
                 mock_config.provider_config.contexts[0].tags,
-                mock_config.provider_config.contexts[0].negative_affinity,
-                mock_config.provider_config.contexts[0].creation_cost,
             ),
             call(
                 mock_config.provider_config.contexts[1].context_config,
-                mock_config.provider_config.contexts[1].max_instances,
                 mock_config.provider_config.contexts[1].tags,
-                mock_config.provider_config.contexts[1].negative_affinity,
-                mock_config.provider_config.contexts[1].creation_cost,
             ),
         ]
     )
@@ -220,20 +208,31 @@ def test_loads_context(
 
 # pylint: disable=unused-argument
 def test_creates_worker_pool(
+    mock_config: Config,
     mock_logger: Logger,
     mock_worker_pool_import: MagicMock,
     mock_context_instances: list[MagicMock],
     transcription_service: TranscriptionService,
 ):
     """
-    Test that transcription service creates worker pool with correct config
+    Test that transcription service creates worker pool with ContextAssignments
+    built from each config entry and its worker_ids
     """
-    # Arrange / Acts
-    context_def = {0: mock_context_instances[0], 1: mock_context_instances[1]}
+    # Arrange
+    expected_assignments = [
+        ContextAssignment(
+            context_def=mock_context_instances[0],
+            worker_ids=mock_config.provider_config.contexts[0].worker_ids,
+        ),
+        ContextAssignment(
+            context_def=mock_context_instances[1],
+            worker_ids=mock_config.provider_config.contexts[1].worker_ids,
+        ),
+    ]
 
     # Assert
     mock_worker_pool_import.assert_called_once_with(
-        mock_logger, NUM_WORKERS, context_def, ROLLING_UTILIZATION_WINDOW_SEC
+        mock_logger, NUM_WORKERS, expected_assignments
     )
 
 
@@ -252,12 +251,16 @@ def test_loads_provider(
     mock_provider_import[TranscriptionProviderUID.DEBUG].assert_has_calls(
         [
             call(
-                mock_config.provider_config.providers[0].provider_config,
+                mock_config.provider_config.providers[
+                    "debug_0"
+                ].provider_config,
                 mock_logger,
                 mock_worker_pool_instance,
             ),
             call(
-                mock_config.provider_config.providers[1].provider_config,
+                mock_config.provider_config.providers[
+                    "debug_1"
+                ].provider_config,
                 mock_logger,
                 mock_worker_pool_instance,
             ),


### PR DESCRIPTION
Update worker pool to immediately initialize context on startup. Instead of dynamically assigning context to workers, context assignment is defined in worker pool config instead. This simplifies configuration and speeds up cold starts for transcription streams.

Closes #65 