### PR TITLE
Latency Metrics (end-to-end) — re-implemented on new architecture

### DIFF
--- a/TOBEREVIEWED.md
+++ b/TOBEREVIEWED.md
@@ -18,9 +18,9 @@ wholesale:
 
 None of PR #67's ~42 files applied cleanly, and the new pipeline carried **no
 chunk-id or timestamp** to hang latency off of. The feature was therefore
-rebuilt on the new architecture rather than conflict-merged. **Action:** decide
-how to reconcile this work with the existing `latency-metrics` branch (force-update
-it to this state, or open a fresh PR from it).
+rebuilt on the new architecture rather than conflict-merged. This rebuild ships
+as **PR #124** (branch `latency-metrics-v2` → `staging`); the original **PR #67
+has been closed as superseded**.
 
 ## What the feature does now
 

--- a/TOBEREVIEWED.md
+++ b/TOBEREVIEWED.md
@@ -1,0 +1,100 @@
+# TOBEREVIEWED — Latency Metrics (re-port of PR #67)
+
+This document flags items the team should review before considering the
+end-to-end latency feature production-ready. It accompanies the re-implementation
+of PR #67 (`latency-metrics`) onto the current `staging` architecture.
+
+## Context: this was a re-implementation, not a merge
+
+PR #67 was written against an architecture `staging` has since replaced
+wholesale:
+
+- the node-server was rewritten (event-bus + orchestrator + schema-driven
+  upstream client);
+- the bespoke `transcription-service-client` lib was **deleted** in favour of
+  `@scribear/base-websocket-client` + shared schema packages;
+- `apps/webapp` was **split** into `apps/client-webapp` + `apps/kiosk-webapp`;
+- the Python worker-pool / provider registry was refactored.
+
+None of PR #67's ~42 files applied cleanly, and the new pipeline carried **no
+chunk-id or timestamp** to hang latency off of. The feature was therefore
+rebuilt on the new architecture rather than conflict-merged. **Action:** decide
+how to reconcile this work with the existing `latency-metrics` branch (force-update
+it to this state, or open a fresh PR from it).
+
+## What the feature does now
+
+- **Kiosk** frames each audio chunk in a versioned, self-describing binary
+  envelope (`@scribear/audio-frame-protocol`, "SAFP" v1: magic + version + TLV
+  fields + CRC-32) carrying a `chunkId` and, once the clock is synced, a
+  clock-corrected `sentAt`.
+- **Node server** decodes the frame, keeps a per-session `chunkId → {recvMono, sentAt}`
+  map, forwards audio upstream, and on each transcript correlates the echoed
+  `chunk_ids` to emit two latency numbers:
+  - `pipelineMs` — measured entirely on the node's **monotonic** clock (skew-free);
+  - `e2eMs` — includes capture + uplink, using the source's clock-corrected
+    `sentAt`; `null` until a clock offset is available.
+- **Clock sync** uses Cristian's algorithm over the source WebSocket
+  (`timeSyncPing`/`timeSyncPong`), keeping the lowest-RTT sample from a sliding
+  window.
+- **Client webapp** renders a 60-sample moving average of both metrics
+  (final / interim).
+
+## Deliberately NOT ported (flagged, low risk to omit)
+
+1. **VAD / silence-threshold tuning in `provider_config`.** PR #67 exposed
+   `vad_detector`, `vad_threshold`, `vad_neg_threshold`, `silence_threshold`
+   in the whisper provider config template. `staging` independently rewrote the
+   provider-config format and the worker pool; those knobs already exist as
+   fields on `WhisperStreamingProviderConfig` (with defaults) but are not
+   surfaced in `provider_config.template.json`. Re-adding them was skipped to
+   avoid regressing `staging`'s VAD/worker-pool rework. **Review:** if runtime
+   VAD tuning is wanted, add the keys to the template and validate against the
+   current schema — this is orthogonal to latency.
+
+2. **Python internal stage-timing diagnostics (`LatencyTracker` / `processing_stats`).**
+   PR #67 added per-batch VAD/ASR stage timers that were **never forwarded to
+   clients** (dev-only). Omitted: they add hot-path work in the whisper job for
+   no user-facing value. **Review:** if backend perf diagnostics are wanted,
+   prefer structured logging/metrics over a payload field.
+
+## Production concerns to review
+
+3. **Clock skew is the main correctness risk for `e2eMs`.** The node-domain
+   `pipelineMs` is the trustworthy number and should be what any alerting keys
+   on. `e2eMs` depends on Cristian's offset, which is biased by **asymmetric**
+   up/down network latency by roughly `(up − down) / 2`. Mitigations in place:
+   min-RTT sample selection, a monotonic-anchored `sentAt` on the kiosk,
+   discarding negative `e2eMs`, and reporting `null` until synced. **Review:**
+   treat `e2eMs` as indicative, not authoritative.
+
+4. **Observability of dropped frames.** A frame that fails CRC/version/magic is
+   dropped with a `warn` log on both the node and Python sides. A systematic
+   framing/version mismatch would **silently stop audio** with only warn logs.
+   **Recommend:** add a metric/alert on the decode-drop rate (node
+   `dropping malformed audio frame`, Python `Dropping malformed audio frame`).
+
+5. **`timeSyncPing` is answered before auth and is not rate-limited.** A
+   connected-but-unauthenticated peer can elicit `timeSyncPong` replies. It only
+   leaks the server wall clock and is cheap, but it is an unauthenticated
+   request surface. **Review:** consider gating on auth and/or a simple rate
+   limit if this matters for the threat model.
+
+6. **`pendingChunks` bound.** Capped at `MAX_PENDING_CHUNKS = 2000` per session,
+   pruned on final transcripts; the oldest entry is evicted when full. At the
+   kiosk's ~10 frames/s that is ~200 s of un-finalized backlog. **Review:**
+   confirm the cap suits the real frame cadence and finalization interval.
+
+7. **Per-frame CRC-32 cost.** CRC is computed at encode (kiosk) and decode
+   (node + Python). Negligible at current size/rate (~3 KB, ~10/s) and it is
+   defense-in-depth on top of TCP/WS integrity. **Review:** if frame size/rate
+   grows a lot, profile — or make CRC optional via a future SAFP flag.
+
+8. **`chunkId` wire size.** Currently a 36-byte UUID string per frame. The
+   versioned protocol makes shrinking it (16-byte raw UUID, or a per-connection
+   counter) a **non-breaking** change if uplink bandwidth ever matters.
+   Low priority.
+
+9. **Latency fan-out.** `latencyUpdate` is broadcast to every subscriber of a
+   session (same fan-out as transcripts). No new scaling concern, but note that
+   large rooms multiply these small messages.

--- a/apps/client-webapp/src/app/root.tsx
+++ b/apps/client-webapp/src/app/root.tsx
@@ -41,6 +41,7 @@ import {
 } from '@scribear/transcription-display-ui';
 
 import { JoinSessionModal } from '#src/features/session-provider/components/join-session-modal';
+import { LatencyBadge } from '#src/features/session-provider/components/latency-badge';
 import { useAppDispatch, useAppSelector } from '#src/store/use-redux';
 
 /**
@@ -138,6 +139,7 @@ export const Root = () => {
       headerBreakpoint="md"
     >
       <JoinSessionModal />
+      <LatencyBadge />
       <TranscriptionDisplayContainer
         commitedSections={commitedSections}
         activeSection={activeSection}

--- a/apps/client-webapp/src/features/session-provider/components/latency-badge.tsx
+++ b/apps/client-webapp/src/features/session-provider/components/latency-badge.tsx
@@ -1,0 +1,65 @@
+import { Box, Typography } from '@mui/material';
+
+import {
+  selectFinalE2eLatencyMs,
+  selectFinalPipelineLatencyMs,
+  selectInProgressE2eLatencyMs,
+  selectInProgressPipelineLatencyMs,
+} from '@scribear/transcription-content-store';
+
+import { useAppSelector } from '#src/store/use-redux';
+
+/**
+ * Render a latency value in whole milliseconds, or an em dash when there is no
+ * usable measurement yet (0 or non-finite).
+ */
+function formatLatency(valueMs: number): string {
+  if (!Number.isFinite(valueMs) || valueMs <= 0) return '—';
+  return Math.round(valueMs).toString();
+}
+
+/**
+ * Small unobtrusive overlay showing the moving-average transcription latency.
+ * Two figures per row: finalized / interim transcripts.
+ *
+ * - "Pipeline" is the skew-free server-side latency (audio ingress to
+ *   transcript) and appears as soon as transcripts flow.
+ * - "End-to-end" additionally includes capture and uplink; it appears once the
+ *   source device's clock has been synced, and shows an em dash until then.
+ */
+export const LatencyBadge = () => {
+  const pipelineFinal = useAppSelector(selectFinalPipelineLatencyMs);
+  const pipelineInterim = useAppSelector(selectInProgressPipelineLatencyMs);
+  const e2eFinal = useAppSelector(selectFinalE2eLatencyMs);
+  const e2eInterim = useAppSelector(selectInProgressE2eLatencyMs);
+
+  // Nothing measured yet - stay out of the way entirely.
+  if (pipelineFinal <= 0 && pipelineInterim <= 0) return null;
+
+  return (
+    <Box
+      sx={{
+        position: 'fixed',
+        top: 8,
+        right: 8,
+        px: 1,
+        py: 0.5,
+        borderRadius: 1,
+        bgcolor: 'rgba(0, 0, 0, 0.6)',
+        color: 'common.white',
+        pointerEvents: 'none',
+        zIndex: (theme) => theme.zIndex.tooltip,
+        fontVariantNumeric: 'tabular-nums',
+      }}
+      aria-label="Transcription latency (final / interim)"
+    >
+      <Typography variant="caption" component="div">
+        Pipeline: {formatLatency(pipelineFinal)} /{' '}
+        {formatLatency(pipelineInterim)} ms
+      </Typography>
+      <Typography variant="caption" component="div">
+        End-to-end: {formatLatency(e2eFinal)} / {formatLatency(e2eInterim)} ms
+      </Typography>
+    </Box>
+  );
+};

--- a/apps/client-webapp/src/features/session-provider/services/client-session-service.ts
+++ b/apps/client-webapp/src/features/session-provider/services/client-session-service.ts
@@ -7,12 +7,16 @@ import {
 } from '@scribear/base-websocket-client';
 import { createNodeServerClient } from '@scribear/node-server-client';
 import {
+  LatencyKind,
   type TRANSCRIPTION_STREAM_SCHEMA,
   TranscriptionStreamClientMessageType,
   TranscriptionStreamServerMessageType,
 } from '@scribear/node-server-schema';
 import { createSessionManagerClient } from '@scribear/session-manager-client';
-import type { TranscriptionSequenceInput } from '@scribear/transcription-content-store';
+import type {
+  LatencySample,
+  TranscriptionSequenceInput,
+} from '@scribear/transcription-content-store';
 
 import {
   ClientLifecycle,
@@ -60,6 +64,7 @@ interface ClientSessionServiceEvents {
   connectionStatus: (status: SessionConnectionStatus) => void;
   sessionStatus: (status: SessionStatusSnapshot) => void;
   transcript: (event: TranscriptEvent) => void;
+  latency: (sample: LatencySample) => void;
   joinError: (error: JoinError | null) => void;
   error: (message: string | null) => void;
 }
@@ -288,6 +293,16 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
         case TranscriptionStreamServerMessageType.SESSION_ENDED:
           // The server will close the socket immediately after; the close
           // handler drives the transition to IDLE.
+          break;
+        case TranscriptionStreamServerMessageType.LATENCY_UPDATE:
+          this.emit('latency', {
+            kind: msg.kind === LatencyKind.FINAL ? 'final' : 'inProgress',
+            pipelineMs: msg.pipelineMs,
+            e2eMs: msg.e2eMs,
+          });
+          break;
+        case TranscriptionStreamServerMessageType.TIME_SYNC_PONG:
+          // The client does not run clock sync (it never sends audio); ignore.
           break;
       }
     });

--- a/apps/client-webapp/src/features/session-provider/stores/client-session-service-middleware.ts
+++ b/apps/client-webapp/src/features/session-provider/stores/client-session-service-middleware.ts
@@ -4,6 +4,7 @@ import { rememberRehydrated } from '@scribear/redux-remember-store';
 import {
   clearTranscription,
   handleTranscript,
+  recordLatency,
 } from '@scribear/transcription-content-store';
 
 import type { RootState } from '#src/store/store';
@@ -75,6 +76,9 @@ export const createClientSessionServiceMiddleware =
     });
     service.on('transcript', (event) => {
       store.dispatch(handleTranscript(event));
+    });
+    service.on('latency', (sample) => {
+      store.dispatch(recordLatency(sample));
     });
     service.on('joinError', (joinError) => {
       store.dispatch(setJoinError(joinError));

--- a/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'eventemitter3';
 
+import { ClockSync, encodeAudioFrame } from '@scribear/audio-frame-protocol';
 import {
   NetworkError,
   UnexpectedResponseError,
@@ -131,6 +132,14 @@ const AUDIO_CHUNK_MS = 100;
 const INIT_RETRY_DELAY_MS = 5_000;
 
 /**
+ * How often the source re-probes the node server's clock (Cristian's
+ * algorithm) to keep the latency `sentAt` correction fresh against drift. The
+ * first probe is sent immediately on connect so an estimate is available
+ * within one round trip.
+ */
+const TIME_SYNC_INTERVAL_MS = 15_000;
+
+/**
  * Cadence for re-fetching `getMyDevice`. Long because device-level changes
  * (rename, room reassignment, source flag flip) are infrequent operator
  * actions. The schedule long-poll already covers per-session changes; this
@@ -232,6 +241,8 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
   private _sessionToken: string | null = null;
   private _tokenRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   private _joinCodeRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private _clockSync = new ClockSync();
+  private _timeSyncTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(microphoneService: MicrophoneService) {
     super();
@@ -682,7 +693,10 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
       });
       this._scheduleTokenRefresh(sessionToken, session.uid);
 
-      if (isSource) void this._beginAudioCapture(socket);
+      if (isSource) {
+        this._startTimeSync(socket);
+        void this._beginAudioCapture(socket);
+      }
     });
 
     socket.on('message', (msg) => {
@@ -706,6 +720,14 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
         case TranscriptionStreamServerMessageType.SESSION_ENDED:
           // The server will close the socket immediately after; the close
           // handler below will drive the transition to IDLE.
+          break;
+        case TranscriptionStreamServerMessageType.TIME_SYNC_PONG:
+          // Complete a clock-sync probe: t0 echoed from our ping, t1 the
+          // server's clock, and now our receive time.
+          this._clockSync.record(msg.t0, msg.t1, Date.now());
+          break;
+        case TranscriptionStreamServerMessageType.LATENCY_UPDATE:
+          // The source device does not display latency; ignore.
           break;
       }
     });
@@ -732,6 +754,25 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
     socket.start();
   }
 
+  /**
+   * Periodically probe the node server's clock so `sentAt` on audio frames can
+   * be corrected into the server's clock domain (see {@link _clockSync}). The
+   * first probe fires immediately; subsequent ones on an interval.
+   */
+  private _startTimeSync(
+    socket: WebSocketClient<typeof TRANSCRIPTION_STREAM_SCHEMA>,
+  ): void {
+    const sendPing = () => {
+      if (this._socket !== socket) return;
+      socket.send({
+        type: TranscriptionStreamClientMessageType.TIME_SYNC_PING,
+        t0: Date.now(),
+      });
+    };
+    sendPing();
+    this._timeSyncTimer = setInterval(sendPing, TIME_SYNC_INTERVAL_MS);
+  }
+
   private async _beginAudioCapture(
     socket: WebSocketClient<typeof TRANSCRIPTION_STREAM_SCHEMA>,
   ): Promise<void> {
@@ -742,7 +783,15 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
       (buffer) => {
         if (this._socket !== socket) return;
         if (this._muted) return;
-        socket.sendBinary(buffer);
+        // Frame each chunk with a correlation id and, once the clock offset is
+        // known, a server-domain send time so the node server can measure
+        // end-to-end latency. Until the first clock-sync probe completes we
+        // omit `sentAt` (the node still reports skew-free pipeline latency).
+        const chunkId = crypto.randomUUID();
+        const sentAt = this._clockSync.toRemote(Date.now());
+        const fields = sentAt !== null ? { chunkId, sentAt } : { chunkId };
+        const frame = encodeAudioFrame(fields, new Uint8Array(buffer));
+        socket.sendBinary(frame.buffer as ArrayBuffer);
       },
     );
     if (this._socket !== socket) {
@@ -850,6 +899,11 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
       clearTimeout(this._joinCodeRefreshTimer);
       this._joinCodeRefreshTimer = null;
     }
+    if (this._timeSyncTimer !== null) {
+      clearInterval(this._timeSyncTimer);
+      this._timeSyncTimer = null;
+    }
+    this._clockSync.reset();
     if (this._audioStream !== null) {
       this._microphoneService.closeAudioStream(this._audioStream);
       this._audioStream = null;

--- a/apps/kiosk-webapp/tsconfig.json
+++ b/apps/kiosk-webapp/tsconfig.json
@@ -26,6 +26,9 @@
   ],
   "references": [
     {
+      "path": "../../libs/audio-frame-protocol"
+    },
+    {
       "path": "../../libs/clients/transcription-service-client"
     },
     {

--- a/apps/node-server/src/server/features/transcription-stream/events/latency.events.ts
+++ b/apps/node-server/src/server/features/transcription-stream/events/latency.events.ts
@@ -1,0 +1,38 @@
+import { type Static, Type } from 'typebox';
+
+import { LatencyKind } from '@scribear/node-server-schema';
+
+import type { ChannelDefinition } from '#src/server/shared/services/event-bus.service.js';
+
+/**
+ * Latency sample delivered to subscribers of {@link LatencyChannel}. Mirrors
+ * the body of the `latencyUpdate` server message in
+ * `@scribear/node-server-schema` so per-connection services can fan it out to
+ * clients without further translation.
+ *
+ * `pipelineMs` is measured entirely on the node's monotonic clock (audio
+ * ingress -> transcript received) and is therefore immune to client/server
+ * clock skew. `e2eMs` additionally includes the capture and uplink legs using
+ * the source's clock corrected via time-sync, and is null when no reliable
+ * offset is available.
+ */
+export const LATENCY_MESSAGE_SCHEMA = Type.Object({
+  kind: Type.Enum(LatencyKind),
+  pipelineMs: Type.Number(),
+  e2eMs: Type.Union([Type.Number(), Type.Null()]),
+});
+export type LatencyMessage = Static<typeof LATENCY_MESSAGE_SCHEMA>;
+
+/**
+ * Bus channel keyed by sessionUid. The orchestrator publishes a sample each
+ * time it correlates a transcript back to the audio frame that produced it;
+ * per-connection services subscribe once authenticated and forward to their
+ * socket.
+ */
+export const LatencyChannel: ChannelDefinition<
+  typeof LATENCY_MESSAGE_SCHEMA,
+  [string]
+> = {
+  schema: LATENCY_MESSAGE_SCHEMA,
+  key: (sessionUid) => `latency:${sessionUid}`,
+};

--- a/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
@@ -1,5 +1,10 @@
+import {
+  AudioFrameError,
+  decodeAudioFrame,
+} from '@scribear/audio-frame-protocol';
 import type { LongPollClient } from '@scribear/base-long-poll-client';
 import type { WebSocketClient } from '@scribear/base-websocket-client';
+import { LatencyKind } from '@scribear/node-server-schema';
 import {
   type SESSION_CONFIG_STREAM_SCHEMA,
   type Session,
@@ -12,12 +17,32 @@ import {
 import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
 
 import { AudioFrameChannel } from './events/audio-frame.events.js';
+import { LatencyChannel } from './events/latency.events.js';
 import { SessionEndedChannel } from './events/session-ended.events.js';
 import {
   SessionStatusChannel,
   type SessionStatusMessage,
 } from './events/session-status.events.js';
 import { TranscriptChannel } from './events/transcript.events.js';
+
+/**
+ * Upper bound on the per-session map of audio frames still awaiting a matching
+ * transcript. Chunks that never yield a transcript (e.g. pure silence) would
+ * otherwise accumulate forever; when the cap is hit the oldest entry is
+ * dropped. Sized generously - at ~10 frames/sec this is minutes of backlog.
+ */
+const MAX_PENDING_CHUNKS = 2000;
+
+/**
+ * A source audio frame awaiting correlation with a transcript.
+ * `recvMono` is a monotonic-clock reading (skew-free) used for the pipeline
+ * latency; `sentAt` is the source's clock-corrected send time (or null) used
+ * for the end-to-end latency.
+ */
+interface PendingChunk {
+  recvMono: number;
+  sentAt: number | null;
+}
 
 type UpstreamClient = WebSocketClient<typeof TRANSCRIPTION_STREAM_SCHEMA>;
 type SessionConfigPoll = LongPollClient<typeof SESSION_CONFIG_STREAM_SCHEMA>;
@@ -45,6 +70,13 @@ interface SessionState {
    * connections without recomputing from sub-objects.
    */
   status: SessionStatusMessage;
+  /**
+   * Audio frames sent upstream but not yet correlated to a transcript, keyed
+   * by chunkId in insertion order. Populated as source frames pass through,
+   * consumed when the upstream echoes matching `chunk_ids` back, and bounded
+   * by {@link MAX_PENDING_CHUNKS}.
+   */
+  pendingChunks: Map<string, PendingChunk>;
   /**
    * Scheduled timer that publishes `SessionEndedChannel` at the session's
    * `effectiveEnd`. Re-armed on every config update so extensions/contractions
@@ -170,6 +202,71 @@ export class TranscriptionOrchestratorService {
     this._eventBus.publish(SessionStatusChannel, next, sessionUid);
   }
 
+  /**
+   * Record an audio frame awaiting correlation, evicting the oldest entry
+   * first if the per-session cap is reached.
+   */
+  private _recordPending(
+    state: SessionState,
+    chunkId: string,
+    sentAt: number | null,
+    recvMono: number,
+  ): void {
+    if (state.pendingChunks.size >= MAX_PENDING_CHUNKS) {
+      const oldest = state.pendingChunks.keys().next().value;
+      if (oldest !== undefined) state.pendingChunks.delete(oldest);
+    }
+    state.pendingChunks.set(chunkId, { recvMono, sentAt });
+  }
+
+  /**
+   * Correlate a transcript back to the earliest audio frame that produced it
+   * and publish a latency sample. `pipelineMs` uses the monotonic clock and is
+   * always emitted; `e2eMs` uses the source's clock-corrected `sentAt` and is
+   * null when unavailable or implausible (negative, i.e. clock still skewed).
+   *
+   * On a `final` transcript the matched frame and everything older are
+   * finalized, so they are pruned; interim (`inProgress`) samples leave the
+   * map intact because those frames are still in the provider's buffer.
+   */
+  private _emitLatency(
+    sessionUid: string,
+    state: SessionState,
+    kind: LatencyKind,
+    chunkIds: string[] | null | undefined,
+  ): void {
+    if (chunkIds === null || chunkIds === undefined || chunkIds.length === 0) {
+      return;
+    }
+    const id = chunkIds[0];
+    if (id === undefined) return;
+    const entry = state.pendingChunks.get(id);
+    if (entry === undefined) return;
+
+    const pipelineMs = performance.now() - entry.recvMono;
+    let e2eMs: number | null = null;
+    if (entry.sentAt !== null) {
+      const candidate = Date.now() - entry.sentAt;
+      // A negative end-to-end time means the source clock is still ahead of
+      // ours despite sync; report null rather than a nonsensical number.
+      e2eMs = candidate >= 0 ? candidate : null;
+    }
+
+    this._eventBus.publish(
+      LatencyChannel,
+      { kind, pipelineMs, e2eMs },
+      sessionUid,
+    );
+
+    if (kind === LatencyKind.FINAL) {
+      for (const [chunkId, pending] of state.pendingChunks) {
+        if (pending.recvMono <= entry.recvMono) {
+          state.pendingChunks.delete(chunkId);
+        }
+      }
+    }
+  }
+
   private async _openSession(sessionUid: string): Promise<SessionState> {
     const longPoll = this._sessionConfigPollFactory(sessionUid);
     const initial = await this._awaitFirstConfig(longPoll, sessionUid);
@@ -189,6 +286,7 @@ export class TranscriptionOrchestratorService {
         transcriptionServiceConnected: false,
         sourceDeviceConnected: false,
       },
+      pendingChunks: new Map<string, PendingChunk>(),
       endTimer: null,
       endTimerArmedFor: null,
       ended: false,
@@ -199,6 +297,18 @@ export class TranscriptionOrchestratorService {
         TranscriptChannel,
         { final: msg.final, inProgress: msg.in_progress },
         sessionUid,
+      );
+      this._emitLatency(
+        sessionUid,
+        state,
+        LatencyKind.FINAL,
+        msg.final_chunk_ids,
+      );
+      this._emitLatency(
+        sessionUid,
+        state,
+        LatencyKind.IN_PROGRESS,
+        msg.in_progress_chunk_ids,
       );
     });
     upstream.on('error', (err) => {
@@ -227,6 +337,31 @@ export class TranscriptionOrchestratorService {
     state.audioUnsubscribe = this._eventBus.subscribe(
       AudioFrameChannel,
       (frame) => {
+        // Stamp ingress on the monotonic clock before any work, so the
+        // pipeline latency excludes our own decode cost.
+        const recvMono = performance.now();
+        try {
+          const decoded = decodeAudioFrame(frame);
+          if (decoded.chunkId !== null) {
+            this._recordPending(
+              state,
+              decoded.chunkId,
+              decoded.sentAt,
+              recvMono,
+            );
+          }
+        } catch (err) {
+          if (err instanceof AudioFrameError) {
+            this._logger.warn(
+              { err: err.message, sessionUid },
+              'dropping malformed audio frame',
+            );
+            return;
+          }
+          throw err;
+        }
+        // Forward the original SAFP frame unchanged; the transcription service
+        // decodes the same envelope to recover the chunkId it echoes back.
         upstream.sendBinary(frame);
       },
       sessionUid,

--- a/apps/node-server/src/server/features/transcription-stream/transcription-stream.controller.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-stream.controller.ts
@@ -4,6 +4,7 @@ import type WebSocket from 'ws';
 
 import {
   TRANSCRIPTION_STREAM_SCHEMA,
+  TranscriptionStreamClientMessageType,
   TranscriptionStreamServerMessageType,
 } from '@scribear/node-server-schema';
 
@@ -213,10 +214,22 @@ export class TranscriptionStreamController {
         return;
       }
 
-      // The schema currently has a single `auth` client-message variant, so
-      // we dispatch directly. When new variants are added, switch on
-      // `parsed.type` and route accordingly.
-      void handleAuth(parsed.sessionToken);
+      switch (parsed.type) {
+        case TranscriptionStreamClientMessageType.AUTH:
+          void handleAuth(parsed.sessionToken);
+          break;
+        case TranscriptionStreamClientMessageType.TIME_SYNC_PING:
+          // Reply immediately with our clock so the source can estimate the
+          // offset (Cristian's algorithm). Deliberately not gated on auth: it
+          // exposes only the server's wall clock and lets the source begin
+          // syncing as early as possible. `t1` is read as late as possible.
+          safeSend({
+            type: TranscriptionStreamServerMessageType.TIME_SYNC_PONG,
+            t0: parsed.t0,
+            t1: Date.now(),
+          });
+          break;
+      }
     });
   }
 }

--- a/apps/node-server/src/server/features/transcription-stream/transcription-stream.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-stream.service.ts
@@ -9,6 +9,7 @@ import {
 import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
 
 import { AudioFrameChannel } from './events/audio-frame.events.js';
+import { LatencyChannel } from './events/latency.events.js';
 import { SessionEndedChannel } from './events/session-ended.events.js';
 import { SessionStatusChannel } from './events/session-status.events.js';
 import { TranscriptChannel } from './events/transcript.events.js';
@@ -49,6 +50,7 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
   private _transcriptionOrchestratorService: AppDependencies['transcriptionOrchestratorService'];
 
   private _unsubscribeTranscripts: (() => void) | null = null;
+  private _unsubscribeLatency: (() => void) | null = null;
   private _unsubscribeSessionStatus: (() => void) | null = null;
   private _unsubscribeSessionEnded: (() => void) | null = null;
   private _orchestratorUnregister: (() => void) | null = null;
@@ -97,6 +99,20 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
           type: TranscriptionStreamServerMessageType.TRANSCRIPT,
           final: transcript.final,
           inProgress: transcript.inProgress,
+        });
+      },
+      this._sessionUid,
+    );
+
+    this._unsubscribeLatency = this._eventBusService.subscribe(
+      LatencyChannel,
+      (latency) => {
+        if (this._closed) return;
+        this.emit('send', {
+          type: TranscriptionStreamServerMessageType.LATENCY_UPDATE,
+          kind: latency.kind,
+          pipelineMs: latency.pipelineMs,
+          e2eMs: latency.e2eMs,
         });
       },
       this._sessionUid,
@@ -172,6 +188,8 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
     this._closed = true;
     this._unsubscribeTranscripts?.();
     this._unsubscribeTranscripts = null;
+    this._unsubscribeLatency?.();
+    this._unsubscribeLatency = null;
     this._unsubscribeSessionStatus?.();
     this._unsubscribeSessionStatus = null;
     this._unsubscribeSessionEnded?.();

--- a/apps/node-server/tests/integration/features/transcription-stream/transcription-stream.routes.test.ts
+++ b/apps/node-server/tests/integration/features/transcription-stream/transcription-stream.routes.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { beforeAll, describe, expect, inject, vi } from 'vitest';
 import type WebSocket from 'ws';
 
+import { encodeAudioFrame } from '@scribear/audio-frame-protocol';
 import {
   TranscriptionStreamClientMessageType,
   TranscriptionStreamServerMessageType,
@@ -247,8 +248,7 @@ describe('Transcription Stream Routes', () => {
           type: TranscriptionStreamServerMessageType.AUTH_OK,
         });
         const status = messages.find(
-          (m) =>
-            m.type === TranscriptionStreamServerMessageType.SESSION_STATUS,
+          (m) => m.type === TranscriptionStreamServerMessageType.SESSION_STATUS,
         );
         expect(status).toBeDefined();
         expect(status).toMatchObject({
@@ -256,6 +256,44 @@ describe('Transcription Stream Routes', () => {
           sourceDeviceConnected: expect.any(Boolean),
           transcriptionServiceConnected: expect.any(Boolean),
         });
+
+        stop();
+        ws.terminate();
+      },
+    );
+
+    it(
+      'answers a timeSyncPing with a timeSyncPong echoing t0',
+      { timeout: 30_000 },
+      async () => {
+        // Arrange
+        const ws = await server.fastify.injectWS(sourcePath(realSessionUid));
+        const { messages, stop } = collectMessages(ws);
+
+        // Act - a clock-sync probe does not require auth
+        const t0 = 1_234_567;
+        ws.send(
+          JSON.stringify({
+            type: TranscriptionStreamClientMessageType.TIME_SYNC_PING,
+            t0,
+          }),
+        );
+
+        // Assert
+        await vi.waitFor(
+          () => {
+            const pong = messages.find(
+              (m) =>
+                m.type === TranscriptionStreamServerMessageType.TIME_SYNC_PONG,
+            );
+            expect(pong).toMatchObject({
+              type: TranscriptionStreamServerMessageType.TIME_SYNC_PONG,
+              t0,
+              t1: expect.any(Number),
+            });
+          },
+          { timeout: 10_000 },
+        );
 
         stop();
         ws.terminate();
@@ -309,8 +347,13 @@ describe('Transcription Stream Routes', () => {
           { timeout: 30_000 },
         );
 
-        // Act - send a real WAV file the AudioDecoder can parse.
-        ws.send(TEST_AUDIO);
+        // Act - send a real WAV file the AudioDecoder can parse, wrapped in a
+        // SAFP frame exactly as the kiosk (via the node server) would.
+        ws.send(
+          Buffer.from(
+            encodeAudioFrame({ chunkId: crypto.randomUUID() }, TEST_AUDIO),
+          ),
+        );
 
         // Wait specifically for the debug provider's audio-decode result
         // ("Processed N seconds") rather than just the start_session echo, so
@@ -332,7 +375,15 @@ describe('Transcription Stream Routes', () => {
                 return [...(final?.text ?? []), ...(inProgress?.text ?? [])];
               })
               .join(' ');
-            expect(allText).toMatch(/Processed [\d.]+ seconds of audio/);
+            // Require a *non-zero* processed duration: the debug provider emits
+            // "Processed 0.0000 seconds" on its periodic tick even with no
+            // audio, so only a positive value proves the SAFP-framed audio
+            // actually round-tripped through the upstream.
+            const processed = allText.match(
+              /Processed ([\d.]+) seconds of audio/,
+            );
+            expect(processed).not.toBeNull();
+            expect(Number(processed?.[1] ?? 0)).toBeGreaterThan(0);
             expect(allText).toContain(
               `sample rate: ${String(DEBUG_SAMPLE_RATE)}`,
             );
@@ -427,8 +478,7 @@ describe('Transcription Stream Routes', () => {
         await vi.waitFor(
           () => {
             const transcripts = client.messages.filter(
-              (m) =>
-                m.type === TranscriptionStreamServerMessageType.TRANSCRIPT,
+              (m) => m.type === TranscriptionStreamServerMessageType.TRANSCRIPT,
             );
             expect(transcripts.length).toBeGreaterThan(0);
           },

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
@@ -1,9 +1,15 @@
 import { EventEmitter } from 'eventemitter3';
 import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 
+import { encodeAudioFrame } from '@scribear/audio-frame-protocol';
+import { LatencyKind } from '@scribear/node-server-schema';
 import type { Session } from '@scribear/session-manager-schema';
 
 import { AudioFrameChannel } from '#src/server/features/transcription-stream/events/audio-frame.events.js';
+import {
+  LatencyChannel,
+  type LatencyMessage,
+} from '#src/server/features/transcription-stream/events/latency.events.js';
 import { SessionStatusChannel } from '#src/server/features/transcription-stream/events/session-status.events.js';
 import { TranscriptChannel } from '#src/server/features/transcription-stream/events/transcript.events.js';
 import {
@@ -257,13 +263,15 @@ describe('TranscriptionOrchestratorService', () => {
   });
 
   describe('audio bus → upstream', (it) => {
-    it('forwards binary frames published to AudioFrameChannel into the upstream', async () => {
+    it('forwards SAFP frames published to AudioFrameChannel into the upstream', async () => {
       // Arrange
       const promise = h.orchestrator.registerSource(SESSION_UID);
       h.longPoll.emit('data', fakeSession());
       await promise;
 
-      const frame = Buffer.from([1, 2, 3]);
+      const frame = Buffer.from(
+        encodeAudioFrame({ chunkId: 'c1' }, new Uint8Array([1, 2, 3])),
+      );
 
       // Act
       h.bus.publish(AudioFrameChannel, frame, SESSION_UID);
@@ -271,6 +279,69 @@ describe('TranscriptionOrchestratorService', () => {
       // Assert
       expect(h.upstream.sendBinary).toHaveBeenCalledTimes(1);
       expect(h.upstream.sendBinary).toHaveBeenCalledWith(frame);
+    });
+
+    it('drops a malformed (non-SAFP) frame instead of forwarding it', async () => {
+      // Arrange
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit('data', fakeSession());
+      await promise;
+
+      // Act - raw bytes with no SAFP envelope
+      h.bus.publish(AudioFrameChannel, Buffer.from([1, 2, 3]), SESSION_UID);
+
+      // Assert
+      expect(h.upstream.sendBinary).not.toHaveBeenCalled();
+    });
+
+    it('correlates an echoed chunk id into a latency sample', async () => {
+      // Arrange
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit('data', fakeSession());
+      await promise;
+
+      const samples: LatencyMessage[] = [];
+      h.bus.subscribe(LatencyChannel, (m) => samples.push(m), SESSION_UID);
+
+      const chunkId = 'chunk-xyz';
+      const sentAt = Date.now() - 5;
+      const frame = Buffer.from(
+        encodeAudioFrame({ chunkId, sentAt }, new Uint8Array([1, 2, 3])),
+      );
+
+      // Act - audio in, then a transcript that references the same chunk
+      h.bus.publish(AudioFrameChannel, frame, SESSION_UID);
+      h.upstream.emit('message', {
+        final: { text: ['hi'], starts: null, ends: null },
+        in_progress: null,
+        final_chunk_ids: [chunkId],
+      });
+
+      // Assert
+      expect(samples).toHaveLength(1);
+      expect(samples[0]?.kind).toBe(LatencyKind.FINAL);
+      expect(typeof samples[0]?.pipelineMs).toBe('number');
+      expect(samples[0]?.e2eMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('emits no latency sample for a transcript with no matching chunk id', async () => {
+      // Arrange
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit('data', fakeSession());
+      await promise;
+
+      const samples: LatencyMessage[] = [];
+      h.bus.subscribe(LatencyChannel, (m) => samples.push(m), SESSION_UID);
+
+      // Act - a transcript referencing a chunk the orchestrator never saw
+      h.upstream.emit('message', {
+        final: { text: ['hi'], starts: null, ends: null },
+        in_progress: null,
+        final_chunk_ids: ['never-seen'],
+      });
+
+      // Assert
+      expect(samples).toHaveLength(0);
     });
 
     it('does not forward audio frames published for a different session', async () => {

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.service.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 
+import { LatencyKind } from '@scribear/node-server-schema';
+
 import { AudioFrameChannel } from '#src/server/features/transcription-stream/events/audio-frame.events.js';
+import { LatencyChannel } from '#src/server/features/transcription-stream/events/latency.events.js';
 import { SessionEndedChannel } from '#src/server/features/transcription-stream/events/session-ended.events.js';
 import { SessionStatusChannel } from '#src/server/features/transcription-stream/events/session-status.events.js';
 import { TranscriptChannel } from '#src/server/features/transcription-stream/events/transcript.events.js';
@@ -68,7 +71,15 @@ function makeHarness(
     closes.push({ code, reason });
   });
 
-  return { service, bus, registerSource, unregisterSource, getStatus, sent, closes };
+  return {
+    service,
+    bus,
+    registerSource,
+    unregisterSource,
+    getStatus,
+    sent,
+    closes,
+  };
 }
 
 beforeEach(() => {
@@ -265,6 +276,27 @@ describe('TranscriptionStreamService', () => {
         type: 'transcript',
         final: { text: ['hello'], starts: null, ends: null },
         inProgress: null,
+      });
+    });
+
+    it('emits a latencyUpdate send message when the bus publishes latency', async () => {
+      // Arrange
+      const h = makeHarness('client');
+      await h.service.start();
+
+      // Act
+      h.bus.publish(
+        LatencyChannel,
+        { kind: LatencyKind.FINAL, pipelineMs: 42, e2eMs: 100 },
+        SESSION_UID,
+      );
+
+      // Assert
+      expect(h.sent).toContainEqual({
+        type: 'latencyUpdate',
+        kind: LatencyKind.FINAL,
+        pipelineMs: 42,
+        e2eMs: 100,
       });
     });
 

--- a/apps/node-server/tsconfig.json
+++ b/apps/node-server/tsconfig.json
@@ -18,6 +18,9 @@
   ],
   "references": [
     {
+      "path": "../../libs/audio-frame-protocol"
+    },
+    {
       "path": "../../libs/base-fastify-server"
     },
     {

--- a/libs/audio-frame-protocol/package.json
+++ b/libs/audio-frame-protocol/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@scribear/audio-frame-protocol",
+  "version": "0.0.0",
+  "description": "Versioned, self-describing binary framing for source audio (SAFP)",
+  "author": "scribear",
+  "main": "dist/src/index.js",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "default": "./dist/src/index.js"
+    }
+  },
+  "type": "module",
+  "imports": {
+    "#src/*": "./dist/src/*",
+    "#tests/*": "./dist/tests/*"
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "dev": "tsc --build --watch",
+    "format": "prettier --check ./src ./tests",
+    "format:fix": "prettier --write ./src ./tests",
+    "lint": "eslint ./src ./tests",
+    "lint:fix": "eslint ./src ./tests --fix",
+    "test:dev": "vitest --ui --coverage",
+    "test:unit": "vitest run --project unit"
+  }
+}

--- a/libs/audio-frame-protocol/src/audio-frame-protocol.ts
+++ b/libs/audio-frame-protocol/src/audio-frame-protocol.ts
@@ -1,0 +1,247 @@
+/**
+ * ScribeAR Audio Frame Protocol (SAFP).
+ *
+ * A versioned, self-describing binary envelope for a single chunk of source
+ * audio plus a small set of metadata fields. It replaces hard-coded byte
+ * offsets so the kiosk, node server, and transcription service can evolve
+ * independently: readers skip fields they do not recognise (via each field's
+ * length), the `version` byte guards structural changes, and a trailing
+ * CRC-32 catches truncation or mis-framing.
+ *
+ * Wire layout (all multi-byte integers little-endian):
+ *
+ *   offset 0   magic[0]     uint8  = 0x53 ('S')
+ *   offset 1   magic[1]     uint8  = 0x41 ('A')
+ *   offset 2   version      uint8  = 1
+ *   offset 3   fieldCount   uint8
+ *   offset 4.. fields[fieldCount], each:
+ *                key        uint8   (see {@link SafpFieldKey})
+ *                wireType   uint8   (see {@link SafpWireType})
+ *                length     uint16  (byte length of value)
+ *                value      length bytes
+ *   ...        audio payload (all remaining bytes up to the CRC)
+ *   last 4     crc32        uint32  CRC-32 over every byte before it
+ *
+ * Adding a new field keeps `version` at 1 (old readers skip it). Bump
+ * `version` only when the envelope structure itself changes.
+ */
+import { crc32 } from './crc32.js';
+
+export const SAFP_MAGIC_0 = 0x53; // 'S'
+export const SAFP_MAGIC_1 = 0x41; // 'A'
+export const SAFP_VERSION = 1;
+
+/** Fixed size of the envelope prefix: magic(2) + version(1) + fieldCount(1). */
+const HEADER_PREFIX_BYTES = 4;
+/** Size of the trailing CRC-32. */
+const CRC_BYTES = 4;
+/** Per-field overhead: key(1) + wireType(1) + length(2). */
+const FIELD_HEADER_BYTES = 4;
+
+/**
+ * Known metadata field keys. Unknown keys are preserved but ignored, so this
+ * enum can grow without breaking older peers.
+ */
+export enum SafpFieldKey {
+  /** `sentAt`: wall-clock send time in ms, already corrected into the node's
+   *  clock domain by the sender (see time-sync). Optional. */
+  SENT_AT = 1,
+  /** `chunkId`: opaque correlation id echoed back with transcripts. */
+  CHUNK_ID = 2,
+}
+
+/**
+ * Self-describing wire types, so a generic decoder can interpret a value
+ * without consulting the field registry.
+ */
+export enum SafpWireType {
+  UINT = 0x01,
+  FLOAT64 = 0x02,
+  BYTES = 0x03,
+  UTF8 = 0x04,
+}
+
+/** Metadata carried alongside an audio chunk when encoding. */
+export interface AudioFrameFields {
+  /** Correlation id; required in practice so transcripts can be matched back. */
+  chunkId: string;
+  /** Optional node-domain send timestamp (ms) for end-to-end latency. */
+  sentAt?: number;
+}
+
+/** A field the decoder did not recognise, kept verbatim for forward-compat. */
+export interface UnknownAudioFrameField {
+  key: number;
+  wireType: number;
+  value: Uint8Array;
+}
+
+/** Result of {@link decodeAudioFrame}. */
+export interface DecodedAudioFrame {
+  version: number;
+  chunkId: string | null;
+  sentAt: number | null;
+  audio: Uint8Array;
+  unknownFields: UnknownAudioFrameField[];
+}
+
+/** Thrown when a buffer is not a valid SAFP frame. */
+export class AudioFrameError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'AudioFrameError';
+  }
+}
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder('utf-8', { fatal: false });
+
+function toUint8Array(input: Uint8Array | ArrayBuffer): Uint8Array {
+  return input instanceof Uint8Array ? input : new Uint8Array(input);
+}
+
+/**
+ * Encode an audio chunk and its metadata into a SAFP frame.
+ *
+ * @param fields Metadata to embed. `chunkId` is always written; `sentAt` is
+ *   written only when provided.
+ * @param audio Raw audio payload (already in the wire format the provider
+ *   expects, e.g. PCM/WAV bytes).
+ * @returns A freshly allocated frame, tightly sized so `.buffer` is safe to
+ *   hand to a WebSocket's binary send.
+ */
+export function encodeAudioFrame(
+  fields: AudioFrameFields,
+  audio: Uint8Array,
+): Uint8Array {
+  const chunkIdBytes = textEncoder.encode(fields.chunkId);
+
+  const fieldBlocks: { key: number; wireType: number; value: Uint8Array }[] = [
+    {
+      key: SafpFieldKey.CHUNK_ID,
+      wireType: SafpWireType.UTF8,
+      value: chunkIdBytes,
+    },
+  ];
+
+  if (fields.sentAt !== undefined) {
+    const sentAtBytes = new Uint8Array(8);
+    new DataView(sentAtBytes.buffer).setFloat64(0, fields.sentAt, true);
+    fieldBlocks.push({
+      key: SafpFieldKey.SENT_AT,
+      wireType: SafpWireType.FLOAT64,
+      value: sentAtBytes,
+    });
+  }
+
+  let fieldsBytes = 0;
+  for (const block of fieldBlocks) {
+    if (block.value.length > 0xffff) {
+      throw new AudioFrameError(
+        `Field ${String(block.key)} value too long (${String(block.value.length)} bytes)`,
+      );
+    }
+    fieldsBytes += FIELD_HEADER_BYTES + block.value.length;
+  }
+
+  const totalLength =
+    HEADER_PREFIX_BYTES + fieldsBytes + audio.length + CRC_BYTES;
+  const frame = new Uint8Array(totalLength);
+  const view = new DataView(frame.buffer);
+
+  frame[0] = SAFP_MAGIC_0;
+  frame[1] = SAFP_MAGIC_1;
+  frame[2] = SAFP_VERSION;
+  frame[3] = fieldBlocks.length;
+
+  let offset = HEADER_PREFIX_BYTES;
+  for (const block of fieldBlocks) {
+    frame[offset] = block.key;
+    frame[offset + 1] = block.wireType;
+    view.setUint16(offset + 2, block.value.length, true);
+    frame.set(block.value, offset + FIELD_HEADER_BYTES);
+    offset += FIELD_HEADER_BYTES + block.value.length;
+  }
+
+  frame.set(audio, offset);
+  offset += audio.length;
+
+  const checksum = crc32(frame.subarray(0, offset));
+  view.setUint32(offset, checksum, true);
+
+  return frame;
+}
+
+/**
+ * Decode a SAFP frame. Verifies the magic, version, and CRC-32 before
+ * returning the metadata and audio payload.
+ *
+ * @throws {AudioFrameError} if the buffer is too short, has a bad magic,
+ *   fails CRC, uses an unsupported version, or is structurally malformed.
+ */
+export function decodeAudioFrame(
+  input: Uint8Array | ArrayBuffer,
+): DecodedAudioFrame {
+  const bytes = toUint8Array(input);
+
+  if (bytes.length < HEADER_PREFIX_BYTES + CRC_BYTES) {
+    throw new AudioFrameError(
+      `Frame too short (${String(bytes.length)} bytes)`,
+    );
+  }
+  if (bytes[0] !== SAFP_MAGIC_0 || bytes[1] !== SAFP_MAGIC_1) {
+    throw new AudioFrameError('Bad magic; not a SAFP frame');
+  }
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const crcOffset = bytes.length - CRC_BYTES;
+  const expected = view.getUint32(crcOffset, true);
+  const actual = crc32(bytes.subarray(0, crcOffset));
+  if (expected !== actual) {
+    throw new AudioFrameError('CRC mismatch; frame corrupted or truncated');
+  }
+
+  const version = bytes[2] ?? 0;
+  if (version !== SAFP_VERSION) {
+    throw new AudioFrameError(`Unsupported SAFP version ${String(version)}`);
+  }
+
+  const fieldCount = bytes[3] ?? 0;
+  let offset = HEADER_PREFIX_BYTES;
+  let chunkId: string | null = null;
+  let sentAt: number | null = null;
+  const unknownFields: UnknownAudioFrameField[] = [];
+
+  for (let i = 0; i < fieldCount; i++) {
+    if (offset + FIELD_HEADER_BYTES > crcOffset) {
+      throw new AudioFrameError('Truncated field header');
+    }
+    const key = bytes[offset] ?? 0;
+    const wireType = bytes[offset + 1] ?? 0;
+    const length = view.getUint16(offset + 2, true);
+    const valueStart = offset + FIELD_HEADER_BYTES;
+    const valueEnd = valueStart + length;
+    if (valueEnd > crcOffset) {
+      throw new AudioFrameError('Field value overruns frame');
+    }
+    const value = bytes.subarray(valueStart, valueEnd);
+
+    if (key === (SafpFieldKey.CHUNK_ID as number)) {
+      chunkId = textDecoder.decode(value);
+    } else if (key === (SafpFieldKey.SENT_AT as number) && length === 8) {
+      sentAt = new DataView(
+        value.buffer,
+        value.byteOffset,
+        value.byteLength,
+      ).getFloat64(0, true);
+    } else {
+      unknownFields.push({ key, wireType, value });
+    }
+
+    offset = valueEnd;
+  }
+
+  const audio = bytes.subarray(offset, crcOffset);
+
+  return { version, chunkId, sentAt, audio, unknownFields };
+}

--- a/libs/audio-frame-protocol/src/clock-sync.ts
+++ b/libs/audio-frame-protocol/src/clock-sync.ts
@@ -1,0 +1,81 @@
+/**
+ * Estimates the offset between a local clock and a remote clock using
+ * Cristian's algorithm, so timestamps taken locally can be translated into the
+ * remote clock's domain.
+ *
+ * For each probe the caller records three timestamps: `t0` (local time the
+ * probe was sent), `t1` (remote time when the remote handled it, echoed back),
+ * and `t3` (local time the reply arrived). Assuming symmetric network delay,
+ * the remote clock at reply time is `t1 + rtt/2`, giving
+ * `offset = t1 - (t0 + t3) / 2` and `rtt = t3 - t0`.
+ *
+ * Network jitter makes individual samples noisy, so the estimate uses the
+ * sample with the smallest round-trip time from a sliding window of recent
+ * probes - the lowest-RTT sample is the least distorted by queueing delay, and
+ * the window lets the estimate track slow clock drift over a long session.
+ */
+
+interface ClockSyncSample {
+  offsetMs: number;
+  rttMs: number;
+}
+
+const DEFAULT_MAX_SAMPLES = 8;
+
+export class ClockSync {
+  private _samples: ClockSyncSample[] = [];
+  private _maxSamples: number;
+
+  public constructor(maxSamples: number = DEFAULT_MAX_SAMPLES) {
+    this._maxSamples = Math.max(1, maxSamples);
+  }
+
+  /**
+   * Record one probe round-trip. Timestamps are in milliseconds. A sample with
+   * a negative round-trip time is discarded as impossible (clock stepped
+   * mid-probe).
+   */
+  public record(t0: number, t1: number, t3: number): void {
+    const rttMs = t3 - t0;
+    if (!(rttMs >= 0)) return;
+    const offsetMs = t1 - (t0 + t3) / 2;
+    this._samples.push({ offsetMs, rttMs });
+    if (this._samples.length > this._maxSamples) {
+      this._samples.shift();
+    }
+  }
+
+  /** Whether at least one usable sample has been recorded. */
+  public get hasSample(): boolean {
+    return this._samples.length > 0;
+  }
+
+  /** Best current offset estimate (remote - local) in ms, or null if none. */
+  public get offsetMs(): number | null {
+    return this._best()?.offsetMs ?? null;
+  }
+
+  /**
+   * Translate a local-clock timestamp into the remote clock's domain, or null
+   * if no offset has been estimated yet.
+   */
+  public toRemote(localMs: number): number | null {
+    const best = this._best();
+    return best === null ? null : localMs + best.offsetMs;
+  }
+
+  /** Drop all samples, e.g. on reconnect to a possibly different server. */
+  public reset(): void {
+    this._samples = [];
+  }
+
+  private _best(): ClockSyncSample | null {
+    let best: ClockSyncSample | null = null;
+    for (const sample of this._samples) {
+      if (best === null || sample.rttMs < best.rttMs) {
+        best = sample;
+      }
+    }
+    return best;
+  }
+}

--- a/libs/audio-frame-protocol/src/crc32.ts
+++ b/libs/audio-frame-protocol/src/crc32.ts
@@ -1,0 +1,29 @@
+/**
+ * CRC-32 (IEEE 802.3, polynomial 0xEDB88320) used to detect corruption or
+ * mis-framing of a {@link encodeAudioFrame} payload. This duplicates the
+ * algorithm behind Python's `zlib.crc32`, so a frame produced by either side
+ * verifies identically on the other.
+ */
+
+const CRC_TABLE: Uint32Array = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = (c & 1) === 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+/**
+ * Compute the CRC-32 of `bytes` as an unsigned 32-bit integer.
+ */
+export function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = (CRC_TABLE[(crc ^ byte) & 0xff] ?? 0) ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}

--- a/libs/audio-frame-protocol/src/index.ts
+++ b/libs/audio-frame-protocol/src/index.ts
@@ -1,0 +1,17 @@
+export {
+  encodeAudioFrame,
+  decodeAudioFrame,
+  AudioFrameError,
+  SafpFieldKey,
+  SafpWireType,
+  SAFP_MAGIC_0,
+  SAFP_MAGIC_1,
+  SAFP_VERSION,
+} from './audio-frame-protocol.js';
+export type {
+  AudioFrameFields,
+  DecodedAudioFrame,
+  UnknownAudioFrameField,
+} from './audio-frame-protocol.js';
+export { crc32 } from './crc32.js';
+export { ClockSync } from './clock-sync.js';

--- a/libs/audio-frame-protocol/tests/unit/audio-frame-protocol.test.ts
+++ b/libs/audio-frame-protocol/tests/unit/audio-frame-protocol.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AudioFrameError,
+  SAFP_MAGIC_0,
+  SAFP_MAGIC_1,
+  SAFP_VERSION,
+  SafpFieldKey,
+  SafpWireType,
+  crc32,
+  decodeAudioFrame,
+  encodeAudioFrame,
+} from '#src/index.js';
+
+const audio = new Uint8Array([0, 1, 2, 3, 250, 251, 252, 253]);
+
+describe('crc32', () => {
+  it('matches the IEEE known-answer for "123456789"', () => {
+    // 0xCBF43926 is the canonical CRC-32 check value; Python's zlib.crc32
+    // produces the same number, guaranteeing cross-language agreement.
+    const bytes = new TextEncoder().encode('123456789');
+    expect(crc32(bytes)).toBe(0xcbf43926);
+  });
+
+  it('is empty-safe', () => {
+    expect(crc32(new Uint8Array(0))).toBe(0);
+  });
+});
+
+describe('encodeAudioFrame / decodeAudioFrame', () => {
+  it('round-trips chunkId + sentAt + audio', () => {
+    const chunkId = crypto.randomUUID();
+    const sentAt = 1_700_000_000_123;
+    const frame = encodeAudioFrame({ chunkId, sentAt }, audio);
+    const decoded = decodeAudioFrame(frame);
+
+    expect(decoded.version).toBe(SAFP_VERSION);
+    expect(decoded.chunkId).toBe(chunkId);
+    expect(decoded.sentAt).toBe(sentAt);
+    expect([...decoded.audio]).toEqual([...audio]);
+    expect(decoded.unknownFields).toEqual([]);
+  });
+
+  it('round-trips a frame with no sentAt (node -> python hop)', () => {
+    const chunkId = 'abc-123';
+    const frame = encodeAudioFrame({ chunkId }, audio);
+    const decoded = decodeAudioFrame(frame);
+
+    expect(decoded.chunkId).toBe(chunkId);
+    expect(decoded.sentAt).toBeNull();
+    expect([...decoded.audio]).toEqual([...audio]);
+  });
+
+  it('writes the documented magic and version', () => {
+    const frame = encodeAudioFrame({ chunkId: 'x' }, audio);
+    expect(frame[0]).toBe(SAFP_MAGIC_0);
+    expect(frame[1]).toBe(SAFP_MAGIC_1);
+    expect(frame[2]).toBe(SAFP_VERSION);
+  });
+
+  it('handles an empty audio payload', () => {
+    const frame = encodeAudioFrame({ chunkId: 'x' }, new Uint8Array(0));
+    const decoded = decodeAudioFrame(frame);
+    expect(decoded.chunkId).toBe('x');
+    expect(decoded.audio.length).toBe(0);
+  });
+
+  it('accepts an ArrayBuffer as input', () => {
+    const frame = encodeAudioFrame({ chunkId: 'y' }, audio);
+    const copy = frame.slice();
+    const decoded = decodeAudioFrame(copy.buffer);
+    expect(decoded.chunkId).toBe('y');
+  });
+
+  it('preserves unicode chunk ids', () => {
+    const chunkId = 'café-⛄-😀';
+    const decoded = decodeAudioFrame(encodeAudioFrame({ chunkId }, audio));
+    expect(decoded.chunkId).toBe(chunkId);
+  });
+});
+
+describe('forward compatibility', () => {
+  it('skips an unknown field and still finds audio + known fields', () => {
+    // Hand-build a frame with an extra unknown field (key 99) between the
+    // known fields and the audio, mimicking a newer sender.
+    const chunkId = 'fwd';
+    const chunkBytes = new TextEncoder().encode(chunkId);
+    const unknownValue = new Uint8Array([9, 9, 9]);
+    const fields = new Uint8Array(
+      4 + chunkBytes.length + (4 + unknownValue.length),
+    );
+    const fView = new DataView(fields.buffer);
+    // field 1: chunkId
+    fields[0] = SafpFieldKey.CHUNK_ID;
+    fields[1] = SafpWireType.UTF8;
+    fView.setUint16(2, chunkBytes.length, true);
+    fields.set(chunkBytes, 4);
+    // field 2: unknown key 99
+    const o = 4 + chunkBytes.length;
+    fields[o] = 99;
+    fields[o + 1] = SafpWireType.BYTES;
+    fView.setUint16(o + 2, unknownValue.length, true);
+    fields.set(unknownValue, o + 4);
+
+    const body = new Uint8Array(4 + fields.length + audio.length);
+    body[0] = SAFP_MAGIC_0;
+    body[1] = SAFP_MAGIC_1;
+    body[2] = SAFP_VERSION;
+    body[3] = 2; // two fields
+    body.set(fields, 4);
+    body.set(audio, 4 + fields.length);
+
+    const frame = new Uint8Array(body.length + 4);
+    frame.set(body, 0);
+    new DataView(frame.buffer).setUint32(body.length, crc32(body), true);
+
+    const decoded = decodeAudioFrame(frame);
+    expect(decoded.chunkId).toBe(chunkId);
+    expect([...decoded.audio]).toEqual([...audio]);
+    expect(decoded.unknownFields).toHaveLength(1);
+    expect(decoded.unknownFields[0]?.key).toBe(99);
+  });
+});
+
+describe('validation', () => {
+  it('rejects a short buffer', () => {
+    expect(() => decodeAudioFrame(new Uint8Array(3))).toThrow(AudioFrameError);
+  });
+
+  it('rejects a bad magic', () => {
+    const frame = encodeAudioFrame({ chunkId: 'x' }, audio);
+    frame[0] = 0x00;
+    // recompute CRC so we isolate the magic check
+    new DataView(frame.buffer).setUint32(
+      frame.length - 4,
+      crc32(frame.subarray(0, frame.length - 4)),
+      true,
+    );
+    expect(() => decodeAudioFrame(frame)).toThrow(/magic/i);
+  });
+
+  it('rejects a corrupted payload via CRC', () => {
+    const frame = encodeAudioFrame({ chunkId: 'x' }, audio);
+    const i = frame.length - 5;
+    frame[i] = (frame[i] ?? 0) ^ 0xff; // flip a byte of audio
+    expect(() => decodeAudioFrame(frame)).toThrow(/CRC/i);
+  });
+
+  it('rejects an unsupported version', () => {
+    const frame = encodeAudioFrame({ chunkId: 'x' }, audio);
+    frame[2] = 2;
+    new DataView(frame.buffer).setUint32(
+      frame.length - 4,
+      crc32(frame.subarray(0, frame.length - 4)),
+      true,
+    );
+    expect(() => decodeAudioFrame(frame)).toThrow(/version/i);
+  });
+});

--- a/libs/audio-frame-protocol/tests/unit/clock-sync.test.ts
+++ b/libs/audio-frame-protocol/tests/unit/clock-sync.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { ClockSync } from '#src/index.js';
+
+describe('ClockSync', () => {
+  it('starts with no sample', () => {
+    const cs = new ClockSync();
+    expect(cs.hasSample).toBe(false);
+    expect(cs.offsetMs).toBeNull();
+    expect(cs.toRemote(1000)).toBeNull();
+  });
+
+  it('estimates a constant offset with symmetric delay', () => {
+    const cs = new ClockSync();
+    // Remote clock is +1000ms ahead. Probe sent at t0=100 (local), round trip
+    // 20ms so reply arrives t3=120; remote handled it at the midpoint + offset:
+    // t1 = ((100 + 120) / 2) + 1000 = 1110.
+    cs.record(100, 1110, 120);
+    expect(cs.offsetMs).toBe(1000);
+    expect(cs.toRemote(5000)).toBe(6000);
+  });
+
+  it('prefers the lowest-RTT sample', () => {
+    const cs = new ClockSync();
+    // A jittery sample (rtt 200) that skews the naive offset...
+    cs.record(0, 1000, 200); // offset = 1000 - 100 = 900
+    // ...and a clean sample (rtt 10) revealing the true +1000 offset.
+    cs.record(0, 1005, 10); // offset = 1005 - 5 = 1000
+    expect(cs.offsetMs).toBe(1000);
+  });
+
+  it('discards impossible (negative-RTT) samples', () => {
+    const cs = new ClockSync();
+    cs.record(100, 1000, 50); // t3 < t0
+    expect(cs.hasSample).toBe(false);
+  });
+
+  it('evicts old samples beyond the window so drift can be tracked', () => {
+    const cs = new ClockSync(2);
+    cs.record(0, 1000, 10); // offset 995, rtt 10  (oldest)
+    cs.record(0, 2000, 20); // offset 1990, rtt 20
+    cs.record(0, 3000, 20); // offset 2990, rtt 20
+    // Window holds the last two; the rtt-10 sample was evicted, so the best of
+    // the remaining (both rtt 20) reflects the newer offsets, not the stale one.
+    expect(cs.offsetMs).toBe(1990);
+  });
+
+  it('reset clears samples', () => {
+    const cs = new ClockSync();
+    cs.record(0, 1000, 10);
+    cs.reset();
+    expect(cs.hasSample).toBe(false);
+  });
+});

--- a/libs/audio-frame-protocol/tsconfig.json
+++ b/libs/audio-frame-protocol/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "paths": {
+      "#src/*": [
+        "./src/*"
+      ],
+      "#tests/*": [
+        "./tests/*"
+      ]
+    }
+  },
+  "include": [
+    "src",
+    "tests"
+  ],
+  "references": []
+}

--- a/libs/audio-frame-protocol/vitest.config.ts
+++ b/libs/audio-frame-protocol/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineProject, mergeConfig } from 'vitest/config';
+
+import sharedConfig from '../../vitest.shared.js';
+
+export default mergeConfig(
+  sharedConfig,
+  defineProject({
+    test: {
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'unit',
+            environment: 'node',
+            exclude: ['tests/integration/**'],
+          },
+        },
+      ],
+    },
+  }),
+);

--- a/libs/schemas/node-server-schema/src/transcription-stream/routes/transcription-stream.schema.ts
+++ b/libs/schemas/node-server-schema/src/transcription-stream/routes/transcription-stream.schema.ts
@@ -11,6 +11,7 @@ import { TRANSCRIPT_FRAGMENT_SCHEMA } from '#src/transcription-stream/entities/t
 
 export enum TranscriptionStreamClientMessageType {
   AUTH = 'auth',
+  TIME_SYNC_PING = 'timeSyncPing',
 }
 
 export enum TranscriptionStreamServerMessageType {
@@ -18,6 +19,17 @@ export enum TranscriptionStreamServerMessageType {
   TRANSCRIPT = 'transcript',
   SESSION_STATUS = 'sessionStatus',
   SESSION_ENDED = 'sessionEnded',
+  TIME_SYNC_PONG = 'timeSyncPong',
+  LATENCY_UPDATE = 'latencyUpdate',
+}
+
+/**
+ * Which transcript a latency sample describes. `final` samples measure a
+ * finalized transcript; `inProgress` samples measure an interim one.
+ */
+export enum LatencyKind {
+  FINAL = 'final',
+  IN_PROGRESS = 'inProgress',
 }
 
 const TRANSCRIPTION_STREAM_SCHEMA = {
@@ -32,6 +44,14 @@ const TRANSCRIPTION_STREAM_SCHEMA = {
     Type.Object({
       type: Type.Literal(TranscriptionStreamClientMessageType.AUTH),
       sessionToken: Type.String({ maxLength: 4096 }),
+    }),
+    // Clock-sync probe (Cristian's algorithm). The source sends its send
+    // time `t0`; the server echoes it with its own receive time `t1` so the
+    // source can estimate the server-vs-client clock offset and correct the
+    // `sentAt` it stamps on audio frames. See `timeSyncPong`.
+    Type.Object({
+      type: Type.Literal(TranscriptionStreamClientMessageType.TIME_SYNC_PING),
+      t0: Type.Number(),
     }),
   ]),
   allowServerBinaryMessage: false,
@@ -57,6 +77,24 @@ const TRANSCRIPTION_STREAM_SCHEMA = {
     }),
     Type.Object({
       type: Type.Literal(TranscriptionStreamServerMessageType.SESSION_ENDED),
+    }),
+    // Reply to a `timeSyncPing`: `t0` echoed from the ping, `t1` the server's
+    // clock when it handled the ping.
+    Type.Object({
+      type: Type.Literal(TranscriptionStreamServerMessageType.TIME_SYNC_PONG),
+      t0: Type.Number(),
+      t1: Type.Number(),
+    }),
+    // End-to-end latency sample for one transcript. `pipelineMs` is measured
+    // entirely on the node's monotonic clock (audio ingress -> transcript)
+    // and is therefore skew-free. `e2eMs` additionally includes the capture
+    // and uplink legs using the source's clock corrected via time-sync; it is
+    // null when no reliable clock offset is available.
+    Type.Object({
+      type: Type.Literal(TranscriptionStreamServerMessageType.LATENCY_UPDATE),
+      kind: Type.Enum(LatencyKind),
+      pipelineMs: Type.Number(),
+      e2eMs: Type.Union([Type.Number(), Type.Null()]),
     }),
   ]),
   closeCodes: {

--- a/libs/schemas/transcription-service-schema/src/transcription-stream/transcription-stream.schema.ts
+++ b/libs/schemas/transcription-service-schema/src/transcription-stream/transcription-stream.schema.ts
@@ -52,6 +52,16 @@ const TRANSCRIPTION_STREAM_SCHEMA = {
       }),
       Type.Null(),
     ]),
+    // Ids of the source audio chunks that contributed to each transcript,
+    // echoed back so the node server can correlate a transcript to the audio
+    // frame it came from and measure latency. Optional so a transcription
+    // service that predates this field still validates.
+    final_chunk_ids: Type.Optional(
+      Type.Union([Type.Array(Type.String()), Type.Null()]),
+    ),
+    in_progress_chunk_ids: Type.Optional(
+      Type.Union([Type.Array(Type.String()), Type.Null()]),
+    ),
   }),
   closeCodes: {
     1000: { description: 'Normal closure' },

--- a/libs/store/transcription-content-store/src/transcription-content-slice.ts
+++ b/libs/store/transcription-content-store/src/transcription-content-slice.ts
@@ -1,6 +1,65 @@
 import { type PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { v4 as uuidv4 } from 'uuid';
 
+/** Sliding-window size for the latency moving averages. */
+const LATENCY_WINDOW_SIZE = 60;
+
+/** Which transcript a latency sample describes. */
+export type LatencyKind = 'final' | 'inProgress';
+
+/**
+ * A latency sample dispatched from the session transport: `pipelineMs` is the
+ * skew-free node-side pipeline latency; `e2eMs` additionally includes capture
+ * and uplink (via clock-synced source timestamps) and is null when no reliable
+ * offset is available.
+ */
+export interface LatencySample {
+  kind: LatencyKind;
+  pipelineMs: number;
+  e2eMs: number | null;
+}
+
+interface LatencyWindow {
+  samples: number[];
+  average: number;
+}
+
+interface LatencyMetric {
+  final: LatencyWindow;
+  inProgress: LatencyWindow;
+}
+
+/**
+ * Rolling latency measurements. `pipeline` (node ingress -> transcript) is
+ * always populated; `e2e` (capture -> display) is only populated once the
+ * source's clock has been synced to the server.
+ */
+export interface LatencyState {
+  pipeline: LatencyMetric;
+  e2e: LatencyMetric;
+}
+
+function emptyWindow(): LatencyWindow {
+  return { samples: [], average: 0 };
+}
+
+function emptyMetric(): LatencyMetric {
+  return { final: emptyWindow(), inProgress: emptyWindow() };
+}
+
+function emptyLatency(): LatencyState {
+  return { pipeline: emptyMetric(), e2e: emptyMetric() };
+}
+
+function pushSample(window: LatencyWindow, value: number): void {
+  window.samples.push(value);
+  if (window.samples.length > LATENCY_WINDOW_SIZE) {
+    window.samples.shift();
+  }
+  window.average =
+    window.samples.reduce((sum, s) => sum + s, 0) / window.samples.length;
+}
+
 /**
  * A sequence of transcribed text tokens with optional word-level timing data.
  * Each committed sequence has a stable `id` so it can be rendered as a keyed
@@ -51,6 +110,7 @@ export interface TranscriptionContentSlice {
   activeSection: ActiveSection;
   finalizedTranscription: TranscriptionSequence[];
   inProgressTranscription: TranscriptionSequenceInput | null;
+  latency: LatencyState;
 }
 
 /**
@@ -65,6 +125,7 @@ const initialState: TranscriptionContentSlice = {
   activeSection: { id: uuidv4(), sequences: [] },
   finalizedTranscription: [],
   inProgressTranscription: null,
+  latency: emptyLatency(),
 };
 
 /**
@@ -88,6 +149,23 @@ export const selectInProgressTranscriptionText = (
   if (state.transcriptionContent.inProgressTranscription === null) return '';
   return state.transcriptionContent.inProgressTranscription.text.join('');
 };
+
+/** Skew-free pipeline latency (ms) for finalized transcripts; 0 if no samples. */
+export const selectFinalPipelineLatencyMs = (state: WithTranscriptionContent) =>
+  state.transcriptionContent.latency.pipeline.final.average;
+
+/** Skew-free pipeline latency (ms) for interim transcripts; 0 if no samples. */
+export const selectInProgressPipelineLatencyMs = (
+  state: WithTranscriptionContent,
+) => state.transcriptionContent.latency.pipeline.inProgress.average;
+
+/** End-to-end latency (ms) for finalized transcripts; 0 until clock-synced. */
+export const selectFinalE2eLatencyMs = (state: WithTranscriptionContent) =>
+  state.transcriptionContent.latency.e2e.final.average;
+
+/** End-to-end latency (ms) for interim transcripts; 0 until clock-synced. */
+export const selectInProgressE2eLatencyMs = (state: WithTranscriptionContent) =>
+  state.transcriptionContent.latency.e2e.inProgress.average;
 
 /**
  * Redux slice managing all transcription content, including committed paragraph
@@ -178,6 +256,18 @@ export const transcriptionContentSlice = createSlice({
       }
     },
     /**
+     * Records a latency sample into the rolling windows. `pipelineMs` always
+     * counts; `e2eMs` counts only when present and non-negative (a negative
+     * value signals residual clock skew and is discarded).
+     */
+    recordLatency: (state, action: PayloadAction<LatencySample>) => {
+      const { kind, pipelineMs, e2eMs } = action.payload;
+      pushSample(state.latency.pipeline[kind], pipelineMs);
+      if (e2eMs !== null && e2eMs >= 0) {
+        pushSample(state.latency.e2e[kind], e2eMs);
+      }
+    },
+    /**
      * Resets all transcription content back to the initial empty state.
      */
     clearTranscription: (state) => {
@@ -185,6 +275,7 @@ export const transcriptionContentSlice = createSlice({
       state.activeSection = { id: uuidv4(), sequences: [] };
       state.finalizedTranscription = [];
       state.inProgressTranscription = null;
+      state.latency = emptyLatency();
     },
   },
 });
@@ -198,5 +289,6 @@ export const {
   commitInProgressTranscription,
   replaceInProgressTranscription,
   handleTranscript,
+  recordLatency,
   clearTranscription,
 } = transcriptionContentSlice.actions;

--- a/package-lock.json
+++ b/package-lock.json
@@ -251,6 +251,10 @@
         "typebox": "1.1.5"
       }
     },
+    "libs/audio-frame-protocol": {
+      "name": "@scribear/audio-frame-protocol",
+      "version": "0.0.0"
+    },
     "libs/base-fastify-server": {
       "name": "@scribear/base-fastify-server",
       "version": "0.0.0",
@@ -3701,6 +3705,10 @@
     },
     "node_modules/@scribear/app-layout-store": {
       "resolved": "libs/store/app-layout-store",
+      "link": true
+    },
+    "node_modules/@scribear/audio-frame-protocol": {
+      "resolved": "libs/audio-frame-protocol",
       "link": true
     },
     "node_modules/@scribear/base-api-client": {

--- a/transcription_service/src/shared/utils/audio_frame_protocol/__init__.py
+++ b/transcription_service/src/shared/utils/audio_frame_protocol/__init__.py
@@ -1,0 +1,23 @@
+"""
+Public exports for the ScribeAR Audio Frame Protocol (SAFP).
+"""
+
+from .audio_frame_protocol import (
+    FIELD_KEY_CHUNK_ID,
+    FIELD_KEY_SENT_AT,
+    SAFP_VERSION,
+    AudioFrameError,
+    DecodedAudioFrame,
+    decode_audio_frame,
+    encode_audio_frame,
+)
+
+__all__ = [
+    "FIELD_KEY_CHUNK_ID",
+    "FIELD_KEY_SENT_AT",
+    "SAFP_VERSION",
+    "AudioFrameError",
+    "DecodedAudioFrame",
+    "decode_audio_frame",
+    "encode_audio_frame",
+]

--- a/transcription_service/src/shared/utils/audio_frame_protocol/audio_frame_protocol.py
+++ b/transcription_service/src/shared/utils/audio_frame_protocol/audio_frame_protocol.py
@@ -1,0 +1,187 @@
+"""
+ScribeAR Audio Frame Protocol (SAFP) - Python decoder/encoder.
+
+Mirrors the TypeScript implementation in
+``libs/audio-frame-protocol``. A frame is a versioned, self-describing
+binary envelope carrying a chunk of source audio plus a few metadata
+fields, so the kiosk, node server, and transcription service can evolve
+independently. Unknown fields are skipped via their length, the ``version``
+byte guards structural changes, and a trailing CRC-32 (``zlib.crc32``,
+identical to the TypeScript table) catches truncation or mis-framing.
+
+Wire layout (all multi-byte integers little-endian):
+
+    offset 0   magic[0]     uint8  = 0x53 ('S')
+    offset 1   magic[1]     uint8  = 0x41 ('A')
+    offset 2   version      uint8  = 1
+    offset 3   field_count  uint8
+    offset 4.. fields[field_count], each:
+                 key         uint8
+                 wire_type   uint8
+                 length      uint16 (byte length of value)
+                 value       length bytes
+    ...        audio payload (all remaining bytes up to the CRC)
+    last 4     crc32        uint32  CRC-32 over every byte before it
+"""
+
+import struct
+import zlib
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+SAFP_MAGIC_0 = 0x53  # 'S'
+SAFP_MAGIC_1 = 0x41  # 'A'
+SAFP_VERSION = 1
+
+# Field keys (see SafpFieldKey in the TypeScript implementation)
+FIELD_KEY_SENT_AT = 1
+FIELD_KEY_CHUNK_ID = 2
+
+# Wire types (see SafpWireType in the TypeScript implementation)
+WIRE_UINT = 0x01
+WIRE_FLOAT64 = 0x02
+WIRE_BYTES = 0x03
+WIRE_UTF8 = 0x04
+
+_HEADER_PREFIX_BYTES = 4  # magic(2) + version(1) + field_count(1)
+_CRC_BYTES = 4
+_FIELD_HEADER_BYTES = 4  # key(1) + wire_type(1) + length(2)
+_MAX_FIELD_LEN = 0xFFFF
+
+
+class AudioFrameError(Exception):
+    """Raised when a buffer is not a valid SAFP frame."""
+
+
+@dataclass
+class DecodedAudioFrame:
+    """
+    Result of decoding a SAFP frame.
+
+    Attributes:
+        version         - Envelope version byte
+        chunk_id        - Correlation id, or None if absent
+        sent_at         - Node-domain send timestamp in ms, or None if absent
+        audio           - Raw audio payload bytes
+        unknown_fields  - (key, wire_type, value) tuples not recognised by
+                          this decoder, preserved for forward compatibility
+    """
+
+    version: int
+    chunk_id: Optional[str]
+    sent_at: Optional[float]
+    audio: bytes
+    unknown_fields: List[Tuple[int, int, bytes]] = field(default_factory=list)
+
+
+def encode_audio_frame(
+    chunk_id: str, audio: bytes, sent_at: Optional[float] = None
+) -> bytes:
+    """
+    Encode an audio chunk and its metadata into a SAFP frame.
+
+    Args:
+        chunk_id    - Correlation id, always written
+        audio       - Raw audio payload bytes
+        sent_at     - Optional node-domain send timestamp in ms
+
+    Returns:
+        The encoded frame bytes.
+    """
+    fields = bytearray()
+    field_count = 0
+
+    chunk_bytes = chunk_id.encode("utf-8")
+    if len(chunk_bytes) > _MAX_FIELD_LEN:
+        raise AudioFrameError(f"chunk_id too long ({len(chunk_bytes)} bytes)")
+    fields += struct.pack(
+        "<BBH", FIELD_KEY_CHUNK_ID, WIRE_UTF8, len(chunk_bytes)
+    )
+    fields += chunk_bytes
+    field_count += 1
+
+    if sent_at is not None:
+        value = struct.pack("<d", sent_at)
+        fields += struct.pack(
+            "<BBH", FIELD_KEY_SENT_AT, WIRE_FLOAT64, len(value)
+        )
+        fields += value
+        field_count += 1
+
+    body = bytearray()
+    body += struct.pack(
+        "<BBBB", SAFP_MAGIC_0, SAFP_MAGIC_1, SAFP_VERSION, field_count
+    )
+    body += fields
+    body += audio
+
+    crc = zlib.crc32(bytes(body)) & 0xFFFFFFFF
+    body += struct.pack("<I", crc)
+    return bytes(body)
+
+
+def decode_audio_frame(data: bytes) -> DecodedAudioFrame:
+    # pylint: disable=too-many-locals
+    """
+    Decode a SAFP frame, verifying magic, version, and CRC-32.
+
+    Args:
+        data    - Raw frame bytes
+
+    Returns:
+        A DecodedAudioFrame with the metadata and audio payload.
+
+    Raises:
+        AudioFrameError - if the buffer is too short, has a bad magic, fails
+            CRC, uses an unsupported version, or is structurally malformed.
+    """
+    if len(data) < _HEADER_PREFIX_BYTES + _CRC_BYTES:
+        raise AudioFrameError(f"Frame too short ({len(data)} bytes)")
+    if data[0] != SAFP_MAGIC_0 or data[1] != SAFP_MAGIC_1:
+        raise AudioFrameError("Bad magic; not a SAFP frame")
+
+    crc_offset = len(data) - _CRC_BYTES
+    (expected,) = struct.unpack_from("<I", data, crc_offset)
+    actual = zlib.crc32(data[:crc_offset]) & 0xFFFFFFFF
+    if expected != actual:
+        raise AudioFrameError("CRC mismatch; frame corrupted or truncated")
+
+    version = data[2]
+    if version != SAFP_VERSION:
+        raise AudioFrameError(f"Unsupported SAFP version {version}")
+
+    field_count = data[3]
+    offset = _HEADER_PREFIX_BYTES
+    chunk_id: Optional[str] = None
+    sent_at: Optional[float] = None
+    unknown_fields: List[Tuple[int, int, bytes]] = []
+
+    for _ in range(field_count):
+        if offset + _FIELD_HEADER_BYTES > crc_offset:
+            raise AudioFrameError("Truncated field header")
+        key = data[offset]
+        wire_type = data[offset + 1]
+        (length,) = struct.unpack_from("<H", data, offset + 2)
+        value_start = offset + _FIELD_HEADER_BYTES
+        value_end = value_start + length
+        if value_end > crc_offset:
+            raise AudioFrameError("Field value overruns frame")
+        value = data[value_start:value_end]
+
+        if key == FIELD_KEY_CHUNK_ID:
+            chunk_id = value.decode("utf-8", errors="replace")
+        elif key == FIELD_KEY_SENT_AT and length == 8:
+            (sent_at,) = struct.unpack("<d", value)
+        else:
+            unknown_fields.append((key, wire_type, value))
+
+        offset = value_end
+
+    audio = data[offset:crc_offset]
+    return DecodedAudioFrame(
+        version=version,
+        chunk_id=chunk_id,
+        sent_at=sent_at,
+        audio=audio,
+        unknown_fields=unknown_fields,
+    )

--- a/transcription_service/src/transcription_provider_interface/__init__.py
+++ b/transcription_service/src/transcription_provider_interface/__init__.py
@@ -4,6 +4,7 @@ Public exports for TranscriptionProviderInterface
 
 from .transcription_client_error import TranscriptionClientError
 from .transcription_provider_interface import TranscriptionProviderInterface
+from .transcription_result import AudioChunkPayload
 from .transcription_sequence import TranscriptionSequence
 from .transcription_session_interface import (
     TranscriptionResult,

--- a/transcription_service/src/transcription_provider_interface/transcription_result.py
+++ b/transcription_service/src/transcription_provider_interface/transcription_result.py
@@ -2,9 +2,22 @@
 Defines TranscriptionResult data class
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .transcription_sequence import TranscriptionSequence
+
+
+@dataclass
+class AudioChunkPayload:
+    """
+    A single source audio chunk paired with its correlation id. Providers that
+    support latency tracking carry this (instead of raw bytes) through their
+    worker-pool job so the chunk id can be echoed back with the transcript it
+    contributes to.
+    """
+
+    chunk_id: str
+    audio_bytes: bytes
 
 
 @dataclass
@@ -20,3 +33,10 @@ class TranscriptionResult:
 
     in_progress: TranscriptionSequence | None = None
     final: TranscriptionSequence | None = None
+
+    # Ids of the source audio chunks that contributed to each transcript, so
+    # the node server can correlate a transcript back to the audio frame it
+    # came from and measure latency. Empty when the provider does not track
+    # chunk ids.
+    final_chunk_ids: list[str] = field(default_factory=list)
+    in_progress_chunk_ids: list[str] = field(default_factory=list)

--- a/transcription_service/src/transcription_provider_interface/transcription_session_interface.py
+++ b/transcription_service/src/transcription_provider_interface/transcription_session_interface.py
@@ -34,13 +34,16 @@ class TranscriptionSessionInterface(ABC, EventEmitter):
         """
 
     @abstractmethod
-    def handle_audio_chunk(self, chunk: bytes):
+    def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
         """
         Called when when an audio chunk arrives from audio stream
         Note: chunk can be any length and format
 
         Args:
-            chunk   - Chunk of audio to handle
+            chunk_id    - Correlation id for this chunk, echoed back with the
+                            transcript it contributes to so the caller can
+                            measure latency. Empty string if unknown.
+            chunk       - Chunk of audio to handle
 
         Raises:
             TranscriptionClientError if error is caused by client

--- a/transcription_service/src/transcription_providers/debug_provider/debug_provider.py
+++ b/transcription_service/src/transcription_providers/debug_provider/debug_provider.py
@@ -80,7 +80,10 @@ class DebugProvider(TranscriptionProviderInterface):
                 ),
             )
 
-        def handle_audio_chunk(self, chunk: bytes):
+        def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
+            # Debug provider does not track chunk ids; the correlation id is
+            # accepted for interface parity and ignored.
+            del chunk_id
             self._job.queue_data([chunk])
 
         def end_session(self):

--- a/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_job.py
+++ b/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_job.py
@@ -13,6 +13,7 @@ from src.shared.utils.worker_pool import JobInterface
 from src.transcription_contexts.faster_whisper_context import WhisperModel
 from src.transcription_contexts.silero_vad_context import SileroVadModelType
 from src.transcription_provider_interface import (
+    AudioChunkPayload,
     TranscriptionClientError,
     TranscriptionResult,
     TranscriptionSequence,
@@ -27,7 +28,7 @@ NUM_CHANNELS = 1
 class WhisperStreamingProviderJob(
     JobInterface[
         tuple[WhisperModel, SileroVadModelType],
-        bytes,
+        AudioChunkPayload,
         TranscriptionResult,
         None,
     ]
@@ -48,6 +49,13 @@ class WhisperStreamingProviderJob(
         )
         self._buffer_offset_samples = 0
 
+        # Latency correlation: total samples ever appended (absolute stream
+        # position) and a ledger mapping each source chunk to the sample span
+        # it occupies, so a transcript's end time can be resolved back to the
+        # chunk ids that produced it.
+        self._total_decoded_samples = 0
+        self._chunk_ledger: list[dict] = []
+
         self._local_agree = LocalAgree(config.local_agree_dim)
         self._last_finalized = ""
 
@@ -66,10 +74,10 @@ class WhisperStreamingProviderJob(
         if self._vad_neg_threshold is not None:
             self._vad_neg_threshold = float(self._vad_neg_threshold)
 
-    def _decode_audio(self, batch: list[bytes]):
+    def _decode_audio(self, batch: list[AudioChunkPayload]):
         """
-        Decodes audio chunks and appends to buffer
-        Pure_silence detection before appends audio to buffer
+        Decodes audio chunks and appends to buffer, recording each chunk's
+        sample span in the ledger for later latency correlation.
 
         Args:
             batch   - Batch of audio chunks to decode and append
@@ -79,11 +87,20 @@ class WhisperStreamingProviderJob(
         """
         for chunk in batch:
             try:
-                samples = self._decoder.decode(chunk)
+                samples = self._decoder.decode(chunk.audio_bytes)
             except ValueError as e:
                 raise TranscriptionClientError(str(e)) from e
 
+            num_samples = len(samples)
+            self._chunk_ledger.append(
+                {
+                    "chunk_id": chunk.chunk_id,
+                    "start_sample": self._total_decoded_samples,
+                    "end_sample": self._total_decoded_samples + num_samples,
+                }
+            )
             extra = self._buffer.append(samples)
+            self._total_decoded_samples += num_samples
             # More than expected number of samples received, client sending audio to fast
             if len(extra) > 0:
                 raise TranscriptionClientError("Client sent audio too quickly.")
@@ -176,6 +193,61 @@ class WhisperStreamingProviderJob(
                     )
         return transcription
 
+    def _extract_chunk_ids_for_time(self, end_time_sec: float) -> list[str]:
+        """
+        Resolve a transcript end time (seconds from stream start) to the ids of
+        the source chunks that contributed to it - every ledger record that
+        starts before that point. Also prunes ledger records whose audio has
+        already been purged from the buffer so the ledger stays bounded.
+
+        Args:
+            end_time_sec    - Transcript end time in seconds, or 0 if unknown
+
+        Returns:
+            Chunk ids in the order the chunks were received (earliest first).
+        """
+        if not end_time_sec or end_time_sec <= 0:
+            return []
+
+        current_sample_idx = int(end_time_sec * SAMPLE_RATE)
+        chunk_ids = [
+            record["chunk_id"]
+            for record in self._chunk_ledger
+            if record["start_sample"] < current_sample_idx
+        ]
+
+        self._chunk_ledger = [
+            record
+            for record in self._chunk_ledger
+            if record["end_sample"] >= self._buffer_offset_samples
+        ]
+
+        return chunk_ids
+
+    def _build_result(
+        self,
+        final: TranscriptionSequence | None,
+        in_progress: TranscriptionSequence | None,
+    ) -> TranscriptionResult:
+        """
+        Assemble a TranscriptionResult, tagging each transcript with the ids of
+        the source chunks that produced it.
+        """
+        final_end_time = final.ends[-1] if final and final.ends else 0
+        in_progress_end_time = (
+            in_progress.ends[-1]
+            if in_progress and in_progress.ends
+            else final_end_time
+        )
+        return TranscriptionResult(
+            in_progress=in_progress,
+            final=final,
+            final_chunk_ids=self._extract_chunk_ids_for_time(final_end_time),
+            in_progress_chunk_ids=self._extract_chunk_ids_for_time(
+                in_progress_end_time
+            ),
+        )
+
     def _append_sequence(
         self, a: TranscriptionSequence, b: TranscriptionSequence
     ):
@@ -196,7 +268,7 @@ class WhisperStreamingProviderJob(
         self,
         log: Logger,
         contexts: tuple[WhisperModel, SileroVadModelType],
-        batch: list[bytes],
+        batch: list[AudioChunkPayload],
     ) -> TranscriptionResult:
         whisper_model, vad_context = contexts
 
@@ -226,7 +298,7 @@ class WhisperStreamingProviderJob(
 
             if forced_final is not None:
                 self._last_finalized = "".join(forced_final.text)
-            return TranscriptionResult(final=forced_final)
+            return self._build_result(forced_final, None)
 
         self._local_agree.append_transcription(segments)
 
@@ -235,9 +307,7 @@ class WhisperStreamingProviderJob(
 
         if final is None:
             # If nothing finalized currently, use forced_final transcription (if any)
-            return TranscriptionResult(
-                in_progress=in_progress, final=forced_final
-            )
+            return self._build_result(forced_final, in_progress)
 
         if final is not None and final.ends:
             # Purge finalized audio from buffer
@@ -255,11 +325,9 @@ class WhisperStreamingProviderJob(
             self._append_sequence(forced_final, final)
 
             self._last_finalized = "".join(forced_final.text)
-            return TranscriptionResult(
-                in_progress=in_progress, final=forced_final
-            )
+            return self._build_result(forced_final, in_progress)
 
-        return TranscriptionResult(in_progress=in_progress, final=final)
+        return self._build_result(final, in_progress)
 
     def update_config(self, log: Logger, contexts: tuple, config: None) -> None:
         raise TranscriptionClientError("On the fly config update not supported")

--- a/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_provider.py
+++ b/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_provider.py
@@ -7,6 +7,7 @@ from dataclasses import asdict
 from src.shared.logger import Logger
 from src.shared.utils.worker_pool import JobException, JobSuccess, WorkerPool
 from src.transcription_provider_interface import (
+    AudioChunkPayload,
     TranscriptionProviderInterface,
     TranscriptionResult,
     TranscriptionSessionInterface,
@@ -87,8 +88,10 @@ class WhisperStreamingProvider(TranscriptionProviderInterface):
             )
             self.emit(self.TranscriptionResultEvent, result.value)
 
-        def handle_audio_chunk(self, chunk: bytes):
-            self._job.queue_data([chunk])
+        def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
+            self._job.queue_data(
+                [AudioChunkPayload(chunk_id=chunk_id, audio_bytes=chunk)]
+            )
 
         def end_session(self):
             super().end_session()

--- a/transcription_service/src/webserver/features/transcription_stream/transcription_stream_controller.py
+++ b/transcription_service/src/webserver/features/transcription_stream/transcription_stream_controller.py
@@ -12,6 +12,10 @@ from starlette.websockets import WebSocket
 
 from src.shared.config import Config
 from src.shared.logger import Logger
+from src.shared.utils.audio_frame_protocol import (
+    AudioFrameError,
+    decode_audio_frame,
+)
 from src.transcription_provider_interface import (
     TranscriptionClientError,
     TranscriptionResult,
@@ -152,23 +156,10 @@ class TranscriptionStreamController(WebsocketHandler):
                     if result.in_progress is not None
                     else None
                 ),
+                final_chunk_ids=result.final_chunk_ids or None,
+                in_progress_chunk_ids=result.in_progress_chunk_ids or None,
             )
         )
-
-    def _audio_chunk(self, chunk: bytes):
-        """
-        Forward an audio chunk to the underlying service once auth + config
-        have completed.
-        """
-        if not self._is_authenticated:
-            self.close(1008, "Audio chunk before authentication")
-            return
-
-        if self._service is None:
-            self.close(1008, "Audio chunk before configuration")
-            return
-
-        self._service.handle_audio_chunk(chunk)
 
     async def _handle_text_message(self, message: str):
         """
@@ -184,9 +175,27 @@ class TranscriptionStreamController(WebsocketHandler):
 
     async def _handle_binary_message(self, message: bytes):
         """
-        Treat any binary client message as a chunk of source audio.
+        Treat any binary client message as a SAFP-framed chunk of source
+        audio. Auth and config are enforced before the frame is decoded so an
+        unauthenticated peer is rejected regardless of framing; a malformed
+        frame from an authenticated peer is dropped (the node server already
+        validated the CRC, so this is defense in depth).
         """
-        self._audio_chunk(message)
+        if not self._is_authenticated:
+            self.close(1008, "Audio chunk before authentication")
+            return
+
+        if self._service is None:
+            self.close(1008, "Audio chunk before configuration")
+            return
+
+        try:
+            frame = decode_audio_frame(message)
+        except AudioFrameError:
+            self._logger.warning("Dropping malformed audio frame")
+            return
+
+        self._service.handle_audio_chunk(frame.chunk_id or "", frame.audio)
 
     def _handle_close(self, code: int, reason: str | None):
         """

--- a/transcription_service/src/webserver/features/transcription_stream/transcription_stream_messages/server_messages.py
+++ b/transcription_service/src/webserver/features/transcription_stream/transcription_stream_messages/server_messages.py
@@ -36,4 +36,8 @@ class TranscriptMessage(JsonServerMessage):
 
     final: TranscriptSequence | None = None
     in_progress: TranscriptSequence | None = None
+    # Ids of the source audio chunks that contributed to each transcript,
+    # echoed back so the node server can measure end-to-end latency.
+    final_chunk_ids: list[str] | None = None
+    in_progress_chunk_ids: list[str] | None = None
     type: Literal[ServerMessageTypes.TRANSCRIPT] = ServerMessageTypes.TRANSCRIPT

--- a/transcription_service/src/webserver/features/transcription_stream/transcription_stream_service.py
+++ b/transcription_service/src/webserver/features/transcription_stream/transcription_stream_service.py
@@ -81,14 +81,14 @@ class TranscriptionStreamService(EventEmitter):
         )
         self._session.start_session()
 
-    def handle_audio_chunk(self, chunk: bytes):
+    def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
         """
         Forward an audio chunk to the underlying session. No-op if the
         service has been closed.
         """
         if self._closed or self._session is None:
             return
-        self._session.handle_audio_chunk(chunk)
+        self._session.handle_audio_chunk(chunk_id, chunk)
 
     def close(self):
         """

--- a/transcription_service/tests/integration/transcription_stream/transcription_stream_test.py
+++ b/transcription_service/tests/integration/transcription_stream/transcription_stream_test.py
@@ -19,6 +19,7 @@ from src.shared.config import (
     TranscriptionProviderUID,
 )
 from src.shared.logger import ContextLogger, Logger
+from src.shared.utils.audio_frame_protocol import encode_audio_frame
 from src.webserver.create_webserver import create_webserver
 
 API_KEY = "TEST_KEY"
@@ -141,6 +142,8 @@ async def test_transcription_stream_accepts_valid_auth_config(
                 "ends": None,
             },
             "in_progress": None,
+            "final_chunk_ids": None,
+            "in_progress_chunk_ids": None,
         }
 
 
@@ -165,7 +168,7 @@ async def test_transcription_stream_accepts_audio(test_client: TestClient):
                     "config": {"sample_rate": 48000, "num_channels": 1},
                 }
             )
-            websocket.send_bytes(chunk)
+            websocket.send_bytes(encode_audio_frame("chunk-1", chunk))
             websocket.receive_json()
 
             # Allow async loop to run

--- a/transcription_service/tests/unit/shared/utils/audio_frame_protocol/audio_frame_protocol_test.py
+++ b/transcription_service/tests/unit/shared/utils/audio_frame_protocol/audio_frame_protocol_test.py
@@ -1,0 +1,132 @@
+"""
+Unit tests for the ScribeAR Audio Frame Protocol (SAFP) codec.
+"""
+
+import struct
+import zlib
+
+import pytest
+
+from src.shared.utils.audio_frame_protocol import (
+    SAFP_VERSION,
+    AudioFrameError,
+    decode_audio_frame,
+    encode_audio_frame,
+)
+from src.shared.utils.audio_frame_protocol.audio_frame_protocol import (
+    FIELD_KEY_CHUNK_ID,
+    SAFP_MAGIC_0,
+    SAFP_MAGIC_1,
+    WIRE_BYTES,
+    WIRE_UTF8,
+)
+
+AUDIO = bytes([0, 1, 2, 3, 250, 251, 252, 253])
+
+
+def test_crc_known_answer_matches_typescript():
+    """zlib.crc32 must produce the canonical CRC-32 check value, which is the
+    same number the TypeScript table-based crc32 produces."""
+    assert zlib.crc32(b"123456789") & 0xFFFFFFFF == 0xCBF43926
+
+
+def test_round_trip_chunk_id_and_sent_at():
+    """A frame with both metadata fields decodes back to the same values."""
+    frame = encode_audio_frame("id-123", AUDIO, sent_at=1_700_000_000_123.0)
+    decoded = decode_audio_frame(frame)
+
+    assert decoded.version == SAFP_VERSION
+    assert decoded.chunk_id == "id-123"
+    assert decoded.sent_at == 1_700_000_000_123.0
+    assert decoded.audio == AUDIO
+    assert decoded.unknown_fields == []
+
+
+def test_round_trip_chunk_id_only():
+    """The node -> python hop carries chunk_id only (no sent_at)."""
+    frame = encode_audio_frame("abc", AUDIO)
+    decoded = decode_audio_frame(frame)
+
+    assert decoded.chunk_id == "abc"
+    assert decoded.sent_at is None
+    assert decoded.audio == AUDIO
+
+
+def test_unicode_chunk_id():
+    """UTF-8 chunk ids round-trip byte-for-byte."""
+    decoded = decode_audio_frame(encode_audio_frame("café-⛄-😀", AUDIO))
+    assert decoded.chunk_id == "café-⛄-😀"
+
+
+def test_empty_audio():
+    """A frame may carry no audio payload."""
+    decoded = decode_audio_frame(encode_audio_frame("x", b""))
+    assert decoded.chunk_id == "x"
+    assert decoded.audio == b""
+
+
+def test_cross_language_frame_shape():
+    """Encoded magic + version bytes match the documented envelope, so a
+    frame from the TypeScript encoder decodes here and vice versa."""
+    frame = encode_audio_frame("x", AUDIO)
+    assert frame[0] == SAFP_MAGIC_0
+    assert frame[1] == SAFP_MAGIC_1
+    assert frame[2] == SAFP_VERSION
+
+
+def test_forward_compatibility_skips_unknown_field():
+    """An unknown field inserted by a newer sender is skipped, and the known
+    field + audio are still recovered."""
+    chunk_bytes = b"fwd"
+    unknown_value = bytes([9, 9, 9])
+    fields = bytearray()
+    fields += struct.pack(
+        "<BBH", FIELD_KEY_CHUNK_ID, WIRE_UTF8, len(chunk_bytes)
+    )
+    fields += chunk_bytes
+    fields += struct.pack("<BBH", 99, WIRE_BYTES, len(unknown_value))
+    fields += unknown_value
+
+    body = bytearray()
+    body += struct.pack("<BBBB", SAFP_MAGIC_0, SAFP_MAGIC_1, SAFP_VERSION, 2)
+    body += fields
+    body += AUDIO
+    body += struct.pack("<I", zlib.crc32(bytes(body)) & 0xFFFFFFFF)
+
+    decoded = decode_audio_frame(bytes(body))
+    assert decoded.chunk_id == "fwd"
+    assert decoded.audio == AUDIO
+    assert len(decoded.unknown_fields) == 1
+    assert decoded.unknown_fields[0][0] == 99
+
+
+def test_rejects_short_buffer():
+    """Buffers shorter than the minimum envelope are rejected."""
+    with pytest.raises(AudioFrameError):
+        decode_audio_frame(b"\x00\x00\x00")
+
+
+def test_rejects_bad_magic():
+    """A frame with the wrong magic is rejected."""
+    frame = bytearray(encode_audio_frame("x", AUDIO))
+    frame[0] = 0x00
+    frame[-4:] = struct.pack("<I", zlib.crc32(bytes(frame[:-4])) & 0xFFFFFFFF)
+    with pytest.raises(AudioFrameError, match="magic"):
+        decode_audio_frame(bytes(frame))
+
+
+def test_rejects_crc_mismatch():
+    """A single flipped audio byte is caught by the CRC."""
+    frame = bytearray(encode_audio_frame("x", AUDIO))
+    frame[-5] ^= 0xFF
+    with pytest.raises(AudioFrameError, match="CRC"):
+        decode_audio_frame(bytes(frame))
+
+
+def test_rejects_unsupported_version():
+    """An unexpected version byte is rejected."""
+    frame = bytearray(encode_audio_frame("x", AUDIO))
+    frame[2] = 2
+    frame[-4:] = struct.pack("<I", zlib.crc32(bytes(frame[:-4])) & 0xFFFFFFFF)
+    with pytest.raises(AudioFrameError, match="version"):
+        decode_audio_frame(bytes(frame))

--- a/transcription_service/tests/unit/transcription_providers/debug_provider/debug_provider_test.py
+++ b/transcription_service/tests/unit/transcription_providers/debug_provider/debug_provider_test.py
@@ -70,7 +70,7 @@ async def test_debug_provider_returns_audio_debug_info(
 
     # Act
     debug_provider_session.start_session()
-    debug_provider_session.handle_audio_chunk(chunk)
+    debug_provider_session.handle_audio_chunk("chunk-1", chunk)
     await asyncio.sleep(1.2)
 
     # Assert
@@ -112,7 +112,7 @@ async def test_debug_provider_throws_exception_on_bad_chunk(
 
     # Act
     debug_provider_session.start_session()
-    debug_provider_session.handle_audio_chunk(chunk)
+    debug_provider_session.handle_audio_chunk("chunk-1", chunk)
     await asyncio.sleep(1.2)
 
     # Assert

--- a/transcription_service/tests/unit/transcription_providers/whisper_streaming_provider/whisper_streaming_job_test.py
+++ b/transcription_service/tests/unit/transcription_providers/whisper_streaming_provider/whisper_streaming_job_test.py
@@ -1,0 +1,104 @@
+"""
+Unit tests for WhisperStreamingProviderJob chunk-id ledger and latency
+correlation. Exercises the pure bookkeeping (which chunk ids a transcript end
+time maps to, and ledger pruning) without invoking the Whisper model.
+"""
+
+# pylint: disable=protected-access
+
+from src.transcription_provider_interface import TranscriptionSequence
+from src.transcription_providers.whisper_streaming_provider.whisper_streaming_config import (
+    WhisperStreamingProviderConfig,
+)
+from src.transcription_providers.whisper_streaming_provider.whisper_streaming_job import (
+    SAMPLE_RATE,
+    WhisperStreamingProviderJob,
+)
+
+
+def make_job() -> WhisperStreamingProviderJob:
+    """A job with a minimal valid config (VAD disabled)."""
+    config = WhisperStreamingProviderConfig(
+        whisper_context_tag="w",
+        silero_context_tag="s",
+        job_period_ms=5000,
+        max_buffer_len_sec=30,
+        local_agree_dim=2,
+    )
+    return WhisperStreamingProviderJob(config)
+
+
+def _one_second_ledger():
+    """Three consecutive 1-second chunks a, b, c."""
+    return [
+        {"chunk_id": "a", "start_sample": 0, "end_sample": SAMPLE_RATE},
+        {
+            "chunk_id": "b",
+            "start_sample": SAMPLE_RATE,
+            "end_sample": 2 * SAMPLE_RATE,
+        },
+        {
+            "chunk_id": "c",
+            "start_sample": 2 * SAMPLE_RATE,
+            "end_sample": 3 * SAMPLE_RATE,
+        },
+    ]
+
+
+def test_extract_selects_chunks_starting_before_end_time():
+    """Chunks that begin before the transcript end time are returned."""
+    job = make_job()
+    job._chunk_ledger = _one_second_ledger()
+    # End at 1.5s -> sample 24000; chunks starting before it are a and b.
+    assert job._extract_chunk_ids_for_time(1.5) == ["a", "b"]
+
+
+def test_extract_zero_or_negative_end_time_returns_empty():
+    """A missing/zero end time yields no chunk ids."""
+    job = make_job()
+    job._chunk_ledger = _one_second_ledger()
+    assert not job._extract_chunk_ids_for_time(0)
+    assert not job._extract_chunk_ids_for_time(-1)
+
+
+def test_extract_prunes_records_purged_from_buffer():
+    """Ledger records whose audio has been purged are dropped."""
+    job = make_job()
+    job._buffer_offset_samples = 2 * SAMPLE_RATE  # first two seconds purged
+    job._chunk_ledger = _one_second_ledger()
+    job._extract_chunk_ids_for_time(3.0)
+    # Records whose audio is fully behind the buffer offset are dropped: 'a'
+    # (ends at 16000 < 32000) goes; 'b' (ends at 32000) and 'c' stay.
+    assert [r["chunk_id"] for r in job._chunk_ledger] == ["b", "c"]
+
+
+def test_build_result_tags_final_and_in_progress_chunk_ids():
+    """Each transcript is tagged with the chunk ids that produced it."""
+    job = make_job()
+    job._chunk_ledger = _one_second_ledger()
+    final = TranscriptionSequence(text=["hi"], starts=[0.0], ends=[0.5])
+    in_progress = TranscriptionSequence(
+        text=["there"], starts=[1.0], ends=[1.5]
+    )
+
+    result = job._build_result(final, in_progress)
+
+    # final ends at 0.5s -> sample 8000 -> only 'a'.
+    assert result.final_chunk_ids == ["a"]
+    # in_progress ends at 1.5s -> sample 24000 -> 'a' and 'b'.
+    assert result.in_progress_chunk_ids == ["a", "b"]
+    assert result.final is final
+    assert result.in_progress is in_progress
+
+
+def test_build_result_without_timestamps_yields_no_chunk_ids():
+    """A transcript with no end timestamps can't be correlated to any chunk."""
+    job = make_job()
+    job._chunk_ledger = _one_second_ledger()
+    # A sequence with no `ends` cannot be correlated to a time.
+    final = TranscriptionSequence(text=["hi"], starts=None, ends=None)
+
+    result = job._build_result(final, None)
+
+    assert not result.final_chunk_ids
+    assert not result.in_progress_chunk_ids

--- a/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_controller_test.py
+++ b/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_controller_test.py
@@ -19,6 +19,7 @@ from starlette.websockets import WebSocket, WebSocketState
 
 from src.shared.config import Config
 from src.shared.logger import Logger
+from src.shared.utils.audio_frame_protocol import encode_audio_frame
 from src.transcription_provider_interface import (
     TranscriptionClientError,
     TranscriptionResult,
@@ -53,6 +54,11 @@ AUDIO_DIR = path.normpath(
 with open(path.join(AUDIO_DIR, "mono_f64le.pcm"), "rb") as f:
     AUDIO_CHUNK = f.read()
 
+# The controller receives SAFP-framed binary; wrap the raw audio the way the
+# node server would before forwarding.
+AUDIO_CHUNK_ID = "test-chunk"
+AUDIO_FRAME = encode_audio_frame(AUDIO_CHUNK_ID, AUDIO_CHUNK)
+
 INIT_TIMEOUT_SEC = 0.1
 
 PROVIDER_UID = "TEST_PROVIDER_UID"
@@ -68,7 +74,7 @@ class MockTranscriptionSession(TranscriptionSessionInterface):
     Dummy transcription session interface implementation for testing
     """
 
-    def handle_audio_chunk(self, chunk: bytes):
+    def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
         return
 
 
@@ -385,10 +391,12 @@ async def test_controller_handles_valid_audio_chunk(
     await controller._handle_text_message(VALID_CONFIG_MESSAGE)
 
     # Act
-    await controller._handle_binary_message(AUDIO_CHUNK)
+    await controller._handle_binary_message(AUDIO_FRAME)
 
     # Assert
-    mock_session.handle_audio_chunk.assert_called_once_with(AUDIO_CHUNK)
+    mock_session.handle_audio_chunk.assert_called_once_with(
+        AUDIO_CHUNK_ID, AUDIO_CHUNK
+    )
 
 
 @pytest.mark.asyncio
@@ -573,7 +581,7 @@ async def test_controller_handles_no_transcription_results(
     await controller._handle_text_message(VALID_CONFIG_MESSAGE)
 
     # Act
-    await controller._handle_binary_message(AUDIO_CHUNK)
+    await controller._handle_binary_message(AUDIO_FRAME)
 
     # Assert
     mock_send_method.assert_not_called()

--- a/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_service_test.py
+++ b/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_service_test.py
@@ -41,7 +41,9 @@ class FakeSession(TranscriptionSessionInterface):
 
     # The abstract method is patched in __init__ above; this satisfies the
     # ABC check at class-construction time.
-    def handle_audio_chunk(self, chunk: bytes):  # type: ignore[override]
+    def handle_audio_chunk(  # type: ignore[override]
+        self, chunk_id: str, chunk: bytes
+    ):
         return None
 
 
@@ -132,10 +134,10 @@ def test_handle_audio_chunk_forwards_to_session(
     chunk = b"\x01\x02\x03"
 
     # Act
-    service.handle_audio_chunk(chunk)
+    service.handle_audio_chunk("chunk-1", chunk)
 
     # Assert
-    fake_session.handle_audio_chunk.assert_called_once_with(chunk)
+    fake_session.handle_audio_chunk.assert_called_once_with("chunk-1", chunk)
 
 
 def test_handle_audio_chunk_is_no_op_before_start(
@@ -146,7 +148,7 @@ def test_handle_audio_chunk_is_no_op_before_start(
     service can't crash from out-of-order controller calls.
     """
     # Arrange / Act
-    service.handle_audio_chunk(b"\x01")
+    service.handle_audio_chunk("chunk-1", b"\x01")
 
     # Assert - no exception raised, no session call attempted (no session yet).
 


### PR DESCRIPTION
Supersedes #67. The original `latency-metrics` PR was built against the pre-refactor architecture and could not be conflict-merged — `staging` had rewritten the node-server, deleted the `transcription-service-client` lib, split `webapp` into `client-webapp`/`kiosk-webapp`, and refactored the Python worker pool, and the new pipeline carried no chunk-id/timestamp to hang latency off of. This PR rebuilds the feature on the current architecture.

## What it does
- **Kiosk** frames each audio chunk in a versioned, self-describing binary envelope (`@scribear/audio-frame-protocol`, "SAFP" v1: magic + version + TLV metadata + CRC-32) carrying a `chunkId` and a clock-corrected `sentAt`.
- **Node server** decodes frames, keeps a bounded per-session `chunkId → {recvMono, sentAt}` map, forwards audio upstream, and on each transcript correlates the echoed `chunk_ids` to emit two latencies:
  - `pipelineMs` — measured on the node's **monotonic** clock (skew-free);
  - `e2eMs` — capture→display, using a clock-synced `sentAt`; `null` until synced.
- **Clock sync** via `timeSyncPing`/`timeSyncPong` (Cristian's algorithm, min-RTT sample).
- **Client webapp** shows a 60-sample moving average of both metrics (final / interim).
- **Python** threads `chunkId` through the provider/job and echoes `final`/`in_progress` `chunk_ids` on the transcript message.

## Design notes
- Replaces PR #67's hard-coded 44-byte header with a versioned TLV+CRC envelope so kiosk/node/python can evolve independently. The TS and Python codecs produce **byte-identical** frames.
- The monotonic `pipelineMs` is the trustworthy metric for alerting; `e2eMs` is indicative (depends on clock-offset estimation).

## Verification
- TS: full build, all-workspace lint + format, node-server **78 tests** (incl. a real transcription-service **container** integration proving SAFP round-trips end-to-end and audio actually flows), `audio-frame-protocol` **19 tests** (codec + CRC known-answer + ClockSync).
- Python: **180 tests**, pylint 10/10, black/isort clean.
- Hardened a latent weak integration test that passed even when audio was dropped (debug provider emits `Processed 0.0000 seconds` on its tick regardless) — it now sends a real SAFP frame and asserts a non-zero processed duration.

## Follow-ups
See `TOBEREVIEWED.md` for deliberately-deferred items (VAD-config exposure, Python stage-timing diagnostics) and production concerns (clock-skew reliability, decode-drop observability, unauthenticated/unthrottled `timeSyncPing`, `pendingChunks` cap, CRC cost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)