### PR TITLE
feat(admin): add admin website (BFF + SPA), SM hardening, deploy wiring

### DIFF
--- a/.changeset/admin-website-foundation.md
+++ b/.changeset/admin-website-foundation.md
@@ -1,0 +1,24 @@
+---
+'@scribear/admin-server': minor
+'@scribear/admin-webapp': minor
+---
+
+Add the ScribeAR Admin website foundation (PLAN-ADMIN Phase 0–1).
+
+- **`apps/admin-server`** — a Fastify Backend-for-Frontend that holds the
+  Session Manager admin key server-side and exposes `/api/admin/v1`. Includes:
+  a pluggable auth layer (local single-account provider now via
+  `ADMIN_LOCAL_CREDENTIALS`, constant-time compare; Azure OIDC stub for later);
+  server-side revocable sessions (HttpOnly + Secure + SameSite=Strict signed
+  cookie) with a session-bound CSRF token; per-route rate limiting (strict on
+  login); a Session Manager gateway that is the single place the admin key is
+  used and injected; a consistent `{ ok, data?, error? }` response envelope;
+  rooms + devices proxy/task endpoints with read-only/read-write role gating;
+  a `/health` rollup; and a Postgres-backed append-only admin audit log
+  (own migration + migration-tracking tables).
+- **`apps/admin-webapp`** — a minimal React SPA placeholder (build + healthcheck)
+  to be built out in later phases.
+
+Both workspaces are wired into the monorepo (workspaces auto-discovery,
+tsconfig project references) with unit + integration tests. Deployment
+(compose/nginx/CI) and the full SPA UI land in later phases.

--- a/.changeset/session-manager-key-hardening.md
+++ b/.changeset/session-manager-key-hardening.md
@@ -1,0 +1,18 @@
+---
+'@scribear/session-manager': patch
+---
+
+Harden Session Manager credential handling (admin website Phase 6):
+
+- Compare the admin and service API keys in constant time
+  (`crypto.timingSafeEqual` over HMAC digests) instead of `===`, closing a
+  timing side-channel.
+- Refuse to start when `ADMIN_API_KEY` / `SESSION_MANAGER_SERVICE_API_KEY` is
+  still the literal placeholder `CHANGEME`.
+- Rate-limit the two unauthenticated credential-exchange routes
+  (`exchange-join-code`, `refresh-session-token`) per client IP via
+  `@fastify/rate-limit` (long-poll, probe, and admin/service routes are
+  intentionally not limited). `trustProxy` is enabled so the limit keys on the
+  real client IP behind nginx.
+
+No change to the wire contract.

--- a/.github/workflows/node-cd.yml
+++ b/.github/workflows/node-cd.yml
@@ -67,6 +67,16 @@ jobs:
             dockerfile: apps/node-server/Dockerfile
             workspace: apps/node-server
             version_file: apps/node-server/package.json
+          - image_name: scribear/admin-server
+            build_context: .
+            dockerfile: apps/admin-server/Dockerfile
+            workspace: apps/admin-server
+            version_file: apps/admin-server/package.json
+          - image_name: scribear/admin-webapp
+            build_context: .
+            dockerfile: apps/admin-webapp/Dockerfile
+            workspace: apps/admin-webapp
+            version_file: apps/admin-webapp/package.json
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -190,6 +190,16 @@ jobs:
             dockerfile: apps/node-server/Dockerfile
             workspace: apps/node-server
             version_file: apps/node-server/package.json
+          - image_name: scribear/admin-server
+            build_context: .
+            dockerfile: apps/admin-server/Dockerfile
+            workspace: apps/admin-server
+            version_file: apps/admin-server/package.json
+          - image_name: scribear/admin-webapp
+            build_context: .
+            dockerfile: apps/admin-webapp/Dockerfile
+            workspace: apps/admin-webapp
+            version_file: apps/admin-webapp/package.json
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+venv/lib/
+venv/lib64/
 parts/
 sdist/
 var/

--- a/PLAN-ADMIN.md
+++ b/PLAN-ADMIN.md
@@ -1,0 +1,820 @@
+# PLAN-ADMIN — ScribeAR Admin Website
+
+A plan for an **admin website for IT professionals** to operate the ScribeAR
+Session Manager: create/list/rename/delete rooms and devices, set up kiosks,
+manage schedules and sessions, and see health/status/error information — securely.
+
+> Status: proposal / design. Nothing here is built yet. This document is the
+> source of truth for scope, architecture, and phased delivery. Owner: TBD.
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+- Give IT staff a **web UI** replacing the current `curl` + `deployment/*.sh` workflow.
+- Support the **common operations**:
+  - Rooms: create, list/search, view, rename, delete, manage member devices, set source device.
+  - Devices: register, list/search, view, rename, delete, re-register (rotate credential).
+  - **Kiosk setup**: guided flow that registers a device, shows the activation code, and assigns it to a room as source.
+  - Schedules & sessions: create/list/edit/delete recurring schedules and auto-session windows; create on-demand sessions; start/end sessions early; toggle a room's auto-session master switch.
+- Be **secure**: the admin API key must never reach the browser; authenticate individual IT staff; audit who did what.
+- **Report clearly**: surface successes, validation errors, failures, service health, and any available status/performance info.
+- Match the repo's existing **stack and conventions** (npm workspaces, React 19 + Vite + MUI + Redux Toolkit, nginx-served, Docker Compose deploy).
+
+### Non-goals (initial release)
+- End-user (viewer/participant) features — those already live in `client-webapp`/`kiosk-webapp`.
+- Replacing session-manager's auth model wholesale (we adapt around it; targeted hardening is listed in §11).
+- Multi-tenant org management beyond what the current schema supports.
+- Editing transcription-provider model configs beyond passing through `transcriptionProviderId` / `transcriptionStreamConfig`.
+
+---
+
+## 2. Current-state findings (from code review)
+
+### 2.1 Where the admin API lives
+The admin API is the **Session Manager** service (`apps/session-manager`), not `node-server`
+(which only proxies transcription websockets). Base path:
+
+```
+/api/session-manager/v1
+```
+
+Served as plain HTTP on `:8001`; TLS + routing handled by nginx
+(`infra/scribear-nginx/nginx.conf`, location `/api/session-manager/`).
+
+### 2.2 API surface (40 routes; 29 are admin-guarded)
+Guards are Fastify `preHandler` hooks (`apps/session-manager/src/server/hooks/`):
+
+| Audience | Credential | Transport |
+|---|---|---|
+| **Admin** (`adminApiKeyHook`) | `ADMIN_API_KEY` | `Authorization: Bearer <key>` |
+| Service (`serviceApiKeyHook`) | `SESSION_MANAGER_SERVICE_API_KEY` | `Authorization: Bearer <key>` |
+| Device (`deviceTokenHook`) | `DEVICE_TOKEN` cookie (`{uid}:{secret}`, bcrypt) | HTTP-only cookie |
+| Public | join code / refresh token / activation code, or none | request body |
+
+**The 29 admin-guarded routes** (the admin site's entire target surface):
+
+- **Device Management** (6): `list-devices` (paginated; filters `search`, `active`, `roomUid`), `get-device/:uid`, `register-device`, `reregister-device`, `update-device`, `delete-device`.
+- **Room Management** (8): `list-rooms` (paginated; `search`), `get-room/:uid`, `create-room`, `update-room`, `delete-room`, `add-device-to-room`, `remove-device-from-room`, `set-source-device`.
+- **Schedule Management** (15): `list-schedules`/`create-schedule`/`get-schedule/:uid`/`update-schedule`/`delete-schedule`; `list-auto-session-windows`/`create-…`/`get-…/:uid`/`update-…`/`delete-…`; `update-room-schedule-config`; `get-session/:uid`, `create-on-demand-session`, `start-session-early`, `end-session-early`.
+
+Not for the admin site: `activate-device`, `get-my-device`, `get-my-room`, `my-schedule`,
+`fetch-join-code`, `exchange-device-token`, `exchange-join-code`, `refresh-session-token`,
+`session-config-stream`, `liveness`, `readiness`.
+
+Conventions: reads are `GET` (single-entity fetch uses a path param); **all mutations are
+`POST` with a JSON body** (no PUT/PATCH/DELETE). Only `list-devices`/`list-rooms` paginate
+(cursor + limit 1–200 default 50; envelope `{ items, nextCursor }`). Two "streaming" routes
+are HTTP long-poll, not WebSocket — and neither is admin-facing.
+
+### 2.3 Domain model (for UI shapes)
+- **Device**: `{ uid, name, active, roomUid|null, isSource|null, createdAt }`. Lifecycle is
+  **pending** (`active=false`, has one-time `activationCode`+`expiry`) → **activated**
+  (`active=true`, holds a bcrypt device-token hash). A device belongs to **≤1 room**.
+- **Room**: `{ uid, name, timezone (IANA), autoSessionEnabled, roomScheduleVersion, createdAt }`.
+  A room must always have **≥1 source device** (v1: exactly one). Deleting a room cascades
+  its memberships, schedules, sessions.
+- **RoomDevice** join: `is_source` marks the audio source; unique on `device_uid`.
+- **Session**: `{ uid, roomUid, name, type (SCHEDULED|ON_DEMAND|AUTO), scheduled/effective start&end, startOverride/endOverride, joinCodeScopes[], transcriptionProviderId, transcriptionStreamConfig, sessionConfigVersion, createdAt }`. Sessions in a room **cannot overlap** in time (DB exclusion constraint). `effectiveStart/End` fold in manual overrides.
+- **Schedule** (recurring template): frequency `ONCE|WEEKLY|BIWEEKLY`, `daysOfWeek[]`, local start/end times (room tz), active window.
+- **AutoSessionWindow**: recurring windows that fill gaps with `AUTO` sessions when the room's `autoSessionEnabled` is on.
+- **SessionScope**: `SEND_AUDIO`, `RECEIVE_TRANSCRIPTIONS`.
+
+### 2.4 Reusable building blocks
+- **Typed client** `@scribear/session-manager-client` — `createSessionManagerClient(baseUrl)`
+  returns `{ probes, roomManagement, deviceManagement, scheduleManagement, sessionAuth }`,
+  each method `(params, init?) => Promise<[response, error]>`. **No credential is embedded** —
+  the caller must attach `Authorization: Bearer <key>` per call. Browser-safe (uses `fetch`/`URL`)
+  but the key must be injected **server-side**.
+- **Schemas** `@scribear/session-manager-schema` — TypeBox request/response schemas + OpenAPI
+  metadata. Swagger UI is served at `/api-docs` **only in `--dev`**.
+- **Frontend conventions** (copy `client-webapp` as the template): React `19.2.5`, Vite, MUI
+  `7.3.8` + Emotion, Redux Toolkit `2.11.2` + `redux-remember`, TypeBox for URL-config, Node
+  `24.10.0`, nginx-alpine runtime image. Feature-based folders; the **service + middleware**
+  idiom for non-React runtime logic; typed `useAppSelector/useAppDispatch`; theme via
+  `AppThemeProvider`. **No router yet** — the admin app would introduce `react-router`.
+- **Current manual workflow**: `deployment/register-device.sh <name>` then
+  `deployment/create-room.sh <name> <sourceDeviceUid> [tz] [auto]`, both sending
+  `Authorization: Bearer $SESSION_MANAGER_API_KEY`.
+
+### 2.5 Deployment topology
+Single nginx terminates TLS and serves everything **same-origin**:
+`/api/session-manager/`, `/api/node-server/`, `/client/`, `/kiosk/`, `/standalone/`.
+Compose stack in `deployment/compose.yml`; images from `ghcr.io/scribear`.
+
+---
+
+## 3. The central constraint (drives the whole architecture)
+
+Session Manager's admin auth is **a single static bearer key**, compared in plaintext
+(`key === ADMIN_API_KEY`, `admin-auth.service.ts`). It has:
+
+- no per-user identity, no audit of *who* acted, no revocation short of rotating the one key;
+- **no CORS** configured (a cross-origin browser SPA cannot call it directly);
+- **no rate limiting** anywhere;
+- non-constant-time comparison and no key-strength enforcement (`CHANGEME` is accepted).
+
+**Consequence:** we cannot ship the admin key to a browser SPA, and we cannot let the SPA call
+Session Manager cross-origin. We need a **Backend-for-Frontend (BFF)** that:
+holds the key server-side, authenticates individual IT staff, and proxies admin calls
+same-origin. This is the recommended architecture (§4).
+
+---
+
+## 4. Architecture
+
+### 4.1 Recommended: Admin SPA + Admin BFF (two new containers)
+
+```
+Browser ──HTTPS──> nginx ──> /admin/       ─> admin-webapp   (static SPA, nginx-alpine)
+                        └──> /api/admin/    ─> admin-server   (BFF: auth, proxy, audit)
+                                                    │
+                                                    └─(server-side, Bearer ADMIN_API_KEY)─>
+                                                       session-manager  /api/session-manager/v1
+```
+
+- **`apps/admin-webapp`** — React SPA, same conventions as `client-webapp`. Talks **only** to
+  `/api/admin/*` on its own origin. Never sees the admin key. Holds a session cookie only.
+- **`apps/admin-server`** — small Fastify BFF built on `@scribear/base-fastify-server`:
+  - authenticates IT staff and issues an **HTTP-only, Secure, SameSite=strict session cookie** (+ CSRF token);
+  - injects `Authorization: Bearer $ADMIN_API_KEY` and calls Session Manager via
+    `@scribear/session-manager-client`;
+  - exposes a thin `/api/admin/*` surface (either 1:1 proxy or task-oriented endpoints, e.g. a single "provision kiosk" call that fans out to register + assign);
+  - adds **audit logging**, **rate limiting**, per-user authorization, and consistent error envelopes.
+
+**Why the BFF:** it is the only design that satisfies "must be secure" given the static-key
+model — it keeps the key server-side, gives real per-admin identity + audit, and lets us add
+rate limiting/CSRF without modifying Session Manager. It also matches the same-origin nginx
+topology (no CORS needed).
+
+**Staff authentication (decided):** a **pluggable auth layer** in the BFF with two providers
+behind one interface — ship the **local provider now**, add **Azure Entra ID (Azure AD) SSO
+later** without reworking session/CSRF/audit. See §4.4 for the design.
+- **Today — local single-account provider.** One username+password supplied via a single env var
+  (`ADMIN_LOCAL_CREDENTIALS`, e.g. `engrit hag3hasdgqwy!`). If the var is empty/unset the local
+  provider is **disabled** (the toggle used to force SSO-only in production).
+- **Future — Azure Entra ID (OIDC) provider.** UIUC Azure AD. Real identities + MFA + central
+  de-provisioning; restrict to an admin group/allowlist. Added as a second provider; everything
+  downstream (session cookie, CSRF, rate limiting, audit) is provider-agnostic and unchanged.
+
+### 4.2 Alternative (lower effort, weaker): nginx gate + header injection
+Put `oauth2-proxy` or nginx basic-auth in front, and have nginx inject the admin key header on
+`/api/admin/session-manager/` → session-manager. No custom BFF.
+- Pros: minimal new code.
+- Cons: no per-user authorization inside the app, coarse audit, no task-oriented endpoints, no
+  place to add CSRF/validation/aggregation. Everything past the gate gets **full** admin power.
+- Verdict: acceptable only as an interim; **not** recommended as the target.
+
+### 4.3 Why not a pure SPA calling session-manager directly
+Would require shipping the admin key to the browser and enabling CORS — both unacceptable given
+§3. Rejected.
+
+### 4.4 Authentication design (pluggable: local now, Azure Entra ID later)
+
+The BFF authenticates a **staff identity** and then issues its **own** session — the identity
+*source* is swappable, the session machinery is not. This keeps the future Azure work to "add one
+provider", touching nothing about cookies, CSRF, rate limiting, authorization, or audit.
+
+```
+AuthProvider (interface)                       Session layer (provider-agnostic)
+  ├─ LocalAuthProvider    ── verify() ─┐        ├─ issueSession(identity) → HttpOnly cookie + CSRF token
+  └─ AzureOidcProvider    ── verify() ─┴──────► ├─ requireSession()  (guards /api/admin/*)
+     (future)                                    ├─ audit(actor = identity)
+                                                 └─ logout()
+```
+
+- **`Identity`** = `{ subject, displayName, provider, roles }`. The rest of the BFF only ever sees
+  an `Identity`, never a provider-specific credential.
+
+**Local provider (build now):**
+- Reads **one** env var `ADMIN_LOCAL_CREDENTIALS` = `"<username> <password>"`, **split on the first
+  space only** so the password may contain spaces (`hag3hasdgqwy!` in the example has none, but the
+  rule keeps it safe). Example: `ADMIN_LOCAL_CREDENTIALS="engrit hag3hasdgqwy!"` → user `engrit`.
+- **Empty or unset ⇒ local login disabled** (provider not registered). This is the switch that
+  makes the deployment SSO-only once Azure lands.
+- Endpoint `POST /api/admin/auth/login` `{ username, password }`. Compare both fields with
+  `crypto.timingSafeEqual` (constant-time; do **not** early-return on username mismatch). On success
+  issue the session; map the local user to a fixed `roles` set (single admin, or read-write).
+- Brute-force defense: **rate-limit `/auth/login`** (per-IP + global), small fixed delay on failure,
+  generic "invalid credentials" message. This is the one credential-guessing surface, so it matters.
+- Never log the password; never return it; treat `ADMIN_LOCAL_CREDENTIALS` like any other secret
+  (compose secret / env, not committed).
+
+**Azure Entra ID provider (future, seams in place now):**
+- Standard OIDC Authorization Code + PKCE against UIUC Entra ID. Endpoints `GET /api/admin/auth/sso/login`
+  (redirect to Microsoft) and `GET /api/admin/auth/sso/callback` (exchange code → validate `id_token`
+  → build `Identity` from claims; authorize by group/allowlist). Then the **same** `issueSession()`.
+- Config via env only (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`,
+  `AZURE_REDIRECT_URI`, `ADMIN_ALLOWED_GROUP`); when unset the SSO provider isn't registered — so
+  the two providers coexist and are independently toggled by presence of their env config.
+- No schema/session/UI rework required to add it; the login page just gains a "Sign in with Illinois
+  (Azure AD)" button alongside (or instead of) the local form.
+
+**Login page behavior:** the SPA asks the BFF `GET /api/admin/auth/config` which returns which
+providers are enabled `{ local: bool, sso: bool }`, and renders the password form and/or the SSO
+button accordingly — so turning SSO on / local off is a pure env change with no frontend rebuild.
+
+---
+
+## 5. Admin operations → endpoint mapping
+
+| Operation (UI) | Session Manager endpoint(s) | Notes / guardrails |
+|---|---|---|
+| List/search rooms | `room-management/list-rooms` | cursor pagination + `search` |
+| View room detail | `get-room/:uid` + `list-devices?roomUid=…` + `list-schedules?roomUid` + `list-auto-session-windows?roomUid` | aggregate in BFF |
+| Create room | `create-room` | needs `name`, IANA `timezone`, `sourceDeviceUids[]` (≥1); can chain from device register |
+| Rename room | `update-room` | |
+| Delete room | `delete-room` | **confirm**: cascades schedules/sessions/memberships |
+| Add/remove device to room | `add-device-to-room`, `remove-device-from-room` | remove blocked (409) if it orphans the source |
+| Set source device | `set-source-device` | transactional swap |
+| Toggle auto-sessions | `update-room-schedule-config` | master switch |
+| List/search devices | `device-management/list-devices` | filters `search`, `active`, `roomUid` (`""`=unassigned) |
+| View device | `get-device/:uid` | |
+| Register device | `register-device` | returns `{ deviceUid, activationCode, expiry }` — surface the code + countdown |
+| Re-register (rotate) device | `reregister-device` | **confirm**: invalidates existing DEVICE_TOKEN |
+| Rename device | `update-device` | |
+| Delete device | `delete-device` | 409 if it is a room's source |
+| **Set up a kiosk (guided)** | `register-device` → (`create-room` with the new uid **or** `add-device-to-room`+`set-source-device`) | see §6.3 wizard |
+| List/create/edit/delete schedules | `list-schedules`, `create-schedule`, `get-schedule/:uid`, `update-schedule`, `delete-schedule` | time-range list; tz-aware time pickers |
+| List/create/edit/delete auto windows | `list-auto-session-windows` (+ CRUD) | |
+| Create on-demand session | `create-on-demand-session` | preempts AUTO; overlap constraint may 409 |
+| Start/end session early | `start-session-early`, `end-session-early` | |
+| View session | `get-session/:uid` | |
+| Service health | `probes/liveness`, `probes/readiness` | readiness reports DB reachability |
+
+---
+
+## 6. UI / UX design
+
+### 6.1 Information architecture (routes in the SPA)
+```
+/login                     (or SSO redirect)
+/                          Dashboard — health, counts, recent activity, quick actions
+/rooms                     Rooms list (search, paginate)
+/rooms/:uid                Room detail — devices, source, schedules, auto-windows, sessions, actions
+/devices                   Devices list (search, filter active/room)
+/devices/:uid              Device detail — status, room, actions
+/kiosk-setup               Guided kiosk provisioning wizard
+/schedules                 (optional top-level) schedule browser, usually reached via a room
+/sessions/:uid             Session detail
+/audit                     Audit log (admin actions), if BFF stores it
+/settings                  Current user, sign out, app/version info
+```
+Introduce `react-router` (first app in the repo to need it). Keep the existing
+provider-composition and service+middleware conventions.
+
+### 6.2 Screen notes
+- **Dashboard**: service health tiles (liveness/readiness, DB), totals (rooms, devices,
+  pending activations, active sessions now), list of activation codes expiring soon, recent
+  admin actions, quick-action buttons (New room, New device, Set up kiosk).
+- **Rooms list / detail**: table with server-side search + cursor pagination ("Load more").
+  Detail groups member devices (with source badge), schedules, auto-windows, and current/upcoming
+  sessions; inline actions with confirmation dialogs for destructive ops.
+- **Devices list / detail**: status chips — `Pending` (with activation code + expiry countdown),
+  `Activated`, `Unassigned` vs room name, `Source` badge. Actions: rename, (re)register, delete,
+  assign to room.
+- **Schedules/auto-windows editors**: timezone-aware time pickers (room tz shown explicitly),
+  day-of-week multiselect, frequency, join-code scopes, transcription provider/config. Validate
+  client-side against the shared TypeBox schemas before submit.
+
+### 6.3 "Set up a kiosk" wizard (headline feature)
+1. **Device** — enter a device name → `register-device`. Show the **activation code** big +
+   copyable, with an expiry countdown, and instructions ("open `/kiosk` on the kiosk browser and
+   enter this code"). Optionally render the same as a QR/onscreen aid.
+2. **Room** — either create a new room with this device as source (`create-room`) or pick an
+   existing room and `add-device-to-room` (+ `set-source-device` if it should be the source).
+3. **Schedule (optional)** — offer to create a schedule / enable auto-sessions for the room.
+4. **Verify** — poll `get-device/:uid` until `active=true` to confirm the kiosk activated;
+   show live "waiting for activation… / activated ✓". Summ表 links to the room/device.
+
+### 6.4 Error / success / status / performance reporting
+- **Successes**: toast/snackbar on every mutation ("Room _Foo_ created", "Device deleted"),
+  optimistic list refresh.
+- **Validation errors**: map 422/400 to inline field errors using the schema; show the API's
+  error `code`/`message` in a non-dismissive alert.
+- **Domain conflicts (409)**: human-readable guidance — e.g. "Can't delete: this device is the
+  source for room _X_. Reassign the source first." for delete-device/remove-from-room; "Session
+  times overlap an existing session" for session ops.
+- **Auth failures (401)**: BFF session expiry → redirect to login; a 401 from Session Manager to
+  the BFF (bad/rotated admin key) is an **operator error** — show a distinct "backend
+  misconfiguration" banner, not a login redirect.
+- **Service health / status**: Dashboard tiles from `probes/*`; the BFF also exposes its **own**
+  `/api/admin/health` that rolls up (BFF up? Session Manager reachable? DB ready?). Poll on an
+  interval; show last-checked time.
+- **Performance info**: what's realistically available today is limited — surface
+  BFF→Session-Manager **request latency** (measured in the BFF, returned as timing metadata or
+  logged), readiness check timing, and per-request IDs (`request-id` header the base server
+  already sets) for correlation. Richer metrics (device online/offline, active-session counts
+  over time) require the enhancements in §11.4 — flag them as "not available yet" rather than
+  faking them.
+- Every BFF response uses a **consistent envelope** `{ ok, data?, error?: { code, message, requestId } }`
+  so the UI can render failures uniformly.
+
+---
+
+## 7. Observability & audit (BFF responsibilities)
+- **Audit log**: every mutating admin action → append `{ actor, action, target, params-summary,
+  result, requestId, timestamp }` to a store (Postgres table via a new migration, or structured
+  logs shipped to the existing logging pipeline). Surfaced at `/audit`.
+- **Structured logging**: reuse base-server pino logger; log upstream status + latency for each
+  Session Manager call; propagate/generate request IDs.
+- **Health rollup** endpoint as in §6.4.
+- Optional: expose Prometheus-style `/metrics` from the BFF (request counts, latencies, error
+  rates) for IT's existing monitoring.
+
+---
+
+## 8. Security requirements (acceptance checklist)
+- [ ] Admin API key **only** in `admin-server` env; never in any browser bundle, URL, or SPA config.
+- [ ] Staff auth via the pluggable provider layer (§4.4): local env-account now, Azure Entra ID SSO later. `ADMIN_LOCAL_CREDENTIALS` empty/unset disables local login; SSO restricted to an admin group/allowlist.
+- [ ] Local login is constant-time-compared and **rate-limited**; SSO uses Auth Code + PKCE and validates `id_token` + group claim.
+- [ ] BFF session cookie: `HttpOnly`, `Secure`, `SameSite=Strict`, short idle + absolute lifetime, server-side revocable.
+- [ ] **CSRF protection** on all state-changing BFF routes (double-submit token or SameSite+origin check).
+- [ ] **Rate limiting** on the BFF (login attempts and admin actions).
+- [ ] Input validation on the BFF using the shared TypeBox schemas before hitting Session Manager.
+- [ ] Strict security headers/CSP for the admin origin (tighter than default helmet; no inline script if feasible).
+- [ ] All traffic HTTPS (nginx); HSTS on.
+- [ ] Audit trail for every mutation (who/what/when/result).
+- [ ] Least privilege: consider read-only vs read-write admin roles in the BFF.
+- [ ] Secrets via env/compose secrets, not committed; enforce a strong `ADMIN_API_KEY` (document rotation).
+- [ ] No admin key, tokens, or PII in client logs or error messages returned to the browser.
+
+---
+
+## 9. Implementation phases
+
+### Phase 0 — Decisions & scaffolding
+- Resolve remaining Open Decisions (§13): BFF-vs-nginx-gate, 1:1-proxy-vs-task-endpoints, roles,
+  audit storage. (Auth is decided — §4.4.)
+- Scaffold `apps/admin-webapp` (copy `client-webapp`) and `apps/admin-server` (copy a base-fastify
+  service, e.g. structure of `session-manager`), wire into workspaces, tsconfig references, eslint.
+
+### Phase 1 — BFF core
+- **Pluggable auth layer** (§4.4): `AuthProvider` interface + session/CSRF/audit machinery, with the
+  **local env-account provider** implemented (`ADMIN_LOCAL_CREDENTIALS`, timing-safe compare,
+  login rate limit, `/auth/login`, `/auth/config`, `/auth/logout`). Leave the `AzureOidcProvider`
+  as a stub/interface so it drops in later. Session cookie + CSRF + rate limiting.
+- Session Manager client wiring with server-side key injection; consistent error envelope.
+- `/api/admin/health` rollup; structured logging + request-id propagation; audit-log store + writes.
+- Proxy/task endpoints for **rooms** and **devices** first.
+
+### Phase 2 — SPA core + rooms/devices
+- App shell: router, layout/nav, auth guard, theme, toasts, error boundary, health tiles.
+- Rooms: list/search/paginate, detail, create, rename, delete, membership + source management.
+- Devices: list/filter, detail, register (activation-code display), rename, re-register, delete.
+- Full success/error/conflict reporting per §6.4.
+
+### Phase 3 — Kiosk setup wizard
+- Multi-step wizard (§6.3) incl. activation-code display + activation polling.
+- Optional "provision kiosk" aggregate endpoint in the BFF.
+
+### Phase 4 — Schedules & sessions
+- Schedule + auto-window CRUD with tz-aware editors; auto-session toggle.
+- On-demand session create; start/end early; session detail.
+
+### Phase 5 — Observability, hardening, deploy
+- Dashboard, audit view, optional `/metrics`.
+- Security review (see `/security-review`), pen-test the auth/CSRF/rate-limit paths.
+- Compose + nginx + CI/CD (§10); docs + runbook; update the wiki.
+
+### Phase 6 (recommended, parallelizable) — Session Manager hardening (§11)
+- Rate limiting, timing-safe key compare, optional audit hooks. Can ship independently.
+
+---
+
+## 9A. Detailed task breakdown (tasks, gates & verification)
+
+Each phase below lists granular **tasks**, an exit **Gate** (binary — all must hold to advance),
+and **Verify** steps (how to prove it). A phase is not "done" until its gate passes in CI on a PR.
+
+### Definition of Done (applies to *every* phase)
+- `npm run lint` and typecheck clean across changed workspaces; `npm run format` applied.
+- `npm run test:unit` and (where applicable) `npm run test:integration` green in CI.
+- A `.changeset/` entry added for each changed workspace (repo uses changesets — see `RELEASING.md`).
+- PR reviewed; no secret (`ADMIN_API_KEY`, `ADMIN_LOCAL_CREDENTIALS`, `ADMIN_SESSION_SECRET`) appears
+  in any committed file or in a built browser bundle.
+- Docs/runbook updated for anything an operator must configure.
+
+---
+
+### Phase 0 — Decisions & scaffolding
+
+**Tasks**
+- [ ] Close remaining Open Decisions (§13 #2–#6): BFF vs nginx-gate, proxy vs task endpoints, roles,
+      audit storage, whether §11 hardening is in-scope. Record the calls at the top of this file.
+- [ ] Create workspace `apps/admin-webapp` by copying `client-webapp` (Dockerfile, `vite.config.ts`,
+      `tsconfig.json`, `eslint.config.js`, `src/{main,app,components,store,config,env.d,types,features/url-config}`).
+      Rename package `@scribear/admin-webapp`; dev `server.port` 3003; keep the `/api/session-manager`→
+      remove it, add `/api/admin` proxy target for local dev.
+- [ ] Create workspace `apps/admin-server` by copying the structure of `apps/session-manager`
+      (app-config, `create-server`, DI, probes feature, tests scaffolding, Dockerfile, esbuild config).
+      Package `@scribear/admin-server`; strip session-manager's domain features.
+- [ ] Add both to root workspaces; add `tsconfig` project references; add `@scribear/session-manager-client`
+      + `@scribear/session-manager-schema` deps to `admin-server`; extend `detect-changes` mapping.
+- [ ] Both apps expose a working `/healthcheck` (webapp) / `probes/liveness` (server) and build.
+
+**Gate**
+- Both new workspaces install, build, lint, and typecheck from a clean `npm install` at the repo root.
+- `admin-webapp` serves a placeholder page; `admin-server` boots and answers its liveness probe.
+- CI's change-detection recognizes the new workspaces.
+
+**Verify**
+- `npm install && npm run build` at root succeeds including both new packages.
+- `npm run dev --workspace @scribear/admin-server` → `curl localhost:<port>/api/admin/v1/probes/liveness` returns `{status:"ok"}` (path prefix TBD in Phase 1).
+- `npm run dev --workspace @scribear/admin-webapp` → placeholder loads in a browser.
+- `npm run lint && npm run test:unit` green.
+
+---
+
+### Phase 1 — BFF core (auth, session, proxy, observability)
+
+**Tasks**
+- [ ] Define `admin-server` app-config schema (env → typed config): `ADMIN_API_KEY`,
+      `SESSION_MANAGER_BASE_URL`, `ADMIN_SESSION_SECRET`, `ADMIN_LOCAL_CREDENTIALS`,
+      `ADMIN_RATE_LIMIT_*`, and *optional* `AZURE_*` (unused now). Fail fast if required ones missing.
+- [ ] **Auth layer (§4.4):** `AuthProvider` interface + `Identity` type; `LocalAuthProvider`
+      (parse `ADMIN_LOCAL_CREDENTIALS` split on first space; `crypto.timingSafeEqual` on username+password;
+      disabled when env empty). Stub `AzureOidcProvider` (interface only).
+- [ ] Session machinery: signed HttpOnly+Secure+SameSite=Strict cookie via `@fastify/cookie`/session;
+      `requireSession` hook guarding `/api/admin/*`; `/auth/login`, `/auth/logout`, `/auth/config`,
+      (future) `/auth/sso/*` route stubs. CSRF protection (double-submit token) on state-changing routes.
+- [ ] Register `@fastify/rate-limit`: strict on `/auth/login`, moderate on mutations.
+- [ ] Session Manager gateway: construct `createSessionManagerClient(SESSION_MANAGER_BASE_URL)`; a helper
+      that injects `Authorization: Bearer ${ADMIN_API_KEY}` on every call; consistent response envelope
+      `{ ok, data?, error?:{code,message,requestId} }`; map upstream 401 → "backend misconfig", 4xx → passthrough.
+- [ ] First proxy/task endpoints: **rooms** (list/get/create/update/delete + membership/source) and
+      **devices** (list/get/register/reregister/update/delete). Validate bodies with shared schemas.
+- [ ] `/api/admin/health` rollup (BFF up? session-manager reachable? readiness?). Structured logging with
+      upstream status+latency and request-id propagation. Audit-log store + write on every mutation.
+
+**Gate**
+- Unauthenticated request to any `/api/admin/*` (non-auth) route → 401; no upstream call made.
+- Valid local login issues a session cookie; wrong password → 401 and is rate-limited after N tries.
+- With `ADMIN_LOCAL_CREDENTIALS` empty, `/auth/config` reports `{local:false}` and `/auth/login` 404/disabled.
+- Admin key is present **only** server-side; it never appears in any response body or log line.
+- Every mutation writes an audit record; CSRF-less state-changing request is rejected.
+
+**Verify**
+- Integration tests (Vitest, mirror `session-manager/tests/integration`) with session-manager **mocked**:
+  login success/failure, session guard, CSRF reject, rate-limit lockout, envelope mapping, key injection
+  (assert the outgoing `Authorization` header), audit write.
+- Manual: `curl` login → capture cookie → call `list-rooms` (200) → call without cookie (401) →
+  hammer `/auth/login` to trip the limiter (429).
+- `grep -r` the built `admin-server` bundle/logs in a test run to confirm no credential leakage.
+- `npm run test:unit && npm run test:integration --workspace @scribear/admin-server` green.
+
+---
+
+### Phase 2 — SPA core + rooms & devices UI
+
+**Tasks**
+- [ ] App shell: introduce `react-router`; layout + nav; `RequireAuth` guard that redirects to `/login`
+      when `/auth/config`+session say unauthenticated; theme via `AppThemeProvider`; global error boundary;
+      snackbar/toast host. Data layer via the **service+middleware** idiom started on `appInitialization`.
+- [ ] Login page: reads `/auth/config`, renders password form (local) and/or SSO button (hidden until Azure).
+- [ ] Rooms: list (server search + cursor "Load more"), detail (devices w/ source badge, schedules,
+      auto-windows, sessions), create, rename, delete (confirm dialog), add/remove device, set source.
+- [ ] Devices: list (filter active/room/search), detail, register (activation-code display + expiry
+      countdown), rename, re-register (confirm), delete.
+- [ ] Error/success/conflict UX (§6.4): toasts on success; 422→inline field errors; 409→human guidance
+      (source-delete, membership orphan); 401→login redirect; backend-misconfig banner distinct from login.
+
+**Gate**
+- An operator can, from the browser, complete every rooms + devices CRUD path end-to-end against a real
+  BFF+session-manager, including the conflict paths (delete-source-device 409, remove-source 409).
+- No admin key or credential is present anywhere in the shipped JS bundle.
+- Session expiry mid-use routes the user cleanly to `/login` without a crash.
+
+**Verify**
+- Component/interaction tests (Vitest + Testing Library) for wizardless forms, list pagination, and the
+  three error classes (422/409/401) rendering correctly.
+- Manual E2E against `deployment/compose.yml` (session-manager + Postgres): register device → create room
+  with it as source → rename → add second device → set source → try to delete source (expect blocked) →
+  delete room.
+- Run the `/verify` skill on the rooms+devices flow (drive the real UI, observe behavior).
+- `grep` production bundle for `ADMIN_API_KEY`/`Bearer ` → no hits.
+
+---
+
+### Phase 3 — Kiosk setup wizard
+
+**Tasks**
+- [ ] Multi-step wizard (§6.3): (1) name → `register-device`, show activation code big/copyable + expiry
+      countdown + instructions; (2) new room as source **or** existing room + `add-device-to-room`/`set-source-device`;
+      (3) optional schedule/auto-session; (4) verify by polling `get-device/:uid` until `active=true`.
+- [ ] Optional BFF aggregate endpoint `POST /api/admin/provision-kiosk` (register + assign in one call,
+      audited as one action) if Open Decision #3 chose task endpoints.
+- [ ] Handle re-entrancy: expired activation code → offer `reregister-device`; back/forward without orphaning.
+
+**Gate**
+- A brand-new device can be taken from "nothing" to "activated kiosk assigned as a room source" entirely
+  in the wizard, with the activation confirmation observed live.
+
+**Verify**
+- E2E: run the wizard; in a second browser open `/kiosk`, enter the shown code (simulating the kiosk's
+  `activate-device`); confirm the wizard's poll flips to "activated ✓" and the device shows `active=true`,
+  correct `roomUid`, `isSource=true`.
+- Negative: let the activation code expire → wizard offers re-register and recovers.
+- `/verify` skill on the full wizard path.
+
+---
+
+### Phase 4 — Schedules & sessions
+
+**Tasks**
+- [ ] Schedule CRUD UI: tz-aware time pickers (room tz shown explicitly), day-of-week multiselect,
+      frequency (ONCE/WEEKLY/BIWEEKLY), join-code scopes, transcription provider/config. Client-validate
+      against shared schemas before submit.
+- [ ] Auto-session-window CRUD UI; room auto-session master toggle (`update-room-schedule-config`).
+- [ ] Session ops: create on-demand session; start-early; end-early; session detail view.
+- [ ] Surface domain conflicts: session overlap (409), invalid override times (422), start/end-early 409/422.
+
+**Gate**
+- All schedule/auto-window/session operations succeed for valid input and show correct, specific errors
+  for the constrained cases (overlap, override ordering, non-empty days for WEEKLY/BIWEEKLY).
+
+**Verify**
+- Integration + component tests covering DST boundaries and midnight-wrap windows (end < start).
+- E2E: create a weekly schedule → confirm a materialized session appears via `list-schedules`/`get-session`;
+  create an overlapping on-demand session → expect 409 rendered clearly; start-early then end-early a session.
+- `/verify` skill on the schedule editor and session-ops paths.
+
+---
+
+### Phase 5 — Observability, hardening, deploy
+
+**Tasks**
+- [ ] Dashboard (health tiles from BFF `/health`, counts, expiring activation codes, recent audit actions,
+      quick actions); `/audit` view; optional BFF `/metrics`.
+- [ ] nginx: add `/admin/` and `/api/admin/` locations + upstreams (§10.1). Compose: add `admin-webapp`
+      and `admin-server` services + env + `depends_on` (§10.2). `deployment/.env.example` env additions (§10.4).
+- [ ] Dockerfiles for both apps (webapp→nginx-alpine SPA; server→Node runtime). Extend `node-ci`/`node-cd`
+      + `detect-changes` to build/test/publish both to GHCR.
+- [ ] Tighten CSP/HSTS for the admin origin; final secrets review.
+- [ ] **Wiki documentation (§10A):** create `Admin-Website.md`, `Developing-Admin.md`,
+      `Admin-Runbook.md`; edit `Home.md`, `Deployment.md`, `Documentation`, `_Sidebar.md`; update repo
+      `README.md` layout/index. Must satisfy the §10A.7 documentation gate.
+- [ ] Run `/security-review` on the branch and resolve findings.
+
+**Gate**
+- The full stack (incl. the two new services) comes up healthy via `docker compose up`; the admin site is
+  reachable at `/admin/` over HTTPS, authenticates, and performs a full rooms/devices/kiosk/schedule flow.
+- `/security-review` findings triaged/closed; no secret in any image layer or browser bundle;
+  CSRF, rate-limit, session-expiry, and role checks pass a manual pen-pass.
+- CI builds and publishes both images on merge to `staging`.
+
+**Verify**
+- `docker compose -f deployment/compose.yml up` → all services `healthy`; nginx `depends_on` satisfied.
+- Browser: hit `https://<host>/admin/`, log in with the local account, run one operation from each feature.
+- Security pass: attempt cross-site state change (CSRF blocked), reuse expired session (redirected),
+  brute-force login (rate-limited), inspect image with `docker history`/layer grep for secrets (none).
+- `/security-review` clean; smoke E2E green in CI against an ephemeral compose stack.
+
+---
+
+### Phase 6 — Session Manager hardening (parallel, independent PRs)
+
+**Tasks**
+- [ ] Add `@fastify/rate-limit` in `libs/base-fastify-server` (or per-service); throttle `exchange-join-code`,
+      `refresh-session-token`, and admin/service key routes.
+- [ ] Replace `key === …` with `crypto.timingSafeEqual` in `admin-auth.service.ts` + `service-auth.service.ts`;
+      enforce a minimum key length / reject `CHANGEME`.
+- [ ] (Optional) multi-key/identity map + audit hook; (optional) `lastSeenAt` + count/metrics endpoints (§11.4).
+
+**Gate**
+- Existing session-manager unit + integration suites stay green; new tests cover rate-limit and
+  timing-safe behavior; no change to the wire contract the BFF depends on (or a coordinated bump).
+
+**Verify**
+- `npm run test:unit && npm run test:integration --workspace @scribear/session-manager` green.
+- Load a burst at `exchange-join-code` → observe 429s; confirm valid flows unaffected.
+- Contract check: the admin-server integration suite still passes against the hardened session-manager.
+
+---
+
+## 10. Deployment & delivery
+
+### 10.1 nginx (`infra/scribear-nginx/nginx.conf`)
+Add two locations inside the `:443` server:
+```nginx
+location /admin/ {
+    proxy_pass http://admin-webapp/;      # static SPA (try_files fallback in its image)
+    # standard proxy_set_header block as elsewhere
+}
+location /api/admin/ {
+    proxy_pass http://admin-server;       # BFF
+    # standard proxy_set_header block; no key here — the BFF holds it
+}
+```
+Add `upstream admin-webapp { server admin-webapp:80; }` and
+`upstream admin-server { server admin-server:80; }`.
+
+### 10.2 Compose (`deployment/compose.yml`)
+Add `admin-webapp` (frontend network) and `admin-server` (both networks; env
+`ADMIN_API_KEY=${SESSION_MANAGER_API_KEY}`, `SESSION_MANAGER_BASE_URL=http://session-manager:80`,
+staff-auth/OIDC config, session-cookie secret, DB creds if audit/local-accounts use Postgres).
+`admin-server` depends on `session-manager` (and `scribear-db` if it persists audit/accounts).
+Add nginx `depends_on` for both new services.
+
+### 10.3 Images & CI/CD
+- Dockerfiles: `admin-webapp` mirrors `client-webapp` (multi-stage → nginx-alpine, SPA fallback,
+  `/healthcheck`). `admin-server` mirrors `session-manager`'s Dockerfile (Node runtime).
+- Extend `.github/workflows/node-ci.yml` / `node-cd.yml` and `detect-changes` to build/test/publish
+  both new workspaces to GHCR alongside the rest.
+
+### 10.4 Env additions (document in `deployment/.env.example`)
+- `ADMIN_API_KEY=${SESSION_MANAGER_API_KEY}` — reused; held only by `admin-server`.
+- `ADMIN_SESSION_SECRET` — signs the session cookie (strong random).
+- `ADMIN_LOCAL_CREDENTIALS` — `"<username> <password>"` for the local account (e.g.
+  `"engrit hag3hasdgqwy!"`); **empty/unset disables local login**.
+- `ADMIN_RATE_LIMIT_*` — login + action throttles.
+- *(future, unset for now)* `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`,
+  `AZURE_REDIRECT_URI`, `ADMIN_ALLOWED_GROUP` — presence enables the Azure SSO provider.
+
+---
+
+## 10A. GitHub wiki documentation additions (user-facing & devops)
+
+The project's user-facing docs live in the **companion wiki**, not in-repo. Per the README, the
+wiki is the *authoritative* reference for API shapes, protocols, config, and deployment. The admin
+website must be documented there for two audiences: **IT operators** (how to use it and deploy it)
+and **developers** (how it's built and how to add Azure SSO). This work is part of **Phase 5** and
+its gate: docs merged before the feature is announced.
+
+### 10A.0 How to edit the wiki
+- The wiki is a **separate git repo**: `https://github.com/scribear/scribear.wiki.git`
+  (clone it alongside the code repo; it is *not* a folder in `scribear/scribear`).
+- Pages are Markdown files at the repo root; **filename = page title with spaces → hyphens**
+  (e.g. page "Admin Website" → `Admin-Website.md`). Links use the page title:
+  `[Admin Website](Admin-Website)`.
+- The left nav is `_Sidebar.md`; a shared footer is `_Footer.md`. New pages must be added to
+  `_Sidebar.md` or they're only reachable by direct URL.
+- Keep the existing tone: short "start here by audience" framing, code-fenced config snippets,
+  and cross-links to sibling pages. Mirror any config/env you document against
+  `deployment/.env.example` and `deployment/compose.yml` so the two never drift.
+
+### 10A.1 NEW page — `Admin-Website.md` (IT operator guide)
+Primary user-facing page. Outline:
+1. **What it is / who it's for** — a web console for IT to manage rooms, devices, kiosks,
+   schedules, and sessions; replaces the `deployment/*.sh` curl scripts.
+2. **Accessing it** — URL `https://<host>/admin/`; supported browsers; that it must be reached
+   over HTTPS.
+3. **Signing in** — local account today (username/password from `ADMIN_LOCAL_CREDENTIALS`); note
+   that **Azure AD SSO is planned** and the login page will show a "Sign in with Illinois" button
+   once enabled. Call out the **shared-account caveat**: with the local account, every action is
+   audited as the same user — per-person attribution arrives with SSO.
+4. **Core tasks** (each a short numbered walkthrough with a screenshot placeholder):
+   Create a room · List/search rooms & devices · Rename/delete · Add/remove a device from a room ·
+   Set a room's source device · **Set up a kiosk** (the wizard: register → show activation code →
+   assign to room → confirm activation) · Create/edit a schedule & auto-sessions · Create an
+   on-demand session · Start/end a session early.
+5. **Reading status & errors** — health tiles, success toasts, what 409/422 messages mean
+   (e.g. "can't delete a device that is a room's source"), the "backend misconfiguration" banner.
+6. **What's not shown yet** — device online/offline and historical metrics aren't available yet
+   (link to the enhancement note in Deployment).
+7. **Troubleshooting** — can't log in, activation code expired (re-register), session expired.
+8. Cross-links to **Deployment** (for admins who also operate the stack) and **Developing Admin**.
+
+### 10A.2 NEW page — `Developing-Admin.md` (developer guide, sibling of "Developing Session Manager")
+1. **Architecture** — BFF (`apps/admin-server`) + SPA (`apps/admin-webapp`); why the BFF exists
+   (admin key stays server-side; §3/§4 of this plan). Small ASCII diagram.
+2. **Local dev** — `npm run dev` for each workspace, dev ports (webapp 3003), the `/api/admin`
+   Vite proxy, running against a local session-manager + Postgres.
+3. **Auth provider layer (§4.4)** — the `AuthProvider`/`Identity` interface; how `LocalAuthProvider`
+   reads `ADMIN_LOCAL_CREDENTIALS`; **"Adding the Azure Entra ID provider"** step-by-step (register
+   an app in Entra, set `AZURE_*`, implement `verify()`, group allowlist) — the seams are already in.
+4. **BFF API surface** — the `/api/admin/*` routes and the `{ ok, data?, error? }` envelope; link to
+   10A.3.
+5. **Conventions** — service+middleware idiom, typed redux hooks, shared TypeBox schemas, testing
+   (Vitest unit/integration), changesets.
+
+### 10A.3 NEW section on the existing `Documentation` page — "Admin BFF API"
+- State that admin operations go through the **BFF** (`/api/admin/*`), which fronts the
+  admin-guarded Session Manager routes; the browser never holds `ADMIN_API_KEY`.
+- Document the BFF envelope, the auth routes (`/auth/login`, `/auth/logout`, `/auth/config`,
+  future `/auth/sso/*`), CSRF-token handling, and the `/api/admin/health` rollup.
+- Cross-reference (don't duplicate) the Session Manager admin endpoints already listed there.
+
+### 10A.4 EDITS to existing pages
+- **`Home.md`** — add `admin-webapp` and `admin-server` to the architecture overview / component
+  list and the request-flow description (browser → nginx `/admin/` & `/api/admin/` → BFF →
+  session-manager). Add both to any diagram.
+- **`Deployment.md`** — add the full **"Admin website"** devops subsection (10A.5 below).
+- **`_Sidebar.md`** — add links to **Admin Website** and **Developing Admin** under the right groups
+  (operator page near Deployment; dev page in the "Developing …" list).
+- **Repo `README.md`** (not wiki, but do it in the same PR) — add `apps/admin-webapp/` and
+  `apps/admin-server/` to the "Repo layout" map and the wiki index list.
+
+### 10A.5 Deployment-page content (devops / deployment config — the important bit)
+Add a self-contained "Admin website" subsection to `Deployment.md` containing:
+
+- **Services** — `admin-webapp` (static SPA, nginx-alpine, `frontend` network) and `admin-server`
+  (BFF, both networks). Paste the `compose.yml` service blocks (mirroring §10.2) and the nginx
+  `/admin/` + `/api/admin/` locations + upstreams (§10.1).
+- **Environment variables** — a table an operator can act on:
+
+  | Var | Required | Meaning |
+  |---|---|---|
+  | `ADMIN_API_KEY` | yes | Session Manager admin key; set on `admin-server` only (reuse `SESSION_MANAGER_API_KEY`). Never on a webapp. |
+  | `ADMIN_SESSION_SECRET` | yes | Signs the admin session cookie; long random string; rotating it logs everyone out. |
+  | `ADMIN_LOCAL_CREDENTIALS` | today | `"<username> <password>"` (split on first space). **Empty/unset disables local login.** |
+  | `ADMIN_RATE_LIMIT_*` | opt | Login/action throttles. |
+  | `AZURE_TENANT_ID`/`CLIENT_ID`/`CLIENT_SECRET`/`REDIRECT_URI`, `ADMIN_ALLOWED_GROUP` | future | Presence enables Azure SSO; unset = SSO off. |
+
+- **TLS / exposure** — must be behind the same HTTPS nginx; recommend restricting `/admin/` and
+  `/api/admin/` to the campus network/VPN or an IP allowlist since it's high-privilege.
+- **First login** — set `ADMIN_LOCAL_CREDENTIALS`, `docker compose up`, browse `https://<host>/admin/`,
+  sign in.
+- **Rotating the local credential** — change the env var and restart `admin-server`; note it
+  invalidates the current login.
+- **Going SSO-only later** — set the `AZURE_*` vars, **clear `ADMIN_LOCAL_CREDENTIALS`**, restart;
+  the login page switches to the SSO button automatically (no rebuild).
+- **Security notes** — admin key is server-side only; shared-account audit caveat; rate limiting is
+  on the BFF; keep the two new images updated with the rest of the stack (same `IMAGE_TAG`).
+- **Enhancement note** — device online/offline & historical metrics require the §11.4 backend work.
+
+### 10A.6 NEW page (or Deployment appendix) — `Admin-Runbook.md` (operator runbook)
+Step-by-step for recurring ops, each as a copy-followable checklist: **provision a new kiosk**,
+**decommission a device** (reassign source first, then delete), **create a room + schedule for a
+new space**, **rotate the admin login**, **respond to "backend misconfiguration" banner** (check
+`ADMIN_API_KEY` matches session-manager), **check stack health** (`/api/admin/health`, probes).
+
+### 10A.7 Documentation gate (rolls into Phase 5)
+- [ ] `Admin-Website.md`, `Developing-Admin.md` created; `Home.md`, `Deployment.md`, `Documentation`,
+      `_Sidebar.md` edited; repo `README.md` layout/index updated in the same feature PR.
+- [ ] Every env var, compose block, and nginx snippet in the wiki **matches** `deployment/.env.example`,
+      `deployment/compose.yml`, and `infra/scribear-nginx/nginx.conf` verbatim (no drift).
+- [ ] A reviewer who has never seen the app can deploy it and set up a kiosk using only the wiki.
+- [ ] No secret values (only placeholders like `CHANGEME`) appear in any wiki page.
+
+---
+
+## 11. Recommended Session Manager hardening (independent PRs)
+1. **Rate limiting** (`@fastify/rate-limit`) — especially the unauthenticated `exchange-join-code`
+   / `refresh-session-token`, and the admin key. (`create-base-server.ts` currently registers none.)
+2. **Timing-safe** admin/service key comparison (`crypto.timingSafeEqual`), matching the
+   session-token path; enforce a minimum key length / reject `CHANGEME`.
+3. **Optional multi-key / audit hooks** — allow several named admin keys (map key→identity) so the
+   BFF can pass a per-operator key, giving Session Manager-side attribution. Lower priority if the
+   BFF owns identity+audit.
+4. **Status/perf surface (enables richer UI)** — none of "device online/offline", "active sessions
+   now", or historical metrics exist today. If IT wants them, add e.g. a device `lastSeenAt`
+   (updated on `my-schedule` poll / token exchange) and lightweight count/metrics endpoints.
+   Until then the admin UI must not fabricate these.
+5. Consider a tightened CSP/HSTS via helmet options for the whole stack.
+
+---
+
+## 12. Testing strategy
+- **BFF unit/integration** (Vitest, mirror `session-manager/tests`): auth, CSRF, rate limiting,
+  key injection, error-envelope mapping, audit writes; upstream calls mocked.
+- **SPA**: component/interaction tests for wizard, forms, error/conflict rendering; typed against
+  shared schemas.
+- **E2E**: against a compose stack with a real session-manager + Postgres — full flows: register
+  device → activate (simulate kiosk) → create room → set source → schedule → start/end session →
+  delete. Include negative paths (409 source-delete, overlap, expired activation code, expired session).
+- **Security**: run `/security-review`; verify no key leaks to the browser; test session expiry,
+  CSRF rejection, rate-limit lockout, authz on read-only vs read-write roles.
+
+---
+
+## 13. Open decisions (need a call before Phase 1)
+1. ~~**Staff authentication**~~ **DECIDED** (§4.4): pluggable auth — local env-account
+   (`ADMIN_LOCAL_CREDENTIALS`) now, Azure Entra ID SSO added later behind the same interface.
+2. **Architecture**: full BFF (§4.1, recommended) vs interim nginx-gate + header injection (§4.2).
+3. **BFF API shape**: thin 1:1 proxy vs task-oriented endpoints (e.g. one "provision kiosk" call).
+   *Recommendation: mostly 1:1, plus a few aggregate endpoints (room detail, provision kiosk).*
+4. **Roles**: single admin role vs read-only + read-write split for launch.
+5. **Audit/local-account storage**: reuse `scribear-db` (new migration) vs a separate store vs
+   logs-only for launch.
+6. **Do we bundle §11 hardening** into this effort or track it separately?
+
+## 14. Risks
+- Static-key model means a BFF compromise = full admin power → invest in BFF auth/audit/rate-limit.
+- No CORS/rate-limit upstream → the BFF must be the enforcement point.
+- Timezone/recurrence correctness in schedule editors is fiddly — lean on the shared schemas and
+  the server's validation; test around DST and midnight-wrap windows.
+- Introducing `react-router` and a first BFF service adds surface the repo hasn't carried before —
+  keep them conventional and well-tested.
+
+## 15. Rough effort (engineering, very approximate)
+- Phase 0–1 (scaffold + BFF core + rooms/devices proxy): ~1.5–2.5 wks
+- Phase 2 (SPA shell + rooms/devices UI): ~2–3 wks
+- Phase 3 (kiosk wizard): ~0.5–1 wk
+- Phase 4 (schedules/sessions): ~1.5–2.5 wks
+- Phase 5 (observability/hardening/deploy/docs): ~1–1.5 wks
+- Phase 6 (session-manager hardening, parallel): ~0.5–1 wk
+
+---
+
+### Appendix A — key files reviewed
+- API/routers: `apps/session-manager/src/server/features/*/*.router.ts`
+- Auth: `apps/session-manager/src/server/hooks/*.hook.ts`, `.../shared/services/admin-auth.service.ts`, `libs/schemas/session-manager-schema/src/shared/security/admin-api-key.ts`
+- Server/base: `apps/session-manager/src/server/create-server.ts`, `libs/base-fastify-server/src/server/create-base-server.ts`
+- Schemas/base path: `libs/schemas/session-manager-schema/src/{base-path.ts,metadata.ts,*/entities,*/routes}`
+- Client lib: `libs/clients/session-manager-client/src/*`
+- Domain/migrations: `infra/scribear-db/src/migrations/*`
+- Kiosk flow: `apps/kiosk-webapp/src/features/kiosk-provider/*`
+- Frontend template: `apps/client-webapp/*`
+- Deploy: `deployment/{compose.yml,.env.example,create-room.sh,register-device.sh}`, `infra/scribear-nginx/nginx.conf`

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ apps/
   standalone-webapp/    # all-in-one viewer+source app, no kiosk/client split
   node-server/           # proxies kiosk/client websockets to transcription-service
   session-manager/       # devices, rooms, sessions, auth — issues session tokens
+  admin-webapp/         # IT admin console SPA (rooms, devices, kiosks) — talks only to admin-server
+  admin-server/          # admin BFF — holds the Session Manager admin key, authenticates staff, proxies + audits
 infra/
   scribear-db/           # Postgres schema + migrations
   scribear-nginx/        # reverse proxy used in the deployment stack
@@ -46,5 +48,7 @@ deployment/               # Docker Compose stack for running the full system
 * [Developing Node Server](https://github.com/scribear/scribear/wiki/Developing-Node-Server)
 * [Developing Session Manager](https://github.com/scribear/scribear/wiki/Developing-Session-Manager)
 * [Developing Transcription Service](https://github.com/scribear/scribear/wiki/Developing-Transcription-Service)
+* [Admin Website](https://github.com/scribear/scribear/wiki/Admin-Website) — operator guide for the IT admin console
+* [Developing Admin](https://github.com/scribear/scribear/wiki/Developing-Admin)
 * [Documentation](https://github.com/scribear/scribear/wiki/Documentation) — full API/protocol/config reference
 * [ScribeAR Multi Tenancy HLD](https://github.com/scribear/scribear/wiki/ScribeAR-Multi-Tenency-HLD) — historical design notes, background only

--- a/apps/admin-server/.env.example
+++ b/apps/admin-server/.env.example
@@ -1,0 +1,52 @@
+#### Log level to use
+LOG_LEVEL=info
+
+#### Host and port server should listen on
+HOST=0.0.0.0
+PORT=8003
+
+#### Session Manager admin API key. Held ONLY by this BFF and presented as
+#### `Authorization: Bearer <key>` on upstream calls. Never shipped to the browser.
+#### In the deployment stack this reuses SESSION_MANAGER_API_KEY.
+ADMIN_API_KEY=CHANGEME
+
+#### Base URL of the Session Manager service (no trailing slash).
+#### In the compose stack this is http://session-manager:80.
+SESSION_MANAGER_BASE_URL=http://localhost:8001
+
+#### Secret used to sign the admin session cookie. Use a long, high-entropy
+#### random string in production. Rotating it invalidates all active sessions.
+#### Minimum length is enforced at boot.
+ADMIN_SESSION_SECRET=CHANGEME-session-secret-at-least-32-characters-long
+
+#### Local staff account, formatted "<username> <password>" (split on the FIRST
+#### space only, so the password may contain spaces). Empty/unset DISABLES local
+#### login (the switch used to force SSO-only once Azure lands).
+ADMIN_LOCAL_CREDENTIALS=
+
+#### Session lifetimes (minutes). Idle: max gap between requests. Absolute: max
+#### total lifetime regardless of activity.
+ADMIN_SESSION_IDLE_TIMEOUT_MINUTES=60
+ADMIN_SESSION_ABSOLUTE_TIMEOUT_MINUTES=480
+
+#### Rate limiting. Global applies to every /api/admin route; login is stricter
+#### because it is the credential-guessing surface.
+ADMIN_RATE_LIMIT_GLOBAL_MAX=300
+ADMIN_RATE_LIMIT_GLOBAL_WINDOW_SEC=60
+ADMIN_RATE_LIMIT_LOGIN_MAX=5
+ADMIN_RATE_LIMIT_LOGIN_WINDOW_SEC=60
+
+#### Database configuration (used for the admin audit log).
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=scribear-db-dev
+DB_USER=scribear
+DB_PASSWORD=CHANGEME
+
+#### (Future) Azure Entra ID SSO. Presence of these enables the SSO provider;
+#### leave unset for now. Documented for forward compatibility only.
+# AZURE_TENANT_ID=
+# AZURE_CLIENT_ID=
+# AZURE_CLIENT_SECRET=
+# AZURE_REDIRECT_URI=
+# ADMIN_ALLOWED_GROUP=

--- a/apps/admin-server/Dockerfile
+++ b/apps/admin-server/Dockerfile
@@ -1,0 +1,47 @@
+# Build in the root directory using:
+#   docker build -f apps/admin-server/Dockerfile .
+
+ARG NODE_VERSION=24.10.0
+
+FROM node:${NODE_VERSION} AS package-jsons
+
+WORKDIR /app
+
+COPY . .
+
+RUN find . -type f ! -name "package*.json" -delete && \
+  find . -empty -type d -delete
+
+FROM node:${NODE_VERSION} AS build-env
+
+WORKDIR /app
+
+COPY --from=package-jsons /app/ .
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build --workspace=@scribear/admin-server
+
+FROM node:${NODE_VERSION}-alpine3.22
+
+RUN apk add --no-cache dumb-init
+
+WORKDIR /app
+
+COPY --from=package-jsons /app/ .
+
+RUN npm ci --omit=dev
+
+COPY --from=build-env /app/apps/admin-server/dist/bundle.mjs /app/apps/admin-server/dist/bundle.mjs
+
+WORKDIR /app/apps/admin-server
+
+ENV HOST=0.0.0.0
+ENV PORT=80
+
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --start-interval=1s --retries=3 CMD wget -qO- http://127.0.0.1:80/api/admin/v1/probes/liveness || exit 1
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["node", "dist/bundle.mjs"]

--- a/apps/admin-server/esbuild.config.mjs
+++ b/apps/admin-server/esbuild.config.mjs
@@ -1,0 +1,21 @@
+import { build } from 'esbuild';
+
+await build({
+  entryPoints: ['dist/src/index.js'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  outfile: 'dist/bundle.mjs',
+  plugins: [
+    {
+      name: 'externalize-non-scribear',
+      setup(build) {
+        // Externalize all imports that aren't relative, subpath (#), or @scribear workspace libs
+        build.onResolve({ filter: /^[^./#]/ }, ({ path }) => {
+          if (path.startsWith('@scribear/')) return null;
+          return { path, external: true };
+        });
+      },
+    },
+  ],
+});

--- a/apps/admin-server/package.json
+++ b/apps/admin-server/package.json
@@ -41,9 +41,9 @@
     "@fastify/rate-limit": "11.1.0",
     "awilix": "13.0.0",
     "env-schema": "7.0.0",
-    "fastify": "5.7.4",
+    "fastify": "5.10.0",
     "fastify-plugin": "5.1.0",
-    "kysely": "0.28.11",
+    "kysely": "0.28.17",
     "pg": "8.19.0",
     "typebox": "1.1.5"
   },

--- a/apps/admin-server/package.json
+++ b/apps/admin-server/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@scribear/admin-server",
+  "version": "0.0.0",
+  "description": "Admin BFF for ScribeAR: authenticates IT staff, holds the Session Manager admin key server-side, and proxies admin operations.",
+  "author": "scribear",
+  "main": "dist/src/index.js",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "default": "./dist/src/index.js"
+    },
+    "./server": {
+      "development": "./src/server/create-server.ts",
+      "default": "./dist/src/server/create-server.js"
+    },
+    "./app-config": {
+      "development": "./src/app-config/app-config.ts",
+      "default": "./dist/src/app-config/app-config.js"
+    }
+  },
+  "type": "module",
+  "imports": {
+    "#src/*": "./dist/src/*",
+    "#tests/*": "./dist/tests/*"
+  },
+  "scripts": {
+    "build": "tsc --build && node esbuild.config.mjs",
+    "start": "node ./dist/src/index.js",
+    "dev": "tsc --build && concurrently -k \"tsc --build --watch\" \"node --watch-path=dist dist/src/index.js --dev | pino-pretty\"",
+    "format": "prettier --check ./src ./tests",
+    "format:fix": "prettier --write ./src ./tests",
+    "lint": "eslint ./src ./tests",
+    "lint:fix": "eslint ./src ./tests --fix",
+    "test:dev": "vitest --ui --coverage",
+    "test:integration": "vitest run --project integration",
+    "test:unit": "vitest run --project unit"
+  },
+  "dependencies": {
+    "@fastify/awilix": "8.2.0",
+    "@fastify/cookie": "11.0.2",
+    "@fastify/rate-limit": "11.1.0",
+    "awilix": "13.0.0",
+    "env-schema": "7.0.0",
+    "fastify": "5.7.4",
+    "fastify-plugin": "5.1.0",
+    "kysely": "0.28.11",
+    "pg": "8.19.0",
+    "typebox": "1.1.5"
+  },
+  "devDependencies": {
+    "@types/pg": "8.16.0"
+  }
+}

--- a/apps/admin-server/src/app-config/app-config.ts
+++ b/apps/admin-server/src/app-config/app-config.ts
@@ -1,0 +1,147 @@
+import envSchema from 'env-schema';
+import { Type } from 'typebox';
+import type { Static } from 'typebox';
+
+import { LogLevel } from '@scribear/base-fastify-server';
+
+import type { AdminDbClientConfig } from '#src/db/admin-db-client.js';
+import type { RateLimitConfig } from '#src/server/plugins/rate-limit.plugin.js';
+import type { AzureAuthConfig } from '#src/server/shared/services/azure-oidc-auth.service.js';
+import type { LocalAuthConfig } from '#src/server/shared/services/local-auth.service.js';
+import type { SessionManagerGatewayConfig } from '#src/server/shared/services/session-manager-gateway.service.js';
+import type { SessionConfig } from '#src/server/shared/services/session.service.js';
+
+const MINUTE_MS = 60_000;
+const SECOND_MS = 1_000;
+
+const CONFIG_SCHEMA = Type.Object({
+  LOG_LEVEL: Type.Enum(LogLevel),
+  PORT: Type.Integer({ minimum: 0, maximum: 65_535 }),
+  HOST: Type.String(),
+
+  // Session Manager gateway
+  ADMIN_API_KEY: Type.String({ minLength: 1 }),
+  SESSION_MANAGER_BASE_URL: Type.String({ minLength: 1 }),
+
+  // Session cookie signing + lifetimes
+  ADMIN_SESSION_SECRET: Type.String({ minLength: 32 }),
+  ADMIN_SESSION_IDLE_TIMEOUT_MINUTES: Type.Integer({
+    minimum: 1,
+    default: 60,
+  }),
+  ADMIN_SESSION_ABSOLUTE_TIMEOUT_MINUTES: Type.Integer({
+    minimum: 1,
+    default: 480,
+  }),
+
+  // Local staff account ("<username> <password>"); empty disables local login.
+  ADMIN_LOCAL_CREDENTIALS: Type.String({ default: '' }),
+
+  // Rate limiting
+  ADMIN_RATE_LIMIT_GLOBAL_MAX: Type.Integer({ minimum: 1, default: 300 }),
+  ADMIN_RATE_LIMIT_GLOBAL_WINDOW_SEC: Type.Integer({ minimum: 1, default: 60 }),
+  ADMIN_RATE_LIMIT_LOGIN_MAX: Type.Integer({ minimum: 1, default: 5 }),
+  ADMIN_RATE_LIMIT_LOGIN_WINDOW_SEC: Type.Integer({ minimum: 1, default: 60 }),
+
+  // Database (admin audit log)
+  DB_HOST: Type.String(),
+  DB_PORT: Type.Integer({ minimum: 0, maximum: 65_535 }),
+  DB_NAME: Type.String(),
+  DB_USER: Type.String(),
+  DB_PASSWORD: Type.String(),
+
+  // Future Azure Entra ID SSO. Presence enables the provider; empty = disabled.
+  AZURE_TENANT_ID: Type.String({ default: '' }),
+  AZURE_CLIENT_ID: Type.String({ default: '' }),
+  AZURE_CLIENT_SECRET: Type.String({ default: '' }),
+  AZURE_REDIRECT_URI: Type.String({ default: '' }),
+  ADMIN_ALLOWED_GROUP: Type.String({ default: '' }),
+});
+
+export interface BaseConfig {
+  isDevelopment: boolean;
+  logLevel: LogLevel;
+  port: number;
+  host: string;
+}
+
+export class AppConfig {
+  private _isDevelopment: boolean;
+  private _env: Static<typeof CONFIG_SCHEMA>;
+
+  get baseConfig(): BaseConfig {
+    return {
+      isDevelopment: this._isDevelopment,
+      logLevel: this._env.LOG_LEVEL,
+      port: this._env.PORT,
+      host: this._env.HOST,
+    };
+  }
+
+  get sessionManagerGatewayConfig(): SessionManagerGatewayConfig {
+    return {
+      adminApiKey: this._env.ADMIN_API_KEY,
+      sessionManagerBaseUrl: this._env.SESSION_MANAGER_BASE_URL,
+    };
+  }
+
+  get sessionConfig(): SessionConfig {
+    return {
+      // In development the cookie must not be `Secure` or it won't be sent over
+      // plain HTTP; in production it always is (nginx terminates TLS).
+      secure: !this._isDevelopment,
+      idleTimeoutMs: this._env.ADMIN_SESSION_IDLE_TIMEOUT_MINUTES * MINUTE_MS,
+      absoluteTimeoutMs:
+        this._env.ADMIN_SESSION_ABSOLUTE_TIMEOUT_MINUTES * MINUTE_MS,
+    };
+  }
+
+  /** Secret used by `@fastify/cookie` to sign the session cookie. */
+  get cookieSecret(): string {
+    return this._env.ADMIN_SESSION_SECRET;
+  }
+
+  get localAuthConfig(): LocalAuthConfig {
+    return {
+      credentials: this._env.ADMIN_LOCAL_CREDENTIALS,
+    };
+  }
+
+  get azureAuthConfig(): AzureAuthConfig {
+    return {
+      tenantId: this._env.AZURE_TENANT_ID,
+      clientId: this._env.AZURE_CLIENT_ID,
+      clientSecret: this._env.AZURE_CLIENT_SECRET,
+      redirectUri: this._env.AZURE_REDIRECT_URI,
+      allowedGroup: this._env.ADMIN_ALLOWED_GROUP,
+    };
+  }
+
+  get rateLimitConfig(): RateLimitConfig {
+    return {
+      globalMax: this._env.ADMIN_RATE_LIMIT_GLOBAL_MAX,
+      globalWindowMs: this._env.ADMIN_RATE_LIMIT_GLOBAL_WINDOW_SEC * SECOND_MS,
+      loginMax: this._env.ADMIN_RATE_LIMIT_LOGIN_MAX,
+      loginWindowMs: this._env.ADMIN_RATE_LIMIT_LOGIN_WINDOW_SEC * SECOND_MS,
+    };
+  }
+
+  get dbClientConfig(): AdminDbClientConfig {
+    return {
+      dbHost: this._env.DB_HOST,
+      dbPort: this._env.DB_PORT,
+      dbName: this._env.DB_NAME,
+      dbUser: this._env.DB_USER,
+      dbPassword: this._env.DB_PASSWORD,
+    };
+  }
+
+  constructor(path?: string) {
+    this._isDevelopment = process.argv.includes('--dev');
+
+    this._env = envSchema<Static<typeof CONFIG_SCHEMA>>({
+      dotenv: path ? { path } : {},
+      schema: CONFIG_SCHEMA,
+    });
+  }
+}

--- a/apps/admin-server/src/db/admin-db-client.ts
+++ b/apps/admin-server/src/db/admin-db-client.ts
@@ -1,0 +1,92 @@
+import { Kysely, PostgresDialect } from 'kysely';
+import pg from 'pg';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+
+import type { AdminDB } from './admin-db.types.js';
+import { getAdminMigrator } from './get-admin-migrator.js';
+
+export interface AdminDbClientConfig {
+  dbHost: string;
+  dbPort: number;
+  dbName: string;
+  dbUser: string;
+  dbPassword: string;
+}
+
+export class AdminDbClient {
+  private _db: Kysely<AdminDB>;
+  private _logger: AppDependencies['logger'];
+
+  get db() {
+    return this._db;
+  }
+
+  constructor(
+    logger: AppDependencies['logger'],
+    dbClientConfig: AppDependencies['dbClientConfig'],
+  ) {
+    this._logger = logger;
+    this._db = new Kysely<AdminDB>({
+      dialect: new PostgresDialect({
+        pool: new pg.Pool({
+          host: dbClientConfig.dbHost,
+          port: dbClientConfig.dbPort,
+          database: dbClientConfig.dbName,
+          user: dbClientConfig.dbUser,
+          password: dbClientConfig.dbPassword,
+        }),
+      }),
+      log: (event) => {
+        if (event.level === 'query') {
+          logger.debug(
+            {
+              sql: event.query.sql,
+              params: event.query.parameters,
+              durationMs: event.queryDurationMillis,
+            },
+            'Database query',
+          );
+        } else {
+          logger.error({ sql: event.query.sql }, 'Database query error');
+        }
+      },
+    });
+  }
+
+  /**
+   * Apply admin-server's own migrations (currently just the audit-log table).
+   * Idempotent and lock-safe across instances. Throws if any migration fails.
+   */
+  async migrateToLatest() {
+    const migrator = getAdminMigrator(this._db as unknown as Kysely<unknown>);
+    const { error, results } = await migrator.migrateToLatest();
+
+    for (const result of results ?? []) {
+      if (result.status === 'Success') {
+        this._logger.info(
+          { migration: result.migrationName },
+          'Applied admin migration',
+        );
+      } else if (result.status === 'Error') {
+        this._logger.error(
+          { migration: result.migrationName },
+          'Failed to apply admin migration',
+        );
+      }
+    }
+
+    if (error) {
+      throw error instanceof Error
+        ? error
+        : new Error('Admin database migration failed', { cause: error });
+    }
+  }
+
+  /**
+   * Destroy the database connection pool. Call on shutdown.
+   */
+  async destroy() {
+    await this._db.destroy();
+  }
+}

--- a/apps/admin-server/src/db/admin-db.types.ts
+++ b/apps/admin-server/src/db/admin-db.types.ts
@@ -1,0 +1,45 @@
+import type { ColumnType } from 'kysely';
+
+type Generated<T> =
+  T extends ColumnType<infer S, infer I, infer U>
+    ? ColumnType<S, I | undefined, U>
+    : ColumnType<T, T | undefined, T>;
+
+type Timestamp = ColumnType<Date, Date | string, Date | string>;
+
+/**
+ * `jsonb` column: Postgres returns parsed JSON on read; on write we pass a
+ * JSON string (Postgres casts text -> jsonb), so the insert/update type is
+ * `string`.
+ */
+type JsonColumn = ColumnType<unknown, string, string>;
+
+/**
+ * Append-only audit trail of admin actions performed through the BFF. Owned by
+ * `admin-server` (separate migrator + migration-tracking tables) so it never
+ * collides with the `@scribear/scribear-db` schema on the shared database.
+ */
+export interface AdminAuditLog {
+  id: Generated<string>;
+  /** Identity subject (e.g. local username, or SSO subject claim). */
+  actor_subject: string;
+  /** Identity provider that authenticated the actor (`local` | `sso`). */
+  actor_provider: string;
+  /** Machine action name, e.g. `create-room`, `delete-device`, `login`. */
+  action: string;
+  /** Primary target of the action (e.g. a room/device uid), if any. */
+  target: string | null;
+  /** Non-sensitive summary of request params. Never contains secrets. */
+  params_summary: JsonColumn;
+  /** Outcome: `success` | `failure`. */
+  result: string;
+  /** HTTP status returned to the client, when applicable. */
+  status_code: number | null;
+  /** Correlating request id (also emitted on the `X-Request-ID` header). */
+  request_id: string | null;
+  created_at: Generated<Timestamp>;
+}
+
+export interface AdminDB {
+  admin_audit_log: AdminAuditLog;
+}

--- a/apps/admin-server/src/db/get-admin-migrator.ts
+++ b/apps/admin-server/src/db/get-admin-migrator.ts
@@ -1,0 +1,35 @@
+import {
+  type Kysely,
+  type Migration,
+  type MigrationProvider,
+  Migrator,
+} from 'kysely';
+
+import * as adminAuditLog from './migrations/00000001-admin-audit-log.js';
+
+/**
+ * Static, in-code migration list. Unlike `FileMigrationProvider`, this bundles
+ * cleanly into the esbuild output (the production image ships only
+ * `dist/bundle.mjs`, not loose migration files on disk).
+ */
+class StaticMigrationProvider implements MigrationProvider {
+  getMigrations(): Promise<Record<string, Migration>> {
+    return Promise.resolve({
+      '00000001-admin-audit-log': adminAuditLog,
+    });
+  }
+}
+
+/**
+ * Migrator for admin-server's own tables. Uses dedicated migration-tracking
+ * table names so it coexists with the `@scribear/scribear-db` migrator on the
+ * same Postgres database without either one seeing the other's migrations.
+ */
+export function getAdminMigrator(db: Kysely<unknown>): Migrator {
+  return new Migrator({
+    db,
+    provider: new StaticMigrationProvider(),
+    migrationTableName: 'admin_kysely_migration',
+    migrationLockTableName: 'admin_kysely_migration_lock',
+  });
+}

--- a/apps/admin-server/src/db/migrations/00000001-admin-audit-log.ts
+++ b/apps/admin-server/src/db/migrations/00000001-admin-audit-log.ts
@@ -1,0 +1,29 @@
+import { type Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE admin_audit_log (
+      id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      actor_subject   TEXT NOT NULL,
+      actor_provider  TEXT NOT NULL,
+      action          TEXT NOT NULL,
+      target          TEXT NULL,
+      params_summary  JSONB NOT NULL DEFAULT '{}'::jsonb,
+      result          TEXT NOT NULL,
+      status_code     INTEGER NULL,
+      request_id      TEXT NULL,
+
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `.execute(db);
+
+  await sql`
+    CREATE INDEX idx_admin_audit_log_created_at
+      ON admin_audit_log (created_at DESC)
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_admin_audit_log_created_at`.execute(db);
+  await sql`DROP TABLE IF EXISTS admin_audit_log`.execute(db);
+}

--- a/apps/admin-server/src/index.ts
+++ b/apps/admin-server/src/index.ts
@@ -1,0 +1,30 @@
+import { AppConfig } from './app-config/app-config.js';
+import createServer from './server/create-server.js';
+
+async function main() {
+  const config = new AppConfig();
+  const { logger, fastify } = await createServer(config);
+
+  process.on('uncaughtException', (err) => {
+    logger.fatal({ msg: 'Uncaught exception', err });
+    throw err;
+  });
+
+  process.on('unhandledRejection', (reason) => {
+    const err = Error('Unhandled rejection', { cause: reason });
+    logger.fatal({ msg: 'Unhandled rejection', err });
+    throw err;
+  });
+
+  try {
+    await fastify.listen({
+      port: config.baseConfig.port,
+      host: config.baseConfig.host,
+    });
+  } catch (err) {
+    logger.fatal({ msg: 'Failed to start fastify webserver', err });
+    throw err;
+  }
+}
+
+await main();

--- a/apps/admin-server/src/server/base-path.ts
+++ b/apps/admin-server/src/server/base-path.ts
@@ -1,0 +1,5 @@
+/**
+ * Base path for every admin BFF route. nginx maps `location /api/admin/` to
+ * this service (preserving the full path), and the SPA calls `/api/admin/v1/*`.
+ */
+export const ADMIN_BASE_PATH = '/api/admin/v1';

--- a/apps/admin-server/src/server/create-server.ts
+++ b/apps/admin-server/src/server/create-server.ts
@@ -1,0 +1,74 @@
+import fastifyCookie from '@fastify/cookie';
+
+import { createBaseServer } from '@scribear/base-fastify-server';
+
+import type { AppConfig } from '#src/app-config/app-config.js';
+// Side-effect import: brings the FastifyRequest augmentation (adminSession /
+// adminIdentity) into the program.
+import '#src/server/shared/types/fastify-augmentation.js';
+
+import type { AppDependencies } from './dependency-injection/app-dependencies.js';
+import registerDependencies from './dependency-injection/register-dependencies.js';
+import { auditRouter } from './features/audit/audit.router.js';
+import { authRouter } from './features/auth/auth.router.js';
+import { devicesRouter } from './features/devices/devices.router.js';
+import { healthRouter } from './features/health/health.router.js';
+import { probesRouter } from './features/probes/probes.router.js';
+import { roomsRouter } from './features/rooms/rooms.router.js';
+import { schedulingRouter } from './features/scheduling/scheduling.router.js';
+import adminErrorHandler from './plugins/error-handler.plugin.js';
+import { registerRateLimit } from './plugins/rate-limit.plugin.js';
+
+/**
+ * Initializes the admin BFF: base server + cookie/session, rate limiting, DI,
+ * and the `/api/admin/v1` routes.
+ */
+async function createServer(config: AppConfig) {
+  // Trust exactly ONE proxy hop (nginx). This makes `req.ip` the client IP
+  // nginx appended to `X-Forwarded-For` — which a client cannot spoof — rather
+  // than the leftmost (client-supplied) entry. Correct keying for rate limits.
+  const { logger, dependencyContainer, fastify } = createBaseServer(
+    config.baseConfig.logLevel,
+    { trustProxy: 1 },
+  );
+
+  // Override the base error handler so every error becomes an envelope.
+  // Registered before routes and after the base server so this handler wins.
+  await fastify.register(adminErrorHandler);
+
+  // Cookie signing secret (session cookie is set with `signed: true`).
+  await fastify.register(fastifyCookie, { secret: config.cookieSecret });
+
+  // Rate limiting must be registered before routes so per-route overrides apply.
+  await registerRateLimit(fastify, config.rateLimitConfig);
+
+  registerDependencies(dependencyContainer, config);
+
+  fastify.register(probesRouter);
+  fastify.register(healthRouter);
+  fastify.register(authRouter, {
+    loginMax: config.rateLimitConfig.loginMax,
+    loginWindowMs: config.rateLimitConfig.loginWindowMs,
+  });
+  fastify.register(roomsRouter);
+  fastify.register(devicesRouter);
+  fastify.register(schedulingRouter);
+  fastify.register(auditRouter);
+
+  const dbClient =
+    dependencyContainer.resolve<AppDependencies['dbClient']>('dbClient');
+
+  // Apply admin-owned migrations (audit log) once, at startup.
+  fastify.addHook('onReady', async () => {
+    await dbClient.migrateToLatest();
+  });
+
+  // Drain the pg pool on shutdown.
+  fastify.addHook('onClose', async () => {
+    await dbClient.destroy();
+  });
+
+  return { logger, fastify };
+}
+
+export default createServer;

--- a/apps/admin-server/src/server/dependency-injection/app-dependencies.ts
+++ b/apps/admin-server/src/server/dependency-injection/app-dependencies.ts
@@ -1,0 +1,100 @@
+// Need to import so that declare module '@fastify/awilix' below works
+import '@fastify/awilix';
+
+import type { BaseDependencies } from '@scribear/base-fastify-server';
+
+import type { AppConfig, BaseConfig } from '#src/app-config/app-config.js';
+import type {
+  AdminDbClient,
+  AdminDbClientConfig,
+} from '#src/db/admin-db-client.js';
+import type { AuditController } from '#src/server/features/audit/audit.controller.js';
+import type { AuthController } from '#src/server/features/auth/auth.controller.js';
+import type { DevicesController } from '#src/server/features/devices/devices.controller.js';
+import type { HealthController } from '#src/server/features/health/health.controller.js';
+import type { LivenessController } from '#src/server/features/probes/liveness.controller.js';
+import type { ReadinessController } from '#src/server/features/probes/readiness.controller.js';
+import type { RoomsController } from '#src/server/features/rooms/rooms.controller.js';
+import type { SchedulingController } from '#src/server/features/scheduling/scheduling.controller.js';
+import type { RateLimitConfig } from '#src/server/plugins/rate-limit.plugin.js';
+import type { AuditRepository } from '#src/server/shared/repositories/audit.repository.js';
+import type { AuditService } from '#src/server/shared/services/audit.service.js';
+import type {
+  AzureAuthConfig,
+  AzureOidcAuthService,
+} from '#src/server/shared/services/azure-oidc-auth.service.js';
+import type {
+  LocalAuthConfig,
+  LocalAuthService,
+} from '#src/server/shared/services/local-auth.service.js';
+import type {
+  SessionManagerGatewayConfig,
+  SessionManagerGatewayService,
+} from '#src/server/shared/services/session-manager-gateway.service.js';
+import type {
+  SessionConfig,
+  SessionService,
+} from '#src/server/shared/services/session.service.js';
+
+/**
+ * All named dependencies available in the Awilix container.
+ */
+interface AppDependencies extends BaseDependencies {
+  // Config
+  baseConfig: BaseConfig;
+  sessionManagerGatewayConfig: SessionManagerGatewayConfig;
+  sessionConfig: SessionConfig;
+  localAuthConfig: LocalAuthConfig;
+  azureAuthConfig: AzureAuthConfig;
+  rateLimitConfig: RateLimitConfig;
+  dbClientConfig: AdminDbClientConfig;
+
+  // Database
+  dbClient: AdminDbClient;
+
+  // Shared services
+  localAuthService: LocalAuthService;
+  azureOidcAuthService: AzureOidcAuthService;
+  sessionService: SessionService;
+  sessionManagerGatewayService: SessionManagerGatewayService;
+  auditService: AuditService;
+
+  // Shared repositories
+  auditRepository: AuditRepository;
+
+  // Probes
+  livenessController: LivenessController;
+  readinessController: ReadinessController;
+
+  // Auth
+  authController: AuthController;
+
+  // Health
+  healthController: HealthController;
+
+  // Rooms
+  roomsController: RoomsController;
+
+  // Devices
+  devicesController: DevicesController;
+
+  // Scheduling
+  schedulingController: SchedulingController;
+
+  // Audit
+  auditController: AuditController;
+}
+
+/**
+ * Ensure the Fastify Awilix container is typed with AppDependencies.
+ * @see https://github.com/fastify/fastify-awilix?tab=readme-ov-file#typescript-usage
+ */
+declare module '@fastify/awilix' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface Cradle extends AppDependencies {}
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface RequestCradle extends AppDependencies {}
+}
+
+export type { AppDependencies, AppConfig };

--- a/apps/admin-server/src/server/dependency-injection/register-dependencies.ts
+++ b/apps/admin-server/src/server/dependency-injection/register-dependencies.ts
@@ -1,0 +1,102 @@
+import {
+  type AwilixContainer,
+  Lifetime,
+  type NameAndRegistrationPair,
+  asClass,
+  asValue,
+} from 'awilix';
+
+import { AdminDbClient } from '#src/db/admin-db-client.js';
+import { AuditController } from '#src/server/features/audit/audit.controller.js';
+import { AuthController } from '#src/server/features/auth/auth.controller.js';
+import { DevicesController } from '#src/server/features/devices/devices.controller.js';
+import { HealthController } from '#src/server/features/health/health.controller.js';
+import { LivenessController } from '#src/server/features/probes/liveness.controller.js';
+import { ReadinessController } from '#src/server/features/probes/readiness.controller.js';
+import { RoomsController } from '#src/server/features/rooms/rooms.controller.js';
+import { SchedulingController } from '#src/server/features/scheduling/scheduling.controller.js';
+import { AuditRepository } from '#src/server/shared/repositories/audit.repository.js';
+import { AuditService } from '#src/server/shared/services/audit.service.js';
+import { AzureOidcAuthService } from '#src/server/shared/services/azure-oidc-auth.service.js';
+import { LocalAuthService } from '#src/server/shared/services/local-auth.service.js';
+import { SessionManagerGatewayService } from '#src/server/shared/services/session-manager-gateway.service.js';
+import { SessionService } from '#src/server/shared/services/session.service.js';
+
+import type { AppConfig } from './app-dependencies.js';
+import type { AppDependencies } from './app-dependencies.js';
+
+/**
+ * Register all controller, service, and repository classes into the Awilix
+ * dependency container.
+ */
+function registerDependencies(
+  dependencyContainer: AwilixContainer,
+  config: AppConfig,
+) {
+  dependencyContainer.register({
+    // Config values
+    baseConfig: asValue(config.baseConfig),
+    sessionManagerGatewayConfig: asValue(config.sessionManagerGatewayConfig),
+    sessionConfig: asValue(config.sessionConfig),
+    localAuthConfig: asValue(config.localAuthConfig),
+    azureAuthConfig: asValue(config.azureAuthConfig),
+    rateLimitConfig: asValue(config.rateLimitConfig),
+    dbClientConfig: asValue(config.dbClientConfig),
+
+    // Database
+    dbClient: asClass(AdminDbClient, { lifetime: Lifetime.SINGLETON }),
+
+    // Shared services. Stateful/expensive-to-build services are SINGLETON:
+    // the session store must persist across requests; the auth providers hold
+    // parsed credentials; the gateway holds the upstream client + admin key.
+    localAuthService: asClass(LocalAuthService, {
+      lifetime: Lifetime.SINGLETON,
+    }),
+    azureOidcAuthService: asClass(AzureOidcAuthService, {
+      lifetime: Lifetime.SINGLETON,
+    }),
+    sessionService: asClass(SessionService, { lifetime: Lifetime.SINGLETON }),
+    sessionManagerGatewayService: asClass(SessionManagerGatewayService, {
+      lifetime: Lifetime.SINGLETON,
+    }),
+    // SCOPED so it resolves the request-scoped logger (with reqId) for audit.
+    auditService: asClass(AuditService, { lifetime: Lifetime.SCOPED }),
+
+    // Shared repositories
+    auditRepository: asClass(AuditRepository, {
+      lifetime: Lifetime.SINGLETON,
+    }),
+
+    // Probes
+    livenessController: asClass(LivenessController, {
+      lifetime: Lifetime.SCOPED,
+    }),
+    readinessController: asClass(ReadinessController, {
+      lifetime: Lifetime.SCOPED,
+    }),
+
+    // Auth
+    authController: asClass(AuthController, { lifetime: Lifetime.SCOPED }),
+
+    // Health
+    healthController: asClass(HealthController, { lifetime: Lifetime.SCOPED }),
+
+    // Rooms
+    roomsController: asClass(RoomsController, { lifetime: Lifetime.SCOPED }),
+
+    // Devices
+    devicesController: asClass(DevicesController, {
+      lifetime: Lifetime.SCOPED,
+    }),
+
+    // Scheduling
+    schedulingController: asClass(SchedulingController, {
+      lifetime: Lifetime.SCOPED,
+    }),
+
+    // Audit
+    auditController: asClass(AuditController, { lifetime: Lifetime.SCOPED }),
+  } as NameAndRegistrationPair<AppDependencies>);
+}
+
+export default registerDependencies;

--- a/apps/admin-server/src/server/dependency-injection/resolve-handler.ts
+++ b/apps/admin-server/src/server/dependency-injection/resolve-handler.ts
@@ -1,0 +1,38 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import type { AppDependencies } from './app-dependencies.js';
+
+/**
+ * Creates a wrapper that resolves a controller from the request DI scope and
+ * delegates to the named method. Keeps routers free of direct class imports.
+ */
+function resolveHandler<
+  C extends keyof AppDependencies,
+  M extends keyof AppDependencies[C],
+>(controller: C, method: M): AppDependencies[C][M] {
+  const wrapper = async (req: FastifyRequest, res: FastifyReply) => {
+    const routeController = req.diScope.resolve(
+      controller,
+    ) as AppDependencies[C];
+
+    if (
+      !(method in routeController) ||
+      typeof routeController[method] !== 'function'
+    ) {
+      throw new Error(
+        `Failed to resolve handler: Property '${String(method)}' on controller '${controller}' is not a function.`,
+      );
+    }
+
+    const handler = routeController[method].bind(routeController) as (
+      req: FastifyRequest,
+      res: FastifyReply,
+    ) => unknown;
+
+    return await handler(req, res);
+  };
+
+  return wrapper as AppDependencies[C][M];
+}
+
+export default resolveHandler;

--- a/apps/admin-server/src/server/features/audit/audit.controller.ts
+++ b/apps/admin-server/src/server/features/audit/audit.controller.ts
@@ -1,0 +1,27 @@
+import type {
+  BaseFastifyReply,
+  BaseFastifyRequest,
+} from '@scribear/base-fastify-server';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+import { okEnvelope } from '#src/server/shared/envelope/envelope.js';
+
+import type { LIST_AUDIT_SCHEMA } from './audit.schema.js';
+
+export class AuditController {
+  private _auditRepository: AppDependencies['auditRepository'];
+
+  constructor(auditRepository: AppDependencies['auditRepository']) {
+    this._auditRepository = auditRepository;
+  }
+
+  /** Most-recent-first page of admin audit records. */
+  async list(
+    req: BaseFastifyRequest<typeof LIST_AUDIT_SCHEMA>,
+    res: BaseFastifyReply,
+  ) {
+    const limit = req.query.limit ?? 50;
+    const items = await this._auditRepository.list(limit);
+    res.code(200).send(okEnvelope({ items }));
+  }
+}

--- a/apps/admin-server/src/server/features/audit/audit.router.ts
+++ b/apps/admin-server/src/server/features/audit/audit.router.ts
@@ -1,0 +1,15 @@
+import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
+
+import resolveHandler from '#src/server/dependency-injection/resolve-handler.js';
+import { requireSessionHook } from '#src/server/shared/hooks/require-session.hook.js';
+
+import { LIST_AUDIT_ROUTE, LIST_AUDIT_SCHEMA } from './audit.schema.js';
+
+export function auditRouter(fastify: BaseFastifyInstance) {
+  fastify.route({
+    ...LIST_AUDIT_ROUTE,
+    schema: LIST_AUDIT_SCHEMA,
+    preHandler: [requireSessionHook],
+    handler: resolveHandler('auditController', 'list'),
+  });
+}

--- a/apps/admin-server/src/server/features/audit/audit.schema.ts
+++ b/apps/admin-server/src/server/features/audit/audit.schema.ts
@@ -1,0 +1,16 @@
+import { Type } from 'typebox';
+
+import { ADMIN_BASE_PATH } from '#src/server/base-path.js';
+
+export const LIST_AUDIT_SCHEMA = {
+  querystring: Type.Object({
+    limit: Type.Optional(
+      Type.Integer({ minimum: 1, maximum: 200, default: 50 }),
+    ),
+  }),
+};
+
+export const LIST_AUDIT_ROUTE = {
+  method: 'GET' as const,
+  url: `${ADMIN_BASE_PATH}/audit`,
+};

--- a/apps/admin-server/src/server/features/auth/auth.controller.ts
+++ b/apps/admin-server/src/server/features/auth/auth.controller.ts
@@ -1,0 +1,181 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import type {
+  BaseFastifyReply,
+  BaseFastifyRequest,
+} from '@scribear/base-fastify-server';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+import {
+  errorEnvelope,
+  okEnvelope,
+} from '#src/server/shared/envelope/envelope.js';
+import {
+  SESSION_COOKIE_NAME,
+  clearSessionCookieOptions,
+  sessionCookieOptions,
+} from '#src/server/shared/http/cookie-options.js';
+
+import type { LOGIN_SCHEMA } from './auth.schema.js';
+
+// Fixed delay applied to failed logins to blunt online password guessing.
+const FAILED_LOGIN_DELAY_MS = 400;
+
+export class AuthController {
+  private _localAuthService: AppDependencies['localAuthService'];
+  private _azureOidcAuthService: AppDependencies['azureOidcAuthService'];
+  private _sessionService: AppDependencies['sessionService'];
+  private _auditService: AppDependencies['auditService'];
+
+  constructor(
+    localAuthService: AppDependencies['localAuthService'],
+    azureOidcAuthService: AppDependencies['azureOidcAuthService'],
+    sessionService: AppDependencies['sessionService'],
+    auditService: AppDependencies['auditService'],
+  ) {
+    this._localAuthService = localAuthService;
+    this._azureOidcAuthService = azureOidcAuthService;
+    this._sessionService = sessionService;
+    this._auditService = auditService;
+  }
+
+  /** Public: which auth providers are enabled, so the SPA renders the right UI. */
+  config(_req: BaseFastifyRequest, res: BaseFastifyReply) {
+    res.code(200).send(
+      okEnvelope({
+        local: this._localAuthService.isEnabled(),
+        sso: this._azureOidcAuthService.isEnabled(),
+      }),
+    );
+  }
+
+  async login(
+    req: BaseFastifyRequest<typeof LOGIN_SCHEMA>,
+    res: BaseFastifyReply,
+  ) {
+    if (!this._localAuthService.isEnabled()) {
+      res
+        .code(404)
+        .send(
+          errorEnvelope(
+            'LOCAL_LOGIN_DISABLED',
+            'Local login is not enabled on this deployment.',
+            req.id,
+          ),
+        );
+      return;
+    }
+
+    const { username, password } = req.body;
+    const identity = this._localAuthService.verify(username, password);
+
+    if (!identity) {
+      await sleep(FAILED_LOGIN_DELAY_MS);
+      await this._auditService.record({
+        actorSubject: username.slice(0, 256),
+        actorProvider: 'local',
+        action: 'login',
+        target: null,
+        paramsSummary: { outcome: 'invalid-credentials' },
+        result: 'failure',
+        statusCode: 401,
+        requestId: req.id,
+      });
+      // Generic message: never reveal whether the username or password was wrong.
+      res
+        .code(401)
+        .send(
+          errorEnvelope('INVALID_CREDENTIALS', 'Invalid credentials.', req.id),
+        );
+      return;
+    }
+
+    const { sessionId, csrfToken } = this._sessionService.create(identity);
+    res.setCookie(
+      SESSION_COOKIE_NAME,
+      sessionId,
+      sessionCookieOptions(
+        this._sessionService.config.secure,
+        this._sessionService.config.absoluteTimeoutMs,
+      ),
+    );
+
+    await this._auditService.record({
+      actorSubject: identity.subject,
+      actorProvider: identity.provider,
+      action: 'login',
+      target: null,
+      paramsSummary: { outcome: 'success' },
+      result: 'success',
+      statusCode: 200,
+      requestId: req.id,
+    });
+
+    res.code(200).send(okEnvelope({ identity, csrfToken }));
+  }
+
+  async logout(req: BaseFastifyRequest, res: BaseFastifyReply) {
+    const identity = req.adminIdentity;
+    this._sessionService.destroy(req.adminSessionId);
+    res.clearCookie(
+      SESSION_COOKIE_NAME,
+      clearSessionCookieOptions(this._sessionService.config.secure),
+    );
+
+    if (identity) {
+      await this._auditService.record({
+        actorSubject: identity.subject,
+        actorProvider: identity.provider,
+        action: 'logout',
+        target: null,
+        paramsSummary: {},
+        result: 'success',
+        statusCode: 200,
+        requestId: req.id,
+      });
+    }
+
+    res.code(200).send(okEnvelope(null));
+  }
+
+  /** Current identity + the session CSRF token (so the SPA can recover it after reload). */
+  me(req: BaseFastifyRequest, res: BaseFastifyReply) {
+    const session = req.adminSession;
+    if (!session) {
+      // Should never happen (guarded by requireSessionHook), but stay safe.
+      res
+        .code(401)
+        .send(
+          errorEnvelope('UNAUTHENTICATED', 'Authentication required.', req.id),
+        );
+      return;
+    }
+    res.code(200).send(
+      okEnvelope({
+        identity: session.identity,
+        csrfToken: session.csrfToken,
+      }),
+    );
+  }
+
+  /** SSO stub: 404 until the Azure provider is configured + implemented. */
+  ssoLogin(req: BaseFastifyRequest, res: BaseFastifyReply) {
+    this._ssoNotAvailable(req, res);
+  }
+
+  ssoCallback(req: BaseFastifyRequest, res: BaseFastifyReply) {
+    this._ssoNotAvailable(req, res);
+  }
+
+  private _ssoNotAvailable(req: BaseFastifyRequest, res: BaseFastifyReply) {
+    res
+      .code(404)
+      .send(
+        errorEnvelope(
+          'SSO_NOT_AVAILABLE',
+          'SSO is not configured on this deployment.',
+          req.id,
+        ),
+      );
+  }
+}

--- a/apps/admin-server/src/server/features/auth/auth.router.ts
+++ b/apps/admin-server/src/server/features/auth/auth.router.ts
@@ -1,0 +1,65 @@
+import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
+
+import resolveHandler from '#src/server/dependency-injection/resolve-handler.js';
+import { csrfHook } from '#src/server/shared/hooks/csrf.hook.js';
+import { requireSessionHook } from '#src/server/shared/hooks/require-session.hook.js';
+
+import {
+  AUTH_CONFIG_ROUTE,
+  AUTH_ME_ROUTE,
+  LOGIN_ROUTE,
+  LOGIN_SCHEMA,
+  LOGOUT_ROUTE,
+  SSO_CALLBACK_ROUTE,
+  SSO_LOGIN_ROUTE,
+} from './auth.schema.js';
+
+export interface AuthRouterOptions {
+  loginMax: number;
+  loginWindowMs: number;
+}
+
+export function authRouter(
+  fastify: BaseFastifyInstance,
+  opts: AuthRouterOptions,
+) {
+  // Public: credential login. Stricter rate limit — the guessing surface.
+  fastify.route({
+    ...LOGIN_ROUTE,
+    schema: { body: LOGIN_SCHEMA.body },
+    config: {
+      rateLimit: { max: opts.loginMax, timeWindow: opts.loginWindowMs },
+    },
+    handler: resolveHandler('authController', 'login'),
+  });
+
+  // Public: which providers are enabled.
+  fastify.route({
+    ...AUTH_CONFIG_ROUTE,
+    handler: resolveHandler('authController', 'config'),
+  });
+
+  // Authenticated: current identity + CSRF token.
+  fastify.route({
+    ...AUTH_ME_ROUTE,
+    preHandler: [requireSessionHook],
+    handler: resolveHandler('authController', 'me'),
+  });
+
+  // Authenticated + CSRF: destroy the session.
+  fastify.route({
+    ...LOGOUT_ROUTE,
+    preHandler: [requireSessionHook, csrfHook],
+    handler: resolveHandler('authController', 'logout'),
+  });
+
+  // SSO stubs (return 404 until Azure is configured).
+  fastify.route({
+    ...SSO_LOGIN_ROUTE,
+    handler: resolveHandler('authController', 'ssoLogin'),
+  });
+  fastify.route({
+    ...SSO_CALLBACK_ROUTE,
+    handler: resolveHandler('authController', 'ssoCallback'),
+  });
+}

--- a/apps/admin-server/src/server/features/auth/auth.schema.ts
+++ b/apps/admin-server/src/server/features/auth/auth.schema.ts
@@ -1,0 +1,44 @@
+import { Type } from 'typebox';
+
+import { ADMIN_BASE_PATH } from '#src/server/base-path.js';
+
+export const LOGIN_SCHEMA = {
+  body: Type.Object(
+    {
+      username: Type.String({ minLength: 1, maxLength: 256 }),
+      // Cap length to bound hashing work on unauthenticated input.
+      password: Type.String({ minLength: 1, maxLength: 1024 }),
+    },
+    { additionalProperties: false },
+  ),
+};
+
+export const LOGIN_ROUTE = {
+  method: 'POST' as const,
+  url: `${ADMIN_BASE_PATH}/auth/login`,
+};
+
+export const LOGOUT_ROUTE = {
+  method: 'POST' as const,
+  url: `${ADMIN_BASE_PATH}/auth/logout`,
+};
+
+export const AUTH_CONFIG_ROUTE = {
+  method: 'GET' as const,
+  url: `${ADMIN_BASE_PATH}/auth/config`,
+};
+
+export const AUTH_ME_ROUTE = {
+  method: 'GET' as const,
+  url: `${ADMIN_BASE_PATH}/auth/me`,
+};
+
+export const SSO_LOGIN_ROUTE = {
+  method: 'GET' as const,
+  url: `${ADMIN_BASE_PATH}/auth/sso/login`,
+};
+
+export const SSO_CALLBACK_ROUTE = {
+  method: 'GET' as const,
+  url: `${ADMIN_BASE_PATH}/auth/sso/callback`,
+};

--- a/apps/admin-server/src/server/features/devices/devices.controller.ts
+++ b/apps/admin-server/src/server/features/devices/devices.controller.ts
@@ -1,0 +1,111 @@
+import type {
+  BaseFastifyReply,
+  BaseFastifyRequest,
+} from '@scribear/base-fastify-server';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+import { auditedMutation } from '#src/server/shared/proxy/audited-proxy.js';
+
+import type {
+  DELETE_DEVICE_INPUT,
+  GET_DEVICE_INPUT,
+  LIST_DEVICES_INPUT,
+  REGISTER_DEVICE_INPUT,
+  REREGISTER_DEVICE_INPUT,
+  UPDATE_DEVICE_INPUT,
+} from './devices.schema.js';
+
+export class DevicesController {
+  private _gateway: AppDependencies['sessionManagerGatewayService'];
+  private _auditService: AppDependencies['auditService'];
+
+  constructor(
+    sessionManagerGatewayService: AppDependencies['sessionManagerGatewayService'],
+    auditService: AppDependencies['auditService'],
+  ) {
+    this._gateway = sessionManagerGatewayService;
+    this._auditService = auditService;
+  }
+
+  // ---- Reads ----
+
+  async list(
+    req: BaseFastifyRequest<typeof LIST_DEVICES_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    this._gateway.respond(req, res, await this._gateway.listDevices(req.query));
+  }
+
+  async get(
+    req: BaseFastifyRequest<typeof GET_DEVICE_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    this._gateway.respond(req, res, await this._gateway.getDevice(req.params));
+  }
+
+  // ---- Mutations (require read-write + CSRF) ----
+
+  async register(
+    req: BaseFastifyRequest<typeof REGISTER_DEVICE_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'register-device',
+      target: null,
+      paramsSummary: { name: req.body.name },
+      call: () => this._gateway.registerDevice(req.body),
+    });
+  }
+
+  async reregister(
+    req: BaseFastifyRequest<typeof REREGISTER_DEVICE_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'reregister-device',
+      target: req.body.deviceUid,
+      paramsSummary: {},
+      call: () => this._gateway.reregisterDevice(req.body),
+    });
+  }
+
+  async update(
+    req: BaseFastifyRequest<typeof UPDATE_DEVICE_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'update-device',
+      target: req.body.deviceUid,
+      paramsSummary: { name: req.body.name },
+      call: () => this._gateway.updateDevice(req.body),
+    });
+  }
+
+  async delete(
+    req: BaseFastifyRequest<typeof DELETE_DEVICE_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'delete-device',
+      target: req.body.deviceUid,
+      paramsSummary: {},
+      call: () => this._gateway.deleteDevice(req.body),
+    });
+  }
+}

--- a/apps/admin-server/src/server/features/devices/devices.router.ts
+++ b/apps/admin-server/src/server/features/devices/devices.router.ts
@@ -1,0 +1,73 @@
+import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
+
+import resolveHandler from '#src/server/dependency-injection/resolve-handler.js';
+import { csrfHook } from '#src/server/shared/hooks/csrf.hook.js';
+import { requireRole } from '#src/server/shared/hooks/require-role.hook.js';
+import { requireSessionHook } from '#src/server/shared/hooks/require-session.hook.js';
+import { ROLE_READ_WRITE } from '#src/server/shared/types/identity.js';
+
+import {
+  DELETE_DEVICE_INPUT,
+  DELETE_DEVICE_ROUTE,
+  GET_DEVICE_INPUT,
+  GET_DEVICE_ROUTE,
+  LIST_DEVICES_INPUT,
+  LIST_DEVICES_ROUTE,
+  REGISTER_DEVICE_INPUT,
+  REGISTER_DEVICE_ROUTE,
+  REREGISTER_DEVICE_INPUT,
+  REREGISTER_DEVICE_ROUTE,
+  UPDATE_DEVICE_INPUT,
+  UPDATE_DEVICE_ROUTE,
+} from './devices.schema.js';
+
+export function devicesRouter(fastify: BaseFastifyInstance) {
+  const readGuards = [requireSessionHook];
+  const writeGuards = [
+    requireSessionHook,
+    csrfHook,
+    requireRole(ROLE_READ_WRITE),
+  ];
+
+  fastify.route({
+    ...LIST_DEVICES_ROUTE,
+    schema: LIST_DEVICES_INPUT,
+    preHandler: readGuards,
+    handler: resolveHandler('devicesController', 'list'),
+  });
+
+  fastify.route({
+    ...GET_DEVICE_ROUTE,
+    schema: GET_DEVICE_INPUT,
+    preHandler: readGuards,
+    handler: resolveHandler('devicesController', 'get'),
+  });
+
+  fastify.route({
+    ...REGISTER_DEVICE_ROUTE,
+    schema: REGISTER_DEVICE_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('devicesController', 'register'),
+  });
+
+  fastify.route({
+    ...REREGISTER_DEVICE_ROUTE,
+    schema: REREGISTER_DEVICE_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('devicesController', 'reregister'),
+  });
+
+  fastify.route({
+    ...UPDATE_DEVICE_ROUTE,
+    schema: UPDATE_DEVICE_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('devicesController', 'update'),
+  });
+
+  fastify.route({
+    ...DELETE_DEVICE_ROUTE,
+    schema: DELETE_DEVICE_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('devicesController', 'delete'),
+  });
+}

--- a/apps/admin-server/src/server/features/devices/devices.schema.ts
+++ b/apps/admin-server/src/server/features/devices/devices.schema.ts
@@ -1,0 +1,47 @@
+import {
+  DELETE_DEVICE_SCHEMA,
+  GET_DEVICE_SCHEMA,
+  LIST_DEVICES_SCHEMA,
+  REGISTER_DEVICE_SCHEMA,
+  REREGISTER_DEVICE_SCHEMA,
+  UPDATE_DEVICE_SCHEMA,
+} from '@scribear/session-manager-schema';
+
+import { ADMIN_BASE_PATH } from '#src/server/base-path.js';
+
+const P = `${ADMIN_BASE_PATH}/devices`;
+
+export const LIST_DEVICES_INPUT = {
+  querystring: LIST_DEVICES_SCHEMA.querystring,
+};
+export const LIST_DEVICES_ROUTE = { method: 'GET' as const, url: `${P}/list` };
+
+export const GET_DEVICE_INPUT = { params: GET_DEVICE_SCHEMA.params };
+export const GET_DEVICE_ROUTE = {
+  method: 'GET' as const,
+  url: `${P}/get/:deviceUid`,
+};
+
+export const REGISTER_DEVICE_INPUT = { body: REGISTER_DEVICE_SCHEMA.body };
+export const REGISTER_DEVICE_ROUTE = {
+  method: 'POST' as const,
+  url: `${P}/register`,
+};
+
+export const REREGISTER_DEVICE_INPUT = { body: REREGISTER_DEVICE_SCHEMA.body };
+export const REREGISTER_DEVICE_ROUTE = {
+  method: 'POST' as const,
+  url: `${P}/reregister`,
+};
+
+export const UPDATE_DEVICE_INPUT = { body: UPDATE_DEVICE_SCHEMA.body };
+export const UPDATE_DEVICE_ROUTE = {
+  method: 'POST' as const,
+  url: `${P}/update`,
+};
+
+export const DELETE_DEVICE_INPUT = { body: DELETE_DEVICE_SCHEMA.body };
+export const DELETE_DEVICE_ROUTE = {
+  method: 'POST' as const,
+  url: `${P}/delete`,
+};

--- a/apps/admin-server/src/server/features/health/health.controller.ts
+++ b/apps/admin-server/src/server/features/health/health.controller.ts
@@ -1,0 +1,59 @@
+import { sql } from 'kysely';
+
+import type {
+  BaseFastifyReply,
+  BaseFastifyRequest,
+} from '@scribear/base-fastify-server';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+import { okEnvelope } from '#src/server/shared/envelope/envelope.js';
+
+type ComponentStatus = 'ok' | 'degraded' | 'unreachable' | 'fail';
+
+export class HealthController {
+  private _dbClient: AppDependencies['dbClient'];
+  private _sessionManagerGatewayService: AppDependencies['sessionManagerGatewayService'];
+
+  constructor(
+    dbClient: AppDependencies['dbClient'],
+    sessionManagerGatewayService: AppDependencies['sessionManagerGatewayService'],
+  ) {
+    this._dbClient = dbClient;
+    this._sessionManagerGatewayService = sessionManagerGatewayService;
+  }
+
+  /**
+   * Rollup of the pieces the admin console depends on. Requires a session — it
+   * exposes infrastructure state. (Container/orchestration probes use the
+   * unauthenticated `/probes/*` routes instead.)
+   */
+  async health(_req: BaseFastifyRequest, res: BaseFastifyReply) {
+    let database: ComponentStatus = 'ok';
+    try {
+      await sql`SELECT 1`.execute(this._dbClient.db);
+    } catch {
+      database = 'fail';
+    }
+
+    let sessionManager: ComponentStatus = 'ok';
+    const start = Date.now();
+    const [readinessResponse, readinessError] =
+      await this._sessionManagerGatewayService.readiness();
+    const sessionManagerLatencyMs = Date.now() - start;
+    if (readinessError) {
+      sessionManager = 'unreachable';
+    } else if (readinessResponse.status !== 200) {
+      sessionManager = 'degraded';
+    }
+
+    res.code(200).send(
+      okEnvelope({
+        bff: 'ok' as const,
+        database,
+        sessionManager,
+        sessionManagerLatencyMs,
+        checkedAt: new Date().toISOString(),
+      }),
+    );
+  }
+}

--- a/apps/admin-server/src/server/features/health/health.router.ts
+++ b/apps/admin-server/src/server/features/health/health.router.ts
@@ -1,0 +1,14 @@
+import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
+
+import resolveHandler from '#src/server/dependency-injection/resolve-handler.js';
+import { requireSessionHook } from '#src/server/shared/hooks/require-session.hook.js';
+
+import { HEALTH_ROUTE } from './health.schema.js';
+
+export function healthRouter(fastify: BaseFastifyInstance) {
+  fastify.route({
+    ...HEALTH_ROUTE,
+    preHandler: [requireSessionHook],
+    handler: resolveHandler('healthController', 'health'),
+  });
+}

--- a/apps/admin-server/src/server/features/health/health.schema.ts
+++ b/apps/admin-server/src/server/features/health/health.schema.ts
@@ -1,0 +1,6 @@
+import { ADMIN_BASE_PATH } from '#src/server/base-path.js';
+
+export const HEALTH_ROUTE = {
+  method: 'GET' as const,
+  url: `${ADMIN_BASE_PATH}/health`,
+};

--- a/apps/admin-server/src/server/features/probes/liveness.controller.ts
+++ b/apps/admin-server/src/server/features/probes/liveness.controller.ts
@@ -1,0 +1,15 @@
+import type {
+  BaseFastifyReply,
+  BaseFastifyRequest,
+} from '@scribear/base-fastify-server';
+
+import { LIVENESS_SCHEMA } from './probes.schema.js';
+
+export class LivenessController {
+  liveness(
+    _req: BaseFastifyRequest<typeof LIVENESS_SCHEMA>,
+    res: BaseFastifyReply<typeof LIVENESS_SCHEMA>,
+  ) {
+    res.code(200).send({ status: 'ok' });
+  }
+}

--- a/apps/admin-server/src/server/features/probes/probes.router.ts
+++ b/apps/admin-server/src/server/features/probes/probes.router.ts
@@ -1,0 +1,27 @@
+import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
+
+import resolveHandler from '#src/server/dependency-injection/resolve-handler.js';
+
+import {
+  LIVENESS_ROUTE,
+  LIVENESS_SCHEMA,
+  READINESS_ROUTE,
+  READINESS_SCHEMA,
+} from './probes.schema.js';
+
+export function probesRouter(fastify: BaseFastifyInstance) {
+  fastify.route({
+    ...LIVENESS_ROUTE,
+    schema: LIVENESS_SCHEMA,
+    // Opt out of rate limiting: container health checks poll this frequently.
+    config: { rateLimit: false },
+    handler: resolveHandler('livenessController', 'liveness'),
+  });
+
+  fastify.route({
+    ...READINESS_ROUTE,
+    schema: READINESS_SCHEMA,
+    config: { rateLimit: false },
+    handler: resolveHandler('readinessController', 'readiness'),
+  });
+}

--- a/apps/admin-server/src/server/features/probes/probes.schema.ts
+++ b/apps/admin-server/src/server/features/probes/probes.schema.ts
@@ -1,0 +1,29 @@
+import { Type } from 'typebox';
+
+import { ADMIN_BASE_PATH } from '#src/server/base-path.js';
+
+export const LIVENESS_SCHEMA = {
+  response: {
+    200: Type.Object({ status: Type.Literal('ok') }),
+  },
+};
+
+export const LIVENESS_ROUTE = {
+  method: 'GET' as const,
+  url: `${ADMIN_BASE_PATH}/probes/liveness`,
+};
+
+export const READINESS_SCHEMA = {
+  response: {
+    200: Type.Object({ status: Type.Literal('ok') }),
+    503: Type.Object({
+      status: Type.Literal('fail'),
+      checks: Type.Object({ database: Type.Literal('fail') }),
+    }),
+  },
+};
+
+export const READINESS_ROUTE = {
+  method: 'GET' as const,
+  url: `${ADMIN_BASE_PATH}/probes/readiness`,
+};

--- a/apps/admin-server/src/server/features/probes/readiness.controller.ts
+++ b/apps/admin-server/src/server/features/probes/readiness.controller.ts
@@ -1,0 +1,30 @@
+import { sql } from 'kysely';
+
+import type {
+  BaseFastifyReply,
+  BaseFastifyRequest,
+} from '@scribear/base-fastify-server';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+
+import { READINESS_SCHEMA } from './probes.schema.js';
+
+export class ReadinessController {
+  private _dbClient: AppDependencies['dbClient'];
+
+  constructor(dbClient: AppDependencies['dbClient']) {
+    this._dbClient = dbClient;
+  }
+
+  async readiness(
+    _req: BaseFastifyRequest<typeof READINESS_SCHEMA>,
+    res: BaseFastifyReply<typeof READINESS_SCHEMA>,
+  ) {
+    try {
+      await sql`SELECT 1`.execute(this._dbClient.db);
+      res.code(200).send({ status: 'ok' });
+    } catch {
+      res.code(503).send({ status: 'fail', checks: { database: 'fail' } });
+    }
+  }
+}

--- a/apps/admin-server/src/server/features/rooms/rooms.controller.ts
+++ b/apps/admin-server/src/server/features/rooms/rooms.controller.ts
@@ -1,0 +1,179 @@
+import type {
+  BaseFastifyReply,
+  BaseFastifyRequest,
+} from '@scribear/base-fastify-server';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+import { okEnvelope } from '#src/server/shared/envelope/envelope.js';
+import { auditedMutation } from '#src/server/shared/proxy/audited-proxy.js';
+
+import type {
+  ADD_DEVICE_INPUT,
+  CREATE_ROOM_INPUT,
+  DELETE_ROOM_INPUT,
+  GET_ROOM_INPUT,
+  LIST_ROOMS_INPUT,
+  REMOVE_DEVICE_INPUT,
+  ROOM_DETAIL_INPUT,
+  SET_SOURCE_INPUT,
+  UPDATE_ROOM_INPUT,
+} from './rooms.schema.js';
+
+export class RoomsController {
+  private _gateway: AppDependencies['sessionManagerGatewayService'];
+  private _auditService: AppDependencies['auditService'];
+
+  constructor(
+    sessionManagerGatewayService: AppDependencies['sessionManagerGatewayService'],
+    auditService: AppDependencies['auditService'],
+  ) {
+    this._gateway = sessionManagerGatewayService;
+    this._auditService = auditService;
+  }
+
+  // ---- Reads ----
+
+  async list(
+    req: BaseFastifyRequest<typeof LIST_ROOMS_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    this._gateway.respond(req, res, await this._gateway.listRooms(req.query));
+  }
+
+  async get(
+    req: BaseFastifyRequest<typeof GET_ROOM_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    this._gateway.respond(req, res, await this._gateway.getRoom(req.params));
+  }
+
+  /**
+   * Aggregate view: the room plus its member devices. Fetching devices is
+   * best-effort — a room that resolves but whose device list fails still
+   * returns the room with an empty device list.
+   */
+  async detail(
+    req: BaseFastifyRequest<typeof ROOM_DETAIL_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    const [roomResponse, roomError] = await this._gateway.getRoom(req.params);
+    if (roomResponse?.status !== 200) {
+      this._gateway.respond(req, res, [roomResponse, roomError]);
+      return;
+    }
+
+    const [devicesResponse] = await this._gateway.listDevices({
+      roomUid: req.params.roomUid,
+      limit: 200,
+    });
+    const devices =
+      devicesResponse?.status === 200 ? devicesResponse.data.items : [];
+
+    res.code(200).send(okEnvelope({ room: roomResponse.data, devices }));
+  }
+
+  // ---- Mutations (require read-write + CSRF) ----
+
+  async create(
+    req: BaseFastifyRequest<typeof CREATE_ROOM_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'create-room',
+      target: null,
+      paramsSummary: {
+        name: req.body.name,
+        timezone: req.body.timezone,
+        sourceDeviceUids: req.body.sourceDeviceUids,
+      },
+      call: () => this._gateway.createRoom(req.body),
+    });
+  }
+
+  async update(
+    req: BaseFastifyRequest<typeof UPDATE_ROOM_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'update-room',
+      target: req.body.roomUid,
+      paramsSummary: { name: req.body.name },
+      call: () => this._gateway.updateRoom(req.body),
+    });
+  }
+
+  async delete(
+    req: BaseFastifyRequest<typeof DELETE_ROOM_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'delete-room',
+      target: req.body.roomUid,
+      paramsSummary: {},
+      call: () => this._gateway.deleteRoom(req.body),
+    });
+  }
+
+  async addDevice(
+    req: BaseFastifyRequest<typeof ADD_DEVICE_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'add-device-to-room',
+      target: req.body.roomUid,
+      paramsSummary: {
+        deviceUid: req.body.deviceUid,
+        asSource: req.body.asSource,
+      },
+      call: () => this._gateway.addDeviceToRoom(req.body),
+    });
+  }
+
+  async removeDevice(
+    req: BaseFastifyRequest<typeof REMOVE_DEVICE_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'remove-device-from-room',
+      target: req.body.deviceUid,
+      paramsSummary: {},
+      call: () => this._gateway.removeDeviceFromRoom(req.body),
+    });
+  }
+
+  async setSource(
+    req: BaseFastifyRequest<typeof SET_SOURCE_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'set-source-device',
+      target: req.body.roomUid,
+      paramsSummary: { deviceUid: req.body.deviceUid },
+      call: () => this._gateway.setSourceDevice(req.body),
+    });
+  }
+}

--- a/apps/admin-server/src/server/features/rooms/rooms.router.ts
+++ b/apps/admin-server/src/server/features/rooms/rooms.router.ts
@@ -1,0 +1,102 @@
+import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
+
+import resolveHandler from '#src/server/dependency-injection/resolve-handler.js';
+import { csrfHook } from '#src/server/shared/hooks/csrf.hook.js';
+import { requireRole } from '#src/server/shared/hooks/require-role.hook.js';
+import { requireSessionHook } from '#src/server/shared/hooks/require-session.hook.js';
+import { ROLE_READ_WRITE } from '#src/server/shared/types/identity.js';
+
+import {
+  ADD_DEVICE_INPUT,
+  ADD_DEVICE_ROUTE,
+  CREATE_ROOM_INPUT,
+  CREATE_ROOM_ROUTE,
+  DELETE_ROOM_INPUT,
+  DELETE_ROOM_ROUTE,
+  GET_ROOM_INPUT,
+  GET_ROOM_ROUTE,
+  LIST_ROOMS_INPUT,
+  LIST_ROOMS_ROUTE,
+  REMOVE_DEVICE_INPUT,
+  REMOVE_DEVICE_ROUTE,
+  ROOM_DETAIL_INPUT,
+  ROOM_DETAIL_ROUTE,
+  SET_SOURCE_INPUT,
+  SET_SOURCE_ROUTE,
+  UPDATE_ROOM_INPUT,
+  UPDATE_ROOM_ROUTE,
+} from './rooms.schema.js';
+
+export function roomsRouter(fastify: BaseFastifyInstance) {
+  // Reads: any authenticated session.
+  const readGuards = [requireSessionHook];
+  // Mutations: authenticated + CSRF + read-write role.
+  const writeGuards = [
+    requireSessionHook,
+    csrfHook,
+    requireRole(ROLE_READ_WRITE),
+  ];
+
+  fastify.route({
+    ...LIST_ROOMS_ROUTE,
+    schema: LIST_ROOMS_INPUT,
+    preHandler: readGuards,
+    handler: resolveHandler('roomsController', 'list'),
+  });
+
+  fastify.route({
+    ...GET_ROOM_ROUTE,
+    schema: GET_ROOM_INPUT,
+    preHandler: readGuards,
+    handler: resolveHandler('roomsController', 'get'),
+  });
+
+  fastify.route({
+    ...ROOM_DETAIL_ROUTE,
+    schema: ROOM_DETAIL_INPUT,
+    preHandler: readGuards,
+    handler: resolveHandler('roomsController', 'detail'),
+  });
+
+  fastify.route({
+    ...CREATE_ROOM_ROUTE,
+    schema: CREATE_ROOM_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('roomsController', 'create'),
+  });
+
+  fastify.route({
+    ...UPDATE_ROOM_ROUTE,
+    schema: UPDATE_ROOM_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('roomsController', 'update'),
+  });
+
+  fastify.route({
+    ...DELETE_ROOM_ROUTE,
+    schema: DELETE_ROOM_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('roomsController', 'delete'),
+  });
+
+  fastify.route({
+    ...ADD_DEVICE_ROUTE,
+    schema: ADD_DEVICE_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('roomsController', 'addDevice'),
+  });
+
+  fastify.route({
+    ...REMOVE_DEVICE_ROUTE,
+    schema: REMOVE_DEVICE_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('roomsController', 'removeDevice'),
+  });
+
+  fastify.route({
+    ...SET_SOURCE_ROUTE,
+    schema: SET_SOURCE_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('roomsController', 'setSource'),
+  });
+}

--- a/apps/admin-server/src/server/features/rooms/rooms.schema.ts
+++ b/apps/admin-server/src/server/features/rooms/rooms.schema.ts
@@ -1,0 +1,71 @@
+import {
+  ADD_DEVICE_TO_ROOM_SCHEMA,
+  CREATE_ROOM_SCHEMA,
+  DELETE_ROOM_SCHEMA,
+  GET_ROOM_SCHEMA,
+  LIST_ROOMS_SCHEMA,
+  REMOVE_DEVICE_FROM_ROOM_SCHEMA,
+  SET_SOURCE_DEVICE_SCHEMA,
+  UPDATE_ROOM_SCHEMA,
+} from '@scribear/session-manager-schema';
+
+import { ADMIN_BASE_PATH } from '#src/server/base-path.js';
+
+const P = `${ADMIN_BASE_PATH}/rooms`;
+
+// Input validation reuses the exact Session Manager request shapes (body /
+// querystring / params) — NEVER the `authorization` header, which the BFF
+// injects server-side.
+
+export const LIST_ROOMS_INPUT = { querystring: LIST_ROOMS_SCHEMA.querystring };
+export const LIST_ROOMS_ROUTE = { method: 'GET' as const, url: `${P}/list` };
+
+export const GET_ROOM_INPUT = { params: GET_ROOM_SCHEMA.params };
+export const GET_ROOM_ROUTE = {
+  method: 'GET' as const,
+  url: `${P}/get/:roomUid`,
+};
+
+export const ROOM_DETAIL_INPUT = { params: GET_ROOM_SCHEMA.params };
+export const ROOM_DETAIL_ROUTE = {
+  method: 'GET' as const,
+  url: `${P}/detail/:roomUid`,
+};
+
+export const CREATE_ROOM_INPUT = { body: CREATE_ROOM_SCHEMA.body };
+export const CREATE_ROOM_ROUTE = {
+  method: 'POST' as const,
+  url: `${P}/create`,
+};
+
+export const UPDATE_ROOM_INPUT = { body: UPDATE_ROOM_SCHEMA.body };
+export const UPDATE_ROOM_ROUTE = {
+  method: 'POST' as const,
+  url: `${P}/update`,
+};
+
+export const DELETE_ROOM_INPUT = { body: DELETE_ROOM_SCHEMA.body };
+export const DELETE_ROOM_ROUTE = {
+  method: 'POST' as const,
+  url: `${P}/delete`,
+};
+
+export const ADD_DEVICE_INPUT = { body: ADD_DEVICE_TO_ROOM_SCHEMA.body };
+export const ADD_DEVICE_ROUTE = {
+  method: 'POST' as const,
+  url: `${P}/add-device`,
+};
+
+export const REMOVE_DEVICE_INPUT = {
+  body: REMOVE_DEVICE_FROM_ROOM_SCHEMA.body,
+};
+export const REMOVE_DEVICE_ROUTE = {
+  method: 'POST' as const,
+  url: `${P}/remove-device`,
+};
+
+export const SET_SOURCE_INPUT = { body: SET_SOURCE_DEVICE_SCHEMA.body };
+export const SET_SOURCE_ROUTE = {
+  method: 'POST' as const,
+  url: `${P}/set-source`,
+};

--- a/apps/admin-server/src/server/features/scheduling/scheduling.controller.ts
+++ b/apps/admin-server/src/server/features/scheduling/scheduling.controller.ts
@@ -1,0 +1,261 @@
+import type {
+  BaseFastifyReply,
+  BaseFastifyRequest,
+} from '@scribear/base-fastify-server';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+import { auditedMutation } from '#src/server/shared/proxy/audited-proxy.js';
+
+import type {
+  CREATE_AUTO_SESSION_WINDOW_INPUT,
+  CREATE_ON_DEMAND_SESSION_INPUT,
+  CREATE_SCHEDULE_INPUT,
+  DELETE_AUTO_SESSION_WINDOW_INPUT,
+  DELETE_SCHEDULE_INPUT,
+  END_SESSION_EARLY_INPUT,
+  GET_AUTO_SESSION_WINDOW_INPUT,
+  GET_SCHEDULE_INPUT,
+  GET_SESSION_INPUT,
+  LIST_AUTO_SESSION_WINDOWS_INPUT,
+  LIST_SCHEDULES_INPUT,
+  START_SESSION_EARLY_INPUT,
+  UPDATE_AUTO_SESSION_WINDOW_INPUT,
+  UPDATE_ROOM_SCHEDULE_CONFIG_INPUT,
+  UPDATE_SCHEDULE_INPUT,
+} from './scheduling.schema.js';
+
+export class SchedulingController {
+  private _gateway: AppDependencies['sessionManagerGatewayService'];
+  private _auditService: AppDependencies['auditService'];
+
+  constructor(
+    sessionManagerGatewayService: AppDependencies['sessionManagerGatewayService'],
+    auditService: AppDependencies['auditService'],
+  ) {
+    this._gateway = sessionManagerGatewayService;
+    this._auditService = auditService;
+  }
+
+  // ---- Reads ----
+
+  async listSchedules(
+    req: BaseFastifyRequest<typeof LIST_SCHEDULES_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    this._gateway.respond(
+      req,
+      res,
+      await this._gateway.listSchedules(req.query),
+    );
+  }
+
+  async getSchedule(
+    req: BaseFastifyRequest<typeof GET_SCHEDULE_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    this._gateway.respond(
+      req,
+      res,
+      await this._gateway.getSchedule(req.params),
+    );
+  }
+
+  async listAutoWindows(
+    req: BaseFastifyRequest<typeof LIST_AUTO_SESSION_WINDOWS_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    this._gateway.respond(
+      req,
+      res,
+      await this._gateway.listAutoSessionWindows(req.query),
+    );
+  }
+
+  async getAutoWindow(
+    req: BaseFastifyRequest<typeof GET_AUTO_SESSION_WINDOW_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    this._gateway.respond(
+      req,
+      res,
+      await this._gateway.getAutoSessionWindow(req.params),
+    );
+  }
+
+  async getSession(
+    req: BaseFastifyRequest<typeof GET_SESSION_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    this._gateway.respond(req, res, await this._gateway.getSession(req.params));
+  }
+
+  // ---- Mutations (require read-write + CSRF) ----
+
+  async createSchedule(
+    req: BaseFastifyRequest<typeof CREATE_SCHEDULE_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'create-schedule',
+      target: null,
+      paramsSummary: {
+        name: req.body.name,
+        roomUid: req.body.roomUid,
+      },
+      call: () => this._gateway.createSchedule(req.body),
+    });
+  }
+
+  async updateSchedule(
+    req: BaseFastifyRequest<typeof UPDATE_SCHEDULE_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'update-schedule',
+      target: req.body.scheduleUid,
+      paramsSummary: { name: req.body.name },
+      call: () => this._gateway.updateSchedule(req.body),
+    });
+  }
+
+  async deleteSchedule(
+    req: BaseFastifyRequest<typeof DELETE_SCHEDULE_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'delete-schedule',
+      target: req.body.scheduleUid,
+      paramsSummary: {},
+      call: () => this._gateway.deleteSchedule(req.body),
+    });
+  }
+
+  async createAutoWindow(
+    req: BaseFastifyRequest<typeof CREATE_AUTO_SESSION_WINDOW_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'create-auto-session-window',
+      target: null,
+      paramsSummary: { roomUid: req.body.roomUid },
+      call: () => this._gateway.createAutoSessionWindow(req.body),
+    });
+  }
+
+  async updateAutoWindow(
+    req: BaseFastifyRequest<typeof UPDATE_AUTO_SESSION_WINDOW_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'update-auto-session-window',
+      target: req.body.windowUid,
+      paramsSummary: {},
+      call: () => this._gateway.updateAutoSessionWindow(req.body),
+    });
+  }
+
+  async deleteAutoWindow(
+    req: BaseFastifyRequest<typeof DELETE_AUTO_SESSION_WINDOW_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'delete-auto-session-window',
+      target: req.body.windowUid,
+      paramsSummary: {},
+      call: () => this._gateway.deleteAutoSessionWindow(req.body),
+    });
+  }
+
+  async updateRoomScheduleConfig(
+    req: BaseFastifyRequest<typeof UPDATE_ROOM_SCHEDULE_CONFIG_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'update-room-schedule-config',
+      target: req.body.roomUid,
+      paramsSummary: {
+        autoSessionEnabled: req.body.autoSessionEnabled ?? null,
+      },
+      call: () => this._gateway.updateRoomScheduleConfig(req.body),
+    });
+  }
+
+  async createOnDemandSession(
+    req: BaseFastifyRequest<typeof CREATE_ON_DEMAND_SESSION_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'create-on-demand-session',
+      target: null,
+      paramsSummary: {
+        name: req.body.name,
+        roomUid: req.body.roomUid,
+      },
+      call: () => this._gateway.createOnDemandSession(req.body),
+    });
+  }
+
+  async startSessionEarly(
+    req: BaseFastifyRequest<typeof START_SESSION_EARLY_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'start-session-early',
+      target: req.body.sessionUid,
+      paramsSummary: {},
+      call: () => this._gateway.startSessionEarly(req.body),
+    });
+  }
+
+  async endSessionEarly(
+    req: BaseFastifyRequest<typeof END_SESSION_EARLY_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    await auditedMutation({
+      gateway: this._gateway,
+      auditService: this._auditService,
+      req,
+      reply: res,
+      action: 'end-session-early',
+      target: req.body.sessionUid,
+      paramsSummary: {},
+      call: () => this._gateway.endSessionEarly(req.body),
+    });
+  }
+}

--- a/apps/admin-server/src/server/features/scheduling/scheduling.router.ts
+++ b/apps/admin-server/src/server/features/scheduling/scheduling.router.ts
@@ -1,0 +1,156 @@
+import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
+
+import resolveHandler from '#src/server/dependency-injection/resolve-handler.js';
+import { csrfHook } from '#src/server/shared/hooks/csrf.hook.js';
+import { requireRole } from '#src/server/shared/hooks/require-role.hook.js';
+import { requireSessionHook } from '#src/server/shared/hooks/require-session.hook.js';
+import { ROLE_READ_WRITE } from '#src/server/shared/types/identity.js';
+
+import {
+  CREATE_AUTO_SESSION_WINDOW_INPUT,
+  CREATE_AUTO_SESSION_WINDOW_ROUTE,
+  CREATE_ON_DEMAND_SESSION_INPUT,
+  CREATE_ON_DEMAND_SESSION_ROUTE,
+  CREATE_SCHEDULE_INPUT,
+  CREATE_SCHEDULE_ROUTE,
+  DELETE_AUTO_SESSION_WINDOW_INPUT,
+  DELETE_AUTO_SESSION_WINDOW_ROUTE,
+  DELETE_SCHEDULE_INPUT,
+  DELETE_SCHEDULE_ROUTE,
+  END_SESSION_EARLY_INPUT,
+  END_SESSION_EARLY_ROUTE,
+  GET_AUTO_SESSION_WINDOW_INPUT,
+  GET_AUTO_SESSION_WINDOW_ROUTE,
+  GET_SCHEDULE_INPUT,
+  GET_SCHEDULE_ROUTE,
+  GET_SESSION_INPUT,
+  GET_SESSION_ROUTE,
+  LIST_AUTO_SESSION_WINDOWS_INPUT,
+  LIST_AUTO_SESSION_WINDOWS_ROUTE,
+  LIST_SCHEDULES_INPUT,
+  LIST_SCHEDULES_ROUTE,
+  START_SESSION_EARLY_INPUT,
+  START_SESSION_EARLY_ROUTE,
+  UPDATE_AUTO_SESSION_WINDOW_INPUT,
+  UPDATE_AUTO_SESSION_WINDOW_ROUTE,
+  UPDATE_ROOM_SCHEDULE_CONFIG_INPUT,
+  UPDATE_ROOM_SCHEDULE_CONFIG_ROUTE,
+  UPDATE_SCHEDULE_INPUT,
+  UPDATE_SCHEDULE_ROUTE,
+} from './scheduling.schema.js';
+
+export function schedulingRouter(fastify: BaseFastifyInstance) {
+  // Reads: any authenticated session.
+  const readGuards = [requireSessionHook];
+  // Mutations: authenticated + CSRF + read-write role.
+  const writeGuards = [
+    requireSessionHook,
+    csrfHook,
+    requireRole(ROLE_READ_WRITE),
+  ];
+
+  fastify.route({
+    ...LIST_SCHEDULES_ROUTE,
+    schema: LIST_SCHEDULES_INPUT,
+    preHandler: readGuards,
+    handler: resolveHandler('schedulingController', 'listSchedules'),
+  });
+
+  fastify.route({
+    ...GET_SCHEDULE_ROUTE,
+    schema: GET_SCHEDULE_INPUT,
+    preHandler: readGuards,
+    handler: resolveHandler('schedulingController', 'getSchedule'),
+  });
+
+  fastify.route({
+    ...LIST_AUTO_SESSION_WINDOWS_ROUTE,
+    schema: LIST_AUTO_SESSION_WINDOWS_INPUT,
+    preHandler: readGuards,
+    handler: resolveHandler('schedulingController', 'listAutoWindows'),
+  });
+
+  fastify.route({
+    ...GET_AUTO_SESSION_WINDOW_ROUTE,
+    schema: GET_AUTO_SESSION_WINDOW_INPUT,
+    preHandler: readGuards,
+    handler: resolveHandler('schedulingController', 'getAutoWindow'),
+  });
+
+  fastify.route({
+    ...GET_SESSION_ROUTE,
+    schema: GET_SESSION_INPUT,
+    preHandler: readGuards,
+    handler: resolveHandler('schedulingController', 'getSession'),
+  });
+
+  fastify.route({
+    ...CREATE_SCHEDULE_ROUTE,
+    schema: CREATE_SCHEDULE_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('schedulingController', 'createSchedule'),
+  });
+
+  fastify.route({
+    ...UPDATE_SCHEDULE_ROUTE,
+    schema: UPDATE_SCHEDULE_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('schedulingController', 'updateSchedule'),
+  });
+
+  fastify.route({
+    ...DELETE_SCHEDULE_ROUTE,
+    schema: DELETE_SCHEDULE_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('schedulingController', 'deleteSchedule'),
+  });
+
+  fastify.route({
+    ...CREATE_AUTO_SESSION_WINDOW_ROUTE,
+    schema: CREATE_AUTO_SESSION_WINDOW_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('schedulingController', 'createAutoWindow'),
+  });
+
+  fastify.route({
+    ...UPDATE_AUTO_SESSION_WINDOW_ROUTE,
+    schema: UPDATE_AUTO_SESSION_WINDOW_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('schedulingController', 'updateAutoWindow'),
+  });
+
+  fastify.route({
+    ...DELETE_AUTO_SESSION_WINDOW_ROUTE,
+    schema: DELETE_AUTO_SESSION_WINDOW_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('schedulingController', 'deleteAutoWindow'),
+  });
+
+  fastify.route({
+    ...UPDATE_ROOM_SCHEDULE_CONFIG_ROUTE,
+    schema: UPDATE_ROOM_SCHEDULE_CONFIG_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('schedulingController', 'updateRoomScheduleConfig'),
+  });
+
+  fastify.route({
+    ...CREATE_ON_DEMAND_SESSION_ROUTE,
+    schema: CREATE_ON_DEMAND_SESSION_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('schedulingController', 'createOnDemandSession'),
+  });
+
+  fastify.route({
+    ...START_SESSION_EARLY_ROUTE,
+    schema: START_SESSION_EARLY_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('schedulingController', 'startSessionEarly'),
+  });
+
+  fastify.route({
+    ...END_SESSION_EARLY_ROUTE,
+    schema: END_SESSION_EARLY_INPUT,
+    preHandler: writeGuards,
+    handler: resolveHandler('schedulingController', 'endSessionEarly'),
+  });
+}

--- a/apps/admin-server/src/server/features/scheduling/scheduling.schema.ts
+++ b/apps/admin-server/src/server/features/scheduling/scheduling.schema.ts
@@ -1,0 +1,135 @@
+import {
+  CREATE_AUTO_SESSION_WINDOW_SCHEMA,
+  CREATE_ON_DEMAND_SESSION_SCHEMA,
+  CREATE_SCHEDULE_SCHEMA,
+  DELETE_AUTO_SESSION_WINDOW_SCHEMA,
+  DELETE_SCHEDULE_SCHEMA,
+  END_SESSION_EARLY_SCHEMA,
+  GET_AUTO_SESSION_WINDOW_SCHEMA,
+  GET_SCHEDULE_SCHEMA,
+  GET_SESSION_SCHEMA,
+  LIST_AUTO_SESSION_WINDOWS_SCHEMA,
+  LIST_SCHEDULES_SCHEMA,
+  START_SESSION_EARLY_SCHEMA,
+  UPDATE_AUTO_SESSION_WINDOW_SCHEMA,
+  UPDATE_ROOM_SCHEDULE_CONFIG_SCHEMA,
+  UPDATE_SCHEDULE_SCHEMA,
+} from '@scribear/session-manager-schema';
+
+import { ADMIN_BASE_PATH } from '#src/server/base-path.js';
+
+const P_SCHEDULES = `${ADMIN_BASE_PATH}/schedules`;
+const P_AUTO_WINDOWS = `${ADMIN_BASE_PATH}/auto-windows`;
+const P_SESSIONS = `${ADMIN_BASE_PATH}/sessions`;
+
+// Input validation reuses the exact Session Manager request shapes (body /
+// querystring / params) — NEVER the `authorization` header, which the BFF
+// injects server-side.
+
+export const LIST_SCHEDULES_INPUT = {
+  querystring: LIST_SCHEDULES_SCHEMA.querystring,
+};
+export const LIST_SCHEDULES_ROUTE = {
+  method: 'GET' as const,
+  url: `${P_SCHEDULES}/list`,
+};
+
+export const GET_SCHEDULE_INPUT = { params: GET_SCHEDULE_SCHEMA.params };
+export const GET_SCHEDULE_ROUTE = {
+  method: 'GET' as const,
+  url: `${P_SCHEDULES}/get/:scheduleUid`,
+};
+
+export const CREATE_SCHEDULE_INPUT = { body: CREATE_SCHEDULE_SCHEMA.body };
+export const CREATE_SCHEDULE_ROUTE = {
+  method: 'POST' as const,
+  url: `${P_SCHEDULES}/create`,
+};
+
+export const UPDATE_SCHEDULE_INPUT = { body: UPDATE_SCHEDULE_SCHEMA.body };
+export const UPDATE_SCHEDULE_ROUTE = {
+  method: 'POST' as const,
+  url: `${P_SCHEDULES}/update`,
+};
+
+export const DELETE_SCHEDULE_INPUT = { body: DELETE_SCHEDULE_SCHEMA.body };
+export const DELETE_SCHEDULE_ROUTE = {
+  method: 'POST' as const,
+  url: `${P_SCHEDULES}/delete`,
+};
+
+export const LIST_AUTO_SESSION_WINDOWS_INPUT = {
+  querystring: LIST_AUTO_SESSION_WINDOWS_SCHEMA.querystring,
+};
+export const LIST_AUTO_SESSION_WINDOWS_ROUTE = {
+  method: 'GET' as const,
+  url: `${P_AUTO_WINDOWS}/list`,
+};
+
+export const GET_AUTO_SESSION_WINDOW_INPUT = {
+  params: GET_AUTO_SESSION_WINDOW_SCHEMA.params,
+};
+export const GET_AUTO_SESSION_WINDOW_ROUTE = {
+  method: 'GET' as const,
+  url: `${P_AUTO_WINDOWS}/get/:windowUid`,
+};
+
+export const CREATE_AUTO_SESSION_WINDOW_INPUT = {
+  body: CREATE_AUTO_SESSION_WINDOW_SCHEMA.body,
+};
+export const CREATE_AUTO_SESSION_WINDOW_ROUTE = {
+  method: 'POST' as const,
+  url: `${P_AUTO_WINDOWS}/create`,
+};
+
+export const UPDATE_AUTO_SESSION_WINDOW_INPUT = {
+  body: UPDATE_AUTO_SESSION_WINDOW_SCHEMA.body,
+};
+export const UPDATE_AUTO_SESSION_WINDOW_ROUTE = {
+  method: 'POST' as const,
+  url: `${P_AUTO_WINDOWS}/update`,
+};
+
+export const DELETE_AUTO_SESSION_WINDOW_INPUT = {
+  body: DELETE_AUTO_SESSION_WINDOW_SCHEMA.body,
+};
+export const DELETE_AUTO_SESSION_WINDOW_ROUTE = {
+  method: 'POST' as const,
+  url: `${P_AUTO_WINDOWS}/delete`,
+};
+
+export const UPDATE_ROOM_SCHEDULE_CONFIG_INPUT = {
+  body: UPDATE_ROOM_SCHEDULE_CONFIG_SCHEMA.body,
+};
+export const UPDATE_ROOM_SCHEDULE_CONFIG_ROUTE = {
+  method: 'POST' as const,
+  url: `${P_SCHEDULES}/room-config`,
+};
+
+export const GET_SESSION_INPUT = { params: GET_SESSION_SCHEMA.params };
+export const GET_SESSION_ROUTE = {
+  method: 'GET' as const,
+  url: `${P_SESSIONS}/get/:sessionUid`,
+};
+
+export const CREATE_ON_DEMAND_SESSION_INPUT = {
+  body: CREATE_ON_DEMAND_SESSION_SCHEMA.body,
+};
+export const CREATE_ON_DEMAND_SESSION_ROUTE = {
+  method: 'POST' as const,
+  url: `${P_SESSIONS}/create-on-demand`,
+};
+
+export const START_SESSION_EARLY_INPUT = {
+  body: START_SESSION_EARLY_SCHEMA.body,
+};
+export const START_SESSION_EARLY_ROUTE = {
+  method: 'POST' as const,
+  url: `${P_SESSIONS}/start-early`,
+};
+
+export const END_SESSION_EARLY_INPUT = { body: END_SESSION_EARLY_SCHEMA.body };
+export const END_SESSION_EARLY_ROUTE = {
+  method: 'POST' as const,
+  url: `${P_SESSIONS}/end-early`,
+};

--- a/apps/admin-server/src/server/plugins/error-handler.plugin.ts
+++ b/apps/admin-server/src/server/plugins/error-handler.plugin.ts
@@ -1,0 +1,62 @@
+import fastifyPlugin from 'fastify-plugin';
+
+import { BaseHttpError } from '@scribear/base-fastify-server';
+import type {
+  BaseFastifyInstance,
+  BaseFastifyReply,
+  BaseFastifyRequest,
+} from '@scribear/base-fastify-server';
+
+import { errorEnvelope } from '../shared/envelope/envelope.js';
+
+/**
+ * Admin BFF error handler. Overrides the base handler so that EVERY error
+ * (validation, not-found, rate-limit, thrown application errors) is serialized
+ * as the consistent `{ ok: false, error: { code, message, requestId } }`
+ * envelope the SPA expects — never a bare `{ code, message }`.
+ *
+ * Registered after the base server so this `setErrorHandler` wins.
+ */
+export default fastifyPlugin((fastify: BaseFastifyInstance) => {
+  fastify.setErrorHandler(
+    (err: unknown, req: BaseFastifyRequest, reply: BaseFastifyReply) => {
+      const requestId = req.id;
+
+      // BaseHttpError covers validation (400), not-found (404), rate-limit
+      // (429), and anything thrown via HttpError.* in the app.
+      if (err instanceof BaseHttpError) {
+        return reply
+          .code(err.statusCode)
+          .send(errorEnvelope(err.code, err.message, requestId, err.details));
+      }
+
+      // Other framework errors carrying a 4xx status: pass the status through.
+      const status = (err as { statusCode?: unknown }).statusCode;
+      if (typeof status === 'number' && status >= 400 && status < 500) {
+        const rawCode = (err as { code?: unknown }).code;
+        const rawMessage = (err as { message?: unknown }).message;
+        return reply
+          .code(status)
+          .send(
+            errorEnvelope(
+              typeof rawCode === 'string' ? rawCode : 'REQUEST_ERROR',
+              typeof rawMessage === 'string' ? rawMessage : 'Request failed.',
+              requestId,
+            ),
+          );
+      }
+
+      // Everything else: log and return a generic 500 (no internals leaked).
+      req.log.error({ err }, 'Unhandled error in admin BFF');
+      return reply
+        .code(500)
+        .send(
+          errorEnvelope(
+            'INTERNAL_ERROR',
+            'Server encountered an unexpected error.',
+            requestId,
+          ),
+        );
+    },
+  );
+});

--- a/apps/admin-server/src/server/plugins/rate-limit.plugin.ts
+++ b/apps/admin-server/src/server/plugins/rate-limit.plugin.ts
@@ -1,0 +1,37 @@
+import fastifyRateLimit from '@fastify/rate-limit';
+
+import { HttpError } from '@scribear/base-fastify-server';
+import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
+
+export interface RateLimitConfig {
+  globalMax: number;
+  globalWindowMs: number;
+  loginMax: number;
+  loginWindowMs: number;
+}
+
+/**
+ * Registers `@fastify/rate-limit` globally. The default keys by client IP;
+ * because the BFF sits behind nginx we enable `trustProxy` on the Fastify
+ * instance so the key is the real client IP (leftmost `X-Forwarded-For`).
+ *
+ * The login route tightens this via per-route `config.rateLimit` (see the auth
+ * router); probes opt out via `config.rateLimit: false` so container health
+ * checks are never throttled.
+ */
+export async function registerRateLimit(
+  fastify: BaseFastifyInstance,
+  config: RateLimitConfig,
+): Promise<void> {
+  await fastify.register(fastifyRateLimit, {
+    global: true,
+    max: config.globalMax,
+    timeWindow: config.globalWindowMs,
+    // The plugin THROWS whatever this returns, so return a BaseHttpError; the
+    // admin error handler then serializes it as a `RATE_LIMITED` envelope.
+    errorResponseBuilder: (_req, context) =>
+      HttpError.rateLimited(
+        `Too many requests. Please retry after ${context.after}.`,
+      ),
+  });
+}

--- a/apps/admin-server/src/server/shared/envelope/envelope.ts
+++ b/apps/admin-server/src/server/shared/envelope/envelope.ts
@@ -1,0 +1,36 @@
+/**
+ * Consistent response envelope for every `/api/admin` route so the SPA can
+ * render successes and failures uniformly.
+ */
+export interface OkEnvelope<T> {
+  ok: true;
+  data: T;
+}
+
+export interface ErrorEnvelope {
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+    requestId: string;
+    details?: Record<string, unknown>;
+  };
+}
+
+export function okEnvelope<T>(data: T): OkEnvelope<T> {
+  return { ok: true, data };
+}
+
+export function errorEnvelope(
+  code: string,
+  message: string,
+  requestId: string,
+  details?: Record<string, unknown>,
+): ErrorEnvelope {
+  return {
+    ok: false,
+    error: details
+      ? { code, message, requestId, details }
+      : { code, message, requestId },
+  };
+}

--- a/apps/admin-server/src/server/shared/hooks/csrf.hook.ts
+++ b/apps/admin-server/src/server/shared/hooks/csrf.hook.ts
@@ -1,0 +1,37 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { errorEnvelope } from '../envelope/envelope.js';
+import { CSRF_HEADER_NAME } from '../services/session.service.js';
+
+/**
+ * CSRF protection for state-changing routes (synchronizer-token pattern). The
+ * SPA reads the session-bound CSRF token from the login / `/auth/me` response
+ * body and echoes it in the `x-csrf-token` header. We compare it (constant
+ * time) to the token stored on the session server-side.
+ *
+ * This is defense-in-depth on top of `SameSite=Strict`. MUST run after
+ * `requireSessionHook`.
+ */
+export async function csrfHook(
+  req: FastifyRequest,
+  reply: FastifyReply,
+): Promise<FastifyReply | undefined> {
+  const sessionService = req.diScope.resolve('sessionService');
+  const session = req.adminSession;
+
+  const headerValue = req.headers[CSRF_HEADER_NAME];
+  const presented = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+
+  if (!session || !sessionService.verifyCsrf(session, presented)) {
+    reply
+      .code(403)
+      .send(
+        errorEnvelope(
+          'CSRF_TOKEN_INVALID',
+          'Missing or invalid CSRF token.',
+          req.id,
+        ),
+      );
+    return reply;
+  }
+}

--- a/apps/admin-server/src/server/shared/hooks/require-role.hook.ts
+++ b/apps/admin-server/src/server/shared/hooks/require-role.hook.ts
@@ -1,0 +1,32 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { errorEnvelope } from '../envelope/envelope.js';
+import type { Role } from '../types/identity.js';
+import { identityHasRole } from '../types/identity.js';
+
+/**
+ * Guards a route behind a required role. MUST run after `requireSessionHook`
+ * (which populates `req.adminIdentity`). Mutations require `read-write`.
+ *
+ * @param role The role the caller must hold.
+ */
+export function requireRole(role: Role) {
+  return async function requireRoleHook(
+    req: FastifyRequest,
+    reply: FastifyReply,
+  ): Promise<FastifyReply | undefined> {
+    const identity = req.adminIdentity;
+    if (!identity || !identityHasRole(identity, role)) {
+      reply
+        .code(403)
+        .send(
+          errorEnvelope(
+            'FORBIDDEN',
+            'You do not have permission to perform this action.',
+            req.id,
+          ),
+        );
+      return reply;
+    }
+  };
+}

--- a/apps/admin-server/src/server/shared/hooks/require-session.hook.ts
+++ b/apps/admin-server/src/server/shared/hooks/require-session.hook.ts
@@ -1,0 +1,46 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { errorEnvelope } from '../envelope/envelope.js';
+import {
+  SESSION_COOKIE_NAME,
+  clearSessionCookieOptions,
+} from '../http/cookie-options.js';
+
+/**
+ * Guards `/api/admin` routes: requires a valid, unexpired session cookie.
+ * Attaches the resolved session + identity to the request. On failure, clears
+ * the (stale) cookie and returns a 401 envelope — the SPA treats 401 as
+ * "session expired, go to login".
+ *
+ * IMPORTANT: no upstream call is made when this fails.
+ */
+export async function requireSessionHook(
+  req: FastifyRequest,
+  reply: FastifyReply,
+): Promise<FastifyReply | undefined> {
+  const sessionService = req.diScope.resolve('sessionService');
+
+  const raw = req.cookies[SESSION_COOKIE_NAME];
+  const unsigned = raw ? req.unsignCookie(raw) : null;
+  const sessionId =
+    unsigned && unsigned.valid && unsigned.value ? unsigned.value : undefined;
+
+  const record = sessionService.validate(sessionId);
+  if (!record) {
+    reply.clearCookie(
+      SESSION_COOKIE_NAME,
+      clearSessionCookieOptions(sessionService.config.secure),
+    );
+    reply
+      .code(401)
+      .send(
+        errorEnvelope('UNAUTHENTICATED', 'Authentication required.', req.id),
+      );
+    return reply;
+  }
+
+  req.adminSession = record;
+  req.adminIdentity = record.identity;
+  // `sessionId` is necessarily defined here (validate() returns null otherwise).
+  if (sessionId) req.adminSessionId = sessionId;
+}

--- a/apps/admin-server/src/server/shared/http/cookie-options.ts
+++ b/apps/admin-server/src/server/shared/http/cookie-options.ts
@@ -1,0 +1,42 @@
+import type { CookieSerializeOptions } from '@fastify/cookie';
+
+import { SESSION_COOKIE_NAME } from '../services/session.service.js';
+
+/** Path the session cookie is scoped to (covers all /api/admin/v1 routes). */
+export const SESSION_COOKIE_PATH = '/api/admin';
+
+/**
+ * Options for the admin session cookie: HttpOnly (JS cannot read it), Secure in
+ * production, SameSite=Strict (blocks cross-site sends — first CSRF defense),
+ * signed with `ADMIN_SESSION_SECRET`, and scoped to the admin API path.
+ *
+ * @param secure Whether to set the `Secure` attribute (false only in dev/HTTP).
+ * @param absoluteTimeoutMs Cookie max-age, aligned to the absolute session lifetime.
+ */
+export function sessionCookieOptions(
+  secure: boolean,
+  absoluteTimeoutMs: number,
+): CookieSerializeOptions {
+  return {
+    httpOnly: true,
+    secure,
+    sameSite: 'strict',
+    signed: true,
+    path: SESSION_COOKIE_PATH,
+    maxAge: Math.floor(absoluteTimeoutMs / 1000),
+  };
+}
+
+/** Options used when clearing the session cookie (must match path/attributes). */
+export function clearSessionCookieOptions(
+  secure: boolean,
+): CookieSerializeOptions {
+  return {
+    httpOnly: true,
+    secure,
+    sameSite: 'strict',
+    path: SESSION_COOKIE_PATH,
+  };
+}
+
+export { SESSION_COOKIE_NAME };

--- a/apps/admin-server/src/server/shared/proxy/audited-proxy.ts
+++ b/apps/admin-server/src/server/shared/proxy/audited-proxy.ts
@@ -1,0 +1,47 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+
+import type { GatewayResult } from '../services/session-manager-gateway.service.js';
+
+/**
+ * Run a mutating upstream call, send the mapped envelope, and write exactly one
+ * audit record reflecting the outcome. Success/failure is derived from the same
+ * HTTP status the caller receives (via `gateway.respond`), so audit and the
+ * response never disagree.
+ *
+ * `paramsSummary` must contain ONLY non-sensitive fields (never secrets).
+ */
+export async function auditedMutation(params: {
+  gateway: AppDependencies['sessionManagerGatewayService'];
+  auditService: AppDependencies['auditService'];
+  req: FastifyRequest;
+  reply: FastifyReply;
+  action: string;
+  target: string | null;
+  paramsSummary: Record<string, unknown>;
+  call: () => Promise<GatewayResult>;
+}): Promise<void> {
+  const { gateway, auditService, req, reply, action, target, paramsSummary } =
+    params;
+
+  const result = await params.call();
+  const { httpStatus } = gateway.classify(result);
+
+  // Persist the audit record BEFORE sending the response, so a recorded action
+  // is durable by the time the client is told it succeeded (and so the two can
+  // never disagree). `record` never throws.
+  const identity = req.adminIdentity;
+  await auditService.record({
+    actorSubject: identity?.subject ?? 'unknown',
+    actorProvider: identity?.provider ?? 'local',
+    action,
+    target,
+    paramsSummary,
+    result: httpStatus < 400 ? 'success' : 'failure',
+    statusCode: httpStatus,
+    requestId: req.id,
+  });
+
+  gateway.respond(req, reply, result);
+}

--- a/apps/admin-server/src/server/shared/repositories/audit.repository.ts
+++ b/apps/admin-server/src/server/shared/repositories/audit.repository.ts
@@ -1,0 +1,75 @@
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+
+export interface AuditRecordInput {
+  actorSubject: string;
+  actorProvider: string;
+  action: string;
+  target: string | null;
+  paramsSummary: Record<string, unknown>;
+  result: 'success' | 'failure';
+  statusCode: number | null;
+  requestId: string | null;
+}
+
+export interface AuditRow {
+  id: string;
+  actorSubject: string;
+  actorProvider: string;
+  action: string;
+  target: string | null;
+  paramsSummary: unknown;
+  result: string;
+  statusCode: number | null;
+  requestId: string | null;
+  createdAt: string;
+}
+
+export class AuditRepository {
+  private _dbClient: AppDependencies['dbClient'];
+
+  constructor(dbClient: AppDependencies['dbClient']) {
+    this._dbClient = dbClient;
+  }
+
+  async insert(input: AuditRecordInput): Promise<void> {
+    await this._dbClient.db
+      .insertInto('admin_audit_log')
+      .values({
+        actor_subject: input.actorSubject,
+        actor_provider: input.actorProvider,
+        action: input.action,
+        target: input.target,
+        params_summary: JSON.stringify(input.paramsSummary),
+        result: input.result,
+        status_code: input.statusCode,
+        request_id: input.requestId,
+      })
+      .execute();
+  }
+
+  /** Most-recent-first page of audit rows (for the future /audit view). */
+  async list(limit: number): Promise<AuditRow[]> {
+    const rows = await this._dbClient.db
+      .selectFrom('admin_audit_log')
+      .selectAll()
+      .orderBy('created_at', 'desc')
+      .limit(limit)
+      .execute();
+
+    return rows.map((row) => ({
+      id: row.id,
+      actorSubject: row.actor_subject,
+      actorProvider: row.actor_provider,
+      action: row.action,
+      target: row.target,
+      paramsSummary: row.params_summary,
+      result: row.result,
+      statusCode: row.status_code,
+      requestId: row.request_id,
+      createdAt:
+        row.created_at instanceof Date
+          ? row.created_at.toISOString()
+          : String(row.created_at),
+    }));
+  }
+}

--- a/apps/admin-server/src/server/shared/services/audit.service.ts
+++ b/apps/admin-server/src/server/shared/services/audit.service.ts
@@ -1,0 +1,53 @@
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+
+import type { AuditRecordInput } from '../repositories/audit.repository.js';
+
+/**
+ * Writes the audit trail for admin actions. Every mutating action is recorded
+ * with actor / action / target / params-summary / result / requestId.
+ *
+ * Guarantees:
+ * - A DB write failure NEVER fails the request (the action already happened
+ *   upstream); it is logged loudly instead.
+ * - `paramsSummary` is caller-provided and must never contain secrets
+ *   (passwords, tokens, the admin key). Callers pass only non-sensitive fields.
+ */
+export class AuditService {
+  private _logger: AppDependencies['logger'];
+  private _auditRepository: AppDependencies['auditRepository'];
+
+  constructor(
+    logger: AppDependencies['logger'],
+    auditRepository: AppDependencies['auditRepository'],
+  ) {
+    this._logger = logger;
+    this._auditRepository = auditRepository;
+  }
+
+  async record(input: AuditRecordInput): Promise<void> {
+    // Structured log line for the existing logging pipeline (always emitted).
+    this._logger.info(
+      {
+        audit: {
+          actor: input.actorSubject,
+          provider: input.actorProvider,
+          action: input.action,
+          target: input.target,
+          result: input.result,
+          statusCode: input.statusCode,
+          requestId: input.requestId,
+        },
+      },
+      'admin action',
+    );
+
+    try {
+      await this._auditRepository.insert(input);
+    } catch (err) {
+      this._logger.error(
+        { err, action: input.action, requestId: input.requestId },
+        'Failed to persist audit record',
+      );
+    }
+  }
+}

--- a/apps/admin-server/src/server/shared/services/azure-oidc-auth.service.ts
+++ b/apps/admin-server/src/server/shared/services/azure-oidc-auth.service.ts
@@ -1,0 +1,40 @@
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+
+export interface AzureAuthConfig {
+  tenantId: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  allowedGroup: string;
+}
+
+/**
+ * Stub for the future Azure Entra ID (OIDC, Auth Code + PKCE) provider. The
+ * seams are in place so it drops in later without reworking session/CSRF/audit:
+ * everything downstream sees only an `Identity`.
+ *
+ * Enabled only when all required `AZURE_*` config is present. Until then
+ * `isEnabled()` is false and `/auth/config` reports `sso: false`.
+ */
+export class AzureOidcAuthService {
+  readonly id = 'sso' as const;
+
+  private _enabled: boolean;
+
+  constructor(azureAuthConfig: AppDependencies['azureAuthConfig']) {
+    const cfg = azureAuthConfig;
+    this._enabled =
+      cfg.tenantId.trim() !== '' &&
+      cfg.clientId.trim() !== '' &&
+      cfg.clientSecret.trim() !== '' &&
+      cfg.redirectUri.trim() !== '';
+  }
+
+  isEnabled(): boolean {
+    return this._enabled;
+  }
+
+  // Intentionally not implemented yet. The route handlers guard on
+  // `isEnabled()` and return 404 while disabled; wiring the real OIDC flow
+  // (buildAuthorizationUrl / handleCallback -> Identity) happens here.
+}

--- a/apps/admin-server/src/server/shared/services/local-auth.service.ts
+++ b/apps/admin-server/src/server/shared/services/local-auth.service.ts
@@ -1,0 +1,97 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+
+import type { Identity } from '../types/identity.js';
+import { ROLE_READ_WRITE } from '../types/identity.js';
+
+export interface LocalAuthConfig {
+  /** Raw `ADMIN_LOCAL_CREDENTIALS` value: `"<username> <password>"`. */
+  credentials: string;
+}
+
+/**
+ * Local single-account auth provider. Reads one username+password from
+ * `ADMIN_LOCAL_CREDENTIALS` (split on the FIRST space only, so the password may
+ * contain spaces). Empty/unset/malformed => provider disabled.
+ */
+export class LocalAuthService {
+  readonly id = 'local' as const;
+
+  private _enabled: boolean;
+  private _username: string;
+  private _password: string;
+  // Per-process random key: username/password are HMAC'd to a fixed 32-byte
+  // digest before comparison, so `timingSafeEqual` never sees mismatched
+  // lengths (which would throw and leak length) and the raw secret length is
+  // not observable via timing.
+  private _hmacKey: Buffer;
+
+  constructor(
+    logger: AppDependencies['logger'],
+    localAuthConfig: AppDependencies['localAuthConfig'],
+  ) {
+    this._hmacKey = randomBytes(32);
+    const raw = localAuthConfig.credentials;
+
+    if (raw.trim() === '') {
+      this._enabled = false;
+      this._username = '';
+      this._password = '';
+      return;
+    }
+
+    const spaceIdx = raw.indexOf(' ');
+    if (spaceIdx <= 0 || spaceIdx === raw.length - 1) {
+      // No space, empty username, or empty password: malformed. Disable rather
+      // than accept a half-configured credential.
+      this._enabled = false;
+      this._username = '';
+      this._password = '';
+      logger.warn(
+        'ADMIN_LOCAL_CREDENTIALS is set but malformed (expected "<username> <password>"); local login is disabled.',
+      );
+      return;
+    }
+
+    this._username = raw.slice(0, spaceIdx);
+    this._password = raw.slice(spaceIdx + 1);
+    this._enabled = true;
+  }
+
+  isEnabled(): boolean {
+    return this._enabled;
+  }
+
+  private _digest(value: string): Buffer {
+    return createHmac('sha256', this._hmacKey).update(value, 'utf8').digest();
+  }
+
+  /**
+   * Verify a username+password. Both fields are compared in constant time; the
+   * function never short-circuits on a username mismatch. Returns the resolved
+   * identity on success, or `null` on any mismatch (or when disabled).
+   */
+  verify(username: string, password: string): Identity | null {
+    if (!this._enabled) return null;
+
+    const userOk = timingSafeEqual(
+      this._digest(username),
+      this._digest(this._username),
+    );
+    const passOk = timingSafeEqual(
+      this._digest(password),
+      this._digest(this._password),
+    );
+
+    if (userOk && passOk) {
+      return {
+        subject: this._username,
+        displayName: this._username,
+        provider: 'local',
+        roles: [ROLE_READ_WRITE],
+      };
+    }
+    return null;
+  }
+}

--- a/apps/admin-server/src/server/shared/services/session-manager-gateway.service.ts
+++ b/apps/admin-server/src/server/shared/services/session-manager-gateway.service.ts
@@ -1,0 +1,444 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import type { Static } from 'typebox';
+
+import { NetworkError } from '@scribear/base-api-client';
+import type { EndpointError } from '@scribear/base-api-client';
+import { createSessionManagerClient as buildClient } from '@scribear/session-manager-client';
+import type { SessionManagerClient } from '@scribear/session-manager-client';
+import {
+  ADD_DEVICE_TO_ROOM_SCHEMA,
+  CREATE_AUTO_SESSION_WINDOW_SCHEMA,
+  CREATE_ON_DEMAND_SESSION_SCHEMA,
+  CREATE_ROOM_SCHEMA,
+  CREATE_SCHEDULE_SCHEMA,
+  DELETE_AUTO_SESSION_WINDOW_SCHEMA,
+  DELETE_DEVICE_SCHEMA,
+  DELETE_ROOM_SCHEMA,
+  DELETE_SCHEDULE_SCHEMA,
+  END_SESSION_EARLY_SCHEMA,
+  GET_AUTO_SESSION_WINDOW_SCHEMA,
+  GET_DEVICE_SCHEMA,
+  GET_ROOM_SCHEMA,
+  GET_SCHEDULE_SCHEMA,
+  GET_SESSION_SCHEMA,
+  LIST_AUTO_SESSION_WINDOWS_SCHEMA,
+  LIST_DEVICES_SCHEMA,
+  LIST_ROOMS_SCHEMA,
+  LIST_SCHEDULES_SCHEMA,
+  REGISTER_DEVICE_SCHEMA,
+  REMOVE_DEVICE_FROM_ROOM_SCHEMA,
+  REREGISTER_DEVICE_SCHEMA,
+  SET_SOURCE_DEVICE_SCHEMA,
+  START_SESSION_EARLY_SCHEMA,
+  UPDATE_AUTO_SESSION_WINDOW_SCHEMA,
+  UPDATE_DEVICE_SCHEMA,
+  UPDATE_ROOM_SCHEDULE_CONFIG_SCHEMA,
+  UPDATE_ROOM_SCHEMA,
+  UPDATE_SCHEDULE_SCHEMA,
+} from '@scribear/session-manager-schema';
+
+import { errorEnvelope, okEnvelope } from '../envelope/envelope.js';
+
+export interface SessionManagerGatewayConfig {
+  adminApiKey: string;
+  sessionManagerBaseUrl: string;
+}
+
+/**
+ * Loose shape of any Session Manager client result tuple. The concrete client
+ * methods return more specific unions that are all assignable to this.
+ */
+export type GatewayResult = readonly [
+  { status: number; data: unknown } | null,
+  EndpointError | null,
+];
+
+/**
+ * The ONLY place the Session Manager admin API key is used. Controllers depend
+ * on this gateway, never on the raw client, so the key cannot be sent upstream
+ * without going through an audited wrapper here. The key is never returned to
+ * the caller and never logged.
+ */
+export class SessionManagerGatewayService {
+  private _client: SessionManagerClient;
+  private _adminApiKey: string;
+
+  constructor(sessionManagerGatewayConfig: SessionManagerGatewayConfig) {
+    this._client = buildClient(
+      sessionManagerGatewayConfig.sessionManagerBaseUrl.replace(/\/+$/, ''),
+    );
+    this._adminApiKey = sessionManagerGatewayConfig.adminApiKey;
+  }
+
+  private _authHeaders(): { authorization: string } {
+    return { authorization: `Bearer ${this._adminApiKey}` };
+  }
+
+  // ---- Rooms ----
+
+  listRooms(querystring: Static<(typeof LIST_ROOMS_SCHEMA)['querystring']>) {
+    return this._client.roomManagement.listRooms({
+      headers: this._authHeaders(),
+      querystring,
+    });
+  }
+
+  getRoom(params: Static<(typeof GET_ROOM_SCHEMA)['params']>) {
+    return this._client.roomManagement.getRoom({
+      headers: this._authHeaders(),
+      params,
+    });
+  }
+
+  createRoom(body: Static<(typeof CREATE_ROOM_SCHEMA)['body']>) {
+    return this._client.roomManagement.createRoom({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  updateRoom(body: Static<(typeof UPDATE_ROOM_SCHEMA)['body']>) {
+    return this._client.roomManagement.updateRoom({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  deleteRoom(body: Static<(typeof DELETE_ROOM_SCHEMA)['body']>) {
+    return this._client.roomManagement.deleteRoom({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  addDeviceToRoom(body: Static<(typeof ADD_DEVICE_TO_ROOM_SCHEMA)['body']>) {
+    return this._client.roomManagement.addDeviceToRoom({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  removeDeviceFromRoom(
+    body: Static<(typeof REMOVE_DEVICE_FROM_ROOM_SCHEMA)['body']>,
+  ) {
+    return this._client.roomManagement.removeDeviceFromRoom({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  setSourceDevice(body: Static<(typeof SET_SOURCE_DEVICE_SCHEMA)['body']>) {
+    return this._client.roomManagement.setSourceDevice({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  // ---- Devices ----
+
+  listDevices(
+    querystring: Static<(typeof LIST_DEVICES_SCHEMA)['querystring']>,
+  ) {
+    return this._client.deviceManagement.listDevices({
+      headers: this._authHeaders(),
+      querystring,
+    });
+  }
+
+  getDevice(params: Static<(typeof GET_DEVICE_SCHEMA)['params']>) {
+    return this._client.deviceManagement.getDevice({
+      headers: this._authHeaders(),
+      params,
+    });
+  }
+
+  registerDevice(body: Static<(typeof REGISTER_DEVICE_SCHEMA)['body']>) {
+    return this._client.deviceManagement.registerDevice({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  reregisterDevice(body: Static<(typeof REREGISTER_DEVICE_SCHEMA)['body']>) {
+    return this._client.deviceManagement.reregisterDevice({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  updateDevice(body: Static<(typeof UPDATE_DEVICE_SCHEMA)['body']>) {
+    return this._client.deviceManagement.updateDevice({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  deleteDevice(body: Static<(typeof DELETE_DEVICE_SCHEMA)['body']>) {
+    return this._client.deviceManagement.deleteDevice({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  // ---- Scheduling ----
+
+  listSchedules(
+    querystring: Static<(typeof LIST_SCHEDULES_SCHEMA)['querystring']>,
+  ) {
+    return this._client.scheduleManagement.listSchedules({
+      headers: this._authHeaders(),
+      querystring,
+    });
+  }
+
+  getSchedule(params: Static<(typeof GET_SCHEDULE_SCHEMA)['params']>) {
+    return this._client.scheduleManagement.getSchedule({
+      headers: this._authHeaders(),
+      params,
+    });
+  }
+
+  createSchedule(body: Static<(typeof CREATE_SCHEDULE_SCHEMA)['body']>) {
+    return this._client.scheduleManagement.createSchedule({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  updateSchedule(body: Static<(typeof UPDATE_SCHEDULE_SCHEMA)['body']>) {
+    return this._client.scheduleManagement.updateSchedule({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  deleteSchedule(body: Static<(typeof DELETE_SCHEDULE_SCHEMA)['body']>) {
+    return this._client.scheduleManagement.deleteSchedule({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  listAutoSessionWindows(
+    querystring: Static<
+      (typeof LIST_AUTO_SESSION_WINDOWS_SCHEMA)['querystring']
+    >,
+  ) {
+    return this._client.scheduleManagement.listAutoSessionWindows({
+      headers: this._authHeaders(),
+      querystring,
+    });
+  }
+
+  getAutoSessionWindow(
+    params: Static<(typeof GET_AUTO_SESSION_WINDOW_SCHEMA)['params']>,
+  ) {
+    return this._client.scheduleManagement.getAutoSessionWindow({
+      headers: this._authHeaders(),
+      params,
+    });
+  }
+
+  createAutoSessionWindow(
+    body: Static<(typeof CREATE_AUTO_SESSION_WINDOW_SCHEMA)['body']>,
+  ) {
+    return this._client.scheduleManagement.createAutoSessionWindow({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  updateAutoSessionWindow(
+    body: Static<(typeof UPDATE_AUTO_SESSION_WINDOW_SCHEMA)['body']>,
+  ) {
+    return this._client.scheduleManagement.updateAutoSessionWindow({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  deleteAutoSessionWindow(
+    body: Static<(typeof DELETE_AUTO_SESSION_WINDOW_SCHEMA)['body']>,
+  ) {
+    return this._client.scheduleManagement.deleteAutoSessionWindow({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  updateRoomScheduleConfig(
+    body: Static<(typeof UPDATE_ROOM_SCHEDULE_CONFIG_SCHEMA)['body']>,
+  ) {
+    return this._client.scheduleManagement.updateRoomScheduleConfig({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  getSession(params: Static<(typeof GET_SESSION_SCHEMA)['params']>) {
+    return this._client.scheduleManagement.getSession({
+      headers: this._authHeaders(),
+      params,
+    });
+  }
+
+  createOnDemandSession(
+    body: Static<(typeof CREATE_ON_DEMAND_SESSION_SCHEMA)['body']>,
+  ) {
+    return this._client.scheduleManagement.createOnDemandSession({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  startSessionEarly(body: Static<(typeof START_SESSION_EARLY_SCHEMA)['body']>) {
+    return this._client.scheduleManagement.startSessionEarly({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  endSessionEarly(body: Static<(typeof END_SESSION_EARLY_SCHEMA)['body']>) {
+    return this._client.scheduleManagement.endSessionEarly({
+      headers: this._authHeaders(),
+      body,
+    });
+  }
+
+  // ---- Probes (unauthenticated upstream) ----
+
+  readiness() {
+    return this._client.probes.readiness({});
+  }
+
+  /**
+   * Single source of truth for mapping a Session Manager client result
+   * `[response, error]` to a BFF HTTP status + envelope shape. Used by both
+   * `respond` (to send) and controllers (to audit the outcome).
+   *
+   * - Upstream 2xx -> ok (204 normalized to 200 with `data: null`).
+   * - Upstream declared 4xx (404/409/422/400/403/410) -> passthrough at status.
+   * - Upstream 401 -> our admin key was rejected: an OPERATOR error, not an
+   *   end-user auth failure. Surfaced as 502 `BACKEND_MISCONFIGURATION` so the
+   *   SPA shows a distinct banner and does NOT redirect to login.
+   * - Upstream 429 -> 429 `RATE_LIMITED`.
+   * - Undeclared status -> 502; network failure -> 503.
+   */
+  classify(result: GatewayResult): UpstreamOutcome {
+    const [response, error] = result;
+
+    if (response) {
+      const status = response.status;
+
+      if (status === 401) {
+        return {
+          httpStatus: 502,
+          ok: false,
+          code: 'BACKEND_MISCONFIGURATION',
+          message:
+            'The admin backend rejected our credentials. An operator must verify ADMIN_API_KEY matches Session Manager.',
+        };
+      }
+
+      if (status >= 200 && status < 300) {
+        return {
+          httpStatus: status === 204 ? 200 : status,
+          ok: true,
+          data: response.data ?? null,
+        };
+      }
+
+      const data = (response.data ?? {}) as {
+        code?: string;
+        message?: string;
+        details?: Record<string, unknown>;
+      };
+      return {
+        httpStatus: status,
+        ok: false,
+        code: data.code ?? 'UPSTREAM_ERROR',
+        message: data.message ?? 'The request could not be completed.',
+        ...(data.details ? { details: data.details } : {}),
+      };
+    }
+
+    if (error && !(error instanceof NetworkError)) {
+      if (error.status === 429) {
+        return {
+          httpStatus: 429,
+          ok: false,
+          code: 'RATE_LIMITED',
+          message:
+            'The admin backend is rate limiting requests. Please retry shortly.',
+        };
+      }
+      return {
+        httpStatus: 502,
+        ok: false,
+        code: 'UPSTREAM_ERROR',
+        message: 'The admin backend returned an unexpected response.',
+      };
+    }
+
+    return {
+      httpStatus: 503,
+      ok: false,
+      code: 'UPSTREAM_UNREACHABLE',
+      message: 'The admin backend is currently unreachable.',
+    };
+  }
+
+  /**
+   * Classify a client result, log operator-visible failures, send the envelope,
+   * and return the HTTP status used (so callers can audit the outcome without
+   * re-deriving it).
+   */
+  respond(
+    req: FastifyRequest,
+    reply: FastifyReply,
+    result: GatewayResult,
+  ): number {
+    const outcome = this.classify(result);
+    const [, error] = result;
+
+    if (outcome.code === 'BACKEND_MISCONFIGURATION') {
+      req.log.error(
+        { upstreamStatus: 401 },
+        'Session Manager rejected the admin API key (backend misconfiguration).',
+      );
+    } else if (outcome.code === 'UPSTREAM_UNREACHABLE') {
+      req.log.error({ err: error }, 'Session Manager is unreachable.');
+    } else if (outcome.code === 'UPSTREAM_ERROR' && !result[0]) {
+      req.log.error(
+        { err: error },
+        'Unexpected response from Session Manager.',
+      );
+    }
+
+    if (outcome.ok) {
+      reply.code(outcome.httpStatus).send(okEnvelope(outcome.data ?? null));
+    } else {
+      reply
+        .code(outcome.httpStatus)
+        .send(
+          errorEnvelope(
+            outcome.code ?? 'UPSTREAM_ERROR',
+            outcome.message ?? 'The request could not be completed.',
+            req.id,
+            outcome.details,
+          ),
+        );
+    }
+
+    return outcome.httpStatus;
+  }
+}
+
+export interface UpstreamOutcome {
+  httpStatus: number;
+  ok: boolean;
+  code?: string;
+  message?: string;
+  details?: Record<string, unknown>;
+  data?: unknown;
+}

--- a/apps/admin-server/src/server/shared/services/session.service.ts
+++ b/apps/admin-server/src/server/shared/services/session.service.ts
@@ -1,0 +1,106 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+import type { Identity } from '../types/identity.js';
+
+export interface SessionConfig {
+  /** Whether the cookie carries the `Secure` attribute (false in dev/HTTP). */
+  secure: boolean;
+  /** Max gap between requests before the session is considered idle-expired. */
+  idleTimeoutMs: number;
+  /** Max total session lifetime regardless of activity. */
+  absoluteTimeoutMs: number;
+}
+
+export interface SessionRecord {
+  identity: Identity;
+  /** CSRF token bound to this session (synchronizer-token pattern). */
+  csrfToken: string;
+  createdAt: number;
+  lastSeenAt: number;
+}
+
+export const SESSION_COOKIE_NAME = 'admin_session';
+export const CSRF_COOKIE_NAME = 'admin_csrf';
+export const CSRF_HEADER_NAME = 'x-csrf-token';
+
+/**
+ * Server-side session store. Sessions are revocable (delete removes them) and
+ * carry idle + absolute lifetimes.
+ *
+ * NOTE: the store is in-memory, which is correct for a single BFF instance
+ * (sessions reset on restart and are not shared across replicas). Scaling out
+ * horizontally would require a shared backing store (Redis/Postgres); the
+ * interface here is deliberately small so that swap is localized.
+ */
+export class SessionService {
+  private _config: SessionConfig;
+  private _sessions = new Map<string, SessionRecord>();
+
+  constructor(sessionConfig: SessionConfig) {
+    this._config = sessionConfig;
+  }
+
+  get config(): SessionConfig {
+    return this._config;
+  }
+
+  /** Number of live sessions (used by tests/metrics). */
+  get activeCount(): number {
+    return this._sessions.size;
+  }
+
+  /** Issue a new session for an identity. Returns opaque ids for the cookies. */
+  create(identity: Identity): { sessionId: string; csrfToken: string } {
+    const sessionId = randomBytes(32).toString('base64url');
+    const csrfToken = randomBytes(32).toString('base64url');
+    const now = Date.now();
+    this._sessions.set(sessionId, {
+      identity,
+      csrfToken,
+      createdAt: now,
+      lastSeenAt: now,
+    });
+    return { sessionId, csrfToken };
+  }
+
+  /**
+   * Look up and validate a session id. Enforces idle + absolute lifetimes and,
+   * on success, slides the idle window forward. Expired/unknown ids return null
+   * (expired records are deleted).
+   */
+  validate(sessionId: string | undefined): SessionRecord | null {
+    if (!sessionId) return null;
+    const record = this._sessions.get(sessionId);
+    if (!record) return null;
+
+    const now = Date.now();
+    const absoluteExpired =
+      now - record.createdAt > this._config.absoluteTimeoutMs;
+    const idleExpired = now - record.lastSeenAt > this._config.idleTimeoutMs;
+    if (absoluteExpired || idleExpired) {
+      this._sessions.delete(sessionId);
+      return null;
+    }
+
+    record.lastSeenAt = now;
+    return record;
+  }
+
+  /** Constant-time comparison of a presented CSRF token to the session's. */
+  verifyCsrf(
+    record: SessionRecord,
+    presentedToken: string | undefined,
+  ): boolean {
+    if (!presentedToken) return false;
+    const expected = Buffer.from(record.csrfToken, 'utf8');
+    const actual = Buffer.from(presentedToken, 'utf8');
+    // Token length is fixed and non-secret, so an early length check is safe.
+    if (expected.length !== actual.length) return false;
+    return timingSafeEqual(expected, actual);
+  }
+
+  /** Revoke a session. */
+  destroy(sessionId: string | undefined): void {
+    if (sessionId) this._sessions.delete(sessionId);
+  }
+}

--- a/apps/admin-server/src/server/shared/types/fastify-augmentation.ts
+++ b/apps/admin-server/src/server/shared/types/fastify-augmentation.ts
@@ -1,0 +1,15 @@
+// Importing this module for its side effect augments FastifyRequest with the
+// admin session/identity attached by `requireSessionHook`.
+import type { SessionRecord } from '../services/session.service.js';
+import type { Identity } from './identity.js';
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    /** The validated admin session, set by `requireSessionHook`. */
+    adminSession?: SessionRecord;
+    /** Convenience alias for `adminSession.identity`. */
+    adminIdentity?: Identity;
+    /** The opaque session id (needed by logout to revoke). */
+    adminSessionId?: string;
+  }
+}

--- a/apps/admin-server/src/server/shared/types/identity.ts
+++ b/apps/admin-server/src/server/shared/types/identity.ts
@@ -1,0 +1,33 @@
+/**
+ * Authorization roles. `read-write` grants mutations; `read-only` grants reads
+ * only. The local account maps to `read-write`; the `read-only` seam exists so
+ * an SSO group can be mapped to reduced privileges later without touching route
+ * wiring.
+ */
+export type Role = 'read-only' | 'read-write';
+
+export const ROLE_READ_ONLY: Role = 'read-only';
+export const ROLE_READ_WRITE: Role = 'read-write';
+
+export type AuthProviderId = 'local' | 'sso';
+
+/**
+ * A resolved staff identity. Everything downstream of authentication (session,
+ * CSRF, authorization, audit) sees only an `Identity` — never a provider
+ * credential.
+ */
+export interface Identity {
+  /** Stable unique identifier for the actor within its provider. */
+  subject: string;
+  /** Human-readable name for display/audit. */
+  displayName: string;
+  /** Which provider authenticated this identity. */
+  provider: AuthProviderId;
+  /** Granted authorization roles. */
+  roles: Role[];
+}
+
+/** True if the identity holds the given role. */
+export function identityHasRole(identity: Identity, role: Role): boolean {
+  return identity.roles.includes(role);
+}

--- a/apps/admin-server/tests/integration/auth.routes.test.ts
+++ b/apps/admin-server/tests/integration/auth.routes.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect } from 'vitest';
+
+import { SessionManagerMock } from '#tests/utils/mock-session-manager.js';
+import {
+  TEST_PASSWORD,
+  TEST_USERNAME,
+  login,
+  useServer,
+} from '#tests/utils/use-server.js';
+
+const BASE = '/api/admin/v1';
+
+describe('Auth routes', () => {
+  const server = useServer();
+  let sm: SessionManagerMock;
+  beforeEach(() => {
+    sm = new SessionManagerMock();
+  });
+  afterEach(() => {
+    sm.restore();
+  });
+
+  describe('GET /auth/config', (it) => {
+    it('reports local enabled, sso disabled', async () => {
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/config`,
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({
+        ok: true,
+        data: { local: true, sso: false },
+      });
+    });
+  });
+
+  describe('POST /auth/login', (it) => {
+    it('succeeds with valid credentials and sets an HttpOnly session cookie', async () => {
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/auth/login`,
+        payload: { username: TEST_USERNAME, password: TEST_PASSWORD },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      const setCookie = String(res.headers['set-cookie']);
+      expect(setCookie).toContain('admin_session=');
+      expect(setCookie.toLowerCase()).toContain('httponly');
+      expect(setCookie.toLowerCase()).toContain('samesite=strict');
+      const body = res.json<{
+        ok: boolean;
+        data: {
+          identity: { subject: string; roles: string[] };
+          csrfToken: string;
+        };
+      }>();
+      expect(body.ok).toBe(true);
+      expect(body.data.identity.subject).toBe(TEST_USERNAME);
+      expect(body.data.identity.roles).toContain('read-write');
+      expect(typeof body.data.csrfToken).toBe('string');
+      expect(body.data.csrfToken.length).toBeGreaterThan(0);
+    });
+
+    it('rejects an invalid password with a generic 401', async () => {
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/auth/login`,
+        payload: { username: TEST_USERNAME, password: 'wrong' },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(401);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'INVALID_CREDENTIALS',
+      );
+      // No session cookie issued on failure.
+      expect(res.headers['set-cookie']).toBeUndefined();
+    });
+
+    it('never contacts Session Manager during login', async () => {
+      // Act
+      await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/auth/login`,
+        payload: { username: TEST_USERNAME, password: TEST_PASSWORD },
+      });
+
+      // Assert
+      expect(sm.requests.length).toBe(0);
+    });
+  });
+
+  describe('GET /auth/me and POST /auth/logout', (it) => {
+    it('returns the identity + csrf token when authenticated, and clears on logout', async () => {
+      // Arrange
+      const { cookie, csrfToken } = await login(server.fastify);
+
+      // Act — /auth/me
+      const meRes = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/me`,
+        headers: { cookie },
+      });
+
+      // Assert
+      expect(meRes.statusCode).toBe(200);
+      const me = meRes.json<{
+        data: { identity: { subject: string }; csrfToken: string };
+      }>();
+      expect(me.data.identity.subject).toBe(TEST_USERNAME);
+      expect(me.data.csrfToken).toBe(csrfToken);
+
+      // Act — logout (requires CSRF)
+      const logoutRes = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/auth/logout`,
+        headers: { cookie, 'x-csrf-token': csrfToken },
+      });
+      expect(logoutRes.statusCode).toBe(200);
+
+      // Assert — session is revoked: /auth/me now 401
+      const afterLogout = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/me`,
+        headers: { cookie },
+      });
+      expect(afterLogout.statusCode).toBe(401);
+    });
+
+    it('rejects /auth/me without a session cookie (401)', async () => {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/me`,
+      });
+      expect(res.statusCode).toBe(401);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'UNAUTHENTICATED',
+      );
+    });
+  });
+});
+
+describe('Auth login rate limiting', () => {
+  // Fresh server => fresh in-memory limiter, isolated from the suite above.
+  const server = useServer({ rateLimitConfig: { loginMax: 3 } });
+
+  describe('POST /auth/login', (it) => {
+    it('locks out with 429 after exceeding the login limit', async () => {
+      // Act — 3 allowed failed attempts, then the 4th is limited.
+      const codes: number[] = [];
+      for (let i = 0; i < 4; i++) {
+        const res = await server.fastify.inject({
+          method: 'POST',
+          url: `${BASE}/auth/login`,
+          payload: { username: TEST_USERNAME, password: 'wrong' },
+        });
+        codes.push(res.statusCode);
+      }
+
+      // Assert
+      expect(codes.slice(0, 3)).toEqual([401, 401, 401]);
+      expect(codes[3]).toBe(429);
+    });
+  });
+});
+
+describe('Auth with local login disabled', () => {
+  const server = useServer({ localAuthConfig: { credentials: '' } });
+
+  describe('config + login', (it) => {
+    it('reports local disabled and rejects login with 404', async () => {
+      const configRes = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/config`,
+      });
+      expect(configRes.json()).toEqual({
+        ok: true,
+        data: { local: false, sso: false },
+      });
+
+      const loginRes = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/auth/login`,
+        payload: { username: TEST_USERNAME, password: TEST_PASSWORD },
+      });
+      expect(loginRes.statusCode).toBe(404);
+      expect(loginRes.json<{ error: { code: string } }>().error.code).toBe(
+        'LOCAL_LOGIN_DISABLED',
+      );
+    });
+  });
+});

--- a/apps/admin-server/tests/integration/global-setup.ts
+++ b/apps/admin-server/tests/integration/global-setup.ts
@@ -1,0 +1,51 @@
+import {
+  GenericContainer,
+  type StartedTestContainer,
+  Wait,
+} from 'testcontainers';
+import type { ProvidedContext } from 'vitest';
+
+const DB_NAME = 'admin_test';
+const DB_USER = 'admin_test';
+const DB_PASSWORD = 'admin_test';
+const DB_PORT = 5432;
+
+let dbContainer: StartedTestContainer;
+
+/**
+ * Spins a plain Postgres for the admin BFF integration tests. The BFF applies
+ * its own `admin_audit_log` migration on server `onReady`, so nothing needs to
+ * be migrated here. A modern Postgres provides `gen_random_uuid()` built-in.
+ */
+export async function setup({
+  provide,
+}: {
+  provide: <T extends keyof ProvidedContext>(
+    key: T,
+    value: ProvidedContext[T],
+  ) => void;
+}) {
+  dbContainer = await new GenericContainer('postgres:16-alpine')
+    .withEnvironment({
+      POSTGRES_DB: DB_NAME,
+      POSTGRES_USER: DB_USER,
+      POSTGRES_PASSWORD: DB_PASSWORD,
+    })
+    .withExposedPorts(DB_PORT)
+    .withWaitStrategy(
+      Wait.forLogMessage(/database system is ready to accept connections/, 2),
+    )
+    .start();
+
+  provide('dbConfig', {
+    dbHost: dbContainer.getHost(),
+    dbPort: dbContainer.getMappedPort(DB_PORT),
+    dbName: DB_NAME,
+    dbUser: DB_USER,
+    dbPassword: DB_PASSWORD,
+  });
+}
+
+export async function teardown() {
+  await dbContainer.stop();
+}

--- a/apps/admin-server/tests/integration/probes.routes.test.ts
+++ b/apps/admin-server/tests/integration/probes.routes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect } from 'vitest';
+
+import { useServer } from '#tests/utils/use-server.js';
+
+const BASE = '/api/admin/v1/probes';
+
+describe('Probes routes', () => {
+  const server = useServer();
+
+  describe('GET /liveness', (it) => {
+    it('returns 200 with status ok (no auth required)', async () => {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/liveness`,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json<{ status: string }>().status).toBe('ok');
+    });
+  });
+
+  describe('GET /readiness', (it) => {
+    it('returns 200 with status ok when the database is reachable', async () => {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/readiness`,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json<{ status: string }>().status).toBe('ok');
+    });
+  });
+});

--- a/apps/admin-server/tests/integration/rooms.routes.test.ts
+++ b/apps/admin-server/tests/integration/rooms.routes.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect } from 'vitest';
+
+import { SessionManagerMock } from '#tests/utils/mock-session-manager.js';
+import { useDb } from '#tests/utils/use-db.js';
+import { TEST_ADMIN_KEY, login, useServer } from '#tests/utils/use-server.js';
+
+const BASE = '/api/admin/v1';
+const UUID = '11111111-1111-1111-1111-111111111111';
+
+const SAMPLE_ROOM = {
+  uid: UUID,
+  name: 'Room A',
+  timezone: 'America/New_York',
+  autoSessionEnabled: false,
+  roomScheduleVersion: 0,
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('Rooms routes', () => {
+  const server = useServer();
+  const dbCtx = useDb();
+  let sm: SessionManagerMock;
+  beforeEach(() => {
+    sm = new SessionManagerMock();
+  });
+  afterEach(() => {
+    sm.restore();
+  });
+
+  describe('auth guard', (it) => {
+    it('rejects an unauthenticated list with 401 and makes NO upstream call', async () => {
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/rooms/list`,
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(401);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'UNAUTHENTICATED',
+      );
+      expect(sm.requests.length).toBe(0);
+    });
+  });
+
+  describe('key injection + envelope mapping', (it) => {
+    it('lists rooms and injects the admin key upstream (never from the browser)', async () => {
+      // Arrange
+      sm.respondWith({ status: 200, body: { items: [], nextCursor: null } });
+      const { cookie } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/rooms/list`,
+        headers: { cookie },
+      });
+
+      // Assert — envelope
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({
+        ok: true,
+        data: { items: [], nextCursor: null },
+      });
+      // Assert — the outgoing upstream request carried the Bearer admin key
+      const upstream = sm.requests.find((r) =>
+        r.url.includes('/room-management/list-rooms'),
+      );
+      expect(upstream).toBeDefined();
+      expect(upstream?.headers['authorization']).toBe(
+        `Bearer ${TEST_ADMIN_KEY}`,
+      );
+    });
+
+    it('passes an upstream 404 through as a 404 error envelope', async () => {
+      // Arrange
+      sm.respondWith({
+        status: 404,
+        body: { code: 'ROOM_NOT_FOUND', message: 'nope' },
+      });
+      const { cookie } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/rooms/get/${UUID}`,
+        headers: { cookie },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(404);
+      const body = res.json<{
+        ok: boolean;
+        error: { code: string; requestId: string };
+      }>();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe('ROOM_NOT_FOUND');
+      expect(typeof body.error.requestId).toBe('string');
+    });
+
+    it('maps an upstream 401 (rejected admin key) to 502 BACKEND_MISCONFIGURATION', async () => {
+      // Arrange — Session Manager rejects our admin key.
+      sm.respondWith({
+        status: 401,
+        body: { code: 'INVALID_ADMIN_KEY', message: 'bad key' },
+      });
+      const { cookie } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/rooms/list`,
+        headers: { cookie },
+      });
+
+      // Assert — must NOT surface as a 401 (which would bounce the user to login).
+      expect(res.statusCode).toBe(502);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'BACKEND_MISCONFIGURATION',
+      );
+    });
+  });
+
+  describe('CSRF + audit on mutations', (it) => {
+    const createPayload = {
+      name: 'Room A',
+      timezone: 'America/New_York',
+      autoSessionEnabled: false,
+      sourceDeviceUids: [UUID],
+    };
+
+    it('rejects a create without a CSRF token (403) and makes NO upstream call', async () => {
+      // Arrange
+      sm.respondWith({ status: 201, body: SAMPLE_ROOM });
+      const { cookie } = await login(server.fastify);
+
+      // Act — authenticated but no x-csrf-token header
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/rooms/create`,
+        headers: { cookie },
+        payload: createPayload,
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(403);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'CSRF_TOKEN_INVALID',
+      );
+      const created = sm.requests.find((r) =>
+        r.url.includes('/room-management/create-room'),
+      );
+      expect(created).toBeUndefined();
+    });
+
+    it('creates a room with a CSRF token, injects the key, and writes an audit record', async () => {
+      // Arrange
+      sm.respondWith({ status: 201, body: SAMPLE_ROOM });
+      const { cookie, csrfToken } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/rooms/create`,
+        headers: { cookie, 'x-csrf-token': csrfToken },
+        payload: createPayload,
+      });
+
+      // Assert — response
+      expect(res.statusCode).toBe(201);
+      expect(res.json()).toEqual({ ok: true, data: SAMPLE_ROOM });
+
+      // Assert — upstream got the key + body
+      const created = sm.requests.find((r) =>
+        r.url.includes('/room-management/create-room'),
+      );
+      expect(created?.headers['authorization']).toBe(
+        `Bearer ${TEST_ADMIN_KEY}`,
+      );
+      expect(created?.body).toMatchObject({ name: 'Room A' });
+
+      // Assert — audit row persisted
+      const rows = await dbCtx.db
+        .selectFrom('admin_audit_log')
+        .selectAll()
+        .where('action', '=', 'create-room')
+        .execute();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.actor_subject).toBe('engrit');
+      expect(rows[0]?.result).toBe('success');
+      expect(rows[0]?.status_code).toBe(201);
+    });
+  });
+});

--- a/apps/admin-server/tests/integration/scheduling.routes.test.ts
+++ b/apps/admin-server/tests/integration/scheduling.routes.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect } from 'vitest';
+
+import { SessionManagerMock } from '#tests/utils/mock-session-manager.js';
+import { useDb } from '#tests/utils/use-db.js';
+import { TEST_ADMIN_KEY, login, useServer } from '#tests/utils/use-server.js';
+
+const BASE = '/api/admin/v1';
+const ROOM_UID = '11111111-1111-1111-1111-111111111111';
+const SCHEDULE_UID = '22222222-2222-2222-2222-222222222222';
+
+const SAMPLE_SCHEDULE = {
+  uid: SCHEDULE_UID,
+  roomUid: ROOM_UID,
+  name: 'Weekly Standup',
+  activeStart: '2026-08-01T00:00:00.000Z',
+  activeEnd: null,
+  anchorStart: '2026-08-01T00:00:00.000Z',
+  localStartTime: '09:00',
+  localEndTime: '10:00',
+  frequency: 'WEEKLY',
+  daysOfWeek: ['MON'],
+  joinCodeScopes: ['SEND_AUDIO'],
+  transcriptionProviderId: 'provider-1',
+  transcriptionStreamConfig: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('Scheduling routes', () => {
+  const server = useServer();
+  const dbCtx = useDb();
+  let sm: SessionManagerMock;
+  beforeEach(() => {
+    sm = new SessionManagerMock();
+  });
+  afterEach(() => {
+    sm.restore();
+  });
+
+  describe('auth guard', (it) => {
+    it('rejects an unauthenticated list with 401 and makes NO upstream call', async () => {
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/schedules/list?roomUid=${ROOM_UID}`,
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(401);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'UNAUTHENTICATED',
+      );
+      expect(sm.requests.length).toBe(0);
+    });
+  });
+
+  describe('CSRF + audit on mutations', (it) => {
+    const createPayload = {
+      roomUid: ROOM_UID,
+      name: 'Weekly Standup',
+      activeStart: '2026-08-01T00:00:00.000Z',
+      activeEnd: null,
+      localStartTime: '09:00',
+      localEndTime: '10:00',
+      frequency: 'WEEKLY',
+      daysOfWeek: ['MON'],
+      joinCodeScopes: ['SEND_AUDIO'],
+      transcriptionProviderId: 'provider-1',
+      transcriptionStreamConfig: null,
+    };
+
+    it('rejects a create without a CSRF token (403) and makes NO upstream call', async () => {
+      // Arrange
+      sm.respondWith({ status: 201, body: SAMPLE_SCHEDULE });
+      const { cookie } = await login(server.fastify);
+
+      // Act — authenticated but no x-csrf-token header
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/schedules/create`,
+        headers: { cookie },
+        payload: createPayload,
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(403);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'CSRF_TOKEN_INVALID',
+      );
+      const created = sm.requests.find((r) =>
+        r.url.includes('/schedule-management/create-schedule'),
+      );
+      expect(created).toBeUndefined();
+    });
+
+    it('creates a schedule with a CSRF token, injects the key, and writes an audit record', async () => {
+      // Arrange
+      sm.respondWith({ status: 201, body: SAMPLE_SCHEDULE });
+      const { cookie, csrfToken } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/schedules/create`,
+        headers: { cookie, 'x-csrf-token': csrfToken },
+        payload: createPayload,
+      });
+
+      // Assert — response
+      expect(res.statusCode).toBe(201);
+      expect(res.json()).toEqual({ ok: true, data: SAMPLE_SCHEDULE });
+
+      // Assert — upstream got the key + body
+      const created = sm.requests.find((r) =>
+        r.url.includes('/schedule-management/create-schedule'),
+      );
+      expect(created?.headers['authorization']).toBe(
+        `Bearer ${TEST_ADMIN_KEY}`,
+      );
+      expect(created?.body).toMatchObject({ name: 'Weekly Standup' });
+
+      // Assert — audit row persisted
+      const rows = await dbCtx.db
+        .selectFrom('admin_audit_log')
+        .selectAll()
+        .where('action', '=', 'create-schedule')
+        .execute();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.actor_subject).toBe('engrit');
+      expect(rows[0]?.result).toBe('success');
+      expect(rows[0]?.status_code).toBe(201);
+    });
+  });
+});

--- a/apps/admin-server/tests/unit/shared/envelope/envelope.test.ts
+++ b/apps/admin-server/tests/unit/shared/envelope/envelope.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect } from 'vitest';
+
+import {
+  errorEnvelope,
+  okEnvelope,
+} from '#src/server/shared/envelope/envelope.js';
+
+describe('envelope', () => {
+  describe('okEnvelope', (it) => {
+    it('wraps data in an ok envelope', () => {
+      // Arrange / Act
+      const result = okEnvelope({ x: 1 });
+
+      // Assert
+      expect(result).toStrictEqual({ ok: true, data: { x: 1 } });
+    });
+  });
+
+  describe('errorEnvelope', (it) => {
+    it('builds an error envelope with no details key when details is omitted', () => {
+      // Arrange / Act
+      const result = errorEnvelope('CODE', 'msg', 'req-1');
+
+      // Assert
+      expect(result).toStrictEqual({
+        ok: false,
+        error: { code: 'CODE', message: 'msg', requestId: 'req-1' },
+      });
+      expect('details' in result.error).toBe(false);
+    });
+
+    it('includes details when provided', () => {
+      // Arrange / Act
+      const result = errorEnvelope('C', 'm', 'r', { a: 1 });
+
+      // Assert
+      expect(result).toStrictEqual({
+        ok: false,
+        error: { code: 'C', message: 'm', requestId: 'r', details: { a: 1 } },
+      });
+    });
+  });
+});

--- a/apps/admin-server/tests/unit/shared/hooks/csrf.hook.test.ts
+++ b/apps/admin-server/tests/unit/shared/hooks/csrf.hook.test.ts
@@ -1,0 +1,93 @@
+import { type Mock, describe, expect, vi } from 'vitest';
+
+import { csrfHook } from '#src/server/shared/hooks/csrf.hook.js';
+
+function makeReply() {
+  return {
+    code: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+  };
+}
+
+function makeRequest(overrides: {
+  verifyCsrf?: Mock;
+  adminSession?: object | undefined;
+  csrfToken?: string;
+}) {
+  const verifyCsrf = overrides.verifyCsrf ?? vi.fn();
+  return {
+    diScope: {
+      resolve: vi.fn().mockReturnValue({ verifyCsrf }),
+    },
+    adminSession: overrides.adminSession,
+    headers: { 'x-csrf-token': overrides.csrfToken },
+    id: 'r1',
+  };
+}
+
+describe('csrfHook', () => {
+  describe('the presented token matches the session', (it) => {
+    it('does not reject the request', async () => {
+      // Arrange
+      const verifyCsrf = vi.fn().mockReturnValue(true);
+      const req = makeRequest({
+        verifyCsrf,
+        adminSession: { csrfToken: 'tok' },
+        csrfToken: 'tok',
+      });
+      const reply = makeReply();
+
+      // Act
+      await csrfHook(req as never, reply as never);
+
+      // Assert
+      expect(reply.code).not.toHaveBeenCalled();
+      expect(reply.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the presented token does not match the session', (it) => {
+    it('replies 403 CSRF_TOKEN_INVALID', async () => {
+      // Arrange
+      const verifyCsrf = vi.fn().mockReturnValue(false);
+      const req = makeRequest({
+        verifyCsrf,
+        adminSession: { csrfToken: 'tok' },
+        csrfToken: 'wrong',
+      });
+      const reply = makeReply();
+
+      // Act
+      await csrfHook(req as never, reply as never);
+
+      // Assert
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          error: expect.objectContaining({ code: 'CSRF_TOKEN_INVALID' }),
+        }),
+      );
+    });
+  });
+
+  describe('there is no adminSession', (it) => {
+    it('replies 403 CSRF_TOKEN_INVALID', async () => {
+      // Arrange
+      const req = makeRequest({ adminSession: undefined, csrfToken: 'tok' });
+      const reply = makeReply();
+
+      // Act
+      await csrfHook(req as never, reply as never);
+
+      // Assert
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          error: expect.objectContaining({ code: 'CSRF_TOKEN_INVALID' }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/admin-server/tests/unit/shared/hooks/require-role.hook.test.ts
+++ b/apps/admin-server/tests/unit/shared/hooks/require-role.hook.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, vi } from 'vitest';
+
+import { requireRole } from '#src/server/shared/hooks/require-role.hook.js';
+import type { Identity } from '#src/server/shared/types/identity.js';
+
+function makeReply() {
+  return {
+    code: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+  };
+}
+
+function makeRequest(adminIdentity?: Identity) {
+  return { adminIdentity, id: 'r1' };
+}
+
+describe('requireRole', () => {
+  describe('caller holds the required role', (it) => {
+    it('does not reject the request', async () => {
+      // Arrange
+      const identity: Identity = {
+        subject: 'u',
+        displayName: 'u',
+        provider: 'local',
+        roles: ['read-write'],
+      };
+      const req = makeRequest(identity);
+      const reply = makeReply();
+      const hook = requireRole('read-write');
+
+      // Act
+      await hook(req as never, reply as never);
+
+      // Assert
+      expect(reply.code).not.toHaveBeenCalled();
+      expect(reply.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('caller lacks the required role', (it) => {
+    it('replies 403 FORBIDDEN', async () => {
+      // Arrange
+      const identity: Identity = {
+        subject: 'u',
+        displayName: 'u',
+        provider: 'local',
+        roles: ['read-only'],
+      };
+      const req = makeRequest(identity);
+      const reply = makeReply();
+      const hook = requireRole('read-write');
+
+      // Act
+      await hook(req as never, reply as never);
+
+      // Assert
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          error: expect.objectContaining({ code: 'FORBIDDEN' }),
+        }),
+      );
+    });
+  });
+
+  describe('caller has no adminIdentity', (it) => {
+    it('replies 403 FORBIDDEN', async () => {
+      // Arrange
+      const req = makeRequest(undefined);
+      const reply = makeReply();
+      const hook = requireRole('read-write');
+
+      // Act
+      await hook(req as never, reply as never);
+
+      // Assert
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          error: expect.objectContaining({ code: 'FORBIDDEN' }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/admin-server/tests/unit/shared/services/local-auth.service.test.ts
+++ b/apps/admin-server/tests/unit/shared/services/local-auth.service.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect } from 'vitest';
+
+import { LocalAuthService } from '#src/server/shared/services/local-auth.service.js';
+import { createMockLogger } from '#tests/utils/mock-logger.js';
+
+describe('LocalAuthService', () => {
+  describe('with valid credentials containing a password with spaces', (it) => {
+    it('is enabled', () => {
+      // Arrange
+      const logger = createMockLogger();
+      const service = new LocalAuthService(logger as never, {
+        credentials: 'engrit super secret pw!',
+      });
+
+      // Act
+      const result = service.isEnabled();
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('verifies the username and full (multi-word) password, splitting on the first space only', () => {
+      // Arrange
+      const logger = createMockLogger();
+      const service = new LocalAuthService(logger as never, {
+        credentials: 'engrit super secret pw!',
+      });
+
+      // Act
+      const result = service.verify('engrit', 'super secret pw!');
+
+      // Assert
+      expect(result).toStrictEqual({
+        subject: 'engrit',
+        displayName: 'engrit',
+        provider: 'local',
+        roles: ['read-write'],
+      });
+    });
+
+    it('returns null for a wrong password', () => {
+      // Arrange
+      const logger = createMockLogger();
+      const service = new LocalAuthService(logger as never, {
+        credentials: 'engrit super secret pw!',
+      });
+
+      // Act
+      const result = service.verify('engrit', 'wrong');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('returns null for a wrong username', () => {
+      // Arrange
+      const logger = createMockLogger();
+      const service = new LocalAuthService(logger as never, {
+        credentials: 'engrit super secret pw!',
+      });
+
+      // Act
+      const result = service.verify('wronguser', 'super secret pw!');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('returns null for an empty password', () => {
+      // Arrange
+      const logger = createMockLogger();
+      const service = new LocalAuthService(logger as never, {
+        credentials: 'engrit super secret pw!',
+      });
+
+      // Act
+      const result = service.verify('engrit', '');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('with empty credentials', (it) => {
+    it('is disabled', () => {
+      // Arrange
+      const logger = createMockLogger();
+      const service = new LocalAuthService(logger as never, {
+        credentials: '',
+      });
+
+      // Act
+      const result = service.isEnabled();
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it('verify returns null for any input', () => {
+      // Arrange
+      const logger = createMockLogger();
+      const service = new LocalAuthService(logger as never, {
+        credentials: '',
+      });
+
+      // Act
+      const result = service.verify('anything', 'anything');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('with whitespace-only credentials', (it) => {
+    it('is disabled', () => {
+      // Arrange
+      const logger = createMockLogger();
+      const service = new LocalAuthService(logger as never, {
+        credentials: '   ',
+      });
+
+      // Act
+      const result = service.isEnabled();
+
+      // Assert
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('with credentials missing a space (no password)', (it) => {
+    it('is disabled and logs a warning', () => {
+      // Arrange
+      const logger = createMockLogger();
+
+      // Act
+      const service = new LocalAuthService(logger as never, {
+        credentials: 'nopassword',
+      });
+
+      // Assert
+      expect(service.isEnabled()).toBe(false);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('with credentials that have a leading space (empty username)', (it) => {
+    it('is disabled', () => {
+      // Arrange
+      const logger = createMockLogger();
+      const service = new LocalAuthService(logger as never, {
+        credentials: ' leadingspace pw',
+      });
+
+      // Act
+      const result = service.isEnabled();
+
+      // Assert
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/admin-server/tests/unit/shared/services/session-manager-gateway.service.test.ts
+++ b/apps/admin-server/tests/unit/shared/services/session-manager-gateway.service.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect } from 'vitest';
+
+import {
+  NetworkError,
+  UnexpectedResponseError,
+} from '@scribear/base-api-client';
+
+import { SessionManagerGatewayService } from '#src/server/shared/services/session-manager-gateway.service.js';
+import type { GatewayResult } from '#src/server/shared/services/session-manager-gateway.service.js';
+
+describe('SessionManagerGatewayService', () => {
+  describe('classify', (it) => {
+    const service = new SessionManagerGatewayService({
+      adminApiKey: 'k',
+      sessionManagerBaseUrl: 'http://sm.test',
+    });
+
+    it('maps a 200 response to an ok outcome carrying the response data', () => {
+      // Arrange
+      const result: GatewayResult = [{ status: 200, data: { a: 1 } }, null];
+
+      // Act
+      const outcome = service.classify(result);
+
+      // Assert
+      expect(outcome).toMatchObject({
+        httpStatus: 200,
+        ok: true,
+        data: { a: 1 },
+      });
+    });
+
+    it('maps a 201 response to an ok outcome preserving the status', () => {
+      // Arrange
+      const result: GatewayResult = [{ status: 201, data: { uid: 'x' } }, null];
+
+      // Act
+      const outcome = service.classify(result);
+
+      // Assert
+      expect(outcome).toMatchObject({ httpStatus: 201, ok: true });
+    });
+
+    it('normalizes a 204 response to a 200 ok outcome with null data', () => {
+      // Arrange
+      const result: GatewayResult = [{ status: 204, data: null }, null];
+
+      // Act
+      const outcome = service.classify(result);
+
+      // Assert
+      expect(outcome).toMatchObject({ httpStatus: 200, ok: true, data: null });
+    });
+
+    it('passes through a declared 404 with its code', () => {
+      // Arrange
+      const result: GatewayResult = [
+        { status: 404, data: { code: 'ROOM_NOT_FOUND', message: 'nope' } },
+        null,
+      ];
+
+      // Act
+      const outcome = service.classify(result);
+
+      // Assert
+      expect(outcome).toMatchObject({
+        httpStatus: 404,
+        ok: false,
+        code: 'ROOM_NOT_FOUND',
+      });
+    });
+
+    it('passes through a declared 409 with its code', () => {
+      // Arrange
+      const result: GatewayResult = [
+        { status: 409, data: { code: 'DEVICE_ALREADY_IN_ROOM', message: 'x' } },
+        null,
+      ];
+
+      // Act
+      const outcome = service.classify(result);
+
+      // Assert
+      expect(outcome).toMatchObject({
+        httpStatus: 409,
+        ok: false,
+        code: 'DEVICE_ALREADY_IN_ROOM',
+      });
+    });
+
+    it('maps an upstream 401 to a 502 BACKEND_MISCONFIGURATION rather than passing 401 through', () => {
+      // Arrange
+      const result: GatewayResult = [
+        { status: 401, data: { code: 'INVALID_ADMIN_KEY', message: 'x' } },
+        null,
+      ];
+
+      // Act
+      const outcome = service.classify(result);
+
+      // Assert
+      expect(outcome).toMatchObject({
+        httpStatus: 502,
+        ok: false,
+        code: 'BACKEND_MISCONFIGURATION',
+      });
+    });
+
+    it('maps an UnexpectedResponseError with status 429 to RATE_LIMITED', () => {
+      // Arrange
+      const result: GatewayResult = [null, new UnexpectedResponseError(429)];
+
+      // Act
+      const outcome = service.classify(result);
+
+      // Assert
+      expect(outcome).toMatchObject({
+        httpStatus: 429,
+        ok: false,
+        code: 'RATE_LIMITED',
+      });
+    });
+
+    it('maps an UnexpectedResponseError with status 503 to a 502 UPSTREAM_ERROR', () => {
+      // Arrange
+      const result: GatewayResult = [null, new UnexpectedResponseError(503)];
+
+      // Act
+      const outcome = service.classify(result);
+
+      // Assert
+      expect(outcome).toMatchObject({
+        httpStatus: 502,
+        ok: false,
+        code: 'UPSTREAM_ERROR',
+      });
+    });
+
+    it('maps a NetworkError to a 503 UPSTREAM_UNREACHABLE', () => {
+      // Arrange
+      const result: GatewayResult = [null, new NetworkError(new Error('boom'))];
+
+      // Act
+      const outcome = service.classify(result);
+
+      // Assert
+      expect(outcome).toMatchObject({
+        httpStatus: 503,
+        ok: false,
+        code: 'UPSTREAM_UNREACHABLE',
+      });
+    });
+  });
+});

--- a/apps/admin-server/tests/unit/shared/services/session.service.test.ts
+++ b/apps/admin-server/tests/unit/shared/services/session.service.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+
+import { SessionService } from '#src/server/shared/services/session.service.js';
+import type { Identity } from '#src/server/shared/types/identity.js';
+
+const IDENTITY: Identity = {
+  subject: 'u',
+  displayName: 'u',
+  provider: 'local',
+  roles: ['read-write'],
+};
+
+describe('SessionService', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('create', (it) => {
+    it('returns a non-empty sessionId and csrfToken that differ from each other', () => {
+      // Arrange
+      const service = new SessionService({
+        secure: true,
+        idleTimeoutMs: 10_000,
+        absoluteTimeoutMs: 100_000,
+      });
+
+      // Act
+      const { sessionId, csrfToken } = service.create(IDENTITY);
+
+      // Assert
+      expect(typeof sessionId).toBe('string');
+      expect(sessionId.length).toBeGreaterThan(0);
+      expect(typeof csrfToken).toBe('string');
+      expect(csrfToken.length).toBeGreaterThan(0);
+      expect(sessionId).not.toBe(csrfToken);
+    });
+  });
+
+  describe('validate', (it) => {
+    it('returns a record whose identity matches the one used to create the session', () => {
+      // Arrange
+      const service = new SessionService({
+        secure: true,
+        idleTimeoutMs: 10_000,
+        absoluteTimeoutMs: 100_000,
+      });
+      const { sessionId } = service.create(IDENTITY);
+
+      // Act
+      const record = service.validate(sessionId);
+
+      // Assert
+      expect(record?.identity).toStrictEqual(IDENTITY);
+    });
+
+    it('returns null for an unknown sessionId', () => {
+      // Arrange
+      const service = new SessionService({
+        secure: true,
+        idleTimeoutMs: 10_000,
+        absoluteTimeoutMs: 100_000,
+      });
+
+      // Act
+      const record = service.validate('unknown');
+
+      // Assert
+      expect(record).toBeNull();
+    });
+
+    it('returns null for an undefined sessionId', () => {
+      // Arrange
+      const service = new SessionService({
+        secure: true,
+        idleTimeoutMs: 10_000,
+        absoluteTimeoutMs: 100_000,
+      });
+
+      // Act
+      const record = service.validate(undefined);
+
+      // Assert
+      expect(record).toBeNull();
+    });
+  });
+
+  describe('idle expiry', (it) => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+    });
+
+    it('returns null once the idle timeout has elapsed with no activity', () => {
+      // Arrange
+      const service = new SessionService({
+        secure: true,
+        idleTimeoutMs: 1_000,
+        absoluteTimeoutMs: 100_000,
+      });
+      const { sessionId } = service.create(IDENTITY);
+
+      // Act
+      vi.advanceTimersByTime(1_001);
+      const record = service.validate(sessionId);
+
+      // Assert
+      expect(record).toBeNull();
+    });
+  });
+
+  describe('absolute expiry', (it) => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+    });
+
+    it('returns null past the absolute timeout even with continued activity that slides the idle window', () => {
+      // Arrange
+      const service = new SessionService({
+        secure: true,
+        idleTimeoutMs: 1_000,
+        absoluteTimeoutMs: 3_000,
+      });
+      const { sessionId } = service.create(IDENTITY);
+
+      // Act
+      // Repeatedly validate at intervals shorter than idleTimeoutMs, sliding the
+      // idle window forward, until we cross absoluteTimeoutMs.
+      vi.advanceTimersByTime(900);
+      expect(service.validate(sessionId)).not.toBeNull();
+      vi.advanceTimersByTime(900);
+      expect(service.validate(sessionId)).not.toBeNull();
+      vi.advanceTimersByTime(900);
+      expect(service.validate(sessionId)).not.toBeNull();
+      vi.advanceTimersByTime(900);
+      const record = service.validate(sessionId);
+
+      // Assert
+      expect(record).toBeNull();
+    });
+  });
+
+  describe('verifyCsrf', (it) => {
+    it('returns true for the record own csrfToken', () => {
+      // Arrange
+      const service = new SessionService({
+        secure: true,
+        idleTimeoutMs: 10_000,
+        absoluteTimeoutMs: 100_000,
+      });
+      const { sessionId, csrfToken } = service.create(IDENTITY);
+      const record = service.validate(sessionId);
+
+      // Act
+      const result = service.verifyCsrf(record!, csrfToken);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('returns false for a wrong token of the same length', () => {
+      // Arrange
+      const service = new SessionService({
+        secure: true,
+        idleTimeoutMs: 10_000,
+        absoluteTimeoutMs: 100_000,
+      });
+      const { sessionId, csrfToken } = service.create(IDENTITY);
+      const record = service.validate(sessionId);
+      const wrongToken =
+        csrfToken.slice(0, -1) + (csrfToken.at(-1) === 'a' ? 'b' : 'a');
+
+      // Act
+      const result = service.verifyCsrf(record!, wrongToken);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      // Arrange
+      const service = new SessionService({
+        secure: true,
+        idleTimeoutMs: 10_000,
+        absoluteTimeoutMs: 100_000,
+      });
+      const { sessionId } = service.create(IDENTITY);
+      const record = service.validate(sessionId);
+
+      // Act
+      const result = service.verifyCsrf(record!, undefined);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it('returns false for a token of a different length', () => {
+      // Arrange
+      const service = new SessionService({
+        secure: true,
+        idleTimeoutMs: 10_000,
+        absoluteTimeoutMs: 100_000,
+      });
+      const { sessionId, csrfToken } = service.create(IDENTITY);
+      const record = service.validate(sessionId);
+
+      // Act
+      const result = service.verifyCsrf(record!, csrfToken + 'x');
+
+      // Assert
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('destroy', (it) => {
+    it('removes the session so subsequent validate calls return null', () => {
+      // Arrange
+      const service = new SessionService({
+        secure: true,
+        idleTimeoutMs: 10_000,
+        absoluteTimeoutMs: 100_000,
+      });
+      const { sessionId } = service.create(IDENTITY);
+
+      // Act
+      service.destroy(sessionId);
+      const record = service.validate(sessionId);
+
+      // Assert
+      expect(record).toBeNull();
+    });
+
+    it('decrements activeCount', () => {
+      // Arrange
+      const service = new SessionService({
+        secure: true,
+        idleTimeoutMs: 10_000,
+        absoluteTimeoutMs: 100_000,
+      });
+      const { sessionId } = service.create(IDENTITY);
+      const before = service.activeCount;
+
+      // Act
+      service.destroy(sessionId);
+
+      // Assert
+      expect(before).toBe(1);
+      expect(service.activeCount).toBe(0);
+    });
+  });
+});

--- a/apps/admin-server/tests/utils/mock-logger.ts
+++ b/apps/admin-server/tests/utils/mock-logger.ts
@@ -1,0 +1,25 @@
+import { type Mock, vi } from 'vitest';
+
+export interface MockLogger {
+  trace: Mock;
+  debug: Mock;
+  info: Mock;
+  warn: Mock;
+  error: Mock;
+  fatal: Mock;
+  child: Mock;
+}
+
+export function createMockLogger(): MockLogger {
+  const logger: MockLogger = {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}

--- a/apps/admin-server/tests/utils/mock-session-manager.ts
+++ b/apps/admin-server/tests/utils/mock-session-manager.ts
@@ -1,0 +1,100 @@
+import { type MockInstance, vi } from 'vitest';
+
+export interface CapturedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+export interface MockResponseSpec {
+  status: number;
+  /** JSON body; omit for 204. Must satisfy the route's declared response schema. */
+  body?: unknown;
+}
+
+function normalizeHeaders(
+  headers: HeadersInit | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!headers) return out;
+  if (headers instanceof Headers) {
+    headers.forEach((v, k) => (out[k.toLowerCase()] = v));
+  } else if (Array.isArray(headers)) {
+    for (const [k, v] of headers) out[k.toLowerCase()] = v;
+  } else {
+    for (const [k, v] of Object.entries(headers)) out[k.toLowerCase()] = v;
+  }
+  return out;
+}
+
+/**
+ * Intercepts global `fetch` so the Session Manager client talks to a canned
+ * upstream. Records every outgoing request (so tests can assert the injected
+ * `Authorization: Bearer <adminKey>` header) and returns a configurable
+ * response.
+ */
+export class SessionManagerMock {
+  readonly requests: CapturedRequest[] = [];
+  private _handler: (req: CapturedRequest) => MockResponseSpec;
+  private _spy: MockInstance;
+
+  constructor() {
+    this._handler = () => ({
+      status: 200,
+      body: { items: [], nextCursor: null },
+    });
+    this._spy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(
+        (input: string | URL | Request, init?: RequestInit) => {
+          const url =
+            typeof input === 'string'
+              ? input
+              : input instanceof URL
+                ? input.href
+                : input.url;
+          // The client always sends a JSON string body (JSON.stringify).
+          const rawBody =
+            typeof init?.body === 'string' ? init.body : undefined;
+          const captured: CapturedRequest = {
+            url,
+            method: init?.method ?? 'GET',
+            headers: normalizeHeaders(init?.headers),
+            body:
+              rawBody != null ? (JSON.parse(rawBody) as unknown) : undefined,
+          };
+          this.requests.push(captured);
+
+          const spec = this._handler(captured);
+          if (spec.status === 204) {
+            return Promise.resolve(new Response(null, { status: 204 }));
+          }
+          return Promise.resolve(
+            new Response(JSON.stringify(spec.body ?? null), {
+              status: spec.status,
+              headers: { 'content-type': 'application/json' },
+            }),
+          );
+        },
+      );
+  }
+
+  /** Route every upstream call to the given response. */
+  respondWith(spec: MockResponseSpec): void {
+    this._handler = () => spec;
+  }
+
+  /** Custom per-request handler (e.g. branch on url/method). */
+  setHandler(handler: (req: CapturedRequest) => MockResponseSpec): void {
+    this._handler = handler;
+  }
+
+  get lastRequest(): CapturedRequest | undefined {
+    return this.requests.at(-1);
+  }
+
+  restore(): void {
+    this._spy.mockRestore();
+  }
+}

--- a/apps/admin-server/tests/utils/use-db.ts
+++ b/apps/admin-server/tests/utils/use-db.ts
@@ -1,0 +1,43 @@
+import { Kysely, PostgresDialect, sql } from 'kysely';
+import pg from 'pg';
+import { afterAll, afterEach, beforeAll, inject } from 'vitest';
+
+import type { AdminDB } from '#src/db/admin-db.types.js';
+
+interface DbCtx {
+  db: Kysely<AdminDB>;
+}
+
+/**
+ * Kysely client against the test postgres for asserting audit rows. Truncates
+ * `admin_audit_log` after each test. Register AFTER `useServer()` so the table
+ * (created by the server's onReady migration) already exists.
+ */
+export function useDb(): DbCtx {
+  const ctx: DbCtx = { db: null as unknown as Kysely<AdminDB> };
+
+  beforeAll(() => {
+    const cfg = inject('dbConfig');
+    ctx.db = new Kysely<AdminDB>({
+      dialect: new PostgresDialect({
+        pool: new pg.Pool({
+          host: cfg.dbHost,
+          port: cfg.dbPort,
+          database: cfg.dbName,
+          user: cfg.dbUser,
+          password: cfg.dbPassword,
+        }),
+      }),
+    });
+  });
+
+  afterEach(async () => {
+    await sql`TRUNCATE admin_audit_log`.execute(ctx.db);
+  });
+
+  afterAll(async () => {
+    await ctx.db.destroy();
+  });
+
+  return ctx;
+}

--- a/apps/admin-server/tests/utils/use-server.ts
+++ b/apps/admin-server/tests/utils/use-server.ts
@@ -1,0 +1,137 @@
+import { afterAll, beforeAll, inject } from 'vitest';
+
+import { LogLevel } from '@scribear/base-fastify-server';
+
+import type { AppConfig } from '#src/app-config/app-config.js';
+import createServer from '#src/server/create-server.js';
+
+export const TEST_ADMIN_KEY = 'test-admin-key';
+export const TEST_USERNAME = 'engrit';
+export const TEST_PASSWORD = 'super secret pw!';
+export const TEST_LOCAL_CREDENTIALS = `${TEST_USERNAME} ${TEST_PASSWORD}`;
+export const TEST_SM_BASE_URL = 'http://session-manager.test';
+export const TEST_COOKIE_SECRET =
+  'test-cookie-secret-at-least-32-characters-long!!';
+
+export interface TestAppConfigOverrides {
+  baseConfig?: Partial<AppConfig['baseConfig']>;
+  sessionManagerGatewayConfig?: Partial<
+    AppConfig['sessionManagerGatewayConfig']
+  >;
+  sessionConfig?: Partial<AppConfig['sessionConfig']>;
+  localAuthConfig?: Partial<AppConfig['localAuthConfig']>;
+  azureAuthConfig?: Partial<AppConfig['azureAuthConfig']>;
+  rateLimitConfig?: Partial<AppConfig['rateLimitConfig']>;
+  dbClientConfig?: Partial<AppConfig['dbClientConfig']>;
+  cookieSecret?: string;
+}
+
+/**
+ * Builds an `AppConfig` for integration tests, wired to the postgres container
+ * from `tests/integration/global-setup.ts`. Must be called inside a vitest hook.
+ */
+export function buildTestAppConfig(
+  overrides: TestAppConfigOverrides = {},
+): AppConfig {
+  const dbConfig = inject('dbConfig');
+
+  return {
+    baseConfig: {
+      isDevelopment: true,
+      logLevel: LogLevel.SILENT,
+      port: 0,
+      host: '127.0.0.1',
+      ...overrides.baseConfig,
+    },
+    sessionManagerGatewayConfig: {
+      adminApiKey: TEST_ADMIN_KEY,
+      sessionManagerBaseUrl: TEST_SM_BASE_URL,
+      ...overrides.sessionManagerGatewayConfig,
+    },
+    sessionConfig: {
+      // Non-secure so the cookie is sent in `inject` (no TLS in tests).
+      secure: false,
+      idleTimeoutMs: 60 * 60 * 1000,
+      absoluteTimeoutMs: 8 * 60 * 60 * 1000,
+      ...overrides.sessionConfig,
+    },
+    localAuthConfig: {
+      credentials: TEST_LOCAL_CREDENTIALS,
+      ...overrides.localAuthConfig,
+    },
+    azureAuthConfig: {
+      tenantId: '',
+      clientId: '',
+      clientSecret: '',
+      redirectUri: '',
+      allowedGroup: '',
+      ...overrides.azureAuthConfig,
+    },
+    rateLimitConfig: {
+      globalMax: 1000,
+      globalWindowMs: 60_000,
+      loginMax: 5,
+      loginWindowMs: 60_000,
+      ...overrides.rateLimitConfig,
+    },
+    dbClientConfig: { ...dbConfig, ...overrides.dbClientConfig },
+    cookieSecret: overrides.cookieSecret ?? TEST_COOKIE_SECRET,
+  } as unknown as AppConfig;
+}
+
+interface ServerCtx {
+  fastify: Awaited<ReturnType<typeof createServer>>['fastify'];
+}
+
+/**
+ * Boots an in-process admin BFF for integration tests, wired to the postgres
+ * container spun up by `tests/integration/global-setup.ts`.
+ */
+export function useServer(overrides: TestAppConfigOverrides = {}): ServerCtx {
+  const ctx: ServerCtx = {
+    fastify: null as unknown as ServerCtx['fastify'],
+  };
+
+  beforeAll(async () => {
+    const config = buildTestAppConfig(overrides);
+    const { fastify } = await createServer(config);
+    await fastify.ready();
+    ctx.fastify = fastify;
+  });
+
+  afterAll(async () => {
+    await ctx.fastify.close();
+  });
+
+  return ctx;
+}
+
+/**
+ * Log in and return the raw `set-cookie` header value(s) plus the CSRF token
+ * from the response body, for use in subsequent authenticated requests.
+ */
+export async function login(
+  fastify: ServerCtx['fastify'],
+  username = TEST_USERNAME,
+  password = TEST_PASSWORD,
+): Promise<{ statusCode: number; cookie: string; csrfToken: string }> {
+  const res = await fastify.inject({
+    method: 'POST',
+    url: '/api/admin/v1/auth/login',
+    payload: { username, password },
+  });
+
+  const setCookie = res.headers['set-cookie'];
+  const cookie = Array.isArray(setCookie)
+    ? (setCookie[0] ?? '')
+    : (setCookie ?? '');
+  // Only the name=value part is needed for the request `cookie` header.
+  const cookiePair = cookie.split(';')[0] ?? '';
+
+  let csrfToken = '';
+  if (res.statusCode === 200) {
+    csrfToken = res.json<{ data: { csrfToken: string } }>().data.csrfToken;
+  }
+
+  return { statusCode: res.statusCode, cookie: cookiePair, csrfToken };
+}

--- a/apps/admin-server/tests/vitest.d.ts
+++ b/apps/admin-server/tests/vitest.d.ts
@@ -1,0 +1,7 @@
+import type { AdminDbClientConfig } from '#src/db/admin-db-client.js';
+
+declare module 'vitest' {
+  export interface ProvidedContext {
+    dbConfig: AdminDbClientConfig;
+  }
+}

--- a/apps/admin-server/tsconfig.json
+++ b/apps/admin-server/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "paths": {
+      "#src/*": [
+        "./src/*"
+      ],
+      "#tests/*": [
+        "./tests/*"
+      ]
+    }
+  },
+  "include": [
+    "src",
+    "tests"
+  ],
+  "references": [
+    {
+      "path": "../../libs/base-fastify-server"
+    },
+    {
+      "path": "../../libs/schemas/base-schema"
+    },
+    {
+      "path": "../../libs/schemas/session-manager-schema"
+    },
+    {
+      "path": "../../libs/clients/base-api-client"
+    },
+    {
+      "path": "../../libs/clients/session-manager-client"
+    }
+  ]
+}

--- a/apps/admin-server/vitest.config.ts
+++ b/apps/admin-server/vitest.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import sharedConfig from '../../vitest.shared.js';
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      coverage: {
+        // Process entrypoint: bootstraps and starts the server. It has no unit-
+        // testable logic and is exercised by the integration suite, so exclude
+        // it rather than report it as uncovered.
+        exclude: ['src/index.ts'],
+      },
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'unit',
+            environment: 'node',
+            exclude: ['tests/integration/**'],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: 'integration',
+            environment: 'node',
+            exclude: ['tests/unit/**'],
+            fileParallelism: false,
+            globalSetup: ['./tests/integration/global-setup.ts'],
+          },
+        },
+      ],
+    },
+  }),
+);

--- a/apps/admin-webapp/Dockerfile
+++ b/apps/admin-webapp/Dockerfile
@@ -1,0 +1,55 @@
+# Build in the root directory using:
+#   docker build -f apps/admin-webapp/Dockerfile .
+
+ARG NODE_VERSION=24.10.0
+
+FROM node:${NODE_VERSION} AS package-jsons
+
+WORKDIR /app
+
+COPY . .
+
+RUN find . -type f ! -name "package*.json" -delete && \
+  find . -empty -type d -delete
+
+FROM node:${NODE_VERSION} AS build-env
+
+WORKDIR /app
+
+COPY --from=package-jsons /app/ .
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build --workspace=@scribear/admin-webapp
+
+FROM nginx:1.29.7-alpine3.23
+
+WORKDIR /usr/share/nginx/html
+
+RUN cat <<'EOF' > /etc/nginx/conf.d/default.conf
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location * {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location = /healthcheck {
+    access_log off;
+    add_header Content-Type text/plain;
+    return 200 'ok';
+  }
+}
+EOF
+
+COPY --from=build-env /app/apps/admin-webapp/dist/ ./
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --start-interval=1s --retries=3 CMD wget --quiet --tries=1 --spider http://127.0.0.1/healthcheck || exit 1

--- a/apps/admin-webapp/eslint.config.js
+++ b/apps/admin-webapp/eslint.config.js
@@ -1,0 +1,34 @@
+import eslintReact from '@eslint-react/eslint-plugin';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import { defineConfig } from 'eslint/config';
+
+import baseConfig from '../../eslint.config.js';
+
+export default defineConfig([
+  ...baseConfig,
+  {
+    // Only apply React rules to React component files
+    files: ['**/*.{ts,mts,cts,tsx}'],
+    extends: [
+      reactHooks.configs.flat.recommended,
+      reactRefresh.configs.vite,
+      eslintReact.configs['recommended-type-checked'],
+    ],
+    rules: {
+      /**
+       * @see https://redux.js.org/usage/usage-with-typescript#use-typed-hooks-in-components
+       * Restrict use of useSelector and useDispatch in favor of useAppDispatch and useAppSelector
+       */
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          name: 'react-redux',
+          importNames: ['useSelector', 'useDispatch'],
+          message:
+            'Use typed hooks `useAppDispatch` and `useAppSelector` instead.',
+        },
+      ],
+    },
+  },
+]);

--- a/apps/admin-webapp/index.html
+++ b/apps/admin-webapp/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ScribeAR Admin</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
+</html>

--- a/apps/admin-webapp/package.json
+++ b/apps/admin-webapp/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@scribear/admin-webapp",
+  "version": "0.0.0",
+  "description": "",
+  "author": "scribear",
+  "main": "dist/src/index.js",
+  "type": "module",
+  "imports": {
+    "#src/*": "./dist/src/*",
+    "#tests/*": "./dist/tests/*"
+  },
+  "scripts": {
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "dev": "vite",
+    "format": "prettier --check ./src",
+    "format:fix": "prettier --write ./src",
+    "lint": "eslint ./src",
+    "lint:fix": "eslint ./src --fix"
+  },
+  "dependencies": {
+    "@emotion/react": "11.14.0",
+    "@emotion/styled": "11.14.1",
+    "@fontsource/roboto": "5.2.10",
+    "@mui/icons-material": "7.3.8",
+    "@mui/material": "7.3.8",
+    "react": "19.2.5",
+    "react-dom": "19.2.5",
+    "react-error-boundary": "6.1.1",
+    "react-router-dom": "7.18.1"
+  },
+  "devDependencies": {
+    "@eslint-react/eslint-plugin": "2.13.0",
+    "eslint-plugin-react-hooks": "7.0.1",
+    "eslint-plugin-react-refresh": "0.5.2"
+  }
+}

--- a/apps/admin-webapp/src/app/app-provider.tsx
+++ b/apps/admin-webapp/src/app/app-provider.tsx
@@ -1,0 +1,36 @@
+import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider } from '@mui/material/styles';
+
+import '@fontsource/roboto/300.css';
+import '@fontsource/roboto/400.css';
+import '@fontsource/roboto/500.css';
+import '@fontsource/roboto/700.css';
+import { ErrorBoundary } from 'react-error-boundary';
+import { BrowserRouter } from 'react-router-dom';
+
+import { MainErrorFallback } from '#src/components/main-error-fallback';
+import { BASE_THEME } from '#src/config/base-theme';
+import { AuthProvider } from '#src/features/auth/auth-provider';
+import { ToastProvider } from '#src/lib/toast-provider';
+
+// Served under /admin/ in production; import.meta.env.BASE_URL is '/admin/'.
+const BASENAME = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
+
+/**
+ * Top-level provider composition: MUI theme, error boundary, toast host,
+ * router, and the auth session.
+ */
+export const AppProvider = ({ children }: React.PropsWithChildren) => {
+  return (
+    <ThemeProvider theme={BASE_THEME}>
+      <CssBaseline />
+      <ErrorBoundary FallbackComponent={MainErrorFallback}>
+        <ToastProvider>
+          <BrowserRouter basename={BASENAME}>
+            <AuthProvider>{children}</AuthProvider>
+          </BrowserRouter>
+        </ToastProvider>
+      </ErrorBoundary>
+    </ThemeProvider>
+  );
+};

--- a/apps/admin-webapp/src/app/app.tsx
+++ b/apps/admin-webapp/src/app/app.tsx
@@ -1,0 +1,14 @@
+import { AppProvider } from './app-provider';
+import { AppRoutes } from './router';
+
+/**
+ * Root application component. Wraps the routed pages in the top-level provider
+ * composition (theme, error boundary, toasts, router, auth).
+ */
+export const App = () => {
+  return (
+    <AppProvider>
+      <AppRoutes />
+    </AppProvider>
+  );
+};

--- a/apps/admin-webapp/src/app/router.tsx
+++ b/apps/admin-webapp/src/app/router.tsx
@@ -1,0 +1,37 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+
+import { AppLayout } from '#src/components/app-layout';
+import { RequireAuth } from '#src/components/require-auth';
+import { AuditPage } from '#src/features/audit/audit-page';
+import { LoginPage } from '#src/features/auth/login-page';
+import { DashboardPage } from '#src/features/dashboard/dashboard-page';
+import { DeviceDetailPage } from '#src/features/devices/device-detail-page';
+import { DevicesListPage } from '#src/features/devices/devices-list-page';
+import { KioskWizardPage } from '#src/features/kiosk-setup/kiosk-wizard-page';
+import { RoomDetailPage } from '#src/features/rooms/room-detail-page';
+import { RoomsListPage } from '#src/features/rooms/rooms-list-page';
+import { RoomSchedulingPage } from '#src/features/scheduling/room-scheduling-page';
+import { SessionDetailPage } from '#src/features/sessions/session-detail-page';
+
+export const AppRoutes = () => (
+  <Routes>
+    <Route path="/login" element={<LoginPage />} />
+    <Route element={<RequireAuth />}>
+      <Route element={<AppLayout />}>
+        <Route path="/" element={<DashboardPage />} />
+        <Route path="/rooms" element={<RoomsListPage />} />
+        <Route path="/rooms/:roomUid" element={<RoomDetailPage />} />
+        <Route
+          path="/rooms/:roomUid/scheduling"
+          element={<RoomSchedulingPage />}
+        />
+        <Route path="/devices" element={<DevicesListPage />} />
+        <Route path="/devices/:deviceUid" element={<DeviceDetailPage />} />
+        <Route path="/sessions/:sessionUid" element={<SessionDetailPage />} />
+        <Route path="/kiosk-setup" element={<KioskWizardPage />} />
+        <Route path="/audit" element={<AuditPage />} />
+      </Route>
+    </Route>
+    <Route path="*" element={<Navigate to="/" replace />} />
+  </Routes>
+);

--- a/apps/admin-webapp/src/components/activation-code-display.tsx
+++ b/apps/admin-webapp/src/components/activation-code-display.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import DoneIcon from '@mui/icons-material/Done';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Paper from '@mui/material/Paper';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+
+export interface ActivationCodeDisplayProps {
+  code: string;
+  /** ISO-8601 expiry timestamp. */
+  expiry: string;
+}
+
+function formatRemaining(ms: number): string {
+  if (ms <= 0) return 'Expired';
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes)}:${seconds.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Big, copyable activation code with a live expiry countdown. Shown after
+ * registering/re-registering a device so an operator can type it on the kiosk.
+ */
+export const ActivationCodeDisplay = ({
+  code,
+  expiry,
+}: ActivationCodeDisplayProps) => {
+  const [remainingMs, setRemainingMs] = useState(
+    () => new Date(expiry).getTime() - Date.now(),
+  );
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const tick = () => {
+      setRemainingMs(new Date(expiry).getTime() - Date.now());
+    };
+    tick();
+    const timer = setInterval(tick, 1000);
+    return () => {
+      clearInterval(timer);
+    };
+  }, [expiry]);
+
+  const handleCopy = () => {
+    void navigator.clipboard
+      .writeText(code)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => {
+          setCopied(false);
+        }, 2000);
+      })
+      .catch(() => {
+        /* clipboard denied — ignore */
+      });
+  };
+
+  const expired = remainingMs <= 0;
+
+  return (
+    <Paper variant="outlined" sx={{ p: 3, textAlign: 'center' }}>
+      <Typography variant="overline" color="text.secondary">
+        Activation code
+      </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 1,
+        }}
+      >
+        <Typography
+          variant="h3"
+          component="p"
+          sx={{
+            fontFamily: 'monospace',
+            letterSpacing: 4,
+            color: expired ? 'text.disabled' : 'text.primary',
+          }}
+        >
+          {code}
+        </Typography>
+        <Tooltip title={copied ? 'Copied' : 'Copy'}>
+          <IconButton onClick={handleCopy} aria-label="Copy activation code">
+            {copied ? <DoneIcon color="success" /> : <ContentCopyIcon />}
+          </IconButton>
+        </Tooltip>
+      </Box>
+      <Typography
+        variant="body2"
+        color={expired ? 'error' : 'text.secondary'}
+        sx={{ mt: 1 }}
+      >
+        {expired
+          ? 'This code has expired.'
+          : `Expires in ${formatRemaining(remainingMs)}`}
+      </Typography>
+    </Paper>
+  );
+};

--- a/apps/admin-webapp/src/components/app-layout.tsx
+++ b/apps/admin-webapp/src/components/app-layout.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+
+import DevicesIcon from '@mui/icons-material/Devices';
+import HistoryIcon from '@mui/icons-material/History';
+import LogoutIcon from '@mui/icons-material/Logout';
+import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
+import SpaceDashboardIcon from '@mui/icons-material/SpaceDashboard';
+import TabletIcon from '@mui/icons-material/Tablet';
+import AppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import Drawer from '@mui/material/Drawer';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+
+import { NavLink, Outlet } from 'react-router-dom';
+
+import { HealthIndicator } from '#src/components/health-indicator';
+import { useAuth } from '#src/features/auth/auth-context';
+
+const DRAWER_WIDTH = 232;
+
+const NAV_ITEMS = [
+  { label: 'Dashboard', to: '/', icon: <SpaceDashboardIcon /> },
+  { label: 'Rooms', to: '/rooms', icon: <MeetingRoomIcon /> },
+  { label: 'Devices', to: '/devices', icon: <DevicesIcon /> },
+  { label: 'Set up a kiosk', to: '/kiosk-setup', icon: <TabletIcon /> },
+  { label: 'Audit log', to: '/audit', icon: <HistoryIcon /> },
+];
+
+/**
+ * Authenticated app shell: top bar (title, health, sign out) + side nav +
+ * routed content area.
+ */
+export const AppLayout = () => {
+  const { identity, logout } = useAuth();
+  const [signingOut, setSigningOut] = useState(false);
+
+  const handleSignOut = () => {
+    setSigningOut(true);
+    void logout().finally(() => {
+      setSigningOut(false);
+    });
+  };
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+      <AppBar
+        position="fixed"
+        sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
+      >
+        <Toolbar sx={{ gap: 2 }}>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+            ScribeAR Admin
+          </Typography>
+          <HealthIndicator />
+          <Typography variant="body2" sx={{ opacity: 0.85 }}>
+            {identity?.displayName ?? ''}
+          </Typography>
+          <Button
+            color="inherit"
+            startIcon={<LogoutIcon />}
+            onClick={handleSignOut}
+            disabled={signingOut}
+          >
+            Sign out
+          </Button>
+        </Toolbar>
+      </AppBar>
+
+      <Drawer
+        variant="permanent"
+        sx={{
+          width: DRAWER_WIDTH,
+          flexShrink: 0,
+          [`& .MuiDrawer-paper`]: {
+            width: DRAWER_WIDTH,
+            boxSizing: 'border-box',
+          },
+        }}
+      >
+        <Toolbar />
+        <Divider />
+        <List>
+          {NAV_ITEMS.map((item) => (
+            <ListItemButton
+              key={item.to}
+              component={NavLink}
+              to={item.to}
+              end={item.to === '/'}
+              sx={{
+                '&.active': {
+                  bgcolor: 'action.selected',
+                  borderRight: 3,
+                  borderColor: 'primary.main',
+                },
+              }}
+            >
+              <ListItemIcon>{item.icon}</ListItemIcon>
+              <ListItemText primary={item.label} />
+            </ListItemButton>
+          ))}
+        </List>
+      </Drawer>
+
+      <Box component="main" sx={{ flexGrow: 1, p: 3, width: 0 }}>
+        <Toolbar />
+        <Outlet />
+      </Box>
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/components/confirm-dialog.tsx
+++ b/apps/admin-webapp/src/components/confirm-dialog.tsx
@@ -1,0 +1,51 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  confirmColor?: 'primary' | 'error';
+  loading?: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+/** Reusable confirmation dialog for destructive/irreversible actions. */
+export const ConfirmDialog = ({
+  open,
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  confirmColor = 'primary',
+  loading = false,
+  onConfirm,
+  onClose,
+}: ConfirmDialogProps) => {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>{message}</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button
+          onClick={onConfirm}
+          color={confirmColor}
+          variant="contained"
+          disabled={loading}
+        >
+          {confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/apps/admin-webapp/src/components/health-indicator.tsx
+++ b/apps/admin-webapp/src/components/health-indicator.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+
+import CircleIcon from '@mui/icons-material/Circle';
+import Chip from '@mui/material/Chip';
+import Tooltip from '@mui/material/Tooltip';
+
+import type { HealthReport } from '#src/lib/admin-api';
+import { adminApi } from '#src/lib/admin-api';
+
+const POLL_MS = 30_000;
+
+function overall(report: HealthReport | null): {
+  color: 'success' | 'warning' | 'error' | 'default';
+  label: string;
+} {
+  if (!report) return { color: 'default', label: 'Unknown' };
+  const ok =
+    report.bff === 'ok' &&
+    report.database === 'ok' &&
+    report.sessionManager === 'ok';
+  if (ok) return { color: 'success', label: 'Healthy' };
+  if (report.sessionManager === 'unreachable' || report.database === 'fail')
+    return { color: 'error', label: 'Degraded' };
+  return { color: 'warning', label: 'Degraded' };
+}
+
+/**
+ * Compact health chip that polls the BFF `/health` rollup. Hover for detail.
+ */
+export const HealthIndicator = () => {
+  const [report, setReport] = useState<HealthReport | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const poll = () => {
+      adminApi
+        .health()
+        .then((r) => {
+          if (!cancelled) setReport(r);
+        })
+        .catch(() => {
+          if (!cancelled) setReport(null);
+        });
+    };
+    poll();
+    const timer = setInterval(poll, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, []);
+
+  const { color, label } = overall(report);
+  const tip = report
+    ? `BFF: ${report.bff} · DB: ${report.database} · Session Manager: ${report.sessionManager} (${String(report.sessionManagerLatencyMs)}ms)`
+    : 'Health unknown';
+
+  return (
+    <Tooltip title={tip}>
+      <Chip
+        size="small"
+        color={color}
+        icon={<CircleIcon sx={{ fontSize: 12 }} />}
+        label={label}
+        variant="outlined"
+        sx={{ color: 'inherit', borderColor: 'currentColor' }}
+      />
+    </Tooltip>
+  );
+};

--- a/apps/admin-webapp/src/components/main-error-fallback.tsx
+++ b/apps/admin-webapp/src/components/main-error-fallback.tsx
@@ -1,0 +1,49 @@
+import Refresh from '@mui/icons-material/Refresh';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+
+/**
+ * Full-page error fallback that prompts the user to refresh.
+ */
+export const MainErrorFallback = () => {
+  const reloadPage = () => {
+    window.location.reload();
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        flexDirection: 'column',
+        height: '100vh',
+        width: '100vw',
+      }}
+    >
+      <Paper
+        sx={{
+          p: 3,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          flexDirection: 'column',
+        }}
+      >
+        <Typography>
+          An unexpected error occurred. Try refreshing the page.
+        </Typography>
+        <Button
+          startIcon={<Refresh />}
+          onClick={() => {
+            reloadPage();
+          }}
+        >
+          Refresh Page
+        </Button>
+      </Paper>
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/components/require-auth.tsx
+++ b/apps/admin-webapp/src/components/require-auth.tsx
@@ -1,0 +1,35 @@
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+
+import { Navigate, Outlet } from 'react-router-dom';
+
+import { useAuth } from '#src/features/auth/auth-context';
+
+/**
+ * Route guard. Shows a spinner while the session is resolving, redirects to
+ * /login when anonymous, and renders the protected routes when authenticated.
+ */
+export const RequireAuth = () => {
+  const { status } = useAuth();
+
+  if (status === 'loading') {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100vh',
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (status === 'anon') {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <Outlet />;
+};

--- a/apps/admin-webapp/src/config/base-theme.ts
+++ b/apps/admin-webapp/src/config/base-theme.ts
@@ -1,0 +1,18 @@
+import type { ThemeOptions } from '@mui/material/styles';
+import { createTheme } from '@mui/material/styles';
+
+/**
+ * Default MUI theme for the admin webapp placeholder. Uses a plain MUI
+ * palette since no shared theme-customization store is wired up yet.
+ */
+export const BASE_THEME: ThemeOptions = createTheme({
+  palette: {
+    background: {
+      default: '#f5f5f5',
+      paper: '#ffffff',
+    },
+    primary: {
+      main: '#1976d2',
+    },
+  },
+});

--- a/apps/admin-webapp/src/features/audit/audit-page.tsx
+++ b/apps/admin-webapp/src/features/audit/audit-page.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useState } from 'react';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Select from '@mui/material/Select';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+
+import type { AuditRow } from '#src/lib/admin-api';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { useToast } from '#src/lib/toast-context';
+
+const LIMIT_OPTIONS = [50, 100, 200] as const;
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof ApiError ? err.message : fallback;
+}
+
+export const AuditPage = () => {
+  const { showError } = useToast();
+  const [items, setItems] = useState<AuditRow[]>([]);
+  const [limit, setLimit] = useState<number>(50);
+  const [loading, setLoading] = useState(true);
+  const [misconfigured, setMisconfigured] = useState(false);
+
+  useEffect(() => {
+    const alive = { current: true };
+    setLoading(true);
+    adminApi
+      .listAudit(limit)
+      .then((res) => {
+        if (!alive.current) return;
+        setMisconfigured(false);
+        setItems(res.items);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else {
+          showError(errorMessage(err, 'Failed to load audit log.'));
+        }
+      })
+      .finally(() => {
+        if (alive.current) setLoading(false);
+      });
+    return () => {
+      alive.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [limit]);
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 2,
+        }}
+      >
+        <Typography variant="h5" component="h1">
+          Audit log
+        </Typography>
+        <FormControl size="small" sx={{ minWidth: 120 }}>
+          <InputLabel id="audit-limit-label">Rows</InputLabel>
+          <Select
+            labelId="audit-limit-label"
+            label="Rows"
+            value={String(limit)}
+            onChange={(e: SelectChangeEvent) => {
+              setLimit(Number(e.target.value));
+            }}
+          >
+            {LIMIT_OPTIONS.map((n) => (
+              <MenuItem key={n} value={String(n)}>
+                {n}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+
+      {misconfigured && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Admin backend misconfiguration — an operator must check the
+          server&apos;s ADMIN_API_KEY.
+        </Alert>
+      )}
+
+      <TableContainer component={Paper}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Time</TableCell>
+              <TableCell>Actor</TableCell>
+              <TableCell>Action</TableCell>
+              <TableCell>Target</TableCell>
+              <TableCell>Result</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Request ID</TableCell>
+              <TableCell>Params</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={8} align="center" sx={{ py: 4 }}>
+                  <CircularProgress size={28} />
+                </TableCell>
+              </TableRow>
+            ) : items.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8} align="center" sx={{ py: 4 }}>
+                  <Typography color="text.secondary">
+                    No audit entries found.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              items.map((row) => {
+                const isSuccess = row.result.toLowerCase() === 'success';
+                return (
+                  <TableRow key={row.id}>
+                    <TableCell>
+                      {new Date(row.createdAt).toLocaleString()}
+                    </TableCell>
+                    <TableCell>
+                      {row.actorSubject} ({row.actorProvider})
+                    </TableCell>
+                    <TableCell>{row.action}</TableCell>
+                    <TableCell>{row.target ?? '—'}</TableCell>
+                    <TableCell>
+                      <Chip
+                        size="small"
+                        label={row.result}
+                        color={isSuccess ? 'success' : 'error'}
+                      />
+                    </TableCell>
+                    <TableCell>{row.statusCode ?? '—'}</TableCell>
+                    <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                      {row.requestId ?? '—'}
+                    </TableCell>
+                    <TableCell
+                      sx={{
+                        fontFamily: 'monospace',
+                        fontSize: 12,
+                        maxWidth: 320,
+                        overflowWrap: 'anywhere',
+                      }}
+                    >
+                      {JSON.stringify(row.paramsSummary)}
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/features/auth/auth-context.ts
+++ b/apps/admin-webapp/src/features/auth/auth-context.ts
@@ -1,0 +1,22 @@
+import { createContext, use } from 'react';
+
+import type { AuthConfig, Identity } from '#src/lib/admin-api';
+
+export type AuthStatus = 'loading' | 'authed' | 'anon';
+
+export interface AuthContextValue {
+  status: AuthStatus;
+  identity: Identity | null;
+  /** Which providers the BFF has enabled (for the login page). */
+  config: AuthConfig | null;
+  login: (username: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function useAuth(): AuthContextValue {
+  const ctx = use(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within an AuthProvider.');
+  return ctx;
+}

--- a/apps/admin-webapp/src/features/auth/auth-provider.tsx
+++ b/apps/admin-webapp/src/features/auth/auth-provider.tsx
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import type { AuthConfig, Identity } from '#src/lib/admin-api';
+import { adminApi } from '#src/lib/admin-api';
+
+import { AuthContext, type AuthStatus } from './auth-context';
+
+/**
+ * Owns the admin session state. On mount it loads which providers are enabled
+ * and probes `/auth/me`; a 401 anywhere (session expiry) flips the app to
+ * anonymous so `RequireAuth` routes to /login. The CSRF token is handed to the
+ * API client so mutations carry it.
+ */
+export const AuthProvider = ({ children }: React.PropsWithChildren) => {
+  const [status, setStatus] = useState<AuthStatus>('loading');
+  const [identity, setIdentity] = useState<Identity | null>(null);
+  const [config, setConfig] = useState<AuthConfig | null>(null);
+
+  useEffect(() => {
+    // Object flag (not a plain boolean) so its mutation in the cleanup closure
+    // is visible to flow analysis.
+    const alive = { current: true };
+
+    adminApi.setOnUnauthorized(() => {
+      adminApi.setCsrfToken('');
+      setIdentity(null);
+      setStatus('anon');
+    });
+
+    void (async () => {
+      const cfg = await adminApi.getAuthConfig().catch(() => null);
+      if (alive.current && cfg) setConfig(cfg);
+
+      try {
+        const info = await adminApi.me();
+        if (!alive.current) return;
+        adminApi.setCsrfToken(info.csrfToken);
+        setIdentity(info.identity);
+        setStatus('authed');
+      } catch {
+        if (alive.current) setStatus('anon');
+      }
+    })();
+
+    return () => {
+      alive.current = false;
+    };
+  }, []);
+
+  const login = useCallback(async (username: string, password: string) => {
+    const info = await adminApi.login(username, password);
+    adminApi.setCsrfToken(info.csrfToken);
+    setIdentity(info.identity);
+    setStatus('authed');
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      await adminApi.logout();
+    } finally {
+      adminApi.setCsrfToken('');
+      setIdentity(null);
+      setStatus('anon');
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({ status, identity, config, login, logout }),
+    [status, identity, config, login, logout],
+  );
+
+  return <AuthContext value={value}>{children}</AuthContext>;
+};

--- a/apps/admin-webapp/src/features/auth/login-page.tsx
+++ b/apps/admin-webapp/src/features/auth/login-page.tsx
@@ -1,0 +1,128 @@
+import { type SyntheticEvent, useState } from 'react';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Divider from '@mui/material/Divider';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+import { Navigate, useNavigate } from 'react-router-dom';
+
+import { useAuth } from '#src/features/auth/auth-context';
+import { ApiError } from '#src/lib/api-error';
+
+export const LoginPage = () => {
+  const { status, config, login } = useAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (status === 'authed') {
+    return <Navigate to="/" replace />;
+  }
+
+  const handleSubmit = (e: SyntheticEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    void login(username, password)
+      .then(() => {
+        void navigate('/', { replace: true });
+      })
+      .catch((err: unknown) => {
+        setError(
+          err instanceof ApiError
+            ? err.message
+            : 'Sign in failed. Please try again.',
+        );
+      })
+      .finally(() => {
+        setSubmitting(false);
+      });
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minHeight: '100vh',
+        p: 2,
+      }}
+    >
+      <Card sx={{ width: '100%', maxWidth: 400 }}>
+        <CardContent sx={{ p: 4 }}>
+          <Typography variant="h5" component="h1" gutterBottom>
+            ScribeAR Admin
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+            Sign in to manage rooms, devices, and kiosks.
+          </Typography>
+
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          {config?.local && (
+            <Box component="form" onSubmit={handleSubmit} noValidate>
+              <TextField
+                label="Username"
+                value={username}
+                onChange={(e) => {
+                  setUsername(e.target.value);
+                }}
+                fullWidth
+                margin="normal"
+                autoComplete="username"
+                autoFocus
+              />
+              <TextField
+                label="Password"
+                type="password"
+                value={password}
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                }}
+                fullWidth
+                margin="normal"
+                autoComplete="current-password"
+              />
+              <Button
+                type="submit"
+                variant="contained"
+                fullWidth
+                size="large"
+                disabled={submitting || username === '' || password === ''}
+                sx={{ mt: 2 }}
+              >
+                {submitting ? 'Signing in…' : 'Sign in'}
+              </Button>
+            </Box>
+          )}
+
+          {config?.local && config.sso && <Divider sx={{ my: 2 }}>or</Divider>}
+
+          {config?.sso && (
+            <Button variant="outlined" fullWidth size="large" disabled>
+              Sign in with Illinois (Azure AD)
+            </Button>
+          )}
+
+          {config && !config.local && !config.sso && (
+            <Alert severity="warning">
+              No sign-in methods are configured. Contact an operator.
+            </Alert>
+          )}
+        </CardContent>
+      </Card>
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/features/dashboard/dashboard-page.tsx
+++ b/apps/admin-webapp/src/features/dashboard/dashboard-page.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState } from 'react';
+
+import AddIcon from '@mui/icons-material/Add';
+import DevicesIcon from '@mui/icons-material/Devices';
+import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
+import TabletIcon from '@mui/icons-material/Tablet';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
+
+import { useNavigate } from 'react-router-dom';
+
+import type { HealthReport } from '#src/lib/admin-api';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
+import { useToast } from '#src/lib/toast-context';
+
+type HealthColor = 'success' | 'warning' | 'error' | 'default';
+
+function statusColor(status: string): HealthColor {
+  if (status === 'ok') return 'success';
+  if (status === 'degraded') return 'warning';
+  if (status === 'unreachable' || status === 'fail') return 'error';
+  return 'default';
+}
+
+interface HealthTileProps {
+  label: string;
+  status: string;
+  detail?: string;
+}
+
+const HealthTile = ({ label, status, detail }: HealthTileProps) => (
+  <Grid size={{ xs: 12, sm: 4 }}>
+    <Card>
+      <CardContent>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          {label}
+        </Typography>
+        <Chip size="small" label={status} color={statusColor(status)} />
+        {detail !== undefined && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: 'block', mt: 1 }}
+          >
+            {detail}
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  </Grid>
+);
+
+export const DashboardPage = () => {
+  const navigate = useNavigate();
+  const { showError } = useToast();
+  const [health, setHealth] = useState<HealthReport | null>(null);
+  const [healthLoading, setHealthLoading] = useState(true);
+  const [pendingCount, setPendingCount] = useState<number | null>(null);
+  const [pendingLoading, setPendingLoading] = useState(true);
+  const [misconfigured, setMisconfigured] = useState(false);
+
+  useEffect(() => {
+    const alive = { current: true };
+    adminApi
+      .health()
+      .then((res) => {
+        if (alive.current) setHealth(res);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError ? err.message : 'Failed to load health.',
+          );
+        }
+      })
+      .finally(() => {
+        if (alive.current) setHealthLoading(false);
+      });
+
+    adminApi
+      .listDevices({ active: false, limit: 200 })
+      .then((res) => {
+        if (alive.current) setPendingCount(res.items.length);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError ? err.message : 'Failed to load devices.',
+          );
+        }
+      })
+      .finally(() => {
+        if (alive.current) setPendingLoading(false);
+      });
+
+    return () => {
+      alive.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Box>
+      <Typography variant="h5" component="h1" sx={{ mb: 2 }}>
+        Dashboard
+      </Typography>
+
+      {misconfigured && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Admin backend misconfiguration — an operator must check the
+          server&apos;s ADMIN_API_KEY.
+        </Alert>
+      )}
+
+      <Typography variant="h6" component="h2" sx={{ mb: 1 }}>
+        System health
+      </Typography>
+      {healthLoading ? (
+        <Box sx={{ display: 'flex', py: 2 }}>
+          <CircularProgress size={24} />
+        </Box>
+      ) : health ? (
+        <Grid container spacing={2} sx={{ mb: 3 }}>
+          <HealthTile label="BFF" status={health.bff} />
+          <HealthTile label="Database" status={health.database} />
+          <HealthTile
+            label="Session Manager"
+            status={health.sessionManager}
+            detail={`${String(health.sessionManagerLatencyMs)}ms · checked ${new Date(health.checkedAt).toLocaleTimeString()}`}
+          />
+        </Grid>
+      ) : (
+        <Typography color="text.secondary" sx={{ mb: 3 }}>
+          Health status unavailable.
+        </Typography>
+      )}
+
+      <Typography variant="h6" component="h2" sx={{ mb: 1 }}>
+        Pending activations
+      </Typography>
+      <Card sx={{ mb: 3, maxWidth: 320 }}>
+        <CardContent>
+          {pendingLoading ? (
+            <CircularProgress size={24} />
+          ) : (
+            <Typography variant="h3" component="div">
+              {pendingCount ?? '—'}
+            </Typography>
+          )}
+          <Typography variant="body2" color="text.secondary">
+            devices awaiting activation
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <Typography variant="h6" component="h2" sx={{ mb: 1 }}>
+        Quick actions
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+        <Button
+          variant="contained"
+          startIcon={<MeetingRoomIcon />}
+          endIcon={<AddIcon />}
+          onClick={() => {
+            void navigate('/rooms');
+          }}
+        >
+          New room
+        </Button>
+        <Button
+          variant="contained"
+          startIcon={<DevicesIcon />}
+          endIcon={<AddIcon />}
+          onClick={() => {
+            void navigate('/devices');
+          }}
+        >
+          New device
+        </Button>
+        <Button
+          variant="outlined"
+          startIcon={<TabletIcon />}
+          onClick={() => {
+            void navigate('/kiosk-setup');
+          }}
+        >
+          Set up a kiosk
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/features/devices/device-detail-page.tsx
+++ b/apps/admin-webapp/src/features/devices/device-detail-page.tsx
@@ -1,0 +1,396 @@
+import { useEffect, useState } from 'react';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Divider from '@mui/material/Divider';
+import Link from '@mui/material/Link';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom';
+
+import type { Device } from '@scribear/session-manager-schema';
+
+import { ActivationCodeDisplay } from '#src/components/activation-code-display';
+import { ConfirmDialog } from '#src/components/confirm-dialog';
+import type { ReregisterDeviceResult } from '#src/lib/admin-api';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { useToast } from '#src/lib/toast-context';
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof ApiError ? err.message : fallback;
+}
+
+interface RenameDeviceDialogProps {
+  open: boolean;
+  currentName: string;
+  onClose: () => void;
+  onRenamed: (device: Device) => void;
+  deviceUid: string;
+}
+
+const RenameDeviceDialog = ({
+  open,
+  currentName,
+  onClose,
+  onRenamed,
+  deviceUid,
+}: RenameDeviceDialogProps) => {
+  const { showSuccess, showError } = useToast();
+  const [name, setName] = useState(currentName);
+  const [submitting, setSubmitting] = useState(false);
+  const [misconfigured, setMisconfigured] = useState(false);
+
+  const handleSave = () => {
+    setSubmitting(true);
+    setMisconfigured(false);
+    adminApi
+      .updateDevice({ deviceUid, name })
+      .then((device) => {
+        showSuccess('Device renamed.');
+        onRenamed(device);
+      })
+      .catch((err: unknown) => {
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else {
+          showError(errorMessage(err, 'Failed to rename device.'));
+        }
+      })
+      .finally(() => {
+        setSubmitting(false);
+      });
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Rename device</DialogTitle>
+      <DialogContent>
+        {misconfigured && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Admin backend misconfiguration — an operator must check the
+            server&apos;s ADMIN_API_KEY.
+          </Alert>
+        )}
+        <TextField
+          label="Name"
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+          }}
+          fullWidth
+          margin="normal"
+          autoFocus
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          disabled={submitting || name.trim() === ''}
+        >
+          {submitting ? 'Saving…' : 'Save'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+interface ReregisterResultDialogProps {
+  result: ReregisterDeviceResult | null;
+  onClose: () => void;
+}
+
+const ReregisterResultDialog = ({
+  result,
+  onClose,
+}: ReregisterResultDialogProps) => (
+  <Dialog open={result !== null} onClose={onClose} maxWidth="xs" fullWidth>
+    <DialogTitle>New activation code</DialogTitle>
+    <DialogContent>
+      {result && (
+        <Box sx={{ mt: 1 }}>
+          <ActivationCodeDisplay
+            code={result.activationCode}
+            expiry={result.expiry}
+          />
+          <DialogContentText sx={{ mt: 2 }}>
+            On the kiosk browser, open /kiosk and enter this code.
+          </DialogContentText>
+        </Box>
+      )}
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onClose} variant="contained">
+        Done
+      </Button>
+    </DialogActions>
+  </Dialog>
+);
+
+export const DeviceDetailPage = () => {
+  const { deviceUid } = useParams<{ deviceUid: string }>();
+  const navigate = useNavigate();
+  const { showSuccess, showError } = useToast();
+
+  const [device, setDevice] = useState<Device | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [misconfigured, setMisconfigured] = useState(false);
+  const [notFound, setNotFound] = useState(false);
+
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [renameDialogKey, setRenameDialogKey] = useState(0);
+  const [reregisterConfirmOpen, setReregisterConfirmOpen] = useState(false);
+  const [reregistering, setReregistering] = useState(false);
+  const [reregisterResult, setReregisterResult] =
+    useState<ReregisterDeviceResult | null>(null);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    if (deviceUid === undefined) return;
+    const alive = { current: true };
+    setLoading(true);
+    setNotFound(false);
+    setMisconfigured(false);
+    adminApi
+      .getDevice(deviceUid)
+      .then((d) => {
+        if (alive.current) setDevice(d);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else if (err instanceof ApiError && err.status === 404) {
+          setNotFound(true);
+        } else {
+          showError(errorMessage(err, 'Failed to load device.'));
+        }
+      })
+      .finally(() => {
+        if (alive.current) setLoading(false);
+      });
+    return () => {
+      alive.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deviceUid]);
+
+  const handleDelete = () => {
+    if (deviceUid === undefined) return;
+    setDeleting(true);
+    adminApi
+      .deleteDevice(deviceUid)
+      .then(() => {
+        showSuccess('Device deleted.');
+        void navigate('/devices');
+      })
+      .catch((err: unknown) => {
+        if (isApiErrorCode(err, 'WOULD_LEAVE_ROOM_WITHOUT_SOURCE')) {
+          showError(
+            "Can't delete: this device is a room's source. Reassign the source first.",
+          );
+        } else {
+          showError(errorMessage(err, 'Failed to delete device.'));
+        }
+      })
+      .finally(() => {
+        setDeleting(false);
+        setDeleteConfirmOpen(false);
+      });
+  };
+
+  const handleReregister = () => {
+    if (deviceUid === undefined) return;
+    setReregistering(true);
+    adminApi
+      .reregisterDevice(deviceUid)
+      .then((r) => {
+        showSuccess('Device re-registered.');
+        setReregisterResult(r);
+        setReregisterConfirmOpen(false);
+      })
+      .catch((err: unknown) => {
+        showError(errorMessage(err, 'Failed to re-register device.'));
+      })
+      .finally(() => {
+        setReregistering(false);
+      });
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (misconfigured) {
+    return (
+      <Alert severity="error">
+        Admin backend misconfiguration — an operator must check the
+        server&apos;s ADMIN_API_KEY.
+      </Alert>
+    );
+  }
+
+  if (notFound || device === null) {
+    return <Alert severity="warning">Device not found.</Alert>;
+  }
+
+  return (
+    <Box>
+      <Typography variant="h5" component="h1" gutterBottom>
+        {device.name}
+      </Typography>
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        <Stack spacing={2}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ minWidth: 100 }}
+            >
+              Status
+            </Typography>
+            <Chip
+              size="small"
+              label={device.active ? 'Activated' : 'Pending'}
+              color={device.active ? 'success' : 'warning'}
+            />
+            {device.isSource === true && (
+              <Chip
+                size="small"
+                label="Source"
+                color="info"
+                variant="outlined"
+              />
+            )}
+          </Box>
+          <Divider />
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ minWidth: 100 }}
+            >
+              Room
+            </Typography>
+            {device.roomUid === null ? (
+              <Typography>Unassigned</Typography>
+            ) : (
+              <Link component={RouterLink} to={`/rooms/${device.roomUid}`}>
+                {device.roomUid}
+              </Link>
+            )}
+          </Box>
+          <Divider />
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ minWidth: 100 }}
+            >
+              Created
+            </Typography>
+            <Typography>
+              {new Date(device.createdAt).toLocaleString()}
+            </Typography>
+          </Box>
+        </Stack>
+      </Paper>
+
+      <Stack direction="row" spacing={2}>
+        <Button
+          variant="outlined"
+          onClick={() => {
+            setRenameDialogKey((k) => k + 1);
+            setRenameOpen(true);
+          }}
+        >
+          Rename
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={() => {
+            setReregisterConfirmOpen(true);
+          }}
+        >
+          Re-register
+        </Button>
+        <Button
+          variant="outlined"
+          color="error"
+          onClick={() => {
+            setDeleteConfirmOpen(true);
+          }}
+        >
+          Delete
+        </Button>
+      </Stack>
+
+      <RenameDeviceDialog
+        key={renameDialogKey}
+        open={renameOpen}
+        currentName={device.name}
+        deviceUid={device.uid}
+        onClose={() => {
+          setRenameOpen(false);
+        }}
+        onRenamed={(updated) => {
+          setDevice(updated);
+          setRenameOpen(false);
+        }}
+      />
+
+      <ConfirmDialog
+        open={reregisterConfirmOpen}
+        title="Re-register device"
+        message="This invalidates the device's current credential."
+        confirmLabel="Re-register"
+        loading={reregistering}
+        onConfirm={handleReregister}
+        onClose={() => {
+          setReregisterConfirmOpen(false);
+        }}
+      />
+
+      <ReregisterResultDialog
+        result={reregisterResult}
+        onClose={() => {
+          setReregisterResult(null);
+        }}
+      />
+
+      <ConfirmDialog
+        open={deleteConfirmOpen}
+        title="Delete device"
+        message="This permanently deletes the device. This cannot be undone."
+        confirmLabel="Delete"
+        confirmColor="error"
+        loading={deleting}
+        onConfirm={handleDelete}
+        onClose={() => {
+          setDeleteConfirmOpen(false);
+        }}
+      />
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/features/devices/devices-list-page.tsx
+++ b/apps/admin-webapp/src/features/devices/devices-list-page.tsx
@@ -1,0 +1,402 @@
+import { useEffect, useState } from 'react';
+
+import AddIcon from '@mui/icons-material/Add';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Select from '@mui/material/Select';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+import { useNavigate } from 'react-router-dom';
+
+import type { Device } from '@scribear/session-manager-schema';
+
+import { ActivationCodeDisplay } from '#src/components/activation-code-display';
+import type { RegisterDeviceResult } from '#src/lib/admin-api';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { useToast } from '#src/lib/toast-context';
+
+const PAGE_LIMIT = 25;
+
+type StatusFilter = 'all' | 'active' | 'pending';
+type RoomFilter = 'all' | 'unassigned';
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof ApiError ? err.message : fallback;
+}
+
+interface RegisterDeviceDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onRegistered: () => void;
+}
+
+/**
+ * "Register device" dialog. Step 1 collects a name; on success it stays open
+ * showing the activation code until the operator dismisses it, so they have
+ * time to type the code on the kiosk.
+ */
+const RegisterDeviceDialog = ({
+  open,
+  onClose,
+  onRegistered,
+}: RegisterDeviceDialogProps) => {
+  const { showSuccess, showError } = useToast();
+  const [name, setName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [misconfigured, setMisconfigured] = useState(false);
+  const [result, setResult] = useState<RegisterDeviceResult | null>(null);
+
+  const handleRegister = () => {
+    setSubmitting(true);
+    setMisconfigured(false);
+    adminApi
+      .registerDevice(name)
+      .then((r) => {
+        setResult(r);
+        showSuccess('Device registered.');
+        onRegistered();
+      })
+      .catch((err: unknown) => {
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else {
+          showError(errorMessage(err, 'Failed to register device.'));
+        }
+      })
+      .finally(() => {
+        setSubmitting(false);
+      });
+  };
+
+  const handleClose = () => {
+    setResult(null);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Register device</DialogTitle>
+      <DialogContent>
+        {misconfigured && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Admin backend misconfiguration — an operator must check the
+            server&apos;s ADMIN_API_KEY.
+          </Alert>
+        )}
+        {result ? (
+          <Box sx={{ mt: 1 }}>
+            <ActivationCodeDisplay
+              code={result.activationCode}
+              expiry={result.expiry}
+            />
+            <DialogContentText sx={{ mt: 2 }}>
+              On the kiosk browser, open /kiosk and enter this code.
+            </DialogContentText>
+          </Box>
+        ) : (
+          <TextField
+            label="Device name"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+            }}
+            fullWidth
+            margin="normal"
+            autoFocus
+          />
+        )}
+      </DialogContent>
+      <DialogActions>
+        {result ? (
+          <Button onClick={handleClose} variant="contained">
+            Done
+          </Button>
+        ) : (
+          <>
+            <Button onClick={handleClose} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleRegister}
+              variant="contained"
+              disabled={submitting || name.trim() === ''}
+            >
+              {submitting ? 'Registering…' : 'Register device'}
+            </Button>
+          </>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export const DevicesListPage = () => {
+  const navigate = useNavigate();
+  const { showError } = useToast();
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [roomFilter, setRoomFilter] = useState<RoomFilter>('all');
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [registerOpen, setRegisterOpen] = useState(false);
+  const [registerDialogKey, setRegisterDialogKey] = useState(0);
+  const [misconfigured, setMisconfigured] = useState(false);
+
+  const buildQuery = (cursor?: string) => {
+    const query: {
+      search?: string;
+      active?: boolean;
+      roomUid?: string;
+      cursor?: string;
+      limit: number;
+    } = { limit: PAGE_LIMIT };
+    if (search !== '') query.search = search;
+    if (statusFilter !== 'all') query.active = statusFilter === 'active';
+    if (roomFilter === 'unassigned') query.roomUid = '';
+    if (cursor !== undefined) query.cursor = cursor;
+    return query;
+  };
+
+  const load = (opts: { cursor?: string; append: boolean }) => {
+    if (opts.append) setLoadingMore(true);
+    else setLoading(true);
+    adminApi
+      .listDevices(buildQuery(opts.cursor))
+      .then((res) => {
+        setMisconfigured(false);
+        setDevices((prev) =>
+          opts.append ? [...prev, ...res.items] : res.items,
+        );
+        setNextCursor(res.nextCursor);
+      })
+      .catch((err: unknown) => {
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else {
+          showError(errorMessage(err, 'Failed to load devices.'));
+        }
+      })
+      .finally(() => {
+        setLoading(false);
+        setLoadingMore(false);
+      });
+  };
+
+  useEffect(() => {
+    const alive = { current: true };
+    setLoading(true);
+    adminApi
+      .listDevices(buildQuery())
+      .then((res) => {
+        if (!alive.current) return;
+        setMisconfigured(false);
+        setDevices(res.items);
+        setNextCursor(res.nextCursor);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else {
+          showError(errorMessage(err, 'Failed to load devices.'));
+        }
+      })
+      .finally(() => {
+        if (alive.current) setLoading(false);
+      });
+    return () => {
+      alive.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search, statusFilter, roomFilter]);
+
+  const handleLoadMore = () => {
+    if (nextCursor === null) return;
+    load({ cursor: nextCursor, append: true });
+  };
+
+  const handleRegistered = () => {
+    load({ append: false });
+  };
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 2,
+        }}
+      >
+        <Typography variant="h5" component="h1">
+          Devices
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => {
+            setRegisterDialogKey((k) => k + 1);
+            setRegisterOpen(true);
+          }}
+        >
+          Register device
+        </Button>
+      </Box>
+
+      {misconfigured && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Admin backend misconfiguration — an operator must check the
+          server&apos;s ADMIN_API_KEY.
+        </Alert>
+      )}
+
+      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+        <TextField
+          label="Search devices"
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+          }}
+          fullWidth
+          size="small"
+        />
+        <FormControl size="small" sx={{ minWidth: 160 }}>
+          <InputLabel id="devices-status-filter-label">Status</InputLabel>
+          <Select
+            labelId="devices-status-filter-label"
+            label="Status"
+            value={statusFilter}
+            onChange={(e: SelectChangeEvent) => {
+              setStatusFilter(e.target.value as StatusFilter);
+            }}
+          >
+            <MenuItem value="all">All</MenuItem>
+            <MenuItem value="active">Activated</MenuItem>
+            <MenuItem value="pending">Pending</MenuItem>
+          </Select>
+        </FormControl>
+        <FormControl size="small" sx={{ minWidth: 160 }}>
+          <InputLabel id="devices-room-filter-label">Room</InputLabel>
+          <Select
+            labelId="devices-room-filter-label"
+            label="Room"
+            value={roomFilter}
+            onChange={(e: SelectChangeEvent) => {
+              setRoomFilter(e.target.value as RoomFilter);
+            }}
+          >
+            <MenuItem value="all">All</MenuItem>
+            <MenuItem value="unassigned">Unassigned</MenuItem>
+          </Select>
+        </FormControl>
+      </Box>
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Room</TableCell>
+              <TableCell>Created</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={4} align="center" sx={{ py: 4 }}>
+                  <CircularProgress size={28} />
+                </TableCell>
+              </TableRow>
+            ) : devices.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} align="center" sx={{ py: 4 }}>
+                  <Typography color="text.secondary">
+                    No devices found.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              devices.map((device) => (
+                <TableRow
+                  key={device.uid}
+                  hover
+                  onClick={() => {
+                    void navigate(`/devices/${device.uid}`);
+                  }}
+                  sx={{ cursor: 'pointer' }}
+                >
+                  <TableCell>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      {device.name}
+                      {device.isSource === true && (
+                        <Chip
+                          size="small"
+                          label="Source"
+                          color="info"
+                          variant="outlined"
+                        />
+                      )}
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      size="small"
+                      label={device.active ? 'Activated' : 'Pending'}
+                      color={device.active ? 'success' : 'warning'}
+                    />
+                  </TableCell>
+                  <TableCell>{device.roomUid ?? 'Unassigned'}</TableCell>
+                  <TableCell>
+                    {new Date(device.createdAt).toLocaleString()}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {nextCursor !== null && !loading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+          <Button onClick={handleLoadMore} disabled={loadingMore}>
+            {loadingMore ? 'Loading…' : 'Load more'}
+          </Button>
+        </Box>
+      )}
+
+      <RegisterDeviceDialog
+        key={registerDialogKey}
+        open={registerOpen}
+        onClose={() => {
+          setRegisterOpen(false);
+        }}
+        onRegistered={handleRegistered}
+      />
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/features/kiosk-setup/kiosk-wizard-page.tsx
+++ b/apps/admin-webapp/src/features/kiosk-setup/kiosk-wizard-page.tsx
@@ -1,0 +1,569 @@
+import { useEffect, useState } from 'react';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import InputLabel from '@mui/material/InputLabel';
+import Link from '@mui/material/Link';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import Select from '@mui/material/Select';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import Stack from '@mui/material/Stack';
+import Step from '@mui/material/Step';
+import StepLabel from '@mui/material/StepLabel';
+import Stepper from '@mui/material/Stepper';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+import { Link as RouterLink } from 'react-router-dom';
+
+import type { Room } from '@scribear/session-manager-schema';
+
+import { ActivationCodeDisplay } from '#src/components/activation-code-display';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { useToast } from '#src/lib/toast-context';
+
+const DEFAULT_TIMEZONE = 'America/Chicago';
+const POLL_MS = 3000;
+const STEPS = ['Device', 'Room', 'Schedule', 'Verify'];
+
+type RoomChoice = 'new' | 'existing';
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof ApiError ? err.message : fallback;
+}
+
+interface DeviceStepProps {
+  deviceName: string;
+  setDeviceName: (name: string) => void;
+  deviceUid: string | null;
+  activationCode: string | null;
+  activationExpiry: string | null;
+  registering: boolean;
+  reregistering: boolean;
+  misconfigured: boolean;
+  onRegister: () => void;
+  onReregister: () => void;
+}
+
+const DeviceStep = ({
+  deviceName,
+  setDeviceName,
+  deviceUid,
+  activationCode,
+  activationExpiry,
+  registering,
+  reregistering,
+  misconfigured,
+  onRegister,
+  onReregister,
+}: DeviceStepProps) => (
+  <Stack spacing={2}>
+    <Typography variant="body2" color="text.secondary">
+      Register a new device to get an activation code. Enter the code on the
+      kiosk to link it to this device record.
+    </Typography>
+    {misconfigured && (
+      <Alert severity="error">
+        Admin backend misconfiguration — an operator must check the
+        server&apos;s ADMIN_API_KEY.
+      </Alert>
+    )}
+    <TextField
+      label="Device name"
+      value={deviceName}
+      onChange={(e) => {
+        setDeviceName(e.target.value);
+      }}
+      disabled={deviceUid !== null}
+      fullWidth
+    />
+    {deviceUid === null ? (
+      <Box>
+        <Button
+          variant="contained"
+          onClick={onRegister}
+          disabled={registering || deviceName.trim() === ''}
+        >
+          {registering ? 'Registering…' : 'Register device'}
+        </Button>
+      </Box>
+    ) : (
+      activationCode !== null &&
+      activationExpiry !== null && (
+        <Stack spacing={1} alignItems="center">
+          <ActivationCodeDisplay
+            code={activationCode}
+            expiry={activationExpiry}
+          />
+          <Typography variant="body2" color="text.secondary">
+            On the kiosk browser, open /kiosk and enter this code.
+          </Typography>
+          <Button onClick={onReregister} disabled={reregistering} size="small">
+            {reregistering ? 'Re-registering…' : 'Code expired? Re-register'}
+          </Button>
+        </Stack>
+      )
+    )}
+  </Stack>
+);
+
+interface RoomStepProps {
+  deviceUid: string | null;
+  roomUid: string | null;
+  roomChoice: RoomChoice;
+  setRoomChoice: (choice: RoomChoice) => void;
+  newRoomName: string;
+  setNewRoomName: (name: string) => void;
+  newRoomTimezone: string;
+  setNewRoomTimezone: (tz: string) => void;
+  existingRooms: Room[];
+  existingRoomsLoading: boolean;
+  selectedRoomUid: string;
+  setSelectedRoomUid: (uid: string) => void;
+  roomSubmitting: boolean;
+  misconfigured: boolean;
+  onCreateRoom: () => void;
+  onAddToRoom: () => void;
+}
+
+const RoomStep = ({
+  roomUid,
+  roomChoice,
+  setRoomChoice,
+  newRoomName,
+  setNewRoomName,
+  newRoomTimezone,
+  setNewRoomTimezone,
+  existingRooms,
+  existingRoomsLoading,
+  selectedRoomUid,
+  setSelectedRoomUid,
+  roomSubmitting,
+  misconfigured,
+  onCreateRoom,
+  onAddToRoom,
+}: RoomStepProps) => {
+  if (roomUid !== null) {
+    return (
+      <Alert severity="success">
+        Device added to room <strong>{roomUid}</strong>.
+      </Alert>
+    );
+  }
+
+  return (
+    <Stack spacing={2}>
+      {misconfigured && (
+        <Alert severity="error">
+          Admin backend misconfiguration — an operator must check the
+          server&apos;s ADMIN_API_KEY.
+        </Alert>
+      )}
+      <RadioGroup
+        value={roomChoice}
+        onChange={(_e, value) => {
+          setRoomChoice(value as RoomChoice);
+        }}
+      >
+        <FormControlLabel
+          value="new"
+          control={<Radio />}
+          label="Create a new room"
+        />
+        <FormControlLabel
+          value="existing"
+          control={<Radio />}
+          label="Add to an existing room"
+        />
+      </RadioGroup>
+
+      {roomChoice === 'new' ? (
+        <Stack spacing={2}>
+          <TextField
+            label="Room name"
+            value={newRoomName}
+            onChange={(e) => {
+              setNewRoomName(e.target.value);
+            }}
+            fullWidth
+          />
+          <TextField
+            label="Timezone"
+            value={newRoomTimezone}
+            onChange={(e) => {
+              setNewRoomTimezone(e.target.value);
+            }}
+            helperText="IANA timezone identifier, e.g. America/Chicago"
+            fullWidth
+          />
+          <Box>
+            <Button
+              variant="contained"
+              onClick={onCreateRoom}
+              disabled={
+                roomSubmitting ||
+                newRoomName.trim() === '' ||
+                newRoomTimezone.trim() === ''
+              }
+            >
+              {roomSubmitting ? 'Creating…' : 'Create room'}
+            </Button>
+          </Box>
+        </Stack>
+      ) : (
+        <Stack spacing={2}>
+          <FormControl
+            fullWidth
+            disabled={existingRoomsLoading || existingRooms.length === 0}
+          >
+            <InputLabel id="kiosk-wizard-existing-room-label">Room</InputLabel>
+            <Select
+              labelId="kiosk-wizard-existing-room-label"
+              label="Room"
+              value={selectedRoomUid}
+              onChange={(e: SelectChangeEvent) => {
+                setSelectedRoomUid(e.target.value);
+              }}
+            >
+              {existingRooms.map((r) => (
+                <MenuItem key={r.uid} value={r.uid}>
+                  {r.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          {existingRoomsLoading && (
+            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+              <CircularProgress size={24} />
+            </Box>
+          )}
+          {!existingRoomsLoading && existingRooms.length === 0 && (
+            <Typography variant="body2" color="text.secondary">
+              No rooms exist yet. Create a new room instead.
+            </Typography>
+          )}
+          <Box>
+            <Button
+              variant="contained"
+              onClick={onAddToRoom}
+              disabled={roomSubmitting || selectedRoomUid === ''}
+            >
+              {roomSubmitting ? 'Adding…' : 'Add to room'}
+            </Button>
+          </Box>
+        </Stack>
+      )}
+    </Stack>
+  );
+};
+
+interface VerifyStepProps {
+  deviceUid: string | null;
+  roomUid: string | null;
+  deviceActive: boolean;
+}
+
+const VerifyStep = ({ deviceUid, roomUid, deviceActive }: VerifyStepProps) => {
+  if (deviceActive) {
+    return (
+      <Stack spacing={2} alignItems="flex-start">
+        <Alert severity="success" sx={{ width: '100%' }}>
+          Activated ✓
+        </Alert>
+        <Stack direction="row" spacing={3}>
+          {roomUid !== null && (
+            <Link component={RouterLink} to={`/rooms/${roomUid}`}>
+              View room
+            </Link>
+          )}
+          {deviceUid !== null && (
+            <Link component={RouterLink} to={`/devices/${deviceUid}`}>
+              View device
+            </Link>
+          )}
+        </Stack>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack spacing={2} alignItems="center" sx={{ py: 4 }}>
+      <CircularProgress />
+      <Typography color="text.secondary">
+        Waiting for the kiosk to activate…
+      </Typography>
+    </Stack>
+  );
+};
+
+/**
+ * Guided kiosk setup: register a device, attach it to a room (new or
+ * existing), skip schedule configuration for now, then poll until the kiosk
+ * has activated using the code.
+ */
+export const KioskWizardPage = () => {
+  const { showSuccess, showError } = useToast();
+  const [activeStep, setActiveStep] = useState(0);
+
+  // Step 0: device
+  const [deviceName, setDeviceName] = useState('');
+  const [deviceUid, setDeviceUid] = useState<string | null>(null);
+  const [activationCode, setActivationCode] = useState<string | null>(null);
+  const [activationExpiry, setActivationExpiry] = useState<string | null>(null);
+  const [registering, setRegistering] = useState(false);
+  const [reregistering, setReregistering] = useState(false);
+  const [deviceMisconfigured, setDeviceMisconfigured] = useState(false);
+
+  // Step 1: room
+  const [roomChoice, setRoomChoice] = useState<RoomChoice>('new');
+  const [newRoomName, setNewRoomName] = useState('');
+  const [newRoomTimezone, setNewRoomTimezone] = useState(DEFAULT_TIMEZONE);
+  const [existingRooms, setExistingRooms] = useState<Room[]>([]);
+  const [existingRoomsLoading, setExistingRoomsLoading] = useState(false);
+  const [selectedRoomUid, setSelectedRoomUid] = useState('');
+  const [roomUid, setRoomUid] = useState<string | null>(null);
+  const [roomSubmitting, setRoomSubmitting] = useState(false);
+  const [roomMisconfigured, setRoomMisconfigured] = useState(false);
+
+  // Step 3: verify
+  const [deviceActive, setDeviceActive] = useState(false);
+
+  const handleRegister = () => {
+    setRegistering(true);
+    setDeviceMisconfigured(false);
+    adminApi
+      .registerDevice(deviceName)
+      .then((r) => {
+        setDeviceUid(r.deviceUid);
+        setActivationCode(r.activationCode);
+        setActivationExpiry(r.expiry);
+        showSuccess('Device registered.');
+      })
+      .catch((err: unknown) => {
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setDeviceMisconfigured(true);
+        } else {
+          showError(errorMessage(err, 'Failed to register device.'));
+        }
+      })
+      .finally(() => {
+        setRegistering(false);
+      });
+  };
+
+  const handleReregister = () => {
+    if (deviceUid === null) return;
+    setReregistering(true);
+    adminApi
+      .reregisterDevice(deviceUid)
+      .then((r) => {
+        setActivationCode(r.activationCode);
+        setActivationExpiry(r.expiry);
+        showSuccess('New activation code generated.');
+      })
+      .catch((err: unknown) => {
+        showError(errorMessage(err, 'Failed to re-register device.'));
+      })
+      .finally(() => {
+        setReregistering(false);
+      });
+  };
+
+  useEffect(() => {
+    if (roomChoice !== 'existing' || existingRooms.length > 0) return;
+    const alive = { current: true };
+    setExistingRoomsLoading(true);
+    adminApi
+      .listRooms({ limit: 200 })
+      .then((res) => {
+        if (alive.current) setExistingRooms(res.items);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setRoomMisconfigured(true);
+        } else {
+          showError(errorMessage(err, 'Failed to load rooms.'));
+        }
+      })
+      .finally(() => {
+        if (alive.current) setExistingRoomsLoading(false);
+      });
+    return () => {
+      alive.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [roomChoice]);
+
+  const handleCreateRoom = () => {
+    if (deviceUid === null) return;
+    setRoomSubmitting(true);
+    setRoomMisconfigured(false);
+    adminApi
+      .createRoom({
+        name: newRoomName,
+        timezone: newRoomTimezone,
+        autoSessionEnabled: false,
+        sourceDeviceUids: [deviceUid],
+      })
+      .then((room) => {
+        setRoomUid(room.uid);
+        showSuccess('Room created.');
+      })
+      .catch((err: unknown) => {
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setRoomMisconfigured(true);
+        } else {
+          showError(errorMessage(err, 'Failed to create room.'));
+        }
+      })
+      .finally(() => {
+        setRoomSubmitting(false);
+      });
+  };
+
+  const handleAddToRoom = () => {
+    if (deviceUid === null || selectedRoomUid === '') return;
+    setRoomSubmitting(true);
+    setRoomMisconfigured(false);
+    adminApi
+      .addDeviceToRoom({ roomUid: selectedRoomUid, deviceUid, asSource: true })
+      .then(() => {
+        setRoomUid(selectedRoomUid);
+        showSuccess('Device added to room.');
+      })
+      .catch((err: unknown) => {
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setRoomMisconfigured(true);
+        } else {
+          showError(errorMessage(err, 'Failed to add device to room.'));
+        }
+      })
+      .finally(() => {
+        setRoomSubmitting(false);
+      });
+  };
+
+  useEffect(() => {
+    if (activeStep !== 3 || deviceUid === null || deviceActive) return;
+    const alive = { current: true };
+    const poll = () => {
+      adminApi
+        .getDevice(deviceUid)
+        .then((d) => {
+          if (alive.current && d.active) setDeviceActive(true);
+        })
+        .catch(() => {
+          /* transient poll failure — try again on the next tick */
+        });
+    };
+    poll();
+    const timer = setInterval(poll, POLL_MS);
+    return () => {
+      alive.current = false;
+      clearInterval(timer);
+    };
+  }, [activeStep, deviceUid, deviceActive]);
+
+  const canGoNext =
+    (activeStep === 0 && deviceUid !== null) ||
+    (activeStep === 1 && roomUid !== null) ||
+    activeStep === 2;
+
+  const handleNext = () => {
+    setActiveStep((s) => Math.min(s + 1, STEPS.length - 1));
+  };
+  const handleBack = () => {
+    setActiveStep((s) => Math.max(s - 1, 0));
+  };
+
+  return (
+    <Box>
+      <Typography variant="h5" component="h1" gutterBottom>
+        Set up a kiosk
+      </Typography>
+
+      <Stepper activeStep={activeStep} sx={{ mb: 4 }}>
+        {STEPS.map((label) => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        {activeStep === 0 && (
+          <DeviceStep
+            deviceName={deviceName}
+            setDeviceName={setDeviceName}
+            deviceUid={deviceUid}
+            activationCode={activationCode}
+            activationExpiry={activationExpiry}
+            registering={registering}
+            reregistering={reregistering}
+            misconfigured={deviceMisconfigured}
+            onRegister={handleRegister}
+            onReregister={handleReregister}
+          />
+        )}
+        {activeStep === 1 && (
+          <RoomStep
+            deviceUid={deviceUid}
+            roomUid={roomUid}
+            roomChoice={roomChoice}
+            setRoomChoice={setRoomChoice}
+            newRoomName={newRoomName}
+            setNewRoomName={setNewRoomName}
+            newRoomTimezone={newRoomTimezone}
+            setNewRoomTimezone={setNewRoomTimezone}
+            existingRooms={existingRooms}
+            existingRoomsLoading={existingRoomsLoading}
+            selectedRoomUid={selectedRoomUid}
+            setSelectedRoomUid={setSelectedRoomUid}
+            roomSubmitting={roomSubmitting}
+            misconfigured={roomMisconfigured}
+            onCreateRoom={handleCreateRoom}
+            onAddToRoom={handleAddToRoom}
+          />
+        )}
+        {activeStep === 2 && (
+          <Stack spacing={2} alignItems="flex-start">
+            <Typography color="text.secondary">
+              Schedules can be configured later from the room page.
+            </Typography>
+          </Stack>
+        )}
+        {activeStep === 3 && (
+          <VerifyStep
+            deviceUid={deviceUid}
+            roomUid={roomUid}
+            deviceActive={deviceActive}
+          />
+        )}
+      </Paper>
+
+      <Stack direction="row" spacing={2} justifyContent="space-between">
+        <Button onClick={handleBack} disabled={activeStep === 0}>
+          Back
+        </Button>
+        {activeStep < STEPS.length - 1 && (
+          <Button
+            variant="contained"
+            onClick={handleNext}
+            disabled={!canGoNext}
+          >
+            {activeStep === 2 ? 'Skip' : 'Next'}
+          </Button>
+        )}
+      </Stack>
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
+++ b/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
@@ -1,0 +1,664 @@
+import { useEffect, useState } from 'react';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Checkbox from '@mui/material/Checkbox';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Grid from '@mui/material/Grid';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Select from '@mui/material/Select';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+import { useNavigate, useParams } from 'react-router-dom';
+
+import type { Device, Room } from '@scribear/session-manager-schema';
+
+import { ConfirmDialog } from '#src/components/confirm-dialog';
+import type { RoomDetail } from '#src/lib/admin-api';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
+import { useToast } from '#src/lib/toast-context';
+
+interface RenameRoomDialogProps {
+  room: Room;
+  onClose: () => void;
+  onRenamed: () => void;
+}
+
+/**
+ * Rendered only while the rename dialog should be open (the parent
+ * mounts/unmounts it), so `name` initializes fresh from `room.name` via a
+ * `useState` literal rather than an effect-driven reset.
+ */
+const RenameRoomDialog = ({
+  room,
+  onClose,
+  onRenamed,
+}: RenameRoomDialogProps) => {
+  const { showSuccess, showError } = useToast();
+  const [name, setName] = useState(room.name);
+  const [submitting, setSubmitting] = useState(false);
+  const [misconfigured, setMisconfigured] = useState(false);
+
+  const handleSubmit = () => {
+    setSubmitting(true);
+    setMisconfigured(false);
+    adminApi
+      .updateRoom({ roomUid: room.uid, name })
+      .then(() => {
+        showSuccess('Room renamed.');
+        onRenamed();
+      })
+      .catch((err: unknown) => {
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError ? err.message : 'Failed to rename room.',
+          );
+        }
+      })
+      .finally(() => {
+        setSubmitting(false);
+      });
+  };
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Rename room</DialogTitle>
+      <DialogContent>
+        {misconfigured && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Admin backend misconfiguration — an operator must check the
+            server&apos;s ADMIN_API_KEY.
+          </Alert>
+        )}
+        <TextField
+          label="Name"
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+          }}
+          fullWidth
+          margin="normal"
+          autoFocus
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={submitting || name.trim() === ''}
+        >
+          {submitting ? 'Saving…' : 'Save'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+interface AddDeviceDialogProps {
+  roomUid: string;
+  onClose: () => void;
+  onAdded: () => void;
+}
+
+/**
+ * Rendered only while the "Add device" dialog should be open (the parent
+ * mounts/unmounts it), so local form state initializes fresh via `useState`
+ * literals rather than an effect-driven reset.
+ */
+const AddDeviceDialog = ({
+  roomUid,
+  onClose,
+  onAdded,
+}: AddDeviceDialogProps) => {
+  const { showSuccess, showError } = useToast();
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [devicesLoading, setDevicesLoading] = useState(true);
+  const [deviceUid, setDeviceUid] = useState('');
+  const [asSource, setAsSource] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [misconfigured, setMisconfigured] = useState(false);
+
+  useEffect(() => {
+    const alive = { current: true };
+    adminApi
+      .listDevices({ roomUid: '', limit: 200 })
+      .then((res) => {
+        if (alive.current) setDevices(res.items);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError ? err.message : 'Failed to load devices.',
+          );
+        }
+      })
+      .finally(() => {
+        if (alive.current) setDevicesLoading(false);
+      });
+    return () => {
+      alive.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSubmit = () => {
+    setSubmitting(true);
+    setMisconfigured(false);
+    adminApi
+      .addDeviceToRoom({ roomUid, deviceUid, asSource })
+      .then(() => {
+        showSuccess('Device added to room.');
+        onAdded();
+      })
+      .catch((err: unknown) => {
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError ? err.message : 'Failed to add device.',
+          );
+        }
+      })
+      .finally(() => {
+        setSubmitting(false);
+      });
+  };
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Add device</DialogTitle>
+      <DialogContent>
+        {misconfigured && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Admin backend misconfiguration — an operator must check the
+            server&apos;s ADMIN_API_KEY.
+          </Alert>
+        )}
+        <FormControl
+          fullWidth
+          margin="normal"
+          disabled={devicesLoading || devices.length === 0}
+        >
+          <InputLabel id="add-device-select-label">Device</InputLabel>
+          <Select
+            labelId="add-device-select-label"
+            label="Device"
+            value={deviceUid}
+            onChange={(e: SelectChangeEvent) => {
+              setDeviceUid(e.target.value);
+            }}
+          >
+            {devices.map((d) => (
+              <MenuItem key={d.uid} value={d.uid}>
+                {d.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        {!devicesLoading && devices.length === 0 && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            No unassigned devices are available.
+          </Typography>
+        )}
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={asSource}
+              onChange={(e) => {
+                setAsSource(e.target.checked);
+              }}
+            />
+          }
+          label="Add as source device"
+          sx={{ mt: 1 }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={submitting || deviceUid === ''}
+        >
+          {submitting ? 'Adding…' : 'Add'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export const RoomDetailPage = () => {
+  const { roomUid } = useParams<{ roomUid: string }>();
+  const navigate = useNavigate();
+  const { showSuccess, showError } = useToast();
+
+  const [detail, setDetail] = useState<RoomDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [misconfigured, setMisconfigured] = useState(false);
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [addDeviceOpen, setAddDeviceOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [rowActionUid, setRowActionUid] = useState<string | null>(null);
+
+  const load = () => {
+    if (roomUid === undefined) return;
+    setLoading(true);
+    adminApi
+      .roomDetail(roomUid)
+      .then((res) => {
+        setMisconfigured(false);
+        setDetail(res);
+      })
+      .catch((err: unknown) => {
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError ? err.message : 'Failed to load room.',
+          );
+        }
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    const alive = { current: true };
+    if (roomUid === undefined) return;
+    setLoading(true);
+    adminApi
+      .roomDetail(roomUid)
+      .then((res) => {
+        if (!alive.current) return;
+        setMisconfigured(false);
+        setDetail(res);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError ? err.message : 'Failed to load room.',
+          );
+        }
+      })
+      .finally(() => {
+        if (alive.current) setLoading(false);
+      });
+    return () => {
+      alive.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [roomUid]);
+
+  const handleSetSource = (deviceUid: string) => {
+    if (roomUid === undefined) return;
+    setRowActionUid(deviceUid);
+    adminApi
+      .setSourceDevice({ roomUid, deviceUid })
+      .then(() => {
+        showSuccess('Source device updated.');
+        load();
+      })
+      .catch((err: unknown) => {
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError
+              ? err.message
+              : 'Failed to set source device.',
+          );
+        }
+      })
+      .finally(() => {
+        setRowActionUid(null);
+      });
+  };
+
+  const handleRemoveDevice = (deviceUid: string) => {
+    setRowActionUid(deviceUid);
+    adminApi
+      .removeDeviceFromRoom(deviceUid)
+      .then(() => {
+        showSuccess('Device removed from room.');
+        load();
+      })
+      .catch((err: unknown) => {
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError ? err.message : 'Failed to remove device.',
+          );
+        }
+      })
+      .finally(() => {
+        setRowActionUid(null);
+      });
+  };
+
+  const handleDelete = () => {
+    if (roomUid === undefined) return;
+    setDeleting(true);
+    adminApi
+      .deleteRoom(roomUid)
+      .then(() => {
+        showSuccess('Room deleted.');
+        void navigate('/rooms');
+      })
+      .catch((err: unknown) => {
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError ? err.message : 'Failed to delete room.',
+          );
+        }
+      })
+      .finally(() => {
+        setDeleting(false);
+        setDeleteOpen(false);
+      });
+  };
+
+  if (loading && !detail) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!detail) {
+    return misconfigured ? (
+      <Alert severity="error">
+        Admin backend misconfiguration — an operator must check the
+        server&apos;s ADMIN_API_KEY.
+      </Alert>
+    ) : (
+      <Typography color="text.secondary">Room not found.</Typography>
+    );
+  }
+
+  const { room, devices } = detail;
+
+  return (
+    <Box>
+      {misconfigured && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Admin backend misconfiguration — an operator must check the
+          server&apos;s ADMIN_API_KEY.
+        </Alert>
+      )}
+
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 2,
+        }}
+      >
+        <Typography variant="h5" component="h1">
+          {room.name}
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button
+            variant="outlined"
+            onClick={() => {
+              void navigate(`/rooms/${room.uid}/scheduling`);
+            }}
+          >
+            Manage scheduling
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={() => {
+              setRenameOpen(true);
+            }}
+          >
+            Rename
+          </Button>
+          <Button
+            variant="outlined"
+            color="error"
+            onClick={() => {
+              setDeleteOpen(true);
+            }}
+          >
+            Delete room
+          </Button>
+        </Box>
+      </Box>
+
+      <Card sx={{ mb: 3 }}>
+        <CardContent>
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <Typography variant="body2" color="text.secondary">
+                Timezone
+              </Typography>
+              <Typography variant="body1">{room.timezone}</Typography>
+            </Grid>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <Typography variant="body2" color="text.secondary">
+                Auto-sessions
+              </Typography>
+              <Chip
+                size="small"
+                label={room.autoSessionEnabled ? 'Enabled' : 'Disabled'}
+                color={room.autoSessionEnabled ? 'success' : 'default'}
+                variant="outlined"
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <Typography variant="body2" color="text.secondary">
+                Created
+              </Typography>
+              <Typography variant="body1">
+                {new Date(room.createdAt).toLocaleString()}
+              </Typography>
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 1,
+        }}
+      >
+        <Typography variant="h6" component="h2">
+          Devices
+        </Typography>
+        <Button
+          variant="contained"
+          onClick={() => {
+            setAddDeviceOpen(true);
+          }}
+        >
+          Add device
+        </Button>
+      </Box>
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Role</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {devices.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} align="center" sx={{ py: 4 }}>
+                  <Typography color="text.secondary">
+                    No devices assigned to this room.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              devices.map((device) => (
+                <TableRow key={device.uid}>
+                  <TableCell>{device.name}</TableCell>
+                  <TableCell>
+                    <Chip
+                      size="small"
+                      label={device.active ? 'Active' : 'Pending'}
+                      color={device.active ? 'success' : 'warning'}
+                      variant="outlined"
+                    />
+                  </TableCell>
+                  <TableCell>
+                    {device.isSource === true ? (
+                      <Chip size="small" label="Source" color="primary" />
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">
+                        —
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell align="right">
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        gap: 1,
+                        justifyContent: 'flex-end',
+                      }}
+                    >
+                      {device.isSource !== true && (
+                        <Button
+                          size="small"
+                          disabled={rowActionUid === device.uid}
+                          onClick={() => {
+                            handleSetSource(device.uid);
+                          }}
+                        >
+                          Set as source
+                        </Button>
+                      )}
+                      <Button
+                        size="small"
+                        color="error"
+                        disabled={rowActionUid === device.uid}
+                        onClick={() => {
+                          handleRemoveDevice(device.uid);
+                        }}
+                      >
+                        Remove
+                      </Button>
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {renameOpen && (
+        <RenameRoomDialog
+          room={room}
+          onClose={() => {
+            setRenameOpen(false);
+          }}
+          onRenamed={() => {
+            setRenameOpen(false);
+            load();
+          }}
+        />
+      )}
+
+      {addDeviceOpen && (
+        <AddDeviceDialog
+          roomUid={room.uid}
+          onClose={() => {
+            setAddDeviceOpen(false);
+          }}
+          onAdded={() => {
+            setAddDeviceOpen(false);
+            load();
+          }}
+        />
+      )}
+
+      <ConfirmDialog
+        open={deleteOpen}
+        title="Delete room"
+        message="This deletes the room and its schedules/sessions/memberships."
+        confirmLabel="Delete"
+        confirmColor="error"
+        loading={deleting}
+        onConfirm={handleDelete}
+        onClose={() => {
+          setDeleteOpen(false);
+        }}
+      />
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/features/rooms/rooms-list-page.tsx
+++ b/apps/admin-webapp/src/features/rooms/rooms-list-page.tsx
@@ -1,0 +1,402 @@
+import { useEffect, useState } from 'react';
+
+import AddIcon from '@mui/icons-material/Add';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Select from '@mui/material/Select';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+import { useNavigate } from 'react-router-dom';
+
+import type { Device, Room } from '@scribear/session-manager-schema';
+
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
+import { useToast } from '#src/lib/toast-context';
+
+const DEFAULT_TIMEZONE = 'America/Chicago';
+const PAGE_LIMIT = 25;
+
+interface CreateRoomDialogProps {
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+/**
+ * Rendered only while the "New room" dialog should be open (the parent
+ * mounts/unmounts it), so all local state initializes fresh via `useState`
+ * literals rather than an effect-driven reset.
+ */
+const CreateRoomDialog = ({ onClose, onCreated }: CreateRoomDialogProps) => {
+  const { showSuccess, showError } = useToast();
+  const [name, setName] = useState('');
+  const [timezone, setTimezone] = useState(DEFAULT_TIMEZONE);
+  const [sourceDeviceUid, setSourceDeviceUid] = useState('');
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [devicesLoading, setDevicesLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [misconfigured, setMisconfigured] = useState(false);
+
+  useEffect(() => {
+    const alive = { current: true };
+    adminApi
+      .listDevices({ limit: 200 })
+      .then((res) => {
+        if (alive.current) setDevices(res.items);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError ? err.message : 'Failed to load devices.',
+          );
+        }
+      })
+      .finally(() => {
+        if (alive.current) setDevicesLoading(false);
+      });
+    return () => {
+      alive.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSubmit = () => {
+    setSubmitting(true);
+    setMisconfigured(false);
+    adminApi
+      .createRoom({
+        name,
+        timezone,
+        autoSessionEnabled: false,
+        sourceDeviceUids: [sourceDeviceUid],
+      })
+      .then(() => {
+        showSuccess('Room created.');
+        onCreated();
+      })
+      .catch((err: unknown) => {
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError ? err.message : 'Failed to create room.',
+          );
+        }
+      })
+      .finally(() => {
+        setSubmitting(false);
+      });
+  };
+
+  const canSubmit =
+    name.trim() !== '' && timezone.trim() !== '' && sourceDeviceUid !== '';
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>New room</DialogTitle>
+      <DialogContent>
+        {misconfigured && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Admin backend misconfiguration — an operator must check the
+            server&apos;s ADMIN_API_KEY.
+          </Alert>
+        )}
+        <TextField
+          label="Name"
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+          }}
+          fullWidth
+          margin="normal"
+          autoFocus
+        />
+        <TextField
+          label="Timezone"
+          value={timezone}
+          onChange={(e) => {
+            setTimezone(e.target.value);
+          }}
+          fullWidth
+          margin="normal"
+          helperText="IANA timezone identifier, e.g. America/Chicago"
+        />
+        <FormControl
+          fullWidth
+          margin="normal"
+          disabled={devicesLoading || devices.length === 0}
+        >
+          <InputLabel id="create-room-source-device-label">
+            Source device
+          </InputLabel>
+          <Select
+            labelId="create-room-source-device-label"
+            label="Source device"
+            value={sourceDeviceUid}
+            onChange={(e: SelectChangeEvent) => {
+              setSourceDeviceUid(e.target.value);
+            }}
+          >
+            {devices.map((d) => (
+              <MenuItem key={d.uid} value={d.uid}>
+                {d.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        {!devicesLoading && devices.length === 0 && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            No devices are registered yet. Register a device before creating a
+            room.
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={!canSubmit || submitting}
+        >
+          {submitting ? 'Creating…' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export const RoomsListPage = () => {
+  const navigate = useNavigate();
+  const { showError } = useToast();
+  const [rooms, setRooms] = useState<Room[]>([]);
+  const [search, setSearch] = useState('');
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [misconfigured, setMisconfigured] = useState(false);
+
+  const load = (opts: { search: string; cursor?: string; append: boolean }) => {
+    if (opts.append) setLoadingMore(true);
+    else setLoading(true);
+    const query: { search?: string; cursor?: string; limit: number } = {
+      limit: PAGE_LIMIT,
+    };
+    if (opts.search !== '') query.search = opts.search;
+    if (opts.cursor !== undefined) query.cursor = opts.cursor;
+    adminApi
+      .listRooms(query)
+      .then((res) => {
+        setMisconfigured(false);
+        setRooms((prev) => (opts.append ? [...prev, ...res.items] : res.items));
+        setNextCursor(res.nextCursor);
+      })
+      .catch((err: unknown) => {
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError ? err.message : 'Failed to load rooms.',
+          );
+        }
+      })
+      .finally(() => {
+        setLoading(false);
+        setLoadingMore(false);
+      });
+  };
+
+  useEffect(() => {
+    const alive = { current: true };
+    setLoading(true);
+    const query: { search?: string; limit: number } = { limit: PAGE_LIMIT };
+    if (search !== '') query.search = search;
+    adminApi
+      .listRooms(query)
+      .then((res) => {
+        if (!alive.current) return;
+        setMisconfigured(false);
+        setRooms(res.items);
+        setNextCursor(res.nextCursor);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (
+          err instanceof ApiError &&
+          err.code === 'BACKEND_MISCONFIGURATION'
+        ) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            err instanceof ApiError ? err.message : 'Failed to load rooms.',
+          );
+        }
+      })
+      .finally(() => {
+        if (alive.current) setLoading(false);
+      });
+    return () => {
+      alive.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search]);
+
+  const handleLoadMore = () => {
+    if (nextCursor === null) return;
+    load({ search, cursor: nextCursor, append: true });
+  };
+
+  const handleCreated = () => {
+    setCreateOpen(false);
+    load({ search, append: false });
+  };
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 2,
+        }}
+      >
+        <Typography variant="h5" component="h1">
+          Rooms
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => {
+            setCreateOpen(true);
+          }}
+        >
+          New room
+        </Button>
+      </Box>
+
+      {misconfigured && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Admin backend misconfiguration — an operator must check the
+          server&apos;s ADMIN_API_KEY.
+        </Alert>
+      )}
+
+      <TextField
+        label="Search rooms"
+        value={search}
+        onChange={(e) => {
+          setSearch(e.target.value);
+        }}
+        fullWidth
+        sx={{ mb: 2 }}
+        size="small"
+      />
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Timezone</TableCell>
+              <TableCell>Auto-sessions</TableCell>
+              <TableCell>Created</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={4} align="center" sx={{ py: 4 }}>
+                  <CircularProgress size={28} />
+                </TableCell>
+              </TableRow>
+            ) : rooms.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} align="center" sx={{ py: 4 }}>
+                  <Typography color="text.secondary">
+                    No rooms found.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              rooms.map((room) => (
+                <TableRow
+                  key={room.uid}
+                  hover
+                  onClick={() => {
+                    void navigate(`/rooms/${room.uid}`);
+                  }}
+                  sx={{ cursor: 'pointer' }}
+                >
+                  <TableCell>{room.name}</TableCell>
+                  <TableCell>{room.timezone}</TableCell>
+                  <TableCell>
+                    <Chip
+                      size="small"
+                      label={room.autoSessionEnabled ? 'Enabled' : 'Disabled'}
+                      color={room.autoSessionEnabled ? 'success' : 'default'}
+                      variant="outlined"
+                    />
+                  </TableCell>
+                  <TableCell>
+                    {new Date(room.createdAt).toLocaleString()}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {nextCursor !== null && !loading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+          <Button onClick={handleLoadMore} disabled={loadingMore}>
+            {loadingMore ? 'Loading…' : 'Load more'}
+          </Button>
+        </Box>
+      )}
+
+      {createOpen && (
+        <CreateRoomDialog
+          onClose={() => {
+            setCreateOpen(false);
+          }}
+          onCreated={handleCreated}
+        />
+      )}
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
+++ b/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
@@ -1,0 +1,1497 @@
+import { type SyntheticEvent, useEffect, useState } from 'react';
+
+import AddIcon from '@mui/icons-material/Add';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Checkbox from '@mui/material/Checkbox';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Grid from '@mui/material/Grid';
+import InputLabel from '@mui/material/InputLabel';
+import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Select from '@mui/material/Select';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+import { useNavigate, useParams } from 'react-router-dom';
+
+import type {
+  AutoSessionWindow,
+  Room,
+  SessionSchedule,
+} from '@scribear/session-manager-schema';
+
+import { ConfirmDialog } from '#src/components/confirm-dialog';
+import type {
+  CreateAutoWindowBody,
+  CreateOnDemandSessionBody,
+  CreateScheduleBody,
+  DayOfWeek,
+  ScheduleFrequency,
+  SessionScope,
+  UpdateAutoWindowBody,
+  UpdateScheduleBody,
+} from '#src/lib/admin-api';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { useToast } from '#src/lib/toast-context';
+
+const DAYS_OF_WEEK: readonly DayOfWeek[] = [
+  'SUN',
+  'MON',
+  'TUE',
+  'WED',
+  'THU',
+  'FRI',
+  'SAT',
+];
+const SCOPES: readonly SessionScope[] = [
+  'SEND_AUDIO',
+  'RECEIVE_TRANSCRIPTIONS',
+];
+const FREQUENCIES: readonly ScheduleFrequency[] = [
+  'ONCE',
+  'WEEKLY',
+  'BIWEEKLY',
+];
+const RANGE_DAYS = 90;
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof ApiError ? err.message : fallback;
+}
+
+function formatInRoomTz(iso: string, timezone: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(new Date(iso));
+  } catch {
+    return new Date(iso).toLocaleString();
+  }
+}
+
+/** Converts a `datetime-local` input value to an ISO instant, or null if empty. */
+function localInputToIso(value: string): string | null {
+  if (value === '') return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
+/** Converts an ISO instant to a `datetime-local` input value (browser-local). */
+function isoToLocalInput(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const year = String(d.getFullYear());
+  return `${year}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function sameStringArray(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+}
+
+interface MultiSelectFieldProps<T extends string> {
+  label: string;
+  options: readonly T[];
+  value: T[];
+  onChange: (value: T[]) => void;
+  disabled: boolean;
+}
+
+function MultiSelectField<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+  disabled,
+}: MultiSelectFieldProps<T>) {
+  const labelId = `multiselect-${label.replace(/\s+/g, '-').toLowerCase()}`;
+  return (
+    <FormControl fullWidth margin="normal" disabled={disabled}>
+      <InputLabel id={labelId}>{label}</InputLabel>
+      <Select<T[]>
+        labelId={labelId}
+        label={label}
+        multiple
+        value={value}
+        onChange={(e: SelectChangeEvent<T[]>) => {
+          const v = e.target.value;
+          onChange(typeof v === 'string' ? (v.split(',') as T[]) : v);
+        }}
+        renderValue={(selected) => selected.join(', ')}
+      >
+        {options.map((opt) => (
+          <MenuItem key={opt} value={opt}>
+            <Checkbox checked={value.includes(opt)} />
+            <ListItemText primary={opt} />
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}
+
+/** JSON textarea for `transcriptionStreamConfig`. Parsing happens on submit. */
+interface JsonConfigFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  error: string | null;
+}
+
+const JsonConfigField = ({ value, onChange, error }: JsonConfigFieldProps) => (
+  <TextField
+    label="Transcription stream config (JSON)"
+    value={value}
+    onChange={(e) => {
+      onChange(e.target.value);
+    }}
+    fullWidth
+    margin="normal"
+    multiline
+    minRows={3}
+    error={error !== null}
+    helperText={error ?? 'Must be valid JSON, e.g. {}'}
+  />
+);
+
+interface ScheduleFormState {
+  name: string;
+  frequency: ScheduleFrequency;
+  daysOfWeek: DayOfWeek[];
+  localStartTime: string;
+  localEndTime: string;
+  activeStart: string;
+  activeEndInput: string;
+  indefinite: boolean;
+  joinCodeScopes: SessionScope[];
+  transcriptionProviderId: string;
+  transcriptionStreamConfig: string;
+}
+
+function scheduleToFormState(schedule: SessionSchedule): ScheduleFormState {
+  return {
+    name: schedule.name,
+    frequency: schedule.frequency,
+    daysOfWeek: schedule.daysOfWeek ?? [],
+    localStartTime: schedule.localStartTime.slice(0, 5),
+    localEndTime: schedule.localEndTime.slice(0, 5),
+    activeStart: isoToLocalInput(schedule.activeStart),
+    activeEndInput:
+      schedule.activeEnd === null ? '' : isoToLocalInput(schedule.activeEnd),
+    indefinite: schedule.activeEnd === null,
+    joinCodeScopes: schedule.joinCodeScopes,
+    transcriptionProviderId: schedule.transcriptionProviderId ?? 'whisper',
+    transcriptionStreamConfig: JSON.stringify(
+      schedule.transcriptionStreamConfig ?? {},
+    ),
+  };
+}
+
+interface ScheduleDialogProps {
+  roomUid: string;
+  schedule: SessionSchedule | null;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+const ScheduleDialog = ({
+  roomUid,
+  schedule,
+  onClose,
+  onSaved,
+}: ScheduleDialogProps) => {
+  const { showSuccess, showError } = useToast();
+  const [form, setForm] = useState<ScheduleFormState>(
+    schedule
+      ? scheduleToFormState(schedule)
+      : {
+          name: '',
+          frequency: 'ONCE',
+          daysOfWeek: [],
+          localStartTime: '09:00',
+          localEndTime: '10:00',
+          activeStart: '',
+          activeEndInput: '',
+          indefinite: true,
+          joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+          transcriptionProviderId: 'whisper',
+          transcriptionStreamConfig: '{}',
+        },
+  );
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [misconfigured, setMisconfigured] = useState(false);
+
+  const handleSubmit = () => {
+    setJsonError(null);
+    if (form.frequency !== 'ONCE' && form.daysOfWeek.length === 0) {
+      showError('Select at least one day of week for a recurring schedule.');
+      return;
+    }
+    const activeStartIso = localInputToIso(form.activeStart);
+    if (activeStartIso === null) {
+      showError('Enter a valid start date/time.');
+      return;
+    }
+    const activeStartChanged = activeStartIso !== schedule?.activeStart;
+    if (
+      activeStartChanged &&
+      new Date(activeStartIso).getTime() <= Date.now()
+    ) {
+      showError('Active start must be in the future.');
+      return;
+    }
+    let activeEndIso: string | null = null;
+    if (!form.indefinite) {
+      activeEndIso = localInputToIso(form.activeEndInput);
+      if (activeEndIso === null) {
+        showError('Enter a valid end date/time, or mark this indefinite.');
+        return;
+      }
+    }
+    let transcriptionStreamConfig: unknown;
+    try {
+      transcriptionStreamConfig = JSON.parse(form.transcriptionStreamConfig);
+    } catch {
+      setJsonError('Invalid JSON.');
+      return;
+    }
+    const daysOfWeek = form.frequency === 'ONCE' ? null : form.daysOfWeek;
+
+    setSubmitting(true);
+    setMisconfigured(false);
+
+    if (schedule === null) {
+      const body: CreateScheduleBody = {
+        roomUid,
+        name: form.name,
+        activeStart: activeStartIso,
+        activeEnd: activeEndIso,
+        localStartTime: form.localStartTime,
+        localEndTime: form.localEndTime,
+        frequency: form.frequency,
+        daysOfWeek,
+        joinCodeScopes: form.joinCodeScopes,
+        transcriptionProviderId: form.transcriptionProviderId,
+        transcriptionStreamConfig,
+      };
+      adminApi
+        .createSchedule(body)
+        .then(() => {
+          showSuccess('Schedule created.');
+          onSaved();
+        })
+        .catch((err: unknown) => {
+          if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+            setMisconfigured(true);
+          } else {
+            showError(errorMessage(err, 'Failed to create schedule.'));
+          }
+        })
+        .finally(() => {
+          setSubmitting(false);
+        });
+    } else {
+      const body: UpdateScheduleBody = { scheduleUid: schedule.uid };
+      if (form.name !== schedule.name) body.name = form.name;
+      if (activeStartIso !== schedule.activeStart) {
+        body.activeStart = activeStartIso;
+      }
+      if (activeEndIso !== schedule.activeEnd) body.activeEnd = activeEndIso;
+      if (form.localStartTime !== schedule.localStartTime.slice(0, 5)) {
+        body.localStartTime = form.localStartTime;
+      }
+      if (form.localEndTime !== schedule.localEndTime.slice(0, 5)) {
+        body.localEndTime = form.localEndTime;
+      }
+      if (form.frequency !== schedule.frequency)
+        body.frequency = form.frequency;
+      if (JSON.stringify(daysOfWeek) !== JSON.stringify(schedule.daysOfWeek)) {
+        body.daysOfWeek = daysOfWeek;
+      }
+      if (!sameStringArray(form.joinCodeScopes, schedule.joinCodeScopes)) {
+        body.joinCodeScopes = form.joinCodeScopes;
+      }
+      if (
+        form.transcriptionProviderId !==
+        (schedule.transcriptionProviderId ?? '')
+      ) {
+        body.transcriptionProviderId = form.transcriptionProviderId;
+      }
+      if (
+        JSON.stringify(transcriptionStreamConfig) !==
+        JSON.stringify(schedule.transcriptionStreamConfig ?? {})
+      ) {
+        body.transcriptionStreamConfig = transcriptionStreamConfig;
+      }
+      adminApi
+        .updateSchedule(body)
+        .then(() => {
+          showSuccess('Schedule updated.');
+          onSaved();
+        })
+        .catch((err: unknown) => {
+          if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+            setMisconfigured(true);
+          } else {
+            showError(errorMessage(err, 'Failed to update schedule.'));
+          }
+        })
+        .finally(() => {
+          setSubmitting(false);
+        });
+    }
+  };
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        {schedule === null ? 'New schedule' : 'Edit schedule'}
+      </DialogTitle>
+      <DialogContent>
+        {misconfigured && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Admin backend misconfiguration — an operator must check the
+            server&apos;s ADMIN_API_KEY.
+          </Alert>
+        )}
+        <TextField
+          label="Name"
+          value={form.name}
+          onChange={(e) => {
+            setForm((f) => ({ ...f, name: e.target.value }));
+          }}
+          fullWidth
+          margin="normal"
+          autoFocus
+        />
+        <FormControl fullWidth margin="normal">
+          <InputLabel id="schedule-frequency-label">Frequency</InputLabel>
+          <Select
+            labelId="schedule-frequency-label"
+            label="Frequency"
+            value={form.frequency}
+            onChange={(e: SelectChangeEvent) => {
+              setForm((f) => ({
+                ...f,
+                frequency: e.target.value as ScheduleFrequency,
+              }));
+            }}
+          >
+            {FREQUENCIES.map((f) => (
+              <MenuItem key={f} value={f}>
+                {f}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <MultiSelectField
+          label="Days of week"
+          options={DAYS_OF_WEEK}
+          value={form.daysOfWeek}
+          onChange={(v) => {
+            setForm((f) => ({ ...f, daysOfWeek: v }));
+          }}
+          disabled={form.frequency === 'ONCE'}
+        />
+        <Stack direction="row" spacing={2}>
+          <TextField
+            label="Local start time"
+            type="time"
+            value={form.localStartTime}
+            onChange={(e) => {
+              setForm((f) => ({ ...f, localStartTime: e.target.value }));
+            }}
+            margin="normal"
+            fullWidth
+            slotProps={{ inputLabel: { shrink: true } }}
+          />
+          <TextField
+            label="Local end time"
+            type="time"
+            value={form.localEndTime}
+            onChange={(e) => {
+              setForm((f) => ({ ...f, localEndTime: e.target.value }));
+            }}
+            margin="normal"
+            fullWidth
+            slotProps={{ inputLabel: { shrink: true } }}
+          />
+        </Stack>
+        <TextField
+          label="Active start"
+          type="datetime-local"
+          value={form.activeStart}
+          onChange={(e) => {
+            setForm((f) => ({ ...f, activeStart: e.target.value }));
+          }}
+          margin="normal"
+          fullWidth
+          helperText="Must be in the future. Interpreted in your browser's local time zone."
+          slotProps={{ inputLabel: { shrink: true } }}
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={form.indefinite}
+              onChange={(e) => {
+                setForm((f) => ({ ...f, indefinite: e.target.checked }));
+              }}
+            />
+          }
+          label="No end date (indefinite)"
+        />
+        {!form.indefinite && (
+          <TextField
+            label="Active end"
+            type="datetime-local"
+            value={form.activeEndInput}
+            onChange={(e) => {
+              setForm((f) => ({ ...f, activeEndInput: e.target.value }));
+            }}
+            margin="normal"
+            fullWidth
+            slotProps={{ inputLabel: { shrink: true } }}
+          />
+        )}
+        <MultiSelectField
+          label="Join code scopes"
+          options={SCOPES}
+          value={form.joinCodeScopes}
+          onChange={(v) => {
+            setForm((f) => ({ ...f, joinCodeScopes: v }));
+          }}
+          disabled={false}
+        />
+        <TextField
+          label="Transcription provider ID"
+          value={form.transcriptionProviderId}
+          onChange={(e) => {
+            setForm((f) => ({ ...f, transcriptionProviderId: e.target.value }));
+          }}
+          fullWidth
+          margin="normal"
+        />
+        <JsonConfigField
+          value={form.transcriptionStreamConfig}
+          onChange={(v) => {
+            setForm((f) => ({ ...f, transcriptionStreamConfig: v }));
+          }}
+          error={jsonError}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={submitting || form.name.trim() === ''}
+        >
+          {submitting ? 'Saving…' : 'Save'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+interface AutoWindowFormState {
+  localStartTime: string;
+  localEndTime: string;
+  daysOfWeek: DayOfWeek[];
+  activeStart: string;
+  activeEndInput: string;
+  indefinite: boolean;
+  joinCodeScopes: SessionScope[];
+  transcriptionProviderId: string;
+  transcriptionStreamConfig: string;
+}
+
+function windowToFormState(w: AutoSessionWindow): AutoWindowFormState {
+  return {
+    localStartTime: w.localStartTime.slice(0, 5),
+    localEndTime: w.localEndTime.slice(0, 5),
+    daysOfWeek: w.daysOfWeek,
+    activeStart: isoToLocalInput(w.activeStart),
+    activeEndInput: w.activeEnd === null ? '' : isoToLocalInput(w.activeEnd),
+    indefinite: w.activeEnd === null,
+    joinCodeScopes: w.joinCodeScopes,
+    transcriptionProviderId: w.transcriptionProviderId,
+    transcriptionStreamConfig: JSON.stringify(
+      w.transcriptionStreamConfig ?? {},
+    ),
+  };
+}
+
+interface AutoWindowDialogProps {
+  roomUid: string;
+  window: AutoSessionWindow | null;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+const AutoWindowDialog = ({
+  roomUid,
+  window: autoWindow,
+  onClose,
+  onSaved,
+}: AutoWindowDialogProps) => {
+  const { showSuccess, showError } = useToast();
+  const [form, setForm] = useState<AutoWindowFormState>(
+    autoWindow
+      ? windowToFormState(autoWindow)
+      : {
+          localStartTime: '09:00',
+          localEndTime: '10:00',
+          daysOfWeek: [],
+          activeStart: '',
+          activeEndInput: '',
+          indefinite: true,
+          joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+          transcriptionProviderId: 'whisper',
+          transcriptionStreamConfig: '{}',
+        },
+  );
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [misconfigured, setMisconfigured] = useState(false);
+
+  const handleSubmit = () => {
+    setJsonError(null);
+    if (form.daysOfWeek.length === 0) {
+      showError('Select at least one day of week.');
+      return;
+    }
+    const activeStartIso = localInputToIso(form.activeStart);
+    if (activeStartIso === null) {
+      showError('Enter a valid start date/time.');
+      return;
+    }
+    const activeStartChanged = activeStartIso !== autoWindow?.activeStart;
+    if (
+      activeStartChanged &&
+      new Date(activeStartIso).getTime() <= Date.now()
+    ) {
+      showError('Active start must be in the future.');
+      return;
+    }
+    let activeEndIso: string | null = null;
+    if (!form.indefinite) {
+      activeEndIso = localInputToIso(form.activeEndInput);
+      if (activeEndIso === null) {
+        showError('Enter a valid end date/time, or mark this indefinite.');
+        return;
+      }
+    }
+    let transcriptionStreamConfig: unknown;
+    try {
+      transcriptionStreamConfig = JSON.parse(form.transcriptionStreamConfig);
+    } catch {
+      setJsonError('Invalid JSON.');
+      return;
+    }
+
+    setSubmitting(true);
+    setMisconfigured(false);
+
+    if (autoWindow === null) {
+      const body: CreateAutoWindowBody = {
+        roomUid,
+        localStartTime: form.localStartTime,
+        localEndTime: form.localEndTime,
+        daysOfWeek: form.daysOfWeek,
+        activeStart: activeStartIso,
+        activeEnd: activeEndIso,
+        joinCodeScopes: form.joinCodeScopes,
+        transcriptionProviderId: form.transcriptionProviderId,
+        transcriptionStreamConfig,
+      };
+      adminApi
+        .createAutoWindow(body)
+        .then(() => {
+          showSuccess('Auto-session window created.');
+          onSaved();
+        })
+        .catch((err: unknown) => {
+          if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+            setMisconfigured(true);
+          } else {
+            showError(errorMessage(err, 'Failed to create window.'));
+          }
+        })
+        .finally(() => {
+          setSubmitting(false);
+        });
+    } else {
+      const body: UpdateAutoWindowBody = { windowUid: autoWindow.uid };
+      if (form.localStartTime !== autoWindow.localStartTime.slice(0, 5)) {
+        body.localStartTime = form.localStartTime;
+      }
+      if (form.localEndTime !== autoWindow.localEndTime.slice(0, 5)) {
+        body.localEndTime = form.localEndTime;
+      }
+      if (!sameStringArray(form.daysOfWeek, autoWindow.daysOfWeek)) {
+        body.daysOfWeek = form.daysOfWeek;
+      }
+      if (activeStartIso !== autoWindow.activeStart) {
+        body.activeStart = activeStartIso;
+      }
+      if (activeEndIso !== autoWindow.activeEnd) body.activeEnd = activeEndIso;
+      if (!sameStringArray(form.joinCodeScopes, autoWindow.joinCodeScopes)) {
+        body.joinCodeScopes = form.joinCodeScopes;
+      }
+      if (form.transcriptionProviderId !== autoWindow.transcriptionProviderId) {
+        body.transcriptionProviderId = form.transcriptionProviderId;
+      }
+      if (
+        JSON.stringify(transcriptionStreamConfig) !==
+        JSON.stringify(autoWindow.transcriptionStreamConfig)
+      ) {
+        body.transcriptionStreamConfig = transcriptionStreamConfig;
+      }
+      adminApi
+        .updateAutoWindow(body)
+        .then(() => {
+          showSuccess('Auto-session window updated.');
+          onSaved();
+        })
+        .catch((err: unknown) => {
+          if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+            setMisconfigured(true);
+          } else {
+            showError(errorMessage(err, 'Failed to update window.'));
+          }
+        })
+        .finally(() => {
+          setSubmitting(false);
+        });
+    }
+  };
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        {autoWindow === null
+          ? 'New auto-session window'
+          : 'Edit auto-session window'}
+      </DialogTitle>
+      <DialogContent>
+        {misconfigured && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Admin backend misconfiguration — an operator must check the
+            server&apos;s ADMIN_API_KEY.
+          </Alert>
+        )}
+        <Stack direction="row" spacing={2}>
+          <TextField
+            label="Local start time"
+            type="time"
+            value={form.localStartTime}
+            onChange={(e) => {
+              setForm((f) => ({ ...f, localStartTime: e.target.value }));
+            }}
+            margin="normal"
+            fullWidth
+            slotProps={{ inputLabel: { shrink: true } }}
+          />
+          <TextField
+            label="Local end time"
+            type="time"
+            value={form.localEndTime}
+            onChange={(e) => {
+              setForm((f) => ({ ...f, localEndTime: e.target.value }));
+            }}
+            margin="normal"
+            fullWidth
+            slotProps={{ inputLabel: { shrink: true } }}
+          />
+        </Stack>
+        <MultiSelectField
+          label="Days of week"
+          options={DAYS_OF_WEEK}
+          value={form.daysOfWeek}
+          onChange={(v) => {
+            setForm((f) => ({ ...f, daysOfWeek: v }));
+          }}
+          disabled={false}
+        />
+        <TextField
+          label="Active start"
+          type="datetime-local"
+          value={form.activeStart}
+          onChange={(e) => {
+            setForm((f) => ({ ...f, activeStart: e.target.value }));
+          }}
+          margin="normal"
+          fullWidth
+          helperText="Must be in the future. Interpreted in your browser's local time zone."
+          slotProps={{ inputLabel: { shrink: true } }}
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={form.indefinite}
+              onChange={(e) => {
+                setForm((f) => ({ ...f, indefinite: e.target.checked }));
+              }}
+            />
+          }
+          label="No end date (indefinite)"
+        />
+        {!form.indefinite && (
+          <TextField
+            label="Active end"
+            type="datetime-local"
+            value={form.activeEndInput}
+            onChange={(e) => {
+              setForm((f) => ({ ...f, activeEndInput: e.target.value }));
+            }}
+            margin="normal"
+            fullWidth
+            slotProps={{ inputLabel: { shrink: true } }}
+          />
+        )}
+        <MultiSelectField
+          label="Join code scopes"
+          options={SCOPES}
+          value={form.joinCodeScopes}
+          onChange={(v) => {
+            setForm((f) => ({ ...f, joinCodeScopes: v }));
+          }}
+          disabled={false}
+        />
+        <TextField
+          label="Transcription provider ID"
+          value={form.transcriptionProviderId}
+          onChange={(e) => {
+            setForm((f) => ({ ...f, transcriptionProviderId: e.target.value }));
+          }}
+          fullWidth
+          margin="normal"
+        />
+        <JsonConfigField
+          value={form.transcriptionStreamConfig}
+          onChange={(v) => {
+            setForm((f) => ({ ...f, transcriptionStreamConfig: v }));
+          }}
+          error={jsonError}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={submitting}
+        >
+          {submitting ? 'Saving…' : 'Save'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+interface OnDemandFormState {
+  name: string;
+  joinCodeScopes: SessionScope[];
+  transcriptionProviderId: string;
+  transcriptionStreamConfig: string;
+}
+
+interface OnDemandDialogProps {
+  roomUid: string;
+  onClose: () => void;
+  onCreated: (sessionUid: string) => void;
+}
+
+const OnDemandDialog = ({
+  roomUid,
+  onClose,
+  onCreated,
+}: OnDemandDialogProps) => {
+  const { showSuccess, showError } = useToast();
+  const [form, setForm] = useState<OnDemandFormState>({
+    name: '',
+    joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+    transcriptionProviderId: 'whisper',
+    transcriptionStreamConfig: '{}',
+  });
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [misconfigured, setMisconfigured] = useState(false);
+
+  const handleSubmit = () => {
+    setJsonError(null);
+    let transcriptionStreamConfig: unknown;
+    try {
+      transcriptionStreamConfig = JSON.parse(form.transcriptionStreamConfig);
+    } catch {
+      setJsonError('Invalid JSON.');
+      return;
+    }
+    const body: CreateOnDemandSessionBody = {
+      roomUid,
+      name: form.name,
+      joinCodeScopes: form.joinCodeScopes,
+      transcriptionProviderId: form.transcriptionProviderId,
+      transcriptionStreamConfig,
+    };
+    setSubmitting(true);
+    setMisconfigured(false);
+    adminApi
+      .createOnDemandSession(body)
+      .then((created) => {
+        showSuccess('Session started.');
+        onCreated(created.uid);
+      })
+      .catch((err: unknown) => {
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else {
+          showError(errorMessage(err, 'Failed to start session.'));
+        }
+      })
+      .finally(() => {
+        setSubmitting(false);
+      });
+  };
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Start a session now</DialogTitle>
+      <DialogContent>
+        {misconfigured && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Admin backend misconfiguration — an operator must check the
+            server&apos;s ADMIN_API_KEY.
+          </Alert>
+        )}
+        <TextField
+          label="Name"
+          value={form.name}
+          onChange={(e) => {
+            setForm((f) => ({ ...f, name: e.target.value }));
+          }}
+          fullWidth
+          margin="normal"
+          autoFocus
+        />
+        <MultiSelectField
+          label="Join code scopes"
+          options={SCOPES}
+          value={form.joinCodeScopes}
+          onChange={(v) => {
+            setForm((f) => ({ ...f, joinCodeScopes: v }));
+          }}
+          disabled={false}
+        />
+        <TextField
+          label="Transcription provider ID"
+          value={form.transcriptionProviderId}
+          onChange={(e) => {
+            setForm((f) => ({ ...f, transcriptionProviderId: e.target.value }));
+          }}
+          fullWidth
+          margin="normal"
+        />
+        <JsonConfigField
+          value={form.transcriptionStreamConfig}
+          onChange={(v) => {
+            setForm((f) => ({ ...f, transcriptionStreamConfig: v }));
+          }}
+          error={jsonError}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={submitting || form.name.trim() === ''}
+        >
+          {submitting ? 'Starting…' : 'Start session'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export const RoomSchedulingPage = () => {
+  const { roomUid } = useParams<{ roomUid: string }>();
+  const navigate = useNavigate();
+  const { showSuccess, showError } = useToast();
+
+  const [room, setRoom] = useState<Room | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [misconfigured, setMisconfigured] = useState(false);
+  const [autoToggling, setAutoToggling] = useState(false);
+
+  const [schedules, setSchedules] = useState<SessionSchedule[]>([]);
+  const [schedulesLoading, setSchedulesLoading] = useState(true);
+  const [scheduleDialogOpen, setScheduleDialogOpen] = useState(false);
+  const [editingSchedule, setEditingSchedule] =
+    useState<SessionSchedule | null>(null);
+  const [deleteScheduleUid, setDeleteScheduleUid] = useState<string | null>(
+    null,
+  );
+  const [deletingSchedule, setDeletingSchedule] = useState(false);
+
+  const [windows, setWindows] = useState<AutoSessionWindow[]>([]);
+  const [windowsLoading, setWindowsLoading] = useState(true);
+  const [windowDialogOpen, setWindowDialogOpen] = useState(false);
+  const [editingWindow, setEditingWindow] = useState<AutoSessionWindow | null>(
+    null,
+  );
+  const [deleteWindowUid, setDeleteWindowUid] = useState<string | null>(null);
+  const [deletingWindow, setDeletingWindow] = useState(false);
+
+  const [onDemandOpen, setOnDemandOpen] = useState(false);
+
+  const rangeFrom = new Date().toISOString();
+  const rangeTo = new Date(
+    Date.now() + RANGE_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  const loadSchedules = () => {
+    if (roomUid === undefined) return;
+    setSchedulesLoading(true);
+    adminApi
+      .listSchedules({ roomUid, from: rangeFrom, to: rangeTo })
+      .then((res) => {
+        setSchedules(res.items);
+      })
+      .catch((err: unknown) => {
+        if (!isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          showError(errorMessage(err, 'Failed to load schedules.'));
+        }
+      })
+      .finally(() => {
+        setSchedulesLoading(false);
+      });
+  };
+
+  const loadWindows = () => {
+    if (roomUid === undefined) return;
+    setWindowsLoading(true);
+    adminApi
+      .listAutoWindows({ roomUid, from: rangeFrom, to: rangeTo })
+      .then((res) => {
+        setWindows(res.items);
+      })
+      .catch((err: unknown) => {
+        if (!isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          showError(errorMessage(err, 'Failed to load auto-session windows.'));
+        }
+      })
+      .finally(() => {
+        setWindowsLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    const alive = { current: true };
+    if (roomUid === undefined) return;
+    setLoading(true);
+    setSchedulesLoading(true);
+    setWindowsLoading(true);
+    adminApi
+      .roomDetail(roomUid)
+      .then((res) => {
+        if (!alive.current) return;
+        setMisconfigured(false);
+        setRoom(res.room);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else {
+          showError(errorMessage(err, 'Failed to load room.'));
+        }
+      })
+      .finally(() => {
+        if (alive.current) setLoading(false);
+      });
+    adminApi
+      .listSchedules({ roomUid, from: rangeFrom, to: rangeTo })
+      .then((res) => {
+        if (alive.current) setSchedules(res.items);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (!isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          showError(errorMessage(err, 'Failed to load schedules.'));
+        }
+      })
+      .finally(() => {
+        if (alive.current) setSchedulesLoading(false);
+      });
+    adminApi
+      .listAutoWindows({ roomUid, from: rangeFrom, to: rangeTo })
+      .then((res) => {
+        if (alive.current) setWindows(res.items);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (!isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          showError(errorMessage(err, 'Failed to load auto-session windows.'));
+        }
+      })
+      .finally(() => {
+        if (alive.current) setWindowsLoading(false);
+      });
+    return () => {
+      alive.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [roomUid]);
+
+  const handleToggleAuto = (_e: SyntheticEvent, checked: boolean) => {
+    if (roomUid === undefined || room === null) return;
+    setAutoToggling(true);
+    adminApi
+      .updateRoomScheduleConfig({ roomUid, autoSessionEnabled: checked })
+      .then((updated) => {
+        setRoom(updated);
+        showSuccess(
+          checked ? 'Auto-sessions enabled.' : 'Auto-sessions disabled.',
+        );
+      })
+      .catch((err: unknown) => {
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            errorMessage(err, 'Failed to update auto-session setting.'),
+          );
+        }
+      })
+      .finally(() => {
+        setAutoToggling(false);
+      });
+  };
+
+  const handleDeleteSchedule = () => {
+    if (deleteScheduleUid === null) return;
+    setDeletingSchedule(true);
+    adminApi
+      .deleteSchedule(deleteScheduleUid)
+      .then(() => {
+        showSuccess('Schedule deleted.');
+        loadSchedules();
+      })
+      .catch((err: unknown) => {
+        showError(errorMessage(err, 'Failed to delete schedule.'));
+      })
+      .finally(() => {
+        setDeletingSchedule(false);
+        setDeleteScheduleUid(null);
+      });
+  };
+
+  const handleDeleteWindow = () => {
+    if (deleteWindowUid === null) return;
+    setDeletingWindow(true);
+    adminApi
+      .deleteAutoWindow(deleteWindowUid)
+      .then(() => {
+        showSuccess('Auto-session window deleted.');
+        loadWindows();
+      })
+      .catch((err: unknown) => {
+        showError(errorMessage(err, 'Failed to delete window.'));
+      })
+      .finally(() => {
+        setDeletingWindow(false);
+        setDeleteWindowUid(null);
+      });
+  };
+
+  if (loading && room === null) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (room === null) {
+    return misconfigured ? (
+      <Alert severity="error">
+        Admin backend misconfiguration — an operator must check the
+        server&apos;s ADMIN_API_KEY.
+      </Alert>
+    ) : (
+      <Typography color="text.secondary">Room not found.</Typography>
+    );
+  }
+
+  return (
+    <Box>
+      {misconfigured && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Admin backend misconfiguration — an operator must check the
+          server&apos;s ADMIN_API_KEY.
+        </Alert>
+      )}
+
+      <Typography variant="h5" component="h1" gutterBottom>
+        Scheduling — {room.name}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        All times below are shown in this room&apos;s timezone ({room.timezone}
+        ).
+      </Typography>
+
+      <Card sx={{ mb: 3 }}>
+        <CardContent>
+          <Grid container spacing={2} alignItems="center">
+            <Grid size={{ xs: 12, sm: 8 }}>
+              <Typography variant="body1">Auto-sessions</Typography>
+              <Typography variant="body2" color="text.secondary">
+                When enabled, auto-session windows produce AUTO sessions to fill
+                any gaps left by scheduled/on-demand sessions.
+              </Typography>
+            </Grid>
+            <Grid size={{ xs: 12, sm: 4 }} sx={{ textAlign: { sm: 'right' } }}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={room.autoSessionEnabled}
+                    disabled={autoToggling}
+                    onChange={handleToggleAuto}
+                  />
+                }
+                label={room.autoSessionEnabled ? 'Enabled' : 'Disabled'}
+              />
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 1,
+        }}
+      >
+        <Box>
+          <Typography variant="h6" component="h2">
+            Schedules
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Showing occurrences between{' '}
+            {formatInRoomTz(rangeFrom, room.timezone)} and{' '}
+            {formatInRoomTz(rangeTo, room.timezone)} (next {RANGE_DAYS} days).
+          </Typography>
+        </Box>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => {
+            setEditingSchedule(null);
+            setScheduleDialogOpen(true);
+          }}
+        >
+          New schedule
+        </Button>
+      </Box>
+
+      <TableContainer component={Paper} sx={{ mb: 3 }}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Frequency</TableCell>
+              <TableCell>Days</TableCell>
+              <TableCell>Local time</TableCell>
+              <TableCell>Active start</TableCell>
+              <TableCell>Active end</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {schedulesLoading ? (
+              <TableRow>
+                <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
+                  <CircularProgress size={28} />
+                </TableCell>
+              </TableRow>
+            ) : schedules.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
+                  <Typography color="text.secondary">
+                    No schedules in this range.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              schedules.map((s) => (
+                <TableRow key={s.uid}>
+                  <TableCell>{s.name}</TableCell>
+                  <TableCell>{s.frequency}</TableCell>
+                  <TableCell>
+                    {s.daysOfWeek ? s.daysOfWeek.join(', ') : '—'}
+                  </TableCell>
+                  <TableCell>
+                    {s.localStartTime.slice(0, 5)}–{s.localEndTime.slice(0, 5)}
+                  </TableCell>
+                  <TableCell>
+                    {formatInRoomTz(s.activeStart, room.timezone)}
+                  </TableCell>
+                  <TableCell>
+                    {s.activeEnd === null
+                      ? 'Indefinite'
+                      : formatInRoomTz(s.activeEnd, room.timezone)}
+                  </TableCell>
+                  <TableCell align="right">
+                    <Stack
+                      direction="row"
+                      spacing={1}
+                      justifyContent="flex-end"
+                    >
+                      <Button
+                        size="small"
+                        onClick={() => {
+                          setEditingSchedule(s);
+                          setScheduleDialogOpen(true);
+                        }}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        size="small"
+                        color="error"
+                        onClick={() => {
+                          setDeleteScheduleUid(s.uid);
+                        }}
+                      >
+                        Delete
+                      </Button>
+                    </Stack>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 1,
+        }}
+      >
+        <Box>
+          <Typography variant="h6" component="h2">
+            Auto-session windows
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Showing occurrences between{' '}
+            {formatInRoomTz(rangeFrom, room.timezone)} and{' '}
+            {formatInRoomTz(rangeTo, room.timezone)} (next {RANGE_DAYS} days).
+          </Typography>
+        </Box>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => {
+            setEditingWindow(null);
+            setWindowDialogOpen(true);
+          }}
+        >
+          New window
+        </Button>
+      </Box>
+
+      <TableContainer component={Paper} sx={{ mb: 3 }}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Days</TableCell>
+              <TableCell>Local time</TableCell>
+              <TableCell>Active start</TableCell>
+              <TableCell>Active end</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {windowsLoading ? (
+              <TableRow>
+                <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+                  <CircularProgress size={28} />
+                </TableCell>
+              </TableRow>
+            ) : windows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+                  <Typography color="text.secondary">
+                    No auto-session windows in this range.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              windows.map((w) => (
+                <TableRow key={w.uid}>
+                  <TableCell>{w.daysOfWeek.join(', ')}</TableCell>
+                  <TableCell>
+                    {w.localStartTime.slice(0, 5)}–{w.localEndTime.slice(0, 5)}
+                  </TableCell>
+                  <TableCell>
+                    {formatInRoomTz(w.activeStart, room.timezone)}
+                  </TableCell>
+                  <TableCell>
+                    {w.activeEnd === null
+                      ? 'Indefinite'
+                      : formatInRoomTz(w.activeEnd, room.timezone)}
+                  </TableCell>
+                  <TableCell align="right">
+                    <Stack
+                      direction="row"
+                      spacing={1}
+                      justifyContent="flex-end"
+                    >
+                      <Button
+                        size="small"
+                        onClick={() => {
+                          setEditingWindow(w);
+                          setWindowDialogOpen(true);
+                        }}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        size="small"
+                        color="error"
+                        onClick={() => {
+                          setDeleteWindowUid(w.uid);
+                        }}
+                      >
+                        Delete
+                      </Button>
+                    </Stack>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h6" component="h2" gutterBottom>
+          On-demand session
+        </Typography>
+        <Button
+          variant="outlined"
+          onClick={() => {
+            setOnDemandOpen(true);
+          }}
+        >
+          Start a session now
+        </Button>
+      </Box>
+
+      {scheduleDialogOpen && (
+        <ScheduleDialog
+          roomUid={room.uid}
+          schedule={editingSchedule}
+          onClose={() => {
+            setScheduleDialogOpen(false);
+          }}
+          onSaved={() => {
+            setScheduleDialogOpen(false);
+            loadSchedules();
+          }}
+        />
+      )}
+
+      {windowDialogOpen && (
+        <AutoWindowDialog
+          roomUid={room.uid}
+          window={editingWindow}
+          onClose={() => {
+            setWindowDialogOpen(false);
+          }}
+          onSaved={() => {
+            setWindowDialogOpen(false);
+            loadWindows();
+          }}
+        />
+      )}
+
+      {onDemandOpen && (
+        <OnDemandDialog
+          roomUid={room.uid}
+          onClose={() => {
+            setOnDemandOpen(false);
+          }}
+          onCreated={(sessionUid) => {
+            setOnDemandOpen(false);
+            void navigate(`/sessions/${sessionUid}`);
+          }}
+        />
+      )}
+
+      <ConfirmDialog
+        open={deleteScheduleUid !== null}
+        title="Delete schedule"
+        message="This deletes the schedule and its future occurrences."
+        confirmLabel="Delete"
+        confirmColor="error"
+        loading={deletingSchedule}
+        onConfirm={handleDeleteSchedule}
+        onClose={() => {
+          setDeleteScheduleUid(null);
+        }}
+      />
+
+      <ConfirmDialog
+        open={deleteWindowUid !== null}
+        title="Delete auto-session window"
+        message="This deletes the auto-session window and stops it from producing further AUTO sessions."
+        confirmLabel="Delete"
+        confirmColor="error"
+        loading={deletingWindow}
+        onConfirm={handleDeleteWindow}
+        onClose={() => {
+          setDeleteWindowUid(null);
+        }}
+      />
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/features/sessions/session-detail-page.tsx
+++ b/apps/admin-webapp/src/features/sessions/session-detail-page.tsx
@@ -1,0 +1,290 @@
+import type { ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+import Link from '@mui/material/Link';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import { Link as RouterLink, useParams } from 'react-router-dom';
+
+import type { Session } from '@scribear/session-manager-schema';
+
+import { ConfirmDialog } from '#src/components/confirm-dialog';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { useToast } from '#src/lib/toast-context';
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof ApiError ? err.message : fallback;
+}
+
+function formatDateTime(iso: string | null): string {
+  return iso === null ? '—' : new Date(iso).toLocaleString();
+}
+
+interface FieldRowProps {
+  label: string;
+  children: ReactNode;
+}
+
+const FieldRow = ({ label, children }: FieldRowProps) => (
+  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+    <Typography variant="body2" color="text.secondary" sx={{ minWidth: 160 }}>
+      {label}
+    </Typography>
+    {children}
+  </Box>
+);
+
+export const SessionDetailPage = () => {
+  const { sessionUid } = useParams<{ sessionUid: string }>();
+  const { showSuccess, showError } = useToast();
+
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [misconfigured, setMisconfigured] = useState(false);
+  const [notFound, setNotFound] = useState(false);
+
+  const [startConfirmOpen, setStartConfirmOpen] = useState(false);
+  const [starting, setStarting] = useState(false);
+  const [endConfirmOpen, setEndConfirmOpen] = useState(false);
+  const [ending, setEnding] = useState(false);
+
+  const load = () => {
+    if (sessionUid === undefined) return;
+    setLoading(true);
+    setNotFound(false);
+    setMisconfigured(false);
+    adminApi
+      .getSession(sessionUid)
+      .then((s) => {
+        setSession(s);
+      })
+      .catch((err: unknown) => {
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else if (err instanceof ApiError && err.status === 404) {
+          setNotFound(true);
+        } else {
+          showError(errorMessage(err, 'Failed to load session.'));
+        }
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    if (sessionUid === undefined) return;
+    const alive = { current: true };
+    setLoading(true);
+    setNotFound(false);
+    setMisconfigured(false);
+    adminApi
+      .getSession(sessionUid)
+      .then((s) => {
+        if (alive.current) setSession(s);
+      })
+      .catch((err: unknown) => {
+        if (!alive.current) return;
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else if (err instanceof ApiError && err.status === 404) {
+          setNotFound(true);
+        } else {
+          showError(errorMessage(err, 'Failed to load session.'));
+        }
+      })
+      .finally(() => {
+        if (alive.current) setLoading(false);
+      });
+    return () => {
+      alive.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionUid]);
+
+  const handleStartEarly = () => {
+    if (sessionUid === undefined) return;
+    setStarting(true);
+    adminApi
+      .startSessionEarly(sessionUid)
+      .then(() => {
+        showSuccess('Session started early.');
+        load();
+      })
+      .catch((err: unknown) => {
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else {
+          showError(errorMessage(err, 'Failed to start session early.'));
+        }
+      })
+      .finally(() => {
+        setStarting(false);
+        setStartConfirmOpen(false);
+      });
+  };
+
+  const handleEndEarly = () => {
+    if (sessionUid === undefined) return;
+    setEnding(true);
+    adminApi
+      .endSessionEarly(sessionUid)
+      .then(() => {
+        showSuccess('Session ended early.');
+        load();
+      })
+      .catch((err: unknown) => {
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else {
+          showError(errorMessage(err, 'Failed to end session early.'));
+        }
+      })
+      .finally(() => {
+        setEnding(false);
+        setEndConfirmOpen(false);
+      });
+  };
+
+  if (loading && session === null) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (misconfigured && session === null) {
+    return (
+      <Alert severity="error">
+        Admin backend misconfiguration — an operator must check the
+        server&apos;s ADMIN_API_KEY.
+      </Alert>
+    );
+  }
+
+  if (notFound || session === null) {
+    return <Alert severity="warning">Session not found.</Alert>;
+  }
+
+  return (
+    <Box>
+      {misconfigured && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Admin backend misconfiguration — an operator must check the
+          server&apos;s ADMIN_API_KEY.
+        </Alert>
+      )}
+
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <Typography variant="h5" component="h1">
+          {session.name}
+        </Typography>
+        <Chip
+          size="small"
+          label={session.type}
+          color="primary"
+          variant="outlined"
+        />
+      </Box>
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        <Stack spacing={2}>
+          <FieldRow label="Room">
+            <Link component={RouterLink} to={`/rooms/${session.roomUid}`}>
+              {session.roomUid}
+            </Link>
+          </FieldRow>
+          <Divider />
+          <FieldRow label="Scheduled start">
+            <Typography>
+              {formatDateTime(session.scheduledStartTime)}
+            </Typography>
+          </FieldRow>
+          <Divider />
+          <FieldRow label="Scheduled end">
+            <Typography>{formatDateTime(session.scheduledEndTime)}</Typography>
+          </FieldRow>
+          <Divider />
+          <FieldRow label="Effective start">
+            <Typography>{formatDateTime(session.effectiveStart)}</Typography>
+          </FieldRow>
+          <Divider />
+          <FieldRow label="Effective end">
+            <Typography>{formatDateTime(session.effectiveEnd)}</Typography>
+          </FieldRow>
+          <Divider />
+          <FieldRow label="Join code scopes">
+            <Stack direction="row" spacing={1}>
+              {session.joinCodeScopes.map((scope) => (
+                <Chip key={scope} size="small" label={scope} />
+              ))}
+            </Stack>
+          </FieldRow>
+          <Divider />
+          <FieldRow label="Transcription provider">
+            <Typography>{session.transcriptionProviderId}</Typography>
+          </FieldRow>
+          <Divider />
+          <FieldRow label="Created">
+            <Typography>{formatDateTime(session.createdAt)}</Typography>
+          </FieldRow>
+        </Stack>
+      </Paper>
+
+      <Stack direction="row" spacing={2}>
+        <Button
+          variant="outlined"
+          onClick={() => {
+            setStartConfirmOpen(true);
+          }}
+        >
+          Start early
+        </Button>
+        <Button
+          variant="outlined"
+          color="error"
+          onClick={() => {
+            setEndConfirmOpen(true);
+          }}
+        >
+          End early
+        </Button>
+      </Stack>
+
+      <ConfirmDialog
+        open={startConfirmOpen}
+        title="Start session early"
+        message="This starts the session now, ahead of its scheduled start time."
+        confirmLabel="Start early"
+        loading={starting}
+        onConfirm={handleStartEarly}
+        onClose={() => {
+          setStartConfirmOpen(false);
+        }}
+      />
+
+      <ConfirmDialog
+        open={endConfirmOpen}
+        title="End session early"
+        message="This ends the session now, ahead of its scheduled end time."
+        confirmLabel="End early"
+        confirmColor="error"
+        loading={ending}
+        onConfirm={handleEndEarly}
+        onClose={() => {
+          setEndConfirmOpen(false);
+        }}
+      />
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -1,0 +1,390 @@
+import type {
+  AutoSessionWindow,
+  Device,
+  Room,
+  Session,
+  SessionSchedule,
+} from '@scribear/session-manager-schema';
+
+import { ApiError } from './api-error';
+
+export type ScheduleFrequency = 'ONCE' | 'WEEKLY' | 'BIWEEKLY';
+export type DayOfWeek = 'SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT';
+export type SessionScope = 'SEND_AUDIO' | 'RECEIVE_TRANSCRIPTIONS';
+
+export interface AuditRow {
+  id: string;
+  actorSubject: string;
+  actorProvider: string;
+  action: string;
+  target: string | null;
+  paramsSummary: unknown;
+  result: string;
+  statusCode: number | null;
+  requestId: string | null;
+  createdAt: string;
+}
+
+export interface TimeRangeQuery {
+  roomUid: string;
+  from?: string;
+  to?: string;
+}
+
+export interface CreateScheduleBody {
+  roomUid: string;
+  name: string;
+  activeStart: string;
+  activeEnd: string | null;
+  localStartTime: string;
+  localEndTime: string;
+  frequency: ScheduleFrequency;
+  daysOfWeek: DayOfWeek[] | null;
+  joinCodeScopes: SessionScope[];
+  transcriptionProviderId: string;
+  transcriptionStreamConfig: unknown;
+}
+
+export type UpdateScheduleBody = { scheduleUid: string } & Partial<
+  Omit<CreateScheduleBody, 'roomUid'>
+>;
+
+export interface CreateAutoWindowBody {
+  roomUid: string;
+  localStartTime: string;
+  localEndTime: string;
+  daysOfWeek: DayOfWeek[];
+  activeStart: string;
+  activeEnd: string | null;
+  joinCodeScopes: SessionScope[];
+  transcriptionProviderId: string;
+  transcriptionStreamConfig: unknown;
+}
+
+export type UpdateAutoWindowBody = { windowUid: string } & Partial<
+  Omit<CreateAutoWindowBody, 'roomUid'>
+>;
+
+export interface CreateOnDemandSessionBody {
+  roomUid: string;
+  name: string;
+  joinCodeScopes: SessionScope[];
+  transcriptionProviderId: string;
+  transcriptionStreamConfig: unknown;
+}
+
+const BASE = '/api/admin/v1';
+
+export interface AuthConfig {
+  local: boolean;
+  sso: boolean;
+}
+
+export interface Identity {
+  subject: string;
+  displayName: string;
+  provider: 'local' | 'sso';
+  roles: string[];
+}
+
+export interface SessionInfo {
+  identity: Identity;
+  csrfToken: string;
+}
+
+export interface HealthReport {
+  bff: string;
+  database: string;
+  sessionManager: string;
+  sessionManagerLatencyMs: number;
+  checkedAt: string;
+}
+
+export interface Paginated<T> {
+  items: T[];
+  nextCursor: string | null;
+}
+
+export interface RoomDetail {
+  room: Room;
+  devices: Device[];
+}
+
+export interface RegisterDeviceResult {
+  deviceUid: string;
+  activationCode: string;
+  expiry: string;
+}
+
+export interface ReregisterDeviceResult {
+  activationCode: string;
+  expiry: string;
+}
+
+export interface ListRoomsQuery {
+  search?: string;
+  cursor?: string;
+  limit?: number;
+}
+
+export interface ListDevicesQuery {
+  search?: string;
+  active?: boolean;
+  roomUid?: string;
+  cursor?: string;
+  limit?: number;
+}
+
+interface EnvelopeOk<T> {
+  ok: true;
+  data: T;
+}
+interface EnvelopeErr {
+  ok: false;
+  error: { code: string; message: string; requestId?: string };
+}
+
+type QueryValue = string | number | boolean | null | undefined;
+
+function toQueryString(params: Record<string, QueryValue>): string {
+  const usp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== null && v !== '') usp.set(k, String(v));
+  }
+  const s = usp.toString();
+  return s ? `?${s}` : '';
+}
+
+/**
+ * Typed client for the admin BFF. It:
+ * - always sends the session cookie (`credentials: 'include'`),
+ * - attaches the CSRF token header on state-changing requests,
+ * - unwraps the `{ ok, data }` envelope, throwing {@link ApiError} otherwise,
+ * - invokes `onUnauthorized` on a 401 so the app can route to /login.
+ *
+ * The admin API key is NEVER present here — it lives only in the BFF.
+ */
+export class AdminApiClient {
+  private _csrfToken = '';
+  private _onUnauthorized: (() => void) | undefined;
+
+  setCsrfToken(token: string): void {
+    this._csrfToken = token;
+  }
+
+  setOnUnauthorized(cb: () => void): void {
+    this._onUnauthorized = cb;
+  }
+
+  private async _request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const isMutation = method !== 'GET';
+    const headers: Record<string, string> = {};
+    if (body !== undefined) headers['content-type'] = 'application/json';
+    if (isMutation) headers['x-csrf-token'] = this._csrfToken;
+
+    let res: Response;
+    try {
+      res = await fetch(`${BASE}${path}`, {
+        method,
+        credentials: 'include',
+        headers,
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      });
+    } catch {
+      throw new ApiError('NETWORK', 'Could not reach the admin server.', 0);
+    }
+
+    let json: EnvelopeOk<T> | EnvelopeErr | undefined;
+    try {
+      json = (await res.json()) as EnvelopeOk<T> | EnvelopeErr;
+    } catch {
+      json = undefined;
+    }
+
+    if (res.ok && json?.ok) {
+      return json.data;
+    }
+
+    if (res.status === 401) {
+      // Session expired / not authenticated. Let the app react (route to login).
+      this._onUnauthorized?.();
+    }
+
+    const err =
+      json && !json.ok
+        ? json.error
+        : { code: 'UNKNOWN', message: 'The request failed.' };
+    throw new ApiError(err.code, err.message, res.status, err.requestId);
+  }
+
+  // ---- Auth ----
+  getAuthConfig(): Promise<AuthConfig> {
+    return this._request('GET', '/auth/config');
+  }
+  me(): Promise<SessionInfo> {
+    return this._request('GET', '/auth/me');
+  }
+  login(username: string, password: string): Promise<SessionInfo> {
+    return this._request('POST', '/auth/login', { username, password });
+  }
+  logout(): Promise<null> {
+    return this._request('POST', '/auth/logout');
+  }
+
+  // ---- Health ----
+  health(): Promise<HealthReport> {
+    return this._request('GET', '/health');
+  }
+
+  // ---- Rooms ----
+  listRooms(query: ListRoomsQuery = {}): Promise<Paginated<Room>> {
+    return this._request(
+      'GET',
+      `/rooms/list${toQueryString(query as Record<string, QueryValue>)}`,
+    );
+  }
+  getRoom(roomUid: string): Promise<Room> {
+    return this._request('GET', `/rooms/get/${encodeURIComponent(roomUid)}`);
+  }
+  roomDetail(roomUid: string): Promise<RoomDetail> {
+    return this._request('GET', `/rooms/detail/${encodeURIComponent(roomUid)}`);
+  }
+  createRoom(body: {
+    name: string;
+    timezone: string;
+    autoSessionEnabled: boolean;
+    sourceDeviceUids: string[];
+  }): Promise<Room> {
+    return this._request('POST', '/rooms/create', body);
+  }
+  updateRoom(body: { roomUid: string; name?: string }): Promise<Room> {
+    return this._request('POST', '/rooms/update', body);
+  }
+  deleteRoom(roomUid: string): Promise<null> {
+    return this._request('POST', '/rooms/delete', { roomUid });
+  }
+  addDeviceToRoom(body: {
+    roomUid: string;
+    deviceUid: string;
+    asSource: boolean;
+  }): Promise<null> {
+    return this._request('POST', '/rooms/add-device', body);
+  }
+  removeDeviceFromRoom(deviceUid: string): Promise<null> {
+    return this._request('POST', '/rooms/remove-device', { deviceUid });
+  }
+  setSourceDevice(body: { roomUid: string; deviceUid: string }): Promise<null> {
+    return this._request('POST', '/rooms/set-source', body);
+  }
+
+  // ---- Devices ----
+  listDevices(query: ListDevicesQuery = {}): Promise<Paginated<Device>> {
+    return this._request(
+      'GET',
+      `/devices/list${toQueryString(query as Record<string, QueryValue>)}`,
+    );
+  }
+  getDevice(deviceUid: string): Promise<Device> {
+    return this._request(
+      'GET',
+      `/devices/get/${encodeURIComponent(deviceUid)}`,
+    );
+  }
+  registerDevice(name: string): Promise<RegisterDeviceResult> {
+    return this._request('POST', '/devices/register', { name });
+  }
+  reregisterDevice(deviceUid: string): Promise<ReregisterDeviceResult> {
+    return this._request('POST', '/devices/reregister', { deviceUid });
+  }
+  updateDevice(body: { deviceUid: string; name?: string }): Promise<Device> {
+    return this._request('POST', '/devices/update', body);
+  }
+  deleteDevice(deviceUid: string): Promise<null> {
+    return this._request('POST', '/devices/delete', { deviceUid });
+  }
+
+  // ---- Schedules ----
+  listSchedules(query: TimeRangeQuery): Promise<{ items: SessionSchedule[] }> {
+    return this._request(
+      'GET',
+      `/schedules/list${toQueryString(query as unknown as Record<string, QueryValue>)}`,
+    );
+  }
+  getSchedule(scheduleUid: string): Promise<SessionSchedule> {
+    return this._request(
+      'GET',
+      `/schedules/get/${encodeURIComponent(scheduleUid)}`,
+    );
+  }
+  createSchedule(body: CreateScheduleBody): Promise<SessionSchedule> {
+    return this._request('POST', '/schedules/create', body);
+  }
+  updateSchedule(body: UpdateScheduleBody): Promise<SessionSchedule> {
+    return this._request('POST', '/schedules/update', body);
+  }
+  deleteSchedule(scheduleUid: string): Promise<null> {
+    return this._request('POST', '/schedules/delete', { scheduleUid });
+  }
+
+  // ---- Auto-session windows ----
+  listAutoWindows(
+    query: TimeRangeQuery,
+  ): Promise<{ items: AutoSessionWindow[] }> {
+    return this._request(
+      'GET',
+      `/auto-windows/list${toQueryString(query as unknown as Record<string, QueryValue>)}`,
+    );
+  }
+  getAutoWindow(windowUid: string): Promise<AutoSessionWindow> {
+    return this._request(
+      'GET',
+      `/auto-windows/get/${encodeURIComponent(windowUid)}`,
+    );
+  }
+  createAutoWindow(body: CreateAutoWindowBody): Promise<AutoSessionWindow> {
+    return this._request('POST', '/auto-windows/create', body);
+  }
+  updateAutoWindow(body: UpdateAutoWindowBody): Promise<AutoSessionWindow> {
+    return this._request('POST', '/auto-windows/update', body);
+  }
+  deleteAutoWindow(windowUid: string): Promise<null> {
+    return this._request('POST', '/auto-windows/delete', { windowUid });
+  }
+
+  // ---- Room schedule config (auto-session master switch) ----
+  updateRoomScheduleConfig(body: {
+    roomUid: string;
+    autoSessionEnabled?: boolean;
+  }): Promise<Room> {
+    return this._request('POST', '/schedules/room-config', body);
+  }
+
+  // ---- Sessions ----
+  getSession(sessionUid: string): Promise<Session> {
+    return this._request(
+      'GET',
+      `/sessions/get/${encodeURIComponent(sessionUid)}`,
+    );
+  }
+  createOnDemandSession(body: CreateOnDemandSessionBody): Promise<Session> {
+    return this._request('POST', '/sessions/create-on-demand', body);
+  }
+  startSessionEarly(sessionUid: string): Promise<null> {
+    return this._request('POST', '/sessions/start-early', { sessionUid });
+  }
+  endSessionEarly(sessionUid: string): Promise<null> {
+    return this._request('POST', '/sessions/end-early', { sessionUid });
+  }
+
+  // ---- Audit ----
+  listAudit(limit = 50): Promise<{ items: AuditRow[] }> {
+    return this._request('GET', `/audit${toQueryString({ limit })}`);
+  }
+}
+
+/** Shared singleton client. */
+export const adminApi = new AdminApiClient();

--- a/apps/admin-webapp/src/lib/api-error.ts
+++ b/apps/admin-webapp/src/lib/api-error.ts
@@ -1,0 +1,28 @@
+/**
+ * Error thrown by the admin API client for any non-ok response. Carries the
+ * BFF envelope's `code`/`message`/`requestId` plus the HTTP status so callers
+ * can branch (e.g. 409 conflict guidance, 502 backend misconfiguration).
+ */
+export class ApiError extends Error {
+  readonly code: string;
+  readonly status: number;
+  readonly requestId: string | undefined;
+
+  constructor(
+    code: string,
+    message: string,
+    status: number,
+    requestId?: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+    this.code = code;
+    this.status = status;
+    this.requestId = requestId;
+  }
+}
+
+/** True when the error is an ApiError with the given code. */
+export function isApiErrorCode(err: unknown, code: string): boolean {
+  return err instanceof ApiError && err.code === code;
+}

--- a/apps/admin-webapp/src/lib/toast-context.ts
+++ b/apps/admin-webapp/src/lib/toast-context.ts
@@ -1,0 +1,17 @@
+import { createContext, use } from 'react';
+
+export type ToastSeverity = 'success' | 'error' | 'info' | 'warning';
+
+export interface ToastApi {
+  showSuccess: (message: string) => void;
+  showError: (message: string) => void;
+  showInfo: (message: string) => void;
+}
+
+export const ToastContext = createContext<ToastApi | null>(null);
+
+export function useToast(): ToastApi {
+  const ctx = use(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within a ToastProvider.');
+  return ctx;
+}

--- a/apps/admin-webapp/src/lib/toast-provider.tsx
+++ b/apps/admin-webapp/src/lib/toast-provider.tsx
@@ -1,0 +1,71 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import Alert from '@mui/material/Alert';
+import Snackbar from '@mui/material/Snackbar';
+
+import {
+  type ToastApi,
+  ToastContext,
+  type ToastSeverity,
+} from './toast-context';
+
+interface ToastState {
+  open: boolean;
+  message: string;
+  severity: ToastSeverity;
+}
+
+/**
+ * Snackbar host + `useToast()` provider. One toast at a time; auto-hides.
+ */
+export const ToastProvider = ({ children }: React.PropsWithChildren) => {
+  const [state, setState] = useState<ToastState>({
+    open: false,
+    message: '',
+    severity: 'info',
+  });
+
+  const show = useCallback((message: string, severity: ToastSeverity) => {
+    setState({ open: true, message, severity });
+  }, []);
+
+  const api = useMemo<ToastApi>(
+    () => ({
+      showSuccess: (m) => {
+        show(m, 'success');
+      },
+      showError: (m) => {
+        show(m, 'error');
+      },
+      showInfo: (m) => {
+        show(m, 'info');
+      },
+    }),
+    [show],
+  );
+
+  const handleClose = () => {
+    setState((s) => ({ ...s, open: false }));
+  };
+
+  return (
+    <ToastContext value={api}>
+      {children}
+      <Snackbar
+        open={state.open}
+        autoHideDuration={5000}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert
+          severity={state.severity}
+          variant="filled"
+          onClose={handleClose}
+          sx={{ width: '100%' }}
+        >
+          {state.message}
+        </Alert>
+      </Snackbar>
+    </ToastContext>
+  );
+};

--- a/apps/admin-webapp/src/main.tsx
+++ b/apps/admin-webapp/src/main.tsx
@@ -1,0 +1,14 @@
+import { StrictMode } from 'react';
+
+import { createRoot } from 'react-dom/client';
+
+import { App } from './app/app';
+
+const root = document.getElementById('root');
+if (!root) throw new Error('No root element found');
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/admin-webapp/tsconfig.json
+++ b/apps/admin-webapp/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "paths": {
+      "#src/*": [
+        "./src/*"
+      ],
+      "#tests/*": [
+        "./tests/*"
+      ]
+    },
+    "types": [
+      "vite/client"
+    ],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src",
+    "tests"
+  ],
+  "references": [
+    {
+      "path": "../../libs/schemas/session-manager-schema"
+    }
+  ]
+}

--- a/apps/admin-webapp/vite.config.ts
+++ b/apps/admin-webapp/vite.config.ts
@@ -1,0 +1,42 @@
+/// <reference types="vitest" />
+/// <reference types="vite/client" />
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+import viteTsconfigPaths from 'vite-tsconfig-paths';
+
+// https://vite.dev/config/
+export default defineConfig({
+  // Served under /admin/ by nginx; keeping the base aligned lets the router use
+  // `/admin` as its basename in both dev and production.
+  base: '/admin/',
+  plugins: [react(), viteTsconfigPaths()],
+  resolve: {
+    conditions: ['development'],
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: [
+            'react',
+            'react-dom',
+            '@mui/material',
+            '@mui/icons-material',
+            '@emotion/react',
+            '@emotion/styled',
+            'react-router-dom',
+          ],
+        },
+      },
+    },
+  },
+  server: {
+    port: 3003,
+    proxy: {
+      '/api/admin': 'http://localhost:8003',
+    },
+  },
+  preview: {
+    port: 3004,
+  },
+});

--- a/apps/session-manager/package.json
+++ b/apps/session-manager/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@fastify/awilix": "8.2.0",
     "@fastify/cookie": "11.0.2",
+    "@fastify/rate-limit": "11.1.0",
     "@fastify/swagger": "9.7.0",
     "@fastify/swagger-ui": "5.2.5",
     "awilix": "13.0.0",

--- a/apps/session-manager/src/server/create-server.ts
+++ b/apps/session-manager/src/server/create-server.ts
@@ -1,6 +1,7 @@
 import fastifyCookie from '@fastify/cookie';
+import fastifyRateLimit from '@fastify/rate-limit';
 
-import { createBaseServer } from '@scribear/base-fastify-server';
+import { HttpError, createBaseServer } from '@scribear/base-fastify-server';
 
 import type { AppConfig } from '#src/app-config/app-config.js';
 
@@ -18,13 +19,27 @@ import swagger from './plugins/swagger.js';
  */
 async function createServer(config: AppConfig) {
   const { logger, dependencyContainer, fastify } = createBaseServer(
+    // Trust exactly ONE proxy hop (nginx) so `req.ip` is the client IP nginx
+    // appended to `X-Forwarded-For` (not spoofable by the client) — correct
+    // keying for the per-client rate limits below.
     config.baseConfig.logLevel,
+    { trustProxy: 1 },
   );
 
   if (config.baseConfig.isDevelopment) {
     await fastify.register(swagger);
   }
   fastify.register(fastifyCookie);
+
+  // Rate limiting is opt-in per route (`global: false`); only the
+  // unauthenticated credential-exchange routes enable it (see session-auth
+  // router). Long-poll and admin/service routes are intentionally unlimited.
+  // Throw a BaseHttpError so the base error handler serializes it as 429.
+  await fastify.register(fastifyRateLimit, {
+    global: false,
+    errorResponseBuilder: () =>
+      HttpError.rateLimited('Too many requests. Please retry shortly.'),
+  });
 
   registerDependencies(dependencyContainer, config);
 

--- a/apps/session-manager/src/server/features/session-auth/session-auth.router.ts
+++ b/apps/session-manager/src/server/features/session-auth/session-auth.router.ts
@@ -29,16 +29,19 @@ export function sessionAuthRouter(fastify: BaseFastifyInstance) {
   });
 
   // The next two routes are intentionally unauthenticated: the join code and
-  // the refresh token themselves serve as the credential.
+  // the refresh token themselves serve as the credential. They are the
+  // credential-guessing surface, so they are rate-limited per client IP.
   fastify.route({
     ...EXCHANGE_JOIN_CODE_ROUTE,
     schema: EXCHANGE_JOIN_CODE_SCHEMA,
+    config: { rateLimit: { max: 100, timeWindow: 60_000 } },
     handler: resolveHandler('sessionAuthController', 'exchangeJoinCode'),
   });
 
   fastify.route({
     ...REFRESH_SESSION_TOKEN_ROUTE,
     schema: REFRESH_SESSION_TOKEN_SCHEMA,
+    config: { rateLimit: { max: 100, timeWindow: 60_000 } },
     handler: resolveHandler('sessionAuthController', 'refreshSessionToken'),
   });
 }

--- a/apps/session-manager/src/server/shared/services/admin-auth.service.ts
+++ b/apps/session-manager/src/server/shared/services/admin-auth.service.ts
@@ -1,3 +1,8 @@
+import {
+  assertNotPlaceholderKey,
+  constantTimeEqual,
+} from '#src/server/utils/constant-time-equal.js';
+
 const BEARER_PREFIX = 'Bearer ';
 
 export interface AdminAuthConfig {
@@ -8,16 +13,18 @@ export class AdminAuthService {
   private _adminAuthConfig: AdminAuthConfig;
 
   constructor(adminAuthConfig: AdminAuthConfig) {
+    assertNotPlaceholderKey(adminAuthConfig.adminApiKey, 'ADMIN_API_KEY');
     this._adminAuthConfig = adminAuthConfig;
   }
 
   /**
-   * Strips the `Bearer ` prefix and compares the remaining key to the configured API key.
+   * Strips the `Bearer ` prefix and compares the remaining key to the
+   * configured API key in constant time.
    * @param authorizationHeader The raw `Authorization` header value.
    */
   isValid(authorizationHeader: string | undefined): boolean {
     if (!authorizationHeader?.startsWith(BEARER_PREFIX)) return false;
     const key = authorizationHeader.slice(BEARER_PREFIX.length);
-    return key === this._adminAuthConfig.adminApiKey;
+    return constantTimeEqual(key, this._adminAuthConfig.adminApiKey);
   }
 }

--- a/apps/session-manager/src/server/shared/services/service-auth.service.ts
+++ b/apps/session-manager/src/server/shared/services/service-auth.service.ts
@@ -1,3 +1,8 @@
+import {
+  assertNotPlaceholderKey,
+  constantTimeEqual,
+} from '#src/server/utils/constant-time-equal.js';
+
 const BEARER_PREFIX = 'Bearer ';
 
 export interface ServiceAuthConfig {
@@ -8,16 +13,21 @@ export class ServiceAuthService {
   private _serviceAuthConfig: ServiceAuthConfig;
 
   constructor(serviceAuthConfig: ServiceAuthConfig) {
+    assertNotPlaceholderKey(
+      serviceAuthConfig.serviceApiKey,
+      'SESSION_MANAGER_SERVICE_API_KEY',
+    );
     this._serviceAuthConfig = serviceAuthConfig;
   }
 
   /**
-   * Strips the `Bearer ` prefix and compares the remaining key to the configured service API key.
+   * Strips the `Bearer ` prefix and compares the remaining key to the
+   * configured service API key in constant time.
    * @param authorizationHeader The raw `Authorization` header value.
    */
   isValid(authorizationHeader: string | undefined): boolean {
     if (!authorizationHeader?.startsWith(BEARER_PREFIX)) return false;
     const key = authorizationHeader.slice(BEARER_PREFIX.length);
-    return key === this._serviceAuthConfig.serviceApiKey;
+    return constantTimeEqual(key, this._serviceAuthConfig.serviceApiKey);
   }
 }

--- a/apps/session-manager/src/server/utils/constant-time-equal.ts
+++ b/apps/session-manager/src/server/utils/constant-time-equal.ts
@@ -1,0 +1,33 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+// Per-process random key. HMAC-ing both operands to a fixed 32-byte digest
+// before `timingSafeEqual` means the comparison is constant-time regardless of
+// input length and can never throw on a length mismatch — and the raw secret
+// length is not observable via timing.
+const HMAC_KEY = randomBytes(32);
+
+/**
+ * Constant-time string equality. Use for comparing a presented credential to a
+ * configured secret so an attacker cannot recover the secret byte-by-byte from
+ * response timing.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  const da = createHmac('sha256', HMAC_KEY).update(a, 'utf8').digest();
+  const db = createHmac('sha256', HMAC_KEY).update(b, 'utf8').digest();
+  return timingSafeEqual(da, db);
+}
+
+/**
+ * Guard against shipping a service with the literal placeholder key. Throws so
+ * the service refuses to start until a real secret is configured.
+ *
+ * @param key The configured secret value.
+ * @param name Human-readable name for the error message (e.g. `ADMIN_API_KEY`).
+ */
+export function assertNotPlaceholderKey(key: string, name: string): void {
+  if (key === 'CHANGEME') {
+    throw new Error(
+      `${name} is still set to the placeholder "CHANGEME". Set a strong, high-entropy secret before starting.`,
+    );
+  }
+}

--- a/apps/session-manager/tests/unit/utils/constant-time-equal.test.ts
+++ b/apps/session-manager/tests/unit/utils/constant-time-equal.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect } from 'vitest';
+
+import {
+  assertNotPlaceholderKey,
+  constantTimeEqual,
+} from '#src/server/utils/constant-time-equal.js';
+
+describe('constantTimeEqual', (it) => {
+  it('returns true for identical strings', () => {
+    expect(constantTimeEqual('super-secret-key', 'super-secret-key')).toBe(
+      true,
+    );
+  });
+
+  it('returns false for different same-length strings', () => {
+    expect(constantTimeEqual('abcd', 'abce')).toBe(false);
+  });
+
+  it('returns false for different-length strings without throwing', () => {
+    expect(constantTimeEqual('abc', 'abcdef')).toBe(false);
+  });
+
+  it('handles empty strings', () => {
+    expect(constantTimeEqual('', '')).toBe(true);
+    expect(constantTimeEqual('', 'x')).toBe(false);
+    expect(constantTimeEqual('x', '')).toBe(false);
+  });
+});
+
+describe('assertNotPlaceholderKey', (it) => {
+  it('throws when the key is the literal placeholder CHANGEME', () => {
+    expect(() => {
+      assertNotPlaceholderKey('CHANGEME', 'ADMIN_API_KEY');
+    }).toThrow();
+  });
+
+  it('does not throw for a real key', () => {
+    expect(() => {
+      assertNotPlaceholderKey('a-real-high-entropy-secret', 'ADMIN_API_KEY');
+    }).not.toThrow();
+  });
+});

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -31,6 +31,13 @@ NODE_SERVER_LOG_LEVEL=info
 NODE_SERVER_KEY=CHANGEME
 JWT_SECRET=CHANGEME-JWT-must-be-at-least-32-characters-long
 
+# -- Admin Website -----
+# ADMIN_API_KEY reuses SESSION_MANAGER_API_KEY (see Session Manager section above).
+ADMIN_LOG_LEVEL=info
+ADMIN_SESSION_SECRET=CHANGEME-admin-session-secret-at-least-32-characters
+# "<username> <password>"; empty/unset disables local login. Azure SSO (AZURE_*) is future.
+ADMIN_LOCAL_CREDENTIALS=engrit CHANGEME
+
 # -- Transcription Service --
 # "cpu" or "cuda"
 TRANSCRIPTION_DEVICE=cpu

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -19,6 +19,10 @@ services:
         condition: service_healthy
       session-manager:
         condition: service_healthy
+      admin-webapp:
+        condition: service_healthy
+      admin-server:
+        condition: service_healthy
     networks:
       - frontend
       - backend
@@ -49,6 +53,14 @@ services:
       - frontend
     restart: unless-stopped
 
+  admin-webapp:
+    image: ${IMAGE_REGISTRY:-ghcr.io/scribear}/admin-webapp:${IMAGE_TAG:-latest}
+    expose:
+      - "80"
+    networks:
+      - frontend
+    restart: unless-stopped
+
   # Backend APIs
   session-manager:
     image: ${IMAGE_REGISTRY:-ghcr.io/scribear}/session-manager:${IMAGE_TAG:-latest}
@@ -68,6 +80,31 @@ services:
       scribear-db:
         condition: service_healthy
     networks:
+      - backend
+    restart: unless-stopped
+
+  admin-server:
+    image: ${IMAGE_REGISTRY:-ghcr.io/scribear}/admin-server:${IMAGE_TAG:-latest}
+    expose:
+      - "80"
+    environment:
+      LOG_LEVEL: ${ADMIN_LOG_LEVEL:-info}
+      ADMIN_API_KEY: ${SESSION_MANAGER_API_KEY}
+      SESSION_MANAGER_BASE_URL: http://session-manager:80
+      ADMIN_SESSION_SECRET: ${ADMIN_SESSION_SECRET}
+      ADMIN_LOCAL_CREDENTIALS: ${ADMIN_LOCAL_CREDENTIALS}
+      DB_HOST: scribear-db
+      DB_PORT: "5432"
+      DB_NAME: ${DB_NAME}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+    depends_on:
+      session-manager:
+        condition: service_healthy
+      scribear-db:
+        condition: service_healthy
+    networks:
+      - frontend
       - backend
     restart: unless-stopped
 

--- a/infra/scribear-nginx/nginx.conf
+++ b/infra/scribear-nginx/nginx.conf
@@ -11,6 +11,8 @@ http {
     upstream kiosk-webapp        { server kiosk-webapp:80; }
     upstream session-manager     { server session-manager:80; }
     upstream node-server         { server node-server:80; }
+    upstream admin-webapp        { server admin-webapp:80; }
+    upstream admin-server        { server admin-server:80; }
 
     # Shared settings
     sendfile            on;
@@ -38,10 +40,20 @@ http {
         ssl_certificate_key /etc/nginx/ssl/priv.key;
         ssl_protocols       TLSv1.2 TLSv1.3;
 
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
         # -- Backend APIs -------
 
         location /api/session-manager/ {
             proxy_pass http://session-manager;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /api/admin/ {
+            proxy_pass http://admin-server;
             proxy_set_header Host              $host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -86,6 +98,19 @@ http {
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /admin/ {
+            proxy_pass http://admin-webapp/;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'" always;
+            # Re-declare HSTS: an add_header in a location replaces (not merges)
+            # the server-level headers, so it must be repeated here.
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,45 @@
         "node": ">=24.0.0"
       }
     },
+    "apps/admin-server": {
+      "name": "@scribear/admin-server",
+      "version": "0.0.0",
+      "dependencies": {
+        "@fastify/awilix": "8.2.0",
+        "@fastify/cookie": "11.0.2",
+        "@fastify/rate-limit": "11.1.0",
+        "awilix": "13.0.0",
+        "env-schema": "7.0.0",
+        "fastify": "5.7.4",
+        "fastify-plugin": "5.1.0",
+        "kysely": "0.28.11",
+        "pg": "8.19.0",
+        "typebox": "1.1.5"
+      },
+      "devDependencies": {
+        "@types/pg": "8.16.0"
+      }
+    },
+    "apps/admin-webapp": {
+      "name": "@scribear/admin-webapp",
+      "version": "0.0.0",
+      "dependencies": {
+        "@emotion/react": "11.14.0",
+        "@emotion/styled": "11.14.1",
+        "@fontsource/roboto": "5.2.10",
+        "@mui/icons-material": "7.3.8",
+        "@mui/material": "7.3.8",
+        "react": "19.2.5",
+        "react-dom": "19.2.5",
+        "react-error-boundary": "6.1.1",
+        "react-router-dom": "7.18.1"
+      },
+      "devDependencies": {
+        "@eslint-react/eslint-plugin": "2.13.0",
+        "eslint-plugin-react-hooks": "7.0.1",
+        "eslint-plugin-react-refresh": "0.5.2"
+      }
+    },
     "apps/client-webapp": {
       "name": "@scribear/client-webapp",
       "version": "0.0.0",
@@ -125,6 +164,7 @@
       "dependencies": {
         "@fastify/awilix": "8.2.0",
         "@fastify/cookie": "11.0.2",
+        "@fastify/rate-limit": "11.1.0",
         "@fastify/swagger": "9.7.0",
         "@fastify/swagger-ui": "5.2.5",
         "awilix": "13.0.0",
@@ -2249,6 +2289,43 @@
         "ipaddr.js": "^2.1.0"
       }
     },
+    "node_modules/@fastify/rate-limit": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-11.1.0.tgz",
+      "integrity": "sha512-BeJ9tizLvmTXGD7deYU5G04OtHhwk5uHxbpEPVp09gKvUBIXmau/4Bshxhu9ci54MvVWfGjCEx4RzvsTntojwA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^6.0.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/@fastify/rate-limit/node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@fastify/send": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/send/-/send-4.1.0.tgz",
@@ -3613,6 +3690,14 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scribear/admin-server": {
+      "resolved": "apps/admin-server",
+      "link": true
+    },
+    "node_modules/@scribear/admin-webapp": {
+      "resolved": "apps/admin-webapp",
+      "link": true
     },
     "node_modules/@scribear/app-layout-store": {
       "resolved": "libs/store/app-layout-store",
@@ -9565,6 +9650,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-split-pane": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,9 @@
         "@fastify/rate-limit": "11.1.0",
         "awilix": "13.0.0",
         "env-schema": "7.0.0",
-        "fastify": "5.7.4",
+        "fastify": "5.10.0",
         "fastify-plugin": "5.1.0",
-        "kysely": "0.28.11",
+        "kysely": "0.28.17",
         "pg": "8.19.0",
         "typebox": "1.1.5"
       },


### PR DESCRIPTION
Implements PLAN-ADMIN.md: an IT admin console replacing the deployment/*.sh curl workflow, across all planned phases.

apps/admin-server — Fastify Backend-for-Frontend (BFF):
- Pluggable auth: local single-account provider (ADMIN_LOCAL_CREDENTIALS, constant-time compare, first-space split) + Azure OIDC stub; read-only / read-write roles.
- Server-side revocable sessions (HttpOnly+Secure+SameSite=Strict signed cookie) with idle/absolute lifetimes; session-bound CSRF token.
- Session Manager gateway: the sole holder of ADMIN_API_KEY, injected on every upstream call; consistent { ok, data?, error? } envelope; upstream 401 -> 502 BACKEND_MISCONFIGURATION.
- Rooms, devices, scheduling/sessions, and health/audit endpoints; mutations gated by session + CSRF + read-write role and written to a Postgres audit log (own migration + isolated migration-tracking tables).
- Per-route rate limiting; unit + integration tests (SM mocked, testcontainers).

apps/admin-webapp — React 19 + MUI + react-router SPA (served at /admin/):
- App shell, auth provider + RequireAuth guard, login, toasts, health tiles.
- Rooms/devices list+detail, kiosk setup wizard, schedules/auto-windows editors, session detail, dashboard, audit log. Typed admin-api client is the single HTTP surface; the admin key never reaches the browser.

apps/session-manager — hardening (Phase 6):
- Constant-time admin/service key comparison; refuse to start on the CHANGEME placeholder; rate-limit the unauthenticated credential-exchange routes (trustProxy: 1 for non-spoofable client IPs). No wire-contract change.

Deploy: nginx /admin/ + /api/admin/ locations (HSTS + scoped CSP), compose services, .env.example, and CI docker-build matrix entries for both images.

Security review of the branch found no vulnerabilities above threshold.