### PR TITLE
fix: deadlock in WorkerProcessManager.wait_shutdown()

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -59,6 +59,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.transcription_service == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/transcription_service/src/shared/utils/worker_pool/worker_process_manager.py
+++ b/transcription_service/src/shared/utils/worker_pool/worker_process_manager.py
@@ -461,23 +461,51 @@ class WorkerProcessManager:
         """
         self._task_queue.put(TerminateWorkerTask())
 
+    def _drain_logging_results(self, block_timeout: float | None):
+        """
+        Fetch a single result from the result queue, if available, and log it
+        if it is a logging result. Used during shutdown once the async
+        poller has been stopped.
+
+        Args:
+            block_timeout   - None to poll without blocking, a float to block
+                                up to that many seconds waiting for a result
+
+        Returns:
+            True if a result was fetched, False if the queue was empty
+        """
+        try:
+            if block_timeout is None:
+                result = self._result_queue.get_nowait()
+            else:
+                result = self._result_queue.get(timeout=block_timeout)
+        except Empty:
+            return False
+        if result.type == ResultType.LOGGING:
+            self._log.logger.handle(result.record)
+        return True
+
     def wait_shutdown(self):
         """
         Blocks while waiting for worker process to exit before returning
         Should call send_terminate() before wait_shutdown()
         """
+        # Stop the async poller and drain the result queue here instead.
+        # The worker's shutdown path flushes any buffered results through
+        # the queue's feeder thread before it exits (result_queue.join_thread
+        # in _worker_function), so if nothing is reading from this side while
+        # we block on self._process.join(), a large enough backlog can fill
+        # the pipe and deadlock the worker against this process. Draining
+        # while we wait keeps that from ever happening.
+        self._result_poller_task.cancel()
+        while self._process.is_alive():
+            self._drain_logging_results(block_timeout=0.05)
+
         self._process.join()
 
-        # Cancel the async poller and drain any results the worker emitted
-        # during shutdown (e.g. destroy logs) so callers see them.
-        self._result_poller_task.cancel()
-        while True:
-            try:
-                result = self._result_queue.get_nowait()
-            except Empty:
-                break
-            if result.type == ResultType.LOGGING:
-                self._log.logger.handle(result.record)
+        # Drain any results buffered between the last drain and process exit
+        while self._drain_logging_results(block_timeout=None):
+            pass
 
         self._task_queue.close()
         self._result_queue.close()


### PR DESCRIPTION
## Summary
- `wait_shutdown()` blocked synchronously on `self._process.join()` before draining `result_queue`, relying on the async `_poll_results()` task to keep consuming it. When called from inside a running event loop (e.g. pytest-asyncio fixture teardown), that blocking call stalls the loop and stops `_poll_results()` from running, so nothing reads the queue.
- The worker process flushes all buffered results through the queue's feeder thread before it exits (`result_queue.join_thread()` in `_worker_function`'s `finally`), so once the backlog exceeds the OS pipe buffer, the worker blocks writing and never exits — and the parent's `join()` never returns. This is a documented Python multiprocessing footgun (joining a process without guaranteeing its queue is drained).
- `wait_shutdown()` now actively drains the result queue itself while polling process liveness, instead of depending on the event loop being free to run the async poller.
- Also added a 10 minute `timeout-minutes` to the Python CI `test` job so a future hang fails fast instead of tying up a runner for hours (this exact deadlock hung PR #124's CI for 10+ minutes with no end in sight before it was manually cancelled).

Pre-existing bug in `worker_process_manager.py` (last touched in #111), unrelated to any in-flight feature branch — surfaced because CI's slower/shared runner hit the timing window more reliably than local dev machines.

## Test plan
- [x] `pytest tests/unit tests/integration` — 180/180 passed locally, including `tests/unit/shared/utils/worker_pool/*` (42 tests) which previously showed multiprocess resource-tracker warnings on shutdown — now clean.
- [x] `isort --check` / `black --check` / `pylint` — all clean (10.00/10) on the changed file.
- [ ] Confirm this branch's own CI run completes without hanging.