### PR TITLE
fix: bound _poll_results' blocking get() so cancellation actually works

### DIFF
--- a/transcription_service/src/shared/utils/worker_pool/worker_process_manager.py
+++ b/transcription_service/src/shared/utils/worker_pool/worker_process_manager.py
@@ -35,6 +35,10 @@ NS_PER_SEC = 1000000000
 # Rolling window over which a worker's busy/idle ratio is averaged.
 ROLLING_UTILIZATION_WINDOW_NS = 10 * 60 * NS_PER_SEC
 
+# How long a single background get() waits before rechecking for
+# cancellation. Keeps _poll_results's thread from blocking indefinitely.
+RESULT_POLL_TIMEOUT_SEC = 0.1
+
 C = TypeVar("C", bound=tuple)
 D = TypeVar("D")
 R = TypeVar("R")
@@ -387,8 +391,21 @@ class WorkerProcessManager:
         """
         while True:
             # Run the blocking `get()` call in a separate thread to avoid
-            # blocking the asyncio event loop.
-            result = await asyncio.to_thread(self._result_queue.get)
+            # blocking the asyncio event loop. Use a short timeout rather
+            # than blocking indefinitely: asyncio.to_thread's underlying
+            # thread can't be interrupted once it's inside the blocking
+            # get(), so if this task is cancelled (e.g. from wait_shutdown)
+            # while parked there, the thread stays blocked on the queue
+            # forever and can silently steal a result meant for whoever
+            # reads the queue next. Polling with a timeout bounds how long
+            # any single background thread can be stuck, so cancellation
+            # actually takes effect.
+            try:
+                result = await asyncio.to_thread(
+                    self._result_queue.get, True, RESULT_POLL_TIMEOUT_SEC
+                )
+            except Empty:
+                continue
 
             if result.type == ResultType.LOGGING:
                 self._log.logger.handle(result.record)


### PR DESCRIPTION
## Summary
- `_poll_results()` awaited `asyncio.to_thread(self._result_queue.get)` with no timeout. `asyncio.to_thread`'s underlying thread can't be interrupted once it's inside a blocking `get()`, so cancelling the poller task (as `wait_shutdown()` does) just abandons that thread permanently parked on the queue instead of stopping it — and it can silently steal a result meant for whoever reads the queue next afterward.
- Switched to a short-timeout polling loop (`get(True, 0.1)` + catch `Empty` + continue) so the background thread rechecks every 100ms instead of blocking indefinitely, bounding how long it can be stuck and letting cancellation actually take effect.
- Same class of bug as #126 (unbounded blocking call surviving task cancellation), just in `_poll_results` instead of `wait_shutdown`'s `join()`. PR #124's CI still hung (job cancelled at the 10-minute mark added by #126) even with #126's fix in the branch — the thread dump in that run showed this exact `get()` call blocked reading from the result queue during the `worker_pool/config_update_test.py` tests.

## Test plan
- [x] `pytest tests/unit/shared/utils/worker_pool` — 42/42 passed locally (29s, no hang)
- [x] `pytest tests/unit` — 174/174 passed locally
- [x] `black --check` / `isort --check` / `pylint` — clean (10.00/10) on the changed file