### PR TITLE
fix(deployment): forward upstream provider API key to transcription-service

### DIFF
--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -45,3 +45,8 @@ TRANSCRIPTION_LOG_LEVEL=info
 TRANSCRIPTION_API_KEY=CHANGEME
 TRANSCRIPTION_WS_INIT_TIMEOUT_SEC=2.5
 PROVIDER_CONFIG_PATH=./provider_config.json
+# Upstream secret for remote/OpenAI-like transcription providers. Forwarded into
+# the transcription-service container; a provider references it by name via the
+# "api_key_env" field in provider_config.json. Leave empty unless a configured
+# provider forwards audio to an external endpoint.
+TRANSCRIPTION_PROVIDER_API_KEY=

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -161,6 +161,10 @@ services:
       LOG_LEVEL: ${TRANSCRIPTION_LOG_LEVEL:-info}
       API_KEY: ${TRANSCRIPTION_API_KEY}
       WS_INIT_TIMEOUT_SEC: ${TRANSCRIPTION_WS_INIT_TIMEOUT_SEC:-2.5}
+      # Optional upstream secret for remote/OpenAI-like providers that read their
+      # key from an env var named by provider_config.json's "api_key_env". Empty
+      # by default and ignored by local-model providers, so it is safe to leave unset.
+      TRANSCRIPTION_PROVIDER_API_KEY: ${TRANSCRIPTION_PROVIDER_API_KEY:-}
     volumes:
       - ${PROVIDER_CONFIG_PATH:-./provider_config.json}:/app/provider_config.json:ro
     networks:


### PR DESCRIPTION
## Problem

Remote / OpenAI-like transcription providers (an external endpoint whose URL is set in `provider_config.json`) read their upstream API key from an environment variable named by the provider's `api_key_env` field. However, the `transcription-service` service in `deployment/compose.yml` only forwarded `LOG_LEVEL`, `API_KEY`, and `WS_INIT_TIMEOUT_SEC` — no upstream provider secret — so the key was never available inside the container. Local-model providers (faster-whisper) are unaffected, which is why this gap went unnoticed.

## Fix

- `deployment/compose.yml`: add an optional `TRANSCRIPTION_PROVIDER_API_KEY` pass-through to the `transcription-service` environment. It defaults to empty (`${TRANSCRIPTION_PROVIDER_API_KEY:-}`), so it is a no-op for existing local-model deployments.
- `deployment/.env.example`: document the new variable.

A remote provider then sets `"api_key_env": "TRANSCRIPTION_PROVIDER_API_KEY"` in `provider_config.json` and reads it via `os.environ` inside its worker job. Additional upstream keys can be forwarded the same way.

## Notes

- No behavior change for current deployments (variable is empty by default and ignored by local-model providers).
- `docker compose config` validates cleanly with the change.
- Docs for the new remote-provider workflow are updated in the wiki (`How to Create a New Transcription Service`).