### PR TITLE
fix: keep heavy ML deps out of the unit-test import graph

### DIFF
--- a/transcription_service/src/shared/utils/silence_filter/silence_filter.py
+++ b/transcription_service/src/shared/utils/silence_filter/silence_filter.py
@@ -6,7 +6,6 @@ import logging
 
 import numpy as np
 import numpy.typing as npt
-import torch
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +65,10 @@ class SilenceFiltering:
         if neg_th is None:
             neg_th = max(0.01, self.threshold - 0.15)
         neg_th = min(neg_th, self.threshold - 0.001)
+        # Imported lazily so merely importing this module does not pull in the
+        # heavy torch dependency (keeps unit-test collection/spawn fast).
+        import torch  # pylint: disable=import-outside-toplevel
+
         try:
             with torch.inference_mode():
                 wave = torch.from_numpy(array).float()

--- a/transcription_service/src/transcription_contexts/faster_whisper_context/__init__.py
+++ b/transcription_service/src/transcription_contexts/faster_whisper_context/__init__.py
@@ -2,4 +2,13 @@
 Public exports for FasterWhisperContext
 """
 
-from .faster_whisper_context import FasterWhisperContext, WhisperModel
+from typing import TYPE_CHECKING
+
+from .faster_whisper_context import FasterWhisperContext
+
+if TYPE_CHECKING:
+    # Re-exported for typing only; importing WhisperModel at runtime would pull
+    # in the heavy faster_whisper dependency.
+    from .faster_whisper_context import WhisperModel
+
+__all__ = ["FasterWhisperContext", "WhisperModel"]

--- a/transcription_service/src/transcription_contexts/faster_whisper_context/faster_whisper_context.py
+++ b/transcription_service/src/transcription_contexts/faster_whisper_context/faster_whisper_context.py
@@ -2,13 +2,18 @@
 Defines FasterWhisperContext for using faster whisper in WorkerProcess and WorkerPool
 """
 
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
-from faster_whisper import WhisperModel
 from pydantic import BaseModel, TypeAdapter
 
 from src.shared.logger import Logger
 from src.shared.utils.worker_pool import JobContextInterface
+
+if TYPE_CHECKING:
+    # Imported for typing only; the heavy faster_whisper import is deferred to
+    # create() so importing this module (as unit-test collection does) stays
+    # cheap and does not pull in faster_whisper / ctranslate2.
+    from faster_whisper import WhisperModel
 
 
 class FasterWhisperContextConfig(BaseModel):
@@ -25,7 +30,7 @@ faster_whisper_context_config_adapter = TypeAdapter[FasterWhisperContextConfig](
 )
 
 
-class FasterWhisperContext(JobContextInterface[WhisperModel]):
+class FasterWhisperContext(JobContextInterface["WhisperModel"]):
     """
     Job context definition for using faster whisper in WorkerProcess and WorkerPool
     """
@@ -36,13 +41,18 @@ class FasterWhisperContext(JobContextInterface[WhisperModel]):
             context_config
         )
 
-    def create(self, log: Logger) -> WhisperModel:
+    def create(self, log: Logger) -> "WhisperModel":
         log.info(
             f"Creating {self._config.model} whisper model using device: {self._config.device}"
         )
+        # Imported lazily so importing this module stays cheap.
+        from faster_whisper import (  # pylint: disable=import-outside-toplevel
+            WhisperModel,
+        )
+
         return WhisperModel(self._config.model, device=self._config.device)
 
-    def destroy(self, log: Logger, context: WhisperModel) -> None:
+    def destroy(self, log: Logger, context: "WhisperModel") -> None:
         log.info("Destroying whisper model")
         if context.model and context.model.model_is_loaded:
             context.model.unload_model()

--- a/transcription_service/src/transcription_contexts/silero_vad_context/silero_vad_context.py
+++ b/transcription_service/src/transcription_contexts/silero_vad_context/silero_vad_context.py
@@ -4,7 +4,6 @@ Defines SileroVadContext for caching Silero VAD model in WorkerProcess
 
 from typing import Any, Callable, List, Tuple
 
-import torch
 from pydantic import BaseModel, TypeAdapter
 
 from src.shared.logger import Logger
@@ -76,6 +75,10 @@ class SileroVadContext(JobContextInterface[SileroVadModelType]):
     def create(self, log: Logger) -> SileroVadModelType:
         log.info(f"Loading Silero VAD model from {self._config.repo_or_dir}")
 
+        # Imported lazily so importing this module does not pull in torch;
+        # only a worker actually creating the context pays that cost.
+        import torch  # pylint: disable=import-outside-toplevel
+
         torch.set_num_threads(1)
 
         try:
@@ -99,6 +102,9 @@ class SileroVadContext(JobContextInterface[SileroVadModelType]):
 
     def destroy(self, log: Logger, context: SileroVadModelType) -> None:
         log.info("Destroying Silero VAD context")
+
+        import torch  # pylint: disable=import-outside-toplevel
+
         if hasattr(context, "_model"):
             del context._model
         if hasattr(context, "_get_speech_timestamps"):

--- a/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_job.py
+++ b/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_job.py
@@ -2,6 +2,8 @@
 Defines WorkerPool job for DebugProvider that returns number of seconds of audio received
 """
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from src.shared.logger import Logger
@@ -10,7 +12,6 @@ from src.shared.utils.local_agree import LocalAgree, TranscriptionSegment
 from src.shared.utils.np_circular_buffer import NPCircularBuffer
 from src.shared.utils.silence_filter import RMSSilenceDetection
 from src.shared.utils.worker_pool import JobInterface
-from src.transcription_contexts.faster_whisper_context import WhisperModel
 from src.transcription_contexts.silero_vad_context import SileroVadModelType
 from src.transcription_provider_interface import (
     AudioChunkPayload,
@@ -21,13 +22,18 @@ from src.transcription_provider_interface import (
 
 from .whisper_streaming_config import WhisperStreamingProviderConfig
 
+if TYPE_CHECKING:
+    # Typing only; the heavy faster_whisper import is deferred so importing this
+    # module (as unit-test collection does) does not pull in faster_whisper.
+    from src.transcription_contexts.faster_whisper_context import WhisperModel
+
 SAMPLE_RATE = 16000
 NUM_CHANNELS = 1
 
 
 class WhisperStreamingProviderJob(
     JobInterface[
-        tuple[WhisperModel, SileroVadModelType],
+        tuple["WhisperModel", SileroVadModelType],
         AudioChunkPayload,
         TranscriptionResult,
         None,
@@ -131,7 +137,7 @@ class WhisperStreamingProviderJob(
 
     def _transcribe_audio(
         self,
-        whisper: WhisperModel,
+        whisper: "WhisperModel",
         vad_context: SileroVadModelType,
         log: Logger,
     ):
@@ -267,7 +273,7 @@ class WhisperStreamingProviderJob(
     def process_batch(
         self,
         log: Logger,
-        contexts: tuple[WhisperModel, SileroVadModelType],
+        contexts: tuple["WhisperModel", SileroVadModelType],
         batch: list[AudioChunkPayload],
     ) -> TranscriptionResult:
         whisper_model, vad_context = contexts

--- a/transcription_service/tests/conftest.py
+++ b/transcription_service/tests/conftest.py
@@ -1,0 +1,22 @@
+"""
+Shared pytest configuration for the transcription service test suite.
+"""
+
+import freezegun
+
+# freeze_time() walks the attributes of every imported module to patch their
+# datetime references. Heavy ML dependencies pulled in transitively by the
+# transcription providers expose lazy module attributes (e.g. huggingface_hub)
+# that trigger slow submodule imports when walked, which can blow the per-test
+# timeout. Tell freezegun to skip them - tests that use freeze_time never rely
+# on these modules' clocks.
+freezegun.configure(
+    extend_ignore_list=[
+        "torch",
+        "faster_whisper",
+        "huggingface_hub",
+        "transformers",
+        "ctranslate2",
+        "tokenizers",
+    ]
+)

--- a/transcription_service/tests/unit/shared/utils/worker_pool/config_update_test.py
+++ b/transcription_service/tests/unit/shared/utils/worker_pool/config_update_test.py
@@ -14,7 +14,9 @@ from src.shared.utils.worker_pool import (
 
 from .jobs import ConfigBatchResult, ConfigErrorJob, ConfigJob
 
-pytestmark = pytest.mark.timeout(2)
+# Spawns real worker processes; give generous headroom for spawn latency on CI
+# (the per-test budget includes fixture setup). See worker_process_manager_test.
+pytestmark = pytest.mark.timeout(5)
 
 
 @pytest.mark.asyncio

--- a/transcription_service/tests/unit/shared/utils/worker_pool/worker_process_manager_test.py
+++ b/transcription_service/tests/unit/shared/utils/worker_pool/worker_process_manager_test.py
@@ -26,8 +26,12 @@ from .context_definitions import (
 )
 from .jobs import ContextJob, ErrorJob, LoggerJob, SlowJob, SumJob
 
-# Increase default timeout for this slow test suite
-pytestmark = pytest.mark.timeout(2)
+# These tests spawn real worker processes; process spawn alone can take ~1-2s
+# on a loaded CI runner, and pytest-timeout's budget includes fixture setup.
+# Give them generous headroom so spawn latency does not flake them (whole-suite
+# hangs are still caught by the job-level timeout and the init-hang regression
+# test below).
+pytestmark = pytest.mark.timeout(5)
 
 NS_PER_SEC = 10**9
 
@@ -485,7 +489,7 @@ async def test_worker_init_raises_when_worker_dies_without_reporting(
     constructor forever) if the worker process dies during initialization
     without reporting an init error - e.g. a native crash. The parent holds the
     result queue's write fd, so a naive blocking read would never see EOF; the
-    module-level 2s timeout guards against a regression to that hang.
+    module-level timeout guards against a regression to that hang.
     """
     # Arrange
     crashing_defs: dict[int, JobContextInterface[Any]] = {0: CrashContext()}
@@ -599,7 +603,7 @@ async def test_reports_jobs_stats_single_slow_job(wpm: WorkerProcessManager):
     assert_rel_error(job_stats.total_time_ns, slow_worker_time)
 
 
-@pytest.mark.timeout(4)
+@pytest.mark.timeout(6)
 @pytest.mark.asyncio
 async def test_reports_job_stats_multiple_slow_job(wpm: WorkerProcessManager):
     """

--- a/transcription_service/tests/unit/transcription_providers/debug_provider/debug_provider_test.py
+++ b/transcription_service/tests/unit/transcription_providers/debug_provider/debug_provider_test.py
@@ -51,7 +51,7 @@ async def debug_provider_session():
     worker_pool.shutdown()
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.timeout(5)
 @pytest.mark.asyncio
 async def test_debug_provider_returns_audio_debug_info(
     debug_provider_session: TranscriptionSessionInterface,
@@ -93,7 +93,7 @@ async def test_debug_provider_returns_audio_debug_info(
     assert decode_time is not None
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.timeout(5)
 @pytest.mark.asyncio
 async def test_debug_provider_throws_exception_on_bad_chunk(
     debug_provider_session: TranscriptionSessionInterface,


### PR DESCRIPTION
## Problem

After the worker-pool shutdown deadlock was fixed (#129), the transcription-service unit-test job stopped hanging to the 10-min cap and instead **ran to completion, exposing 32 timeout failures** ([run](https://github.com/scribear/scribear/actions/runs/29501959722/job/87632906896?pr=124)). The deadlock had been masking them.

Root cause: importing the whisper provider modules pulls **`faster_whisper` / `torch` / `huggingface_hub`** into the unit-test process (`whisper_streaming_job_test` imports `whisper_streaming_job` at collection). That blows the 1s pytest timeout two ways:

1. **freezegun** `freeze_time()` walks every loaded module's attributes; hitting `huggingface_hub`'s lazy `__getattr__` triggers slow submodule imports (~0.8s for that one module, measured locally) — enough to fail unrelated tests like the JSON-formatter tests.
2. Once **`torch`** is loaded in the parent, its thread pools + memory pressure slow process **spawn**, pushing the worker-pool/debug tests past their budgets.

## Fix

Unit tests shouldn't load `torch` at all. Defer the heavy imports so importing a provider/context/job module stays cheap; the real dependency loads only when a worker actually creates the context at runtime:

- **`silence_filter` / `silero_vad_context`**: `import torch` inside the methods that use it, not at module top.
- **`faster_whisper_context`**: `WhisperModel` under `TYPE_CHECKING` (+ lazy import inside `create()`); string/forward-ref annotations so the runtime generic base no longer needs the symbol.
- **`whisper_streaming_job`**: `WhisperModel` under `TYPE_CHECKING`, forward-refs. (`SileroVadModelType` stays a runtime import — it's a local class alias, cheap once `torch` is deferred.)
- Defensive **freezegun ignore-list** (`torch`, `faster_whisper`, `huggingface_hub`, `transformers`, `ctranslate2`, `tokenizers`) in a top-level test conftest.
- **Headroom (not the fix):** raise the per-test timeout to 5s on the tests that spawn real worker processes (`worker_process_manager`, `config_update`, `debug_provider`). Spawn is ~1–2s and the pytest-timeout budget includes fixture setup, so 2s is tight on a loaded runner. Whole-suite hangs are still caught by the job-level 10-min cap + the init-hang regression test.

## Verification

- Importing the whisper job/provider/context modules no longer loads `torch`/`faster_whisper` (asserted).
- Full unit suite passes with CI's exact `timeout=1 signal` settings, **175 passed / 0 failed** (was 32 failed), stable across 3 back-to-back runs + a coverage run.
- `make format` / `make lint` clean (pylint 10.00/10 on src and tests).

Targets `latency-metrics-v2` since it fixes that branch's test setup.