### PR TITLE
fix(deps): bump testcontainers 11→12 to clear uuid vuln (+ Dependabot audit)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "globals": "17.3.0",
         "pino-pretty": "13.1.3",
         "prettier": "3.8.1",
-        "testcontainers": "11.12.0",
+        "testcontainers": "12.0.4",
         "typescript": "5.9.3",
         "typescript-eslint": "8.56.1",
         "vite": "7.3.6",
@@ -2628,15 +2628,15 @@
       }
     },
     "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
-      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.5.3",
+        "protobufjs": "^7.5.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -6269,9 +6269,9 @@
       }
     },
     "node_modules/dockerode": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.12.tgz",
-      "integrity": "sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.1.tgz",
+      "integrity": "sha512-avsq/xk4YPIrn0CgleX5bjT9Y8IT1p9PxrNQ++RBQ2WEyFfHCTDsT9kmyxz+H/axnjAwg8wJWEIuPGOUuNupiA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6280,11 +6280,10 @@
         "@grpc/proto-loader": "^0.7.13",
         "docker-modem": "^5.0.7",
         "protobufjs": "^7.3.2",
-        "tar-fs": "^2.1.4",
-        "uuid": "^10.0.0"
+        "tar-fs": "^2.1.4"
       },
       "engines": {
-        "node": ">= 8.0"
+        "node": ">= 14.17"
       }
     },
     "node_modules/dockerode/node_modules/readable-stream": {
@@ -6303,9 +6302,9 @@
       }
     },
     "node_modules/dockerode/node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7603,13 +7602,13 @@
       }
     },
     "node_modules/get-port": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
-      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10564,9 +10563,9 @@
       }
     },
     "node_modules/testcontainers": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.12.0.tgz",
-      "integrity": "sha512-VWtH+UQejVYYvb53ohEZRbx2naxyDvwO9lQ6A0VgmVE2Oh8r9EF09I+BfmrXpd9N9ntpzhao9di2yNwibSz5KA==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-12.0.4.tgz",
+      "integrity": "sha512-QIR/8xF1+F/26cIM+9B4yyxNTbKJxAv3hygZyhPRgZ8Q2AhlPZjDdpXRuk16V37X4bgJRI3hXFhoEICMBA7Adg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10576,15 +10575,15 @@
         "async-lock": "^1.4.1",
         "byline": "^5.0.0",
         "debug": "^4.4.3",
-        "docker-compose": "^1.3.1",
-        "dockerode": "^4.0.9",
-        "get-port": "^7.1.0",
+        "docker-compose": "^1.4.2",
+        "dockerode": "^5.0.0",
+        "get-port": "^5.1.1",
         "proper-lockfile": "^4.1.2",
         "properties-reader": "^3.0.1",
         "ssh-remote-port-forward": "^1.0.4",
-        "tar-fs": "^3.1.1",
-        "tmp": "^0.2.5",
-        "undici": "^7.22.0"
+        "tar-fs": "^3.1.2",
+        "tmp": "^0.2.7",
+        "undici": "^8.5.0"
       }
     },
     "node_modules/text-decoder": {
@@ -11115,13 +11114,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
+      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -11196,20 +11195,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -11671,9 +11656,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "globals": "17.3.0",
     "pino-pretty": "13.1.3",
     "prettier": "3.8.1",
-    "testcontainers": "11.12.0",
+    "testcontainers": "12.0.4",
     "typescript": "5.9.3",
     "typescript-eslint": "8.56.1",
     "vite": "7.3.6",


### PR DESCRIPTION
## Summary

Audited all 54 open Dependabot alerts on \`staging\`. **Only 1 was genuinely live**; the rest are already patched in the lockfile and just haven't been auto-dismissed.

## The real fix

- Bump \`testcontainers\` **11.12.0 → 12.0.4**. testcontainers 11 pulled \`uuid@10.0.0\` (via \`dockerode\`), the sole remaining live alert — [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (moderate). It's a **dev-only** integration-test dependency, not in any production runtime.
- \`npm audit\` now reports **0 vulnerabilities**.

## Verification

- Integration suites pass with testcontainers 12 (Docker-backed):
  - session-manager: **308 passed** (confirmed stable over 3 runs)
  - admin-server: **19 passed**
  - node-server: **17 passed**
- One initial session-manager run failed on a transient container-startup flake, not the bump — reproduced green 3× after.

## The other ~52 alerts are stale (not touched here)

Every critical/high/medium-flagged package is **already at a patched version in the \`staging\` lockfile** (shell-quote 1.8.4, vitest 4.1.10, protobufjs 7.6.5, ws 8.21.1, undici 7.28.0, vite 7.3.6, fastify 5.10.0, kysely 0.28.17, tmp 0.2.7, lodash 4.18.1, fast-uri 3.1.3, …), fixed by earlier commits (e.g. \`43d528a\`, \`c4fc540\`). Checked for nested old copies — none remain vulnerable. All these alerts have \`created == updated\` and none newer than 2026-06-24.

⚠️ **Follow-up (not code):** Dependabot isn't auto-dismissing fixed alerts on the default branch — that's why the dashboard shows 54 when only 1 was real. Worth checking Dependabot scanning settings; the 52 stale alerts can be safely dismissed as "fixed" on GitHub.