### PR TITLE
build(deps): bump uuid 13→14

### DIFF
--- a/apps/standalone-webapp/package.json
+++ b/apps/standalone-webapp/package.json
@@ -33,7 +33,7 @@
     "react-redux": "9.2.0",
     "redux-remember": "6.0.2",
     "typebox": "1.1.5",
-    "uuid": "13.0.1"
+    "uuid": "14.0.1"
   },
   "devDependencies": {
     "@eslint-react/eslint-plugin": "2.13.0",

--- a/libs/store/transcription-content-store/package.json
+++ b/libs/store/transcription-content-store/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "2.11.2",
-    "uuid": "13.0.1"
+    "uuid": "14.0.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -218,7 +218,7 @@
         "react-redux": "9.2.0",
         "redux-remember": "6.0.2",
         "typebox": "1.1.5",
-        "uuid": "13.0.1"
+        "uuid": "14.0.1"
       },
       "devDependencies": {
         "@eslint-react/eslint-plugin": "2.13.0",
@@ -226,19 +226,6 @@
         "@types/uuid": "10.0.0",
         "eslint-plugin-react-hooks": "7.0.1",
         "eslint-plugin-react-refresh": "0.5.2"
-      }
-    },
-    "apps/standalone-webapp/node_modules/uuid": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
-      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "infra/scribear-db": {
@@ -393,20 +380,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@reduxjs/toolkit": "2.11.2",
-        "uuid": "13.0.1"
-      }
-    },
-    "libs/store/transcription-content-store/node_modules/uuid": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
-      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
+        "uuid": "14.0.1"
       }
     },
     "libs/store/transcription-display-store": {
@@ -7490,9 +7464,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
-      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -11306,6 +11280,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",


### PR DESCRIPTION
Migrate uuid npm package from 13.0.1 to 14.0.1 (latest 14.x).

## Changes
- Updated uuid dependency in 2 packages:
  - apps/standalone-webapp/package.json
  - libs/store/transcription-content-store/package.json
- No code changes required; uuid v14 maintains backward compatibility with v13 API

## Verification
- npm run build: PASS
- npm run test:unit: PASS (all tests)
- npm audit: PASS (0 vulnerabilities)