### PR TITLE
build(deps): bump isort 7→8 and pylint for compatibility

### DIFF
--- a/transcription_service/pyproject.toml
+++ b/transcription_service/pyproject.toml
@@ -63,8 +63,8 @@ dev = [
 
     # Code linting and formatting
     "black==26.5.1",
-    "isort==7.0.0",
-    "pylint==4.0.0",
+    "isort==8.0.1",
+    "pylint==4.0.6",
 
     # Type hinting
     "multiprocess-stubs==0.1.0",

--- a/transcription_service/uv.lock
+++ b/transcription_service/uv.lock
@@ -651,11 +651,11 @@ wheels = [
 
 [[package]]
 name = "isort"
-version = "7.0.0"
+version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/53/4f3c058e3bace40282876f9b553343376ee687f3c35a525dc79dbd450f88/isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187", size = 805049, upload-time = "2025-10-11T13:30:59.107Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/ed/e3705d6d02b4f7aea715a353c8ce193efd0b5db13e204df895d38734c244/isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1", size = 94672, upload-time = "2025-10-11T13:30:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
 ]
 
 [[package]]
@@ -1206,7 +1206,7 @@ wheels = [
 
 [[package]]
 name = "pylint"
-version = "4.0.0"
+version = "4.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astroid" },
@@ -1217,9 +1217,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/2f/e80cc4301c81c41a8836d726377daeebf5901a33c06ba8c2d5afb94f7612/pylint-4.0.0.tar.gz", hash = "sha256:62da212808c0681e49ffb125f0a994c685d912cf19ae373075649ebb5870ec28", size = 1567676, upload-time = "2025-10-12T15:21:15.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/1d/3bb57f303701549550d74bf7ced2b07412be97125c167a0c9d216aa9f762/pylint-4.0.6.tar.gz", hash = "sha256:52f19191bee08bf103f9705ad1a0ece4aa5a0a4ef2bdcbd969375a1e6f6579d5", size = 1585588, upload-time = "2026-06-14T14:43:26.772Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/af/068a0b92c49927ada0e177561244157dc9d122eeea5987e34c423172a296/pylint-4.0.0-py3-none-any.whl", hash = "sha256:196b92a85204bb0c0a416a6bb324f6185e59ff1d687ee1d614bf0abf34a348e8", size = 535836, upload-time = "2025-10-12T15:21:13.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/da/acb2e7d4dbd2dfb792d38c0d850481f29ad7049b356d23f56c687d35203b/pylint-4.0.6-py3-none-any.whl", hash = "sha256:d11a0e1fdb7b1cd46ec5d6fc78fee8b95f28695b2d6140e5809925f61e32ea54", size = 538389, upload-time = "2026-06-14T14:43:24.873Z" },
 ]
 
 [[package]]
@@ -1467,12 +1467,12 @@ requires-dist = [
     { name = "faster-whisper", marker = "extra == 'faster-whisper'", specifier = "==1.2.1" },
     { name = "freezegun", marker = "extra == 'dev'", specifier = "==1.5.5" },
     { name = "httpx", specifier = "==0.28.1" },
-    { name = "isort", marker = "extra == 'dev'", specifier = "==7.0.0" },
+    { name = "isort", marker = "extra == 'dev'", specifier = "==8.0.1" },
     { name = "multiprocess", specifier = "==0.70.18" },
     { name = "multiprocess-stubs", marker = "extra == 'dev'", specifier = "==0.1.0" },
     { name = "numpy", specifier = "==2.3.3" },
     { name = "pydantic", specifier = "==2.12.0" },
-    { name = "pylint", marker = "extra == 'dev'", specifier = "==4.0.0" },
+    { name = "pylint", marker = "extra == 'dev'", specifier = "==4.0.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.4.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = "==3.15.1" },


### PR DESCRIPTION
## Summary
- Migrates isort from 7.0.0 to 8.0.1 (latest 8.x release)
- Bumps pylint from 4.0.0 to 4.0.6 for isort 8.x compatibility
- No source file changes: isort 8.x produces identical output to 7.0.0 for this codebase

## Verification
✅ format (isort + black check)
✅ lint (pylint with 10.00/10 rating)
✅ test_unit (all unit tests pass)
✅ test_integration (all integration tests pass)

## Changes
Only dependency updates in pyproject.toml and uv.lock (lockfile resolution). No code logic changes.