### PR TITLE
build(deps): bump @types/node 24→26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@changesets/cli": "2.30.0",
         "@eslint/js": "9.38.0",
         "@trivago/prettier-plugin-sort-imports": "6.0.2",
-        "@types/node": "24.9.1",
+        "@types/node": "26.1.1",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "5.1.4",
@@ -4039,13 +4039,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
-      "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -11235,9 +11235,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@changesets/cli": "2.30.0",
     "@eslint/js": "9.38.0",
     "@trivago/prettier-plugin-sort-imports": "6.0.2",
-    "@types/node": "24.9.1",
+    "@types/node": "26.1.1",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "5.1.4",


### PR DESCRIPTION
## Summary
- Bumps `@types/node` from `24.9.1` to `26.1.1` (latest 26.x), pinned only in the repo-root `devDependencies`.
- Confirmed by repo-wide grep that no other workspace `package.json` pins `@types/node` directly.
- Type-only change; transitively bumps `undici-types` `7.16.0` → `8.3.0` in the lockfile. No runtime dependency changed.

## Type-error fixes required
None. `npm run build` (tsc -b across every workspace) completed with zero TypeScript errors under the new type definitions, so no code changes beyond the version bump were needed.

## Verification
- `npm install` at repo root - lockfile updated cleanly (only the `@types/node` / `undici-types` entries changed).
- `npm run build` - all workspaces build successfully, no TS errors.
- `npm run test:unit` - all workspace test suites pass (session-manager 375, node-server 128, monitoring-sidecar 90, scribear-redis 44, and all libs) - exit code 0.

Part of the documented dependency migration plan (PLAN-UPDATE.md row J2).