### PR TITLE
test(admin): admin/server/session-manager coverage + demo caption room + test linting

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -16,11 +16,11 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
         node-version: '24.10.0'
 

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -9,10 +9,10 @@ runs:
 
   steps:
     - name: Set up Git repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -9,7 +9,7 @@ runs:
 
   steps:
     - name: Set up Git repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Pinned to an exact version rather than a floating major: setup-uv stopped
     # publishing moving major tags at v8.0.0, so `@v8` does not resolve.

--- a/.github/workflows/node-cd.yml
+++ b/.github/workflows/node-cd.yml
@@ -19,7 +19,7 @@ jobs:
       workspaces: ${{ steps.changes.outputs.workspaces }}
       has_changes: ${{ steps.changes.outputs.has_changes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Detect Changed Workspaces
         id: changes
@@ -89,7 +89,7 @@ jobs:
             version_file: apps/admin-webapp/package.json
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve image tags
         id: tags
@@ -115,7 +115,7 @@ jobs:
     if: contains(needs.changes.outputs.workspaces, 'apps/standalone-webapp') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-node
 
       - name: Run build

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -20,7 +20,7 @@ jobs:
       workspaces: ${{ steps.changes.outputs.workspaces }}
       has_changes: ${{ steps.changes.outputs.has_changes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Detect Changed Workspaces
         id: changes
@@ -31,7 +31,7 @@ jobs:
     if: needs.changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
@@ -51,7 +51,7 @@ jobs:
     if: needs.changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
@@ -71,7 +71,7 @@ jobs:
     if: needs.changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
@@ -91,7 +91,7 @@ jobs:
     if: needs.changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
@@ -202,7 +202,7 @@ jobs:
             version_file: apps/admin-webapp/package.json
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve image tags
         id: tags
@@ -228,7 +228,7 @@ jobs:
     if: needs.changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
@@ -292,7 +292,7 @@ jobs:
     if: contains(needs.changes.outputs.workspaces, 'infra/scribear-db')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-node
 
       - name: Prepare Scribear DB Container

--- a/.github/workflows/python-cd.yml
+++ b/.github/workflows/python-cd.yml
@@ -19,7 +19,7 @@ jobs:
       transcription_service: ${{ steps.filter.outputs.transcription_service }}
       image_matrix: ${{ steps.image_matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@v3
@@ -44,7 +44,7 @@ jobs:
     name: docker-build (${{ matrix.image_name }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve image tags
         id: tags

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,7 +20,7 @@ jobs:
       transcription_service: ${{ steps.filter.outputs.transcription_service }}
       image_matrix: ${{ steps.image_matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Detect Changed Paths
         id: filter
@@ -39,7 +39,7 @@ jobs:
     if: needs.changes.outputs.transcription_service == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Python
         uses: ./.github/actions/setup-python
 
@@ -52,7 +52,7 @@ jobs:
     if: needs.changes.outputs.transcription_service == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Python
         uses: ./.github/actions/setup-python
 
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Python
         uses: ./.github/actions/setup-python
 
@@ -92,7 +92,7 @@ jobs:
     name: docker-build (${{ matrix.image_name }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve image tags
         id: tags
@@ -118,7 +118,7 @@ jobs:
     if: needs.changes.outputs.transcription_service == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Python
         uses: ./.github/actions/setup-python
 

--- a/apps/admin-server/tests/integration/scheduling.routes.test.ts
+++ b/apps/admin-server/tests/integration/scheduling.routes.test.ts
@@ -7,6 +7,7 @@ import { TEST_ADMIN_KEY, login, useServer } from '#tests/utils/use-server.js';
 const BASE = '/api/admin/v1';
 const ROOM_UID = '11111111-1111-1111-1111-111111111111';
 const SCHEDULE_UID = '22222222-2222-2222-2222-222222222222';
+const WINDOW_UID = '33333333-3333-3333-3333-333333333333';
 
 const SAMPLE_SCHEDULE = {
   uid: SCHEDULE_UID,
@@ -25,8 +26,31 @@ const SAMPLE_SCHEDULE = {
   createdAt: '2026-01-01T00:00:00.000Z',
 };
 
+const SAMPLE_AUTO_WINDOW = {
+  uid: WINDOW_UID,
+  roomUid: ROOM_UID,
+  localStartTime: '09:00',
+  localEndTime: '10:00',
+  daysOfWeek: ['MON'],
+  joinCodeScopes: ['SEND_AUDIO'],
+  transcriptionProviderId: 'provider-1',
+  transcriptionStreamConfig: null,
+  activeStart: '2026-08-01T00:00:00.000Z',
+  activeEnd: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+const SAMPLE_ROOM = {
+  uid: ROOM_UID,
+  name: 'Room 101',
+  timezone: 'America/Chicago',
+  autoSessionEnabled: true,
+  roomScheduleVersion: 2,
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
 describe('Scheduling routes', () => {
-  const server = useServer();
+  const server = useServer({ rateLimitConfig: { loginMax: 20 } });
   const dbCtx = useDb();
   let sm: SessionManagerMock;
   beforeEach(() => {
@@ -128,6 +152,186 @@ describe('Scheduling routes', () => {
       expect(rows[0]?.actor_subject).toBe('engrit');
       expect(rows[0]?.result).toBe('success');
       expect(rows[0]?.status_code).toBe(201);
+    });
+  });
+
+  describe('auto-windows/create', (it) => {
+    const createWindowPayload = {
+      roomUid: ROOM_UID,
+      localStartTime: '09:00',
+      localEndTime: '10:00',
+      daysOfWeek: ['MON'],
+      activeStart: '2026-08-01T00:00:00.000Z',
+      activeEnd: null,
+      joinCodeScopes: ['SEND_AUDIO'],
+      transcriptionProviderId: 'provider-1',
+      transcriptionStreamConfig: null,
+    };
+
+    it('rejects an unauthenticated create with 401 and makes NO upstream call', async () => {
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/auto-windows/create`,
+        payload: createWindowPayload,
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(401);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'UNAUTHENTICATED',
+      );
+      expect(sm.requests.length).toBe(0);
+    });
+
+    it('rejects a create without a CSRF token (403) and makes NO upstream call', async () => {
+      // Arrange
+      sm.respondWith({ status: 201, body: SAMPLE_AUTO_WINDOW });
+      const { cookie } = await login(server.fastify);
+
+      // Act — authenticated but no x-csrf-token header
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/auto-windows/create`,
+        headers: { cookie },
+        payload: createWindowPayload,
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(403);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'CSRF_TOKEN_INVALID',
+      );
+      const created = sm.requests.find((r) =>
+        r.url.includes('/schedule-management/create-auto-session-window'),
+      );
+      expect(created).toBeUndefined();
+    });
+
+    it('creates an auto-window with a CSRF token, injects the key, and writes an audit record', async () => {
+      // Arrange
+      sm.respondWith({ status: 201, body: SAMPLE_AUTO_WINDOW });
+      const { cookie, csrfToken } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/auto-windows/create`,
+        headers: { cookie, 'x-csrf-token': csrfToken },
+        payload: createWindowPayload,
+      });
+
+      // Assert — response
+      expect(res.statusCode).toBe(201);
+      expect(res.json()).toEqual({ ok: true, data: SAMPLE_AUTO_WINDOW });
+
+      // Assert — upstream got the key + body
+      const created = sm.requests.find((r) =>
+        r.url.includes('/schedule-management/create-auto-session-window'),
+      );
+      expect(created?.headers['authorization']).toBe(
+        `Bearer ${TEST_ADMIN_KEY}`,
+      );
+      expect(created?.body).toMatchObject({ roomUid: ROOM_UID });
+
+      // Assert — audit row persisted
+      const rows = await dbCtx.db
+        .selectFrom('admin_audit_log')
+        .selectAll()
+        .where('action', '=', 'create-auto-session-window')
+        .execute();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.actor_subject).toBe('engrit');
+      expect(rows[0]?.result).toBe('success');
+      expect(rows[0]?.status_code).toBe(201);
+    });
+  });
+
+  describe('schedules/room-config', (it) => {
+    const roomConfigPayload = {
+      roomUid: ROOM_UID,
+      autoSessionEnabled: false,
+    };
+
+    it('rejects an unauthenticated update with 401 and makes NO upstream call', async () => {
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/schedules/room-config`,
+        payload: roomConfigPayload,
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(401);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'UNAUTHENTICATED',
+      );
+      expect(sm.requests.length).toBe(0);
+    });
+
+    it('rejects an update without a CSRF token (403) and makes NO upstream call', async () => {
+      // Arrange
+      sm.respondWith({ status: 200, body: SAMPLE_ROOM });
+      const { cookie } = await login(server.fastify);
+
+      // Act — authenticated but no x-csrf-token header
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/schedules/room-config`,
+        headers: { cookie },
+        payload: roomConfigPayload,
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(403);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'CSRF_TOKEN_INVALID',
+      );
+      const updated = sm.requests.find((r) =>
+        r.url.includes('/schedule-management/update-room-schedule-config'),
+      );
+      expect(updated).toBeUndefined();
+    });
+
+    it('updates room schedule config with a CSRF token, injects the key, and writes an audit record', async () => {
+      // Arrange
+      sm.respondWith({ status: 200, body: SAMPLE_ROOM });
+      const { cookie, csrfToken } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/schedules/room-config`,
+        headers: { cookie, 'x-csrf-token': csrfToken },
+        payload: roomConfigPayload,
+      });
+
+      // Assert — response
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ ok: true, data: SAMPLE_ROOM });
+
+      // Assert — upstream got the key + body
+      const updated = sm.requests.find((r) =>
+        r.url.includes('/schedule-management/update-room-schedule-config'),
+      );
+      expect(updated?.headers['authorization']).toBe(
+        `Bearer ${TEST_ADMIN_KEY}`,
+      );
+      expect(updated?.body).toMatchObject({
+        roomUid: ROOM_UID,
+        autoSessionEnabled: false,
+      });
+
+      // Assert — audit row persisted
+      const rows = await dbCtx.db
+        .selectFrom('admin_audit_log')
+        .selectAll()
+        .where('action', '=', 'update-room-schedule-config')
+        .execute();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.actor_subject).toBe('engrit');
+      expect(rows[0]?.result).toBe('success');
+      expect(rows[0]?.status_code).toBe(200);
     });
   });
 });

--- a/apps/admin-webapp/package.json
+++ b/apps/admin-webapp/package.json
@@ -15,8 +15,8 @@
     "dev": "vite",
     "format": "prettier --check ./src",
     "format:fix": "prettier --write ./src",
-    "lint": "eslint ./src",
-    "lint:fix": "eslint ./src --fix",
+    "lint": "eslint ./src ./tests",
+    "lint:fix": "eslint ./src ./tests --fix",
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {

--- a/apps/admin-webapp/package.json
+++ b/apps/admin-webapp/package.json
@@ -37,6 +37,7 @@
     "@testing-library/user-event": "14.6.1",
     "eslint-plugin-react-hooks": "7.0.1",
     "eslint-plugin-react-refresh": "0.5.2",
+    "jest-axe": "10.0.0",
     "jsdom": "29.1.1"
   }
 }

--- a/apps/admin-webapp/package.json
+++ b/apps/admin-webapp/package.json
@@ -16,7 +16,8 @@
     "format": "prettier --check ./src",
     "format:fix": "prettier --write ./src",
     "lint": "eslint ./src",
-    "lint:fix": "eslint ./src --fix"
+    "lint:fix": "eslint ./src --fix",
+    "test:unit": "vitest run --project unit"
   },
   "dependencies": {
     "@emotion/react": "11.14.0",
@@ -31,7 +32,10 @@
   },
   "devDependencies": {
     "@eslint-react/eslint-plugin": "2.13.0",
+    "@testing-library/jest-dom": "7.0.0",
+    "@testing-library/react": "16.3.2",
     "eslint-plugin-react-hooks": "7.0.1",
-    "eslint-plugin-react-refresh": "0.5.2"
+    "eslint-plugin-react-refresh": "0.5.2",
+    "jsdom": "29.1.1"
   }
 }

--- a/apps/admin-webapp/package.json
+++ b/apps/admin-webapp/package.json
@@ -34,6 +34,7 @@
     "@eslint-react/eslint-plugin": "2.13.0",
     "@testing-library/jest-dom": "7.0.0",
     "@testing-library/react": "16.3.2",
+    "@testing-library/user-event": "14.6.1",
     "eslint-plugin-react-hooks": "7.0.1",
     "eslint-plugin-react-refresh": "0.5.2",
     "jsdom": "29.1.1"

--- a/apps/admin-webapp/src/components/activation-code-display.tsx
+++ b/apps/admin-webapp/src/components/activation-code-display.tsx
@@ -101,6 +101,24 @@ export const ActivationCodeDisplay = ({
           ? 'This code has expired.'
           : `Expires in ${formatRemaining(remainingMs)}`}
       </Typography>
+      {/* The visible countdown above ticks every second and deliberately has
+          no live region — announcing it that often would spam a screen
+          reader. This region's content only ever changes once, on the
+          valid -> expired transition, so it announces that one meaningful
+          status change without the per-second noise. */}
+      <Box
+        aria-live="polite"
+        sx={{
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          overflow: 'hidden',
+          clip: 'rect(0 0 0 0)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {expired ? 'This code has expired.' : ''}
+      </Box>
     </Paper>
   );
 };

--- a/apps/admin-webapp/src/components/confirm-dialog.tsx
+++ b/apps/admin-webapp/src/components/confirm-dialog.tsx
@@ -28,10 +28,18 @@ export const ConfirmDialog = ({
   onClose,
 }: ConfirmDialogProps) => {
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="xs"
+      fullWidth
+      aria-describedby="confirm-dialog-description"
+    >
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
-        <DialogContentText>{message}</DialogContentText>
+        <DialogContentText id="confirm-dialog-description">
+          {message}
+        </DialogContentText>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} disabled={loading}>

--- a/apps/admin-webapp/src/features/audit/audit-page.tsx
+++ b/apps/admin-webapp/src/features/audit/audit-page.tsx
@@ -20,8 +20,8 @@ import Typography from '@mui/material/Typography';
 
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
-import { useAsyncData } from '#src/lib/use-async-data';
 import { useToast } from '#src/lib/toast-context';
+import { useAsyncData } from '#src/lib/use-async-data';
 
 const LIMIT_OPTIONS = [50, 100, 200] as const;
 

--- a/apps/admin-webapp/src/features/config-check/config-check-page.tsx
+++ b/apps/admin-webapp/src/features/config-check/config-check-page.tsx
@@ -24,8 +24,8 @@ import type {
 } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError } from '#src/lib/api-error';
-import { useAsyncData } from '#src/lib/use-async-data';
 import { useToast } from '#src/lib/toast-context';
+import { useAsyncData } from '#src/lib/use-async-data';
 
 /**
  * Severity presentation, most severe first. The order of this array is the

--- a/apps/admin-webapp/src/features/dashboard/dashboard-page.tsx
+++ b/apps/admin-webapp/src/features/dashboard/dashboard-page.tsx
@@ -19,8 +19,8 @@ import { useNavigate } from 'react-router-dom';
 import type { HealthReport } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
-import { useAsyncData } from '#src/lib/use-async-data';
 import { useToast } from '#src/lib/toast-context';
+import { useAsyncData } from '#src/lib/use-async-data';
 
 import { FleetPanel } from './fleet-panel';
 

--- a/apps/admin-webapp/src/features/devices/device-detail-page.tsx
+++ b/apps/admin-webapp/src/features/devices/device-detail-page.tsx
@@ -27,9 +27,9 @@ import { NameWithUid } from '#src/components/name-with-uid';
 import type { ReregisterDeviceResult } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
-import { useAsyncData } from '#src/lib/use-async-data';
 import { useSettings } from '#src/lib/settings-context';
 import { useToast } from '#src/lib/toast-context';
+import { useAsyncData } from '#src/lib/use-async-data';
 
 function errorMessage(err: unknown, fallback: string): string {
   return err instanceof ApiError ? err.message : fallback;
@@ -172,7 +172,8 @@ export const DeviceDetailPage = () => {
   // back to showing the raw room uid.
   const roomUid = device?.roomUid ?? null;
   const { data: room } = useAsyncData<Room | null>(
-    () => (roomUid === null ? Promise.resolve(null) : adminApi.getRoom(roomUid)),
+    () =>
+      roomUid === null ? Promise.resolve(null) : adminApi.getRoom(roomUid),
     [roomUid],
   );
 

--- a/apps/admin-webapp/src/features/kiosk-setup/kiosk-wizard-page.tsx
+++ b/apps/admin-webapp/src/features/kiosk-setup/kiosk-wizard-page.tsx
@@ -243,7 +243,7 @@ const RoomStep = ({
           </FormControl>
           {existingRoomsLoading && (
             <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-              <CircularProgress size={24} />
+              <CircularProgress size={24} aria-label="Loading rooms" />
             </Box>
           )}
           {!existingRoomsLoading && existingRooms.length === 0 && (
@@ -297,7 +297,7 @@ const VerifyStep = ({ deviceUid, roomUid, deviceActive }: VerifyStepProps) => {
 
   return (
     <Stack spacing={2} alignItems="center" sx={{ py: 4 }}>
-      <CircularProgress />
+      <CircularProgress aria-label="Waiting for the kiosk to activate" />
       <Typography color="text.secondary">
         Waiting for the kiosk to activate…
       </Typography>
@@ -501,12 +501,30 @@ export const KioskWizardPage = () => {
       </Typography>
 
       <Stepper activeStep={activeStep} sx={{ mb: 4 }}>
-        {STEPS.map((label) => (
+        {STEPS.map((label, index) => (
           <Step key={label}>
-            <StepLabel>{label}</StepLabel>
+            <StepLabel aria-current={index === activeStep ? 'step' : undefined}>
+              {label}
+            </StepLabel>
           </Step>
         ))}
       </Stepper>
+      {/* Plain StepLabel (no StepButton) never gets aria-current from MUI, and
+          the step change is otherwise silent to a screen reader — announce it
+          explicitly. */}
+      <Typography
+        aria-live="polite"
+        sx={{
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          overflow: 'hidden',
+          clip: 'rect(0 0 0 0)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {`Step ${String(activeStep + 1)} of ${String(STEPS.length)}: ${STEPS[activeStep] ?? ''}`}
+      </Typography>
 
       <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
         {activeStep === 0 && (

--- a/apps/admin-webapp/src/features/kiosk-setup/schedule-form-utils.ts
+++ b/apps/admin-webapp/src/features/kiosk-setup/schedule-form-utils.ts
@@ -1,0 +1,116 @@
+import type {
+  AutoSessionWindow,
+  SessionSchedule,
+} from '@scribear/session-manager-schema';
+
+import type { DayOfWeek, SessionScope } from '#src/lib/admin-api';
+
+/**
+ * A schedule's `activeStart` must be strictly in the future server-side, so one
+ * starting today is anchored slightly ahead of now. Occurrences starting before
+ * the anchor are not materialized, so keep the lead small. Windows have no such
+ * rule and are anchored at midnight, which keeps today's open hours intact.
+ */
+export const START_LEAD_MS = 30_000;
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/** Formats a Date as a browser-local `type="date"` input value. */
+export function dateToInput(d: Date): string {
+  return `${String(d.getFullYear())}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}
+
+/**
+ * Parses a `type="date"` input value as browser-local midnight. Avoids
+ * `new Date(value)`, which reads bare `yyyy-mm-dd` as UTC.
+ */
+export function dateInputToLocalMidnight(value: string): Date | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (m === null) return null;
+  const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function hhmm(localTime: string): string {
+  return localTime.slice(0, 5);
+}
+
+export function describeSchedule(s: SessionSchedule): string {
+  const days =
+    s.daysOfWeek === null || s.daysOfWeek.length === 0
+      ? ''
+      : ` ${s.daysOfWeek.join(', ')}`;
+  return `${s.name} — ${s.frequency}${days} ${hhmm(s.localStartTime)}–${hhmm(s.localEndTime)}`;
+}
+
+export function describeWindow(w: AutoSessionWindow): string {
+  return `${w.daysOfWeek.join(', ')} ${hhmm(w.localStartTime)}–${hhmm(w.localEndTime)}`;
+}
+
+/** Fields the schedule form and the window form have in common. */
+export interface CommonFormState {
+  daysOfWeek: DayOfWeek[];
+  localStartTime: string;
+  localEndTime: string;
+  startsOn: string;
+  indefinite: boolean;
+  endsOn: string;
+  joinCodeScopes: SessionScope[];
+  transcriptionProviderId: string;
+  transcriptionStreamConfig: string;
+}
+
+export type RangeResult =
+  | { ok: true; activeStart: string; activeEnd: string | null }
+  | { ok: false; error: string };
+
+/**
+ * Turns the two date inputs into the ISO instants the API wants.
+ * `anchorToFuture` covers the schedule endpoint's strictly-in-the-future rule.
+ */
+export function resolveActiveRange(
+  form: CommonFormState,
+  anchorToFuture: boolean,
+): RangeResult {
+  const startDay = dateInputToLocalMidnight(form.startsOn);
+  if (startDay === null)
+    return { ok: false, error: 'Enter a valid start date.' };
+
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  if (startDay.getTime() < todayStart.getTime()) {
+    return { ok: false, error: 'The start date must be today or later.' };
+  }
+
+  const activeStartMs = anchorToFuture
+    ? Math.max(startDay.getTime(), Date.now() + START_LEAD_MS)
+    : startDay.getTime();
+
+  if (form.indefinite) {
+    return {
+      ok: true,
+      activeStart: new Date(activeStartMs).toISOString(),
+      activeEnd: null,
+    };
+  }
+
+  const endDay = dateInputToLocalMidnight(form.endsOn);
+  if (endDay === null) {
+    return {
+      ok: false,
+      error: 'Enter a valid end date, or tick "No end date".',
+    };
+  }
+  // Inclusive: occurrences on the end date itself still materialize.
+  endDay.setHours(23, 59, 59, 999);
+  if (endDay.getTime() <= activeStartMs) {
+    return { ok: false, error: 'The end date must be after the start date.' };
+  }
+  return {
+    ok: true,
+    activeStart: new Date(activeStartMs).toISOString(),
+    activeEnd: endDay.toISOString(),
+  };
+}

--- a/apps/admin-webapp/src/features/kiosk-setup/schedule-step.tsx
+++ b/apps/admin-webapp/src/features/kiosk-setup/schedule-step.tsx
@@ -165,7 +165,12 @@ const DayToggles = ({
         ))}
       </ToggleButtonGroup>
       {error && (
-        <Typography id={errorId} variant="caption" color="error" display="block">
+        <Typography
+          id={errorId}
+          variant="caption"
+          color="error"
+          display="block"
+        >
           Pick at least one day of the week.
         </Typography>
       )}

--- a/apps/admin-webapp/src/features/kiosk-setup/schedule-step.tsx
+++ b/apps/admin-webapp/src/features/kiosk-setup/schedule-step.tsx
@@ -44,6 +44,14 @@ import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
 
+import type { CommonFormState } from './schedule-form-utils';
+import {
+  dateToInput,
+  describeSchedule,
+  describeWindow,
+  resolveActiveRange,
+} from './schedule-form-utils';
+
 /** Academic day letters: R is Thursday, U is Sunday. */
 const DAY_TOGGLES: readonly {
   value: DayOfWeek;
@@ -70,65 +78,8 @@ const FREQUENCIES: readonly ScheduleFrequency[] = [
 ];
 const RANGE_DAYS = 90;
 
-/**
- * A schedule's `activeStart` must be strictly in the future server-side, so one
- * starting today is anchored slightly ahead of now. Occurrences starting before
- * the anchor are not materialized, so keep the lead small. Windows have no such
- * rule and are anchored at midnight, which keeps today's open hours intact.
- */
-const START_LEAD_MS = 30_000;
-
 function errorMessage(err: unknown, fallback: string): string {
   return err instanceof ApiError ? err.message : fallback;
-}
-
-function pad2(n: number): string {
-  return String(n).padStart(2, '0');
-}
-
-/** Formats a Date as a browser-local `type="date"` input value. */
-function dateToInput(d: Date): string {
-  return `${String(d.getFullYear())}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
-}
-
-/**
- * Parses a `type="date"` input value as browser-local midnight. Avoids
- * `new Date(value)`, which reads bare `yyyy-mm-dd` as UTC.
- */
-function dateInputToLocalMidnight(value: string): Date | null {
-  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-  if (m === null) return null;
-  const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
-  return Number.isNaN(d.getTime()) ? null : d;
-}
-
-function hhmm(localTime: string): string {
-  return localTime.slice(0, 5);
-}
-
-function describeSchedule(s: SessionSchedule): string {
-  const days =
-    s.daysOfWeek === null || s.daysOfWeek.length === 0
-      ? ''
-      : ` ${s.daysOfWeek.join(', ')}`;
-  return `${s.name} — ${s.frequency}${days} ${hhmm(s.localStartTime)}–${hhmm(s.localEndTime)}`;
-}
-
-function describeWindow(w: AutoSessionWindow): string {
-  return `${w.daysOfWeek.join(', ')} ${hhmm(w.localStartTime)}–${hhmm(w.localEndTime)}`;
-}
-
-/** Fields the schedule form and the window form have in common. */
-interface CommonFormState {
-  daysOfWeek: DayOfWeek[];
-  localStartTime: string;
-  localEndTime: string;
-  startsOn: string;
-  indefinite: boolean;
-  endsOn: string;
-  joinCodeScopes: SessionScope[];
-  transcriptionProviderId: string;
-  transcriptionStreamConfig: string;
 }
 
 interface ScheduleFormState extends CommonFormState {
@@ -166,59 +117,6 @@ function emptyWindowForm(): WindowFormState {
     localStartTime: '08:00',
     localEndTime: '17:00',
     enableAutoSessions: true,
-  };
-}
-
-type RangeResult =
-  | { ok: true; activeStart: string; activeEnd: string | null }
-  | { ok: false; error: string };
-
-/**
- * Turns the two date inputs into the ISO instants the API wants.
- * `anchorToFuture` covers the schedule endpoint's strictly-in-the-future rule.
- */
-function resolveActiveRange(
-  form: CommonFormState,
-  anchorToFuture: boolean,
-): RangeResult {
-  const startDay = dateInputToLocalMidnight(form.startsOn);
-  if (startDay === null)
-    return { ok: false, error: 'Enter a valid start date.' };
-
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  if (startDay.getTime() < todayStart.getTime()) {
-    return { ok: false, error: 'The start date must be today or later.' };
-  }
-
-  const activeStartMs = anchorToFuture
-    ? Math.max(startDay.getTime(), Date.now() + START_LEAD_MS)
-    : startDay.getTime();
-
-  if (form.indefinite) {
-    return {
-      ok: true,
-      activeStart: new Date(activeStartMs).toISOString(),
-      activeEnd: null,
-    };
-  }
-
-  const endDay = dateInputToLocalMidnight(form.endsOn);
-  if (endDay === null) {
-    return {
-      ok: false,
-      error: 'Enter a valid end date, or tick "No end date".',
-    };
-  }
-  // Inclusive: occurrences on the end date itself still materialize.
-  endDay.setHours(23, 59, 59, 999);
-  if (endDay.getTime() <= activeStartMs) {
-    return { ok: false, error: 'The end date must be after the start date.' };
-  }
-  return {
-    ok: true,
-    activeStart: new Date(activeStartMs).toISOString(),
-    activeEnd: endDay.toISOString(),
   };
 }
 

--- a/apps/admin-webapp/src/features/kiosk-setup/schedule-step.tsx
+++ b/apps/admin-webapp/src/features/kiosk-setup/schedule-step.tsx
@@ -121,32 +121,57 @@ function emptyWindowForm(): WindowFormState {
 }
 
 interface DayTogglesProps {
+  idPrefix: string;
   value: DayOfWeek[];
   onChange: (days: DayOfWeek[]) => void;
   disabled: boolean;
+  error?: boolean;
 }
 
-const DayToggles = ({ value, onChange, disabled }: DayTogglesProps) => (
-  <Box>
-    <Typography variant="body2" color="text.secondary" gutterBottom>
-      Days
-    </Typography>
-    <ToggleButtonGroup
-      value={value}
-      onChange={(_e, next: DayOfWeek[]) => {
-        onChange(next);
-      }}
-      disabled={disabled}
-      size="small"
-    >
-      {DAY_TOGGLES.map((d) => (
-        <ToggleButton key={d.value} value={d.value} aria-label={d.name}>
-          {d.letter}
-        </ToggleButton>
-      ))}
-    </ToggleButtonGroup>
-  </Box>
-);
+const DayToggles = ({
+  idPrefix,
+  value,
+  onChange,
+  disabled,
+  error = false,
+}: DayTogglesProps) => {
+  const labelId = `${idPrefix}-days-label`;
+  const errorId = `${idPrefix}-days-error`;
+  return (
+    <Box>
+      <Typography
+        id={labelId}
+        variant="body2"
+        color={error ? 'error' : 'text.secondary'}
+        gutterBottom
+      >
+        Days
+      </Typography>
+      <ToggleButtonGroup
+        value={value}
+        onChange={(_e, next: DayOfWeek[]) => {
+          onChange(next);
+        }}
+        disabled={disabled}
+        size="small"
+        aria-labelledby={labelId}
+        aria-invalid={error || undefined}
+        aria-describedby={error ? errorId : undefined}
+      >
+        {DAY_TOGGLES.map((d) => (
+          <ToggleButton key={d.value} value={d.value} aria-label={d.name}>
+            {d.letter}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+      {error && (
+        <Typography id={errorId} variant="caption" color="error" display="block">
+          Pick at least one day of the week.
+        </Typography>
+      )}
+    </Box>
+  );
+};
 
 interface TimeRangeFieldsProps {
   form: CommonFormState;
@@ -352,6 +377,7 @@ export const ScheduleStep = ({
   const [windowForm, setWindowForm] =
     useState<WindowFormState>(emptyWindowForm);
   const [jsonError, setJsonError] = useState<string | null>(null);
+  const [daysError, setDaysError] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [misconfigured, setMisconfigured] = useState(false);
 
@@ -426,6 +452,7 @@ export const ScheduleStep = ({
       scheduleForm.frequency !== 'ONCE' &&
       scheduleForm.daysOfWeek.length === 0
     ) {
+      setDaysError(true);
       showError('Pick at least one day of the week.');
       return;
     }
@@ -480,6 +507,7 @@ export const ScheduleStep = ({
     setJsonError(null);
 
     if (windowForm.daysOfWeek.length === 0) {
+      setDaysError(true);
       showError('Pick at least one day of the week.');
       return;
     }
@@ -577,7 +605,10 @@ export const ScheduleStep = ({
 
       {loading ? (
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-          <CircularProgress size={24} />
+          <CircularProgress
+            size={24}
+            aria-label="Loading this room's schedule"
+          />
         </Box>
       ) : (
         hasExisting && (
@@ -605,6 +636,7 @@ export const ScheduleStep = ({
         onChange={(e) => {
           setMode(e.target.value as Mode);
           setJsonError(null);
+          setDaysError(false);
         }}
       >
         <FormControlLabel
@@ -655,11 +687,14 @@ export const ScheduleStep = ({
           />
           <Box>
             <DayToggles
+              idPrefix="kiosk-schedule"
               value={scheduleForm.daysOfWeek}
               onChange={(days) => {
                 patchSchedule({ daysOfWeek: days });
+                setDaysError(false);
               }}
               disabled={scheduleForm.frequency === 'ONCE'}
+              error={daysError}
             />
             {scheduleForm.frequency === 'ONCE' && (
               <Typography variant="caption" color="text.secondary">
@@ -720,11 +755,14 @@ export const ScheduleStep = ({
       {mode === 'auto' && (
         <Stack spacing={2}>
           <DayToggles
+            idPrefix="kiosk-window"
             value={windowForm.daysOfWeek}
             onChange={(days) => {
               patchWindow({ daysOfWeek: days });
+              setDaysError(false);
             }}
             disabled={false}
+            error={daysError}
           />
           <TimeRangeFields
             form={windowForm}

--- a/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
+++ b/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
@@ -38,9 +38,9 @@ import { NameWithUid } from '#src/components/name-with-uid';
 import type { RoomDetail } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
-import { useAsyncData } from '#src/lib/use-async-data';
 import { useSettings } from '#src/lib/settings-context';
 import { useToast } from '#src/lib/toast-context';
+import { useAsyncData } from '#src/lib/use-async-data';
 
 interface RenameRoomDialogProps {
   room: Room;

--- a/apps/admin-webapp/src/features/rooms/rooms-list-page.tsx
+++ b/apps/admin-webapp/src/features/rooms/rooms-list-page.tsx
@@ -213,14 +213,17 @@ export const RoomsListPage = () => {
     hasMore,
     loadMore,
     reload,
-  } = useAsyncList<Room>((cursor) => {
-    const query: { search?: string; cursor?: string; limit: number } = {
-      limit: PAGE_LIMIT,
-    };
-    if (search !== '') query.search = search;
-    if (cursor !== undefined) query.cursor = cursor;
-    return adminApi.listRooms(query);
-  }, [search]);
+  } = useAsyncList<Room>(
+    (cursor) => {
+      const query: { search?: string; cursor?: string; limit: number } = {
+        limit: PAGE_LIMIT,
+      };
+      if (search !== '') query.search = search;
+      if (cursor !== undefined) query.cursor = cursor;
+      return adminApi.listRooms(query);
+    },
+    [search],
+  );
 
   const misconfigured = isApiErrorCode(error, 'BACKEND_MISCONFIGURATION');
 

--- a/apps/admin-webapp/src/features/scheduling/room-scheduling-form-utils.ts
+++ b/apps/admin-webapp/src/features/scheduling/room-scheduling-form-utils.ts
@@ -22,6 +22,17 @@ export function sameStringArray(
   return sa.every((v, i) => v === sb[i]);
 }
 
+/** `sameStringArray`, but `null` is only equal to `null` (never to an empty
+ * array) — for the one field, `ScheduleDialog`'s `daysOfWeek`, that can be
+ * absent entirely rather than just empty. */
+export function sameDaysOfWeek(
+  a: readonly string[] | null,
+  b: readonly string[] | null,
+): boolean {
+  if (a === null || b === null) return a === b;
+  return sameStringArray(a, b);
+}
+
 /** The schedule dialog's fully-resolved next-state values: validation and
  * JSON-parsing of the raw form have already happened in the caller. */
 export interface ResolvedScheduleFields {
@@ -40,15 +51,6 @@ export interface ResolvedScheduleFields {
 /**
  * Diffs the resolved next-state fields against the loaded schedule and
  * returns only the changed ones, for a PATCH-shaped update body.
- *
- * NOTE (locked-in current behavior, not "fixed" here): `daysOfWeek` below is
- * compared with a plain `JSON.stringify` — order-sensitive — while
- * `joinCodeScopes` a few lines down (and the auto-window dialog's own
- * `daysOfWeek`, see `diffAutoWindowUpdate`) use the order-insensitive
- * `sameStringArray`. A same-set-but-reordered `daysOfWeek` is therefore
- * treated as "changed" here, unlike everywhere else in this file. Whether
- * that asymmetry is intended is unclear; it is preserved as-is rather than
- * "fixed" as part of a test-coverage pass.
  */
 export function diffScheduleUpdate(
   schedule: SessionSchedule,
@@ -67,9 +69,7 @@ export function diffScheduleUpdate(
     body.localEndTime = next.localEndTime;
   }
   if (next.frequency !== schedule.frequency) body.frequency = next.frequency;
-  if (
-    JSON.stringify(next.daysOfWeek) !== JSON.stringify(schedule.daysOfWeek)
-  ) {
+  if (!sameDaysOfWeek(next.daysOfWeek, schedule.daysOfWeek)) {
     body.daysOfWeek = next.daysOfWeek;
   }
   if (!sameStringArray(next.joinCodeScopes, schedule.joinCodeScopes)) {

--- a/apps/admin-webapp/src/features/scheduling/room-scheduling-form-utils.ts
+++ b/apps/admin-webapp/src/features/scheduling/room-scheduling-form-utils.ts
@@ -1,0 +1,140 @@
+import type {
+  AutoSessionWindow,
+  SessionSchedule,
+} from '@scribear/session-manager-schema';
+
+import type {
+  DayOfWeek,
+  ScheduleFrequency,
+  SessionScope,
+  UpdateAutoWindowBody,
+  UpdateScheduleBody,
+} from '#src/lib/admin-api';
+
+/** True iff `a` and `b` contain the same strings, ignoring order. */
+export function sameStringArray(
+  a: readonly string[],
+  b: readonly string[],
+): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+}
+
+/** The schedule dialog's fully-resolved next-state values: validation and
+ * JSON-parsing of the raw form have already happened in the caller. */
+export interface ResolvedScheduleFields {
+  name: string;
+  activeStart: string;
+  activeEnd: string | null;
+  localStartTime: string;
+  localEndTime: string;
+  frequency: ScheduleFrequency;
+  daysOfWeek: DayOfWeek[] | null;
+  joinCodeScopes: SessionScope[];
+  transcriptionProviderId: string;
+  transcriptionStreamConfig: unknown;
+}
+
+/**
+ * Diffs the resolved next-state fields against the loaded schedule and
+ * returns only the changed ones, for a PATCH-shaped update body.
+ *
+ * NOTE (locked-in current behavior, not "fixed" here): `daysOfWeek` below is
+ * compared with a plain `JSON.stringify` — order-sensitive — while
+ * `joinCodeScopes` a few lines down (and the auto-window dialog's own
+ * `daysOfWeek`, see `diffAutoWindowUpdate`) use the order-insensitive
+ * `sameStringArray`. A same-set-but-reordered `daysOfWeek` is therefore
+ * treated as "changed" here, unlike everywhere else in this file. Whether
+ * that asymmetry is intended is unclear; it is preserved as-is rather than
+ * "fixed" as part of a test-coverage pass.
+ */
+export function diffScheduleUpdate(
+  schedule: SessionSchedule,
+  next: ResolvedScheduleFields,
+): Omit<UpdateScheduleBody, 'scheduleUid'> {
+  const body: Omit<UpdateScheduleBody, 'scheduleUid'> = {};
+  if (next.name !== schedule.name) body.name = next.name;
+  if (next.activeStart !== schedule.activeStart) {
+    body.activeStart = next.activeStart;
+  }
+  if (next.activeEnd !== schedule.activeEnd) body.activeEnd = next.activeEnd;
+  if (next.localStartTime !== schedule.localStartTime.slice(0, 5)) {
+    body.localStartTime = next.localStartTime;
+  }
+  if (next.localEndTime !== schedule.localEndTime.slice(0, 5)) {
+    body.localEndTime = next.localEndTime;
+  }
+  if (next.frequency !== schedule.frequency) body.frequency = next.frequency;
+  if (
+    JSON.stringify(next.daysOfWeek) !== JSON.stringify(schedule.daysOfWeek)
+  ) {
+    body.daysOfWeek = next.daysOfWeek;
+  }
+  if (!sameStringArray(next.joinCodeScopes, schedule.joinCodeScopes)) {
+    body.joinCodeScopes = next.joinCodeScopes;
+  }
+  if (
+    next.transcriptionProviderId !== (schedule.transcriptionProviderId ?? '')
+  ) {
+    body.transcriptionProviderId = next.transcriptionProviderId;
+  }
+  if (
+    JSON.stringify(next.transcriptionStreamConfig) !==
+    JSON.stringify(schedule.transcriptionStreamConfig ?? {})
+  ) {
+    body.transcriptionStreamConfig = next.transcriptionStreamConfig;
+  }
+  return body;
+}
+
+/** The auto-window dialog's fully-resolved next-state values: validation and
+ * JSON-parsing of the raw form have already happened in the caller. */
+export interface ResolvedAutoWindowFields {
+  localStartTime: string;
+  localEndTime: string;
+  daysOfWeek: DayOfWeek[];
+  activeStart: string;
+  activeEnd: string | null;
+  joinCodeScopes: SessionScope[];
+  transcriptionProviderId: string;
+  transcriptionStreamConfig: unknown;
+}
+
+/**
+ * Diffs the resolved next-state fields against the loaded auto-session
+ * window and returns only the changed ones, for a PATCH-shaped update body.
+ */
+export function diffAutoWindowUpdate(
+  autoWindow: AutoSessionWindow,
+  next: ResolvedAutoWindowFields,
+): Omit<UpdateAutoWindowBody, 'windowUid'> {
+  const body: Omit<UpdateAutoWindowBody, 'windowUid'> = {};
+  if (next.localStartTime !== autoWindow.localStartTime.slice(0, 5)) {
+    body.localStartTime = next.localStartTime;
+  }
+  if (next.localEndTime !== autoWindow.localEndTime.slice(0, 5)) {
+    body.localEndTime = next.localEndTime;
+  }
+  if (!sameStringArray(next.daysOfWeek, autoWindow.daysOfWeek)) {
+    body.daysOfWeek = next.daysOfWeek;
+  }
+  if (next.activeStart !== autoWindow.activeStart) {
+    body.activeStart = next.activeStart;
+  }
+  if (next.activeEnd !== autoWindow.activeEnd) body.activeEnd = next.activeEnd;
+  if (!sameStringArray(next.joinCodeScopes, autoWindow.joinCodeScopes)) {
+    body.joinCodeScopes = next.joinCodeScopes;
+  }
+  if (next.transcriptionProviderId !== autoWindow.transcriptionProviderId) {
+    body.transcriptionProviderId = next.transcriptionProviderId;
+  }
+  if (
+    JSON.stringify(next.transcriptionStreamConfig) !==
+    JSON.stringify(autoWindow.transcriptionStreamConfig)
+  ) {
+    body.transcriptionStreamConfig = next.transcriptionStreamConfig;
+  }
+  return body;
+}

--- a/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
+++ b/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
@@ -55,6 +55,8 @@ import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
 
+import { diffAutoWindowUpdate, diffScheduleUpdate } from './room-scheduling-form-utils';
+
 const DAYS_OF_WEEK: readonly DayOfWeek[] = [
   'SUN',
   'MON',
@@ -105,13 +107,6 @@ function isoToLocalInput(iso: string): string {
   const pad = (n: number) => String(n).padStart(2, '0');
   const year = String(d.getFullYear());
   return `${year}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
-
-function sameStringArray(a: readonly string[], b: readonly string[]): boolean {
-  if (a.length !== b.length) return false;
-  const sa = [...a].sort();
-  const sb = [...b].sort();
-  return sa.every((v, i) => v === sb[i]);
 }
 
 interface MultiSelectFieldProps<T extends string> {
@@ -316,38 +311,21 @@ const ScheduleDialog = ({
           setSubmitting(false);
         });
     } else {
-      const body: UpdateScheduleBody = { scheduleUid: schedule.uid };
-      if (form.name !== schedule.name) body.name = form.name;
-      if (activeStartIso !== schedule.activeStart) {
-        body.activeStart = activeStartIso;
-      }
-      if (activeEndIso !== schedule.activeEnd) body.activeEnd = activeEndIso;
-      if (form.localStartTime !== schedule.localStartTime.slice(0, 5)) {
-        body.localStartTime = form.localStartTime;
-      }
-      if (form.localEndTime !== schedule.localEndTime.slice(0, 5)) {
-        body.localEndTime = form.localEndTime;
-      }
-      if (form.frequency !== schedule.frequency)
-        body.frequency = form.frequency;
-      if (JSON.stringify(daysOfWeek) !== JSON.stringify(schedule.daysOfWeek)) {
-        body.daysOfWeek = daysOfWeek;
-      }
-      if (!sameStringArray(form.joinCodeScopes, schedule.joinCodeScopes)) {
-        body.joinCodeScopes = form.joinCodeScopes;
-      }
-      if (
-        form.transcriptionProviderId !==
-        (schedule.transcriptionProviderId ?? '')
-      ) {
-        body.transcriptionProviderId = form.transcriptionProviderId;
-      }
-      if (
-        JSON.stringify(transcriptionStreamConfig) !==
-        JSON.stringify(schedule.transcriptionStreamConfig ?? {})
-      ) {
-        body.transcriptionStreamConfig = transcriptionStreamConfig;
-      }
+      const body: UpdateScheduleBody = {
+        scheduleUid: schedule.uid,
+        ...diffScheduleUpdate(schedule, {
+          name: form.name,
+          activeStart: activeStartIso,
+          activeEnd: activeEndIso,
+          localStartTime: form.localStartTime,
+          localEndTime: form.localEndTime,
+          frequency: form.frequency,
+          daysOfWeek,
+          joinCodeScopes: form.joinCodeScopes,
+          transcriptionProviderId: form.transcriptionProviderId,
+          transcriptionStreamConfig,
+        }),
+      };
       adminApi
         .updateSchedule(body)
         .then(() => {
@@ -648,32 +626,19 @@ const AutoWindowDialog = ({
           setSubmitting(false);
         });
     } else {
-      const body: UpdateAutoWindowBody = { windowUid: autoWindow.uid };
-      if (form.localStartTime !== autoWindow.localStartTime.slice(0, 5)) {
-        body.localStartTime = form.localStartTime;
-      }
-      if (form.localEndTime !== autoWindow.localEndTime.slice(0, 5)) {
-        body.localEndTime = form.localEndTime;
-      }
-      if (!sameStringArray(form.daysOfWeek, autoWindow.daysOfWeek)) {
-        body.daysOfWeek = form.daysOfWeek;
-      }
-      if (activeStartIso !== autoWindow.activeStart) {
-        body.activeStart = activeStartIso;
-      }
-      if (activeEndIso !== autoWindow.activeEnd) body.activeEnd = activeEndIso;
-      if (!sameStringArray(form.joinCodeScopes, autoWindow.joinCodeScopes)) {
-        body.joinCodeScopes = form.joinCodeScopes;
-      }
-      if (form.transcriptionProviderId !== autoWindow.transcriptionProviderId) {
-        body.transcriptionProviderId = form.transcriptionProviderId;
-      }
-      if (
-        JSON.stringify(transcriptionStreamConfig) !==
-        JSON.stringify(autoWindow.transcriptionStreamConfig)
-      ) {
-        body.transcriptionStreamConfig = transcriptionStreamConfig;
-      }
+      const body: UpdateAutoWindowBody = {
+        windowUid: autoWindow.uid,
+        ...diffAutoWindowUpdate(autoWindow, {
+          localStartTime: form.localStartTime,
+          localEndTime: form.localEndTime,
+          daysOfWeek: form.daysOfWeek,
+          activeStart: activeStartIso,
+          activeEnd: activeEndIso,
+          joinCodeScopes: form.joinCodeScopes,
+          transcriptionProviderId: form.transcriptionProviderId,
+          transcriptionStreamConfig,
+        }),
+      };
       adminApi
         .updateAutoWindow(body)
         .then(() => {

--- a/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
+++ b/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
@@ -1,9 +1,4 @@
-import {
-  type SyntheticEvent,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { type SyntheticEvent, useEffect, useMemo, useState } from 'react';
 
 import AddIcon from '@mui/icons-material/Add';
 import Alert from '@mui/material/Alert';
@@ -62,7 +57,10 @@ import { ApiError, isApiErrorCode } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 
-import { diffAutoWindowUpdate, diffScheduleUpdate } from './room-scheduling-form-utils';
+import {
+  diffAutoWindowUpdate,
+  diffScheduleUpdate,
+} from './room-scheduling-form-utils';
 
 const DAYS_OF_WEEK: readonly DayOfWeek[] = [
   'SUN',
@@ -159,7 +157,9 @@ function MultiSelectField<T extends string>({
           </MenuItem>
         ))}
       </Select>
-      {helperText && <FormHelperText id={helperId}>{helperText}</FormHelperText>}
+      {helperText && (
+        <FormHelperText id={helperId}>{helperText}</FormHelperText>
+      )}
     </FormControl>
   );
 }
@@ -1045,7 +1045,9 @@ export const RoomSchedulingPage = () => {
       windowsError !== null &&
       !isApiErrorCode(windowsError, 'BACKEND_MISCONFIGURATION')
     ) {
-      showError(errorMessage(windowsError, 'Failed to load auto-session windows.'));
+      showError(
+        errorMessage(windowsError, 'Failed to load auto-session windows.'),
+      );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [windowsError]);

--- a/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
+++ b/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
@@ -14,6 +14,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import FormHelperText from '@mui/material/FormHelperText';
 import Grid from '@mui/material/Grid';
 import InputLabel from '@mui/material/InputLabel';
 import ListItemText from '@mui/material/ListItemText';
@@ -115,6 +116,8 @@ interface MultiSelectFieldProps<T extends string> {
   value: T[];
   onChange: (value: T[]) => void;
   disabled: boolean;
+  error?: boolean;
+  helperText?: string;
 }
 
 function MultiSelectField<T extends string>({
@@ -123,10 +126,13 @@ function MultiSelectField<T extends string>({
   value,
   onChange,
   disabled,
+  error = false,
+  helperText,
 }: MultiSelectFieldProps<T>) {
   const labelId = `multiselect-${label.replace(/\s+/g, '-').toLowerCase()}`;
+  const helperId = `${labelId}-helper`;
   return (
-    <FormControl fullWidth margin="normal" disabled={disabled}>
+    <FormControl fullWidth margin="normal" disabled={disabled} error={error}>
       <InputLabel id={labelId}>{label}</InputLabel>
       <Select<T[]>
         labelId={labelId}
@@ -138,6 +144,7 @@ function MultiSelectField<T extends string>({
           onChange(typeof v === 'string' ? (v.split(',') as T[]) : v);
         }}
         renderValue={(selected) => selected.join(', ')}
+        {...(helperText ? { 'aria-describedby': helperId } : {})}
       >
         {options.map((opt) => (
           <MenuItem key={opt} value={opt}>
@@ -146,6 +153,7 @@ function MultiSelectField<T extends string>({
           </MenuItem>
         ))}
       </Select>
+      {helperText && <FormHelperText id={helperId}>{helperText}</FormHelperText>}
     </FormControl>
   );
 }
@@ -238,12 +246,14 @@ const ScheduleDialog = ({
         },
   );
   const [jsonError, setJsonError] = useState<string | null>(null);
+  const [daysError, setDaysError] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [misconfigured, setMisconfigured] = useState(false);
 
   const handleSubmit = () => {
     setJsonError(null);
     if (form.frequency !== 'ONCE' && form.daysOfWeek.length === 0) {
+      setDaysError(true);
       showError('Select at least one day of week for a recurring schedule.');
       return;
     }
@@ -393,8 +403,15 @@ const ScheduleDialog = ({
           value={form.daysOfWeek}
           onChange={(v) => {
             setForm((f) => ({ ...f, daysOfWeek: v }));
+            setDaysError(false);
           }}
           disabled={form.frequency === 'ONCE'}
+          error={daysError}
+          helperText={
+            daysError
+              ? 'Select at least one day of week for a recurring schedule.'
+              : ''
+          }
         />
         <Stack direction="row" spacing={2}>
           <TextField
@@ -556,12 +573,14 @@ const AutoWindowDialog = ({
         },
   );
   const [jsonError, setJsonError] = useState<string | null>(null);
+  const [daysError, setDaysError] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [misconfigured, setMisconfigured] = useState(false);
 
   const handleSubmit = () => {
     setJsonError(null);
     if (form.daysOfWeek.length === 0) {
+      setDaysError(true);
       showError('Select at least one day of week.');
       return;
     }
@@ -702,8 +721,11 @@ const AutoWindowDialog = ({
           value={form.daysOfWeek}
           onChange={(v) => {
             setForm((f) => ({ ...f, daysOfWeek: v }));
+            setDaysError(false);
           }}
           disabled={false}
+          error={daysError}
+          helperText={daysError ? 'Select at least one day of week.' : ''}
         />
         <TextField
           label="Active start"
@@ -1104,7 +1126,7 @@ export const RoomSchedulingPage = () => {
   if (loading && room === null) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
-        <CircularProgress />
+        <CircularProgress aria-label="Loading room" />
       </Box>
     );
   }
@@ -1210,7 +1232,7 @@ export const RoomSchedulingPage = () => {
             {schedulesLoading ? (
               <TableRow>
                 <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
-                  <CircularProgress size={28} />
+                  <CircularProgress size={28} aria-label="Loading schedules" />
                 </TableCell>
               </TableRow>
             ) : schedules.length === 0 ? (
@@ -1318,7 +1340,10 @@ export const RoomSchedulingPage = () => {
             {windowsLoading ? (
               <TableRow>
                 <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
-                  <CircularProgress size={28} />
+                  <CircularProgress
+                    size={28}
+                    aria-label="Loading auto-session windows"
+                  />
                 </TableCell>
               </TableRow>
             ) : windows.length === 0 ? (

--- a/apps/admin-webapp/src/features/sessions/session-detail-page.tsx
+++ b/apps/admin-webapp/src/features/sessions/session-detail-page.tsx
@@ -19,8 +19,8 @@ import type { Session } from '@scribear/session-manager-schema';
 import { ConfirmDialog } from '#src/components/confirm-dialog';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
-import { useAsyncData } from '#src/lib/use-async-data';
 import { useToast } from '#src/lib/toast-context';
+import { useAsyncData } from '#src/lib/use-async-data';
 
 function errorMessage(err: unknown, fallback: string): string {
   return err instanceof ApiError ? err.message : fallback;

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -428,6 +428,17 @@ export class AdminApiClient {
       this._onUnauthorized?.();
     }
 
+    if (res.ok) {
+      // A 2xx status whose body isn't a valid `{ ok: true, data }` envelope
+      // (unparseable JSON, or an unexpected `ok: false`). Distinct code so
+      // callers can't mistake this for a real declared backend error.
+      throw new ApiError(
+        'INVALID_RESPONSE',
+        'The server returned an unexpected response.',
+        res.status,
+      );
+    }
+
     const err =
       json && !json.ok
         ? json.error

--- a/apps/admin-webapp/src/lib/session-rules.ts
+++ b/apps/admin-webapp/src/lib/session-rules.ts
@@ -1,0 +1,9 @@
+import type { Session } from '@scribear/session-manager-schema';
+
+export type SessionColor = 'info' | 'default' | 'success';
+
+export function sessionTypeColor(type: Session['type']): SessionColor {
+  if (type === 'SCHEDULED') return 'info';
+  if (type === 'ON_DEMAND') return 'success';
+  return 'default'; // AUTO
+}

--- a/apps/admin-webapp/src/lib/toast-provider.tsx
+++ b/apps/admin-webapp/src/lib/toast-provider.tsx
@@ -61,7 +61,18 @@ export const ToastProvider = ({ children }: React.PropsWithChildren) => {
           severity={state.severity}
           variant="filled"
           onClose={handleClose}
-          sx={{ width: '100%' }}
+          sx={{
+            width: '100%',
+            // MUI's default filled-variant text color (white) on these two
+            // severities' `main` falls below the WCAG AA 4.5:1 minimum for
+            // normal text (info ~3.86:1, warning ~3.11:1) — override just
+            // enough to clear it without touching the shared theme palette
+            // used elsewhere (buttons, chips, standard-variant Alerts).
+            ...(state.severity === 'info' && { bgcolor: 'info.dark' }),
+            ...(state.severity === 'warning' && {
+              color: 'rgba(0, 0, 0, 0.87)',
+            }),
+          }}
         >
           {state.message}
         </Alert>

--- a/apps/admin-webapp/tests/components/require-auth.test.tsx
+++ b/apps/admin-webapp/tests/components/require-auth.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import type { AuthContextValue } from '#src/features/auth/auth-context';
+import { useAuth } from '#src/features/auth/auth-context';
+import { RequireAuth } from '#src/components/require-auth';
+
+vi.mock('#src/features/auth/auth-context', () => ({
+  useAuth: vi.fn(),
+}));
+
+function renderGuarded(authValue: Pick<AuthContextValue, 'status'>) {
+  vi.mocked(useAuth).mockReturnValue(authValue as AuthContextValue);
+
+  return render(
+    <MemoryRouter initialEntries={['/dashboard']}>
+      <Routes>
+        <Route path="/login" element={<div>Login page</div>} />
+        <Route element={<RequireAuth />}>
+          <Route path="/dashboard" element={<div>Protected content</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('RequireAuth', (it) => {
+  it('redirects to /login when unauthenticated', () => {
+    // Act
+    renderGuarded({ status: 'anon' });
+
+    // Assert
+    expect(screen.getByText('Login page')).toBeInTheDocument();
+    expect(screen.queryByText('Protected content')).not.toBeInTheDocument();
+  });
+
+  it('renders the protected route when authenticated', () => {
+    // Act
+    renderGuarded({ status: 'authed' });
+
+    // Assert
+    expect(screen.getByText('Protected content')).toBeInTheDocument();
+    expect(screen.queryByText('Login page')).not.toBeInTheDocument();
+  });
+
+  it('shows a loading spinner while the session is still resolving', () => {
+    // Act
+    renderGuarded({ status: 'loading' });
+
+    // Assert
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByText('Protected content')).not.toBeInTheDocument();
+    expect(screen.queryByText('Login page')).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin-webapp/tests/features/dashboard/use-fleet.test.ts
+++ b/apps/admin-webapp/tests/features/dashboard/use-fleet.test.ts
@@ -1,0 +1,169 @@
+import { act } from 'react';
+
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import type { FleetSnapshot, SessionStatusEvent } from '#src/lib/admin-api';
+import { FLEET_STREAM_URL, adminApi } from '#src/lib/admin-api';
+import { useFleet } from '#src/features/dashboard/use-fleet';
+
+vi.mock('#src/lib/admin-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('#src/lib/admin-api')>();
+  return {
+    ...actual,
+    adminApi: { fleet: vi.fn() },
+  };
+});
+
+const emptySnapshot: FleetSnapshot = {
+  generatedAt: 1,
+  nodes: [],
+  sessions: [],
+  transcriptionHosts: [],
+  providers: [],
+};
+
+/**
+ * Minimal stand-in for the browser's `EventSource` — jsdom doesn't implement
+ * one. Records the constructor args and lets a test dispatch `onopen` /
+ * `onmessage` / `onerror` by hand; `close()` just flips a flag so a test can
+ * assert teardown happened.
+ */
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+
+  url: string;
+  withCredentials: boolean;
+  closed = false;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: MessageEvent<string>) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(url: string, options?: { withCredentials?: boolean }) {
+    this.url = url;
+    this.withCredentials = options?.withCredentials ?? false;
+    FakeEventSource.instances.push(this);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+function latestEventSource(): FakeEventSource {
+  const es = FakeEventSource.instances.at(-1);
+  if (!es) throw new Error('No FakeEventSource was constructed.');
+  return es;
+}
+
+describe('useFleet', (it) => {
+  let originalEventSource: typeof globalThis.EventSource | undefined;
+
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.EventSource = FakeEventSource as any;
+    vi.mocked(adminApi.fleet).mockResolvedValue(emptySnapshot);
+  });
+
+  afterEach(() => {
+    if (originalEventSource) {
+      globalThis.EventSource = originalEventSource;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (globalThis as any).EventSource;
+    }
+  });
+
+  it('opens a stream to the right URL on mount', () => {
+    // Act
+    renderHook(() => useFleet());
+
+    // Assert
+    expect(FakeEventSource.instances).toHaveLength(1);
+    const es = latestEventSource();
+    expect(es.url).toBe(FLEET_STREAM_URL);
+    expect(es.withCredentials).toBe(true);
+  });
+
+  it("an incoming message updates the hook's returned state", () => {
+    // Arrange
+    const { result } = renderHook(() => useFleet());
+    const es = latestEventSource();
+    const event: SessionStatusEvent = {
+      t: 'session',
+      sessionUid: 'session-1',
+      transcriptionServiceConnected: true,
+      sourceDeviceConnected: false,
+      at: 123,
+    };
+
+    // Act
+    act(() => {
+      es.onmessage?.({ data: JSON.stringify(event) } as MessageEvent<string>);
+    });
+
+    // Assert
+    expect(result.current.sessionEvents.get('session-1')).toEqual(event);
+  });
+
+  it('reflects connection drops and native browser reconnects via connected', () => {
+    // Arrange: the hook has no timer-based retry of its own — the doc comment
+    // on `connected` says the browser retries the same EventSource on its
+    // own, so a "reconnect" here is simulated by firing `onopen` again on the
+    // same instance, the way the real browser would after a drop.
+    const { result } = renderHook(() => useFleet());
+    const es = latestEventSource();
+
+    act(() => {
+      es.onopen?.();
+    });
+    expect(result.current.connected).toBe(true);
+    const fetchesAfterFirstOpen = vi.mocked(adminApi.fleet).mock.calls.length;
+
+    // Act: connection drops
+    act(() => {
+      es.onerror?.();
+    });
+
+    // Assert
+    expect(result.current.connected).toBe(false);
+
+    // Act: the (same) EventSource reconnects on its own and re-opens
+    act(() => {
+      es.onopen?.();
+    });
+
+    // Assert: connected flips back, and the reconnect re-fetches /fleet so a
+    // dropped connection can't silently miss what happened while it was down
+    expect(result.current.connected).toBe(true);
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(vi.mocked(adminApi.fleet).mock.calls.length).toBeGreaterThan(
+      fetchesAfterFirstOpen,
+    );
+  });
+
+  it('closes the EventSource on unmount and does not reconnect afterwards', () => {
+    // Arrange
+    const { unmount } = renderHook(() => useFleet());
+    const es = latestEventSource();
+
+    // Act
+    unmount();
+
+    // Assert
+    expect(es.closed).toBe(true);
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    // Act: even if the (closed) source somehow fired more events, there is no
+    // live component left to react to them; nothing new is opened.
+    act(() => {
+      es.onerror?.();
+      es.onopen?.();
+    });
+
+    // Assert
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+});

--- a/apps/admin-webapp/tests/features/devices/device-detail-page.test.tsx
+++ b/apps/admin-webapp/tests/features/devices/device-detail-page.test.tsx
@@ -1,0 +1,158 @@
+import type { ReactElement } from 'react';
+
+import { beforeEach, describe, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+
+import { Route, Routes } from 'react-router-dom';
+
+import { DeviceDetailPage } from '#src/features/devices/device-detail-page';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
+
+import { renderWithProviders } from '../../utils/render-with-providers';
+import { buildDevice, buildRoom } from './fixtures';
+
+vi.mock('#src/lib/admin-api', () => ({
+  adminApi: {
+    getDevice: vi.fn(),
+    getRoom: vi.fn(),
+  },
+}));
+
+const DEVICE_UID = 'device-1';
+
+function renderPage(ui: ReactElement = <DeviceDetailPage />) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/devices/:deviceUid" element={ui} />
+    </Routes>,
+    { route: `/devices/${DEVICE_UID}` },
+  );
+}
+
+async function waitForLoad() {
+  await waitFor(() => {
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+}
+
+describe('DeviceDetailPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('loading', (it) => {
+    it('shows a spinner while the initial load is in flight', () => {
+      // Arrange
+      vi.mocked(adminApi.getDevice).mockReturnValue(
+        new Promise(() => {
+          /* never resolves */
+        }),
+      );
+
+      // Act
+      renderPage();
+
+      // Assert
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+  });
+
+  describe('not-found state', (it) => {
+    it('shows "Device not found." on a 404 ApiError', async () => {
+      // Arrange
+      vi.mocked(adminApi.getDevice).mockRejectedValue(
+        new ApiError('NOT_FOUND', 'no such device', 404),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText('Device not found.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', (it) => {
+    it('shows a toast and the not-found fallback on a non-404, non-ApiError rejection', async () => {
+      // Arrange
+      vi.mocked(adminApi.getDevice).mockRejectedValue(
+        new Error('network down'),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText('Failed to load device.'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Device not found.')).toBeInTheDocument();
+    });
+  });
+
+  describe('BACKEND_MISCONFIGURATION', (it) => {
+    it('shows the ADMIN_API_KEY alert as the entire page body', async () => {
+      // Arrange
+      vi.mocked(adminApi.getDevice).mockRejectedValue(
+        new ApiError('BACKEND_MISCONFIGURATION', 'nope', 502),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText(/admin backend misconfiguration/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByText('Device not found.')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Show UUIDs setting', (it) => {
+    it('renders just the names when the setting is off', async () => {
+      // Arrange
+      vi.mocked(adminApi.getDevice).mockResolvedValue(
+        buildDevice({ uid: DEVICE_UID, name: 'Kiosk 1', roomUid: 'room-1' }),
+      );
+      vi.mocked(adminApi.getRoom).mockResolvedValue(
+        buildRoom({ uid: 'room-1', name: 'Room 101' }),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+      await screen.findByText('Room 101');
+
+      // Assert
+      expect(screen.getByText('Kiosk 1')).toBeInTheDocument();
+      expect(screen.queryByText(DEVICE_UID)).not.toBeInTheDocument();
+      expect(screen.queryByText('room-1')).not.toBeInTheDocument();
+    });
+
+    it('renders the uids under the names when the setting is on', async () => {
+      // Arrange
+      localStorage.setItem('scribear-admin:show-uuids', 'true');
+      vi.mocked(adminApi.getDevice).mockResolvedValue(
+        buildDevice({ uid: DEVICE_UID, name: 'Kiosk 1', roomUid: 'room-1' }),
+      );
+      vi.mocked(adminApi.getRoom).mockResolvedValue(
+        buildRoom({ uid: 'room-1', name: 'Room 101' }),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+      await screen.findByText('Room 101');
+
+      // Assert
+      expect(screen.getByText(DEVICE_UID)).toBeInTheDocument();
+      expect(screen.getByText('room-1')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/admin-webapp/tests/features/devices/devices-list-page.test.tsx
+++ b/apps/admin-webapp/tests/features/devices/devices-list-page.test.tsx
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+
+import { DevicesListPage } from '#src/features/devices/devices-list-page';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
+
+import { renderWithProviders } from '../../utils/render-with-providers';
+import { buildDevice } from './fixtures';
+
+vi.mock('#src/lib/admin-api', () => ({
+  adminApi: {
+    listDevices: vi.fn(),
+    listRooms: vi.fn(),
+  },
+}));
+
+async function waitForLoad() {
+  await waitFor(() => {
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+}
+
+describe('DevicesListPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Backs useRoomNameLookup, which every render kicks off regardless of the
+    // states under test here; failures there are swallowed by the hook, but
+    // giving it an empty list keeps it from ever settling into a warning.
+    vi.mocked(adminApi.listRooms).mockResolvedValue({
+      items: [],
+      nextCursor: null,
+    });
+  });
+
+  describe('loading', (it) => {
+    it('shows a spinner while the initial load is in flight', () => {
+      // Arrange
+      vi.mocked(adminApi.listDevices).mockReturnValue(
+        new Promise(() => {
+          /* never resolves */
+        }),
+      );
+
+      // Act
+      renderWithProviders(<DevicesListPage />);
+
+      // Assert
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', (it) => {
+    it('shows "No devices found." when the API returns an empty list', async () => {
+      // Arrange
+      vi.mocked(adminApi.listDevices).mockResolvedValue({
+        items: [],
+        nextCursor: null,
+      });
+
+      // Act
+      renderWithProviders(<DevicesListPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(screen.getByText('No devices found.')).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', (it) => {
+    it('shows a toast and falls back to the empty state on a non-ApiError rejection', async () => {
+      // Arrange
+      vi.mocked(adminApi.listDevices).mockRejectedValue(
+        new Error('network down'),
+      );
+
+      // Act
+      renderWithProviders(<DevicesListPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText('Failed to load devices.'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('No devices found.')).toBeInTheDocument();
+    });
+  });
+
+  describe('BACKEND_MISCONFIGURATION', (it) => {
+    it('shows the ADMIN_API_KEY alert instead of a toast', async () => {
+      // Arrange
+      vi.mocked(adminApi.listDevices).mockRejectedValue(
+        new ApiError('BACKEND_MISCONFIGURATION', 'nope', 502),
+      );
+
+      // Act
+      renderWithProviders(<DevicesListPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText(/admin backend misconfiguration/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Show UUIDs setting', (it) => {
+    it('renders just the name when the setting is off', async () => {
+      // Arrange
+      vi.mocked(adminApi.listDevices).mockResolvedValue({
+        items: [buildDevice({ uid: 'device-1', name: 'Kiosk 1' })],
+        nextCursor: null,
+      });
+
+      // Act
+      renderWithProviders(<DevicesListPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(screen.getByText('Kiosk 1')).toBeInTheDocument();
+      expect(screen.queryByText('device-1')).not.toBeInTheDocument();
+    });
+
+    it('renders the uid under the name when the setting is on', async () => {
+      // Arrange
+      localStorage.setItem('scribear-admin:show-uuids', 'true');
+      vi.mocked(adminApi.listDevices).mockResolvedValue({
+        items: [buildDevice({ uid: 'device-1', name: 'Kiosk 1' })],
+        nextCursor: null,
+      });
+
+      // Act
+      renderWithProviders(<DevicesListPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(screen.getByText('Kiosk 1')).toBeInTheDocument();
+      expect(screen.getByText('device-1')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/admin-webapp/tests/features/devices/fixtures.ts
+++ b/apps/admin-webapp/tests/features/devices/fixtures.ts
@@ -1,0 +1,27 @@
+import type { Device, Room } from '@scribear/session-manager-schema';
+
+export function buildDevice(overrides: Partial<Device> = {}): Device {
+  return {
+    uid: 'device-1',
+    name: 'Kiosk 1',
+    active: false,
+    roomUid: null,
+    isSource: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastSeenAt: null,
+    online: false,
+    ...overrides,
+  };
+}
+
+export function buildRoom(overrides: Partial<Room> = {}): Room {
+  return {
+    uid: 'room-1',
+    name: 'Room 101',
+    timezone: 'America/Chicago',
+    autoSessionEnabled: false,
+    roomScheduleVersion: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}

--- a/apps/admin-webapp/tests/features/kiosk-setup/fixtures.ts
+++ b/apps/admin-webapp/tests/features/kiosk-setup/fixtures.ts
@@ -1,0 +1,66 @@
+import type {
+  AutoSessionWindow,
+  Room,
+  SessionSchedule,
+} from '@scribear/session-manager-schema';
+
+import type { RoomDetail } from '#src/lib/admin-api';
+
+export function buildRoom(overrides: Partial<Room> = {}): Room {
+  return {
+    uid: 'room-1',
+    name: 'Room 101',
+    timezone: 'America/Chicago',
+    autoSessionEnabled: false,
+    roomScheduleVersion: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function buildRoomDetail(
+  overrides: Partial<Room> = {},
+): RoomDetail {
+  return { room: buildRoom(overrides), devices: [] };
+}
+
+export function buildSchedule(
+  overrides: Partial<SessionSchedule> = {},
+): SessionSchedule {
+  return {
+    uid: 'schedule-1',
+    roomUid: 'room-1',
+    name: 'CS 225 Lecture',
+    activeStart: '2026-08-01T14:00:30.000Z',
+    activeEnd: null,
+    anchorStart: '2026-08-01T14:00:30.000Z',
+    localStartTime: '09:00:00',
+    localEndTime: '09:50:00',
+    frequency: 'WEEKLY',
+    daysOfWeek: ['MON', 'WED', 'FRI'],
+    joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+    transcriptionProviderId: 'whisper',
+    transcriptionStreamConfig: {},
+    createdAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function buildWindow(
+  overrides: Partial<AutoSessionWindow> = {},
+): AutoSessionWindow {
+  return {
+    uid: 'window-1',
+    roomUid: 'room-1',
+    localStartTime: '08:00:00',
+    localEndTime: '17:00:00',
+    daysOfWeek: ['MON', 'TUE', 'WED', 'THU', 'FRI'],
+    joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+    transcriptionProviderId: 'whisper',
+    transcriptionStreamConfig: {},
+    activeStart: '2026-08-01T00:00:00.000Z',
+    activeEnd: null,
+    createdAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  };
+}

--- a/apps/admin-webapp/tests/features/kiosk-setup/fixtures.ts
+++ b/apps/admin-webapp/tests/features/kiosk-setup/fixtures.ts
@@ -1,10 +1,25 @@
 import type {
   AutoSessionWindow,
+  Device,
   Room,
   SessionSchedule,
 } from '@scribear/session-manager-schema';
 
 import type { RoomDetail } from '#src/lib/admin-api';
+
+export function buildDevice(overrides: Partial<Device> = {}): Device {
+  return {
+    uid: 'device-1',
+    name: 'Kiosk 1',
+    active: false,
+    roomUid: null,
+    isSource: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastSeenAt: null,
+    online: false,
+    ...overrides,
+  };
+}
 
 export function buildRoom(overrides: Partial<Room> = {}): Room {
   return {

--- a/apps/admin-webapp/tests/features/kiosk-setup/kiosk-wizard-page.test.tsx
+++ b/apps/admin-webapp/tests/features/kiosk-setup/kiosk-wizard-page.test.tsx
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { KioskWizardPage } from '#src/features/kiosk-setup/kiosk-wizard-page';
+import { adminApi } from '#src/lib/admin-api';
+
+import { renderWithProviders } from '../../utils/render-with-providers';
+import { buildDevice, buildRoom } from './fixtures';
+
+vi.mock('#src/lib/admin-api', () => ({
+  adminApi: {
+    registerDevice: vi.fn(),
+    reregisterDevice: vi.fn(),
+    listRooms: vi.fn(),
+    createRoom: vi.fn(),
+    addDeviceToRoom: vi.fn(),
+    getDevice: vi.fn(),
+  },
+}));
+
+// ScheduleStep has its own test file (schedule-step.test.tsx); stubbing it
+// here isolates the wizard's step-gating/timezone/polling logic from having
+// to also stand up schedule/window API mocks it doesn't otherwise need.
+vi.mock('#src/features/kiosk-setup/schedule-step', () => ({
+  ScheduleStep: (props: {
+    roomUid: string | null;
+    roomTimezone: string;
+    onCreated: () => void;
+  }) => (
+    <div>
+      <div data-testid="schedule-step-room-uid">{props.roomUid}</div>
+      <div data-testid="schedule-step-room-timezone">
+        {props.roomTimezone}
+      </div>
+      <button onClick={props.onCreated}>Stub create schedule</button>
+    </div>
+  ),
+}));
+
+async function registerDevice(user: ReturnType<typeof userEvent.setup>) {
+  vi.mocked(adminApi.registerDevice).mockResolvedValue({
+    deviceUid: 'device-1',
+    activationCode: 'ABC123',
+    expiry: new Date(Date.now() + 5 * 60_000).toISOString(),
+  });
+  await user.type(screen.getByLabelText('Device name'), 'Kiosk 1');
+  await user.click(screen.getByRole('button', { name: /register device/i }));
+  await screen.findByText('ABC123');
+}
+
+function clickNext(user: ReturnType<typeof userEvent.setup>) {
+  return user.click(screen.getByRole('button', { name: 'Next' }));
+}
+
+/** The wizard's advance button reads "Skip" on the Schedule step until a
+ * schedule has been created there. */
+function clickNextOrSkip(user: ReturnType<typeof userEvent.setup>) {
+  return user.click(screen.getByRole('button', { name: /^(next|skip)$/i }));
+}
+
+describe('KioskWizardPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('step gating', (it) => {
+    it('disables Next on the Device step until a device is registered', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      renderWithProviders(<KioskWizardPage />);
+
+      // Assert
+      expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+
+      // Act
+      await registerDevice(user);
+
+      // Assert
+      expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled();
+    });
+
+    it('disables Next on the Room step until a room is attached', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      renderWithProviders(<KioskWizardPage />);
+      await registerDevice(user);
+      await clickNext(user);
+
+      // Assert: Room step, no room yet
+      expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+
+      // Act
+      vi.mocked(adminApi.createRoom).mockResolvedValue(
+        buildRoom({ uid: 'room-1' }),
+      );
+      await user.type(screen.getByLabelText('Room name'), 'Room 101');
+      await user.click(screen.getByRole('button', { name: /create room/i }));
+      await screen.findByText('room-1', { selector: 'strong' });
+
+      // Assert
+      expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled();
+    });
+  });
+
+  describe('Schedule step button label', (it) => {
+    async function reachScheduleStep(user: ReturnType<typeof userEvent.setup>) {
+      renderWithProviders(<KioskWizardPage />);
+      await registerDevice(user);
+      await clickNext(user);
+      vi.mocked(adminApi.createRoom).mockResolvedValue(
+        buildRoom({ uid: 'room-1' }),
+      );
+      await user.type(screen.getByLabelText('Room name'), 'Room 101');
+      await user.click(screen.getByRole('button', { name: /create room/i }));
+      await screen.findByText('room-1', { selector: 'strong' });
+      await clickNext(user);
+    }
+
+    it('reads "Skip" before a schedule is created and "Next" after', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      await reachScheduleStep(user);
+
+      // Assert
+      expect(
+        screen.getByRole('button', { name: 'Skip' }),
+      ).toBeInTheDocument();
+
+      // Act
+      await user.click(
+        screen.getByRole('button', { name: /stub create schedule/i }),
+      );
+
+      // Assert
+      expect(
+        screen.queryByRole('button', { name: 'Skip' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Next' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('roomTimezone resolution', (it) => {
+    it('passes the picked timezone down the new-room path', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      renderWithProviders(<KioskWizardPage />);
+      await registerDevice(user);
+      await clickNext(user);
+      vi.mocked(adminApi.createRoom).mockResolvedValue(
+        buildRoom({ uid: 'room-1', timezone: 'Pacific/Auckland' }),
+      );
+
+      // Act
+      await user.type(screen.getByLabelText('Room name'), 'Room 101');
+      const tzField = screen.getByLabelText(/timezone/i);
+      await user.clear(tzField);
+      await user.type(tzField, 'Pacific/Auckland');
+      await user.click(screen.getByRole('button', { name: /create room/i }));
+      await screen.findByText('room-1', { selector: 'strong' });
+      await clickNext(user);
+
+      // Assert
+      expect(screen.getByTestId('schedule-step-room-timezone')).toHaveTextContent(
+        'Pacific/Auckland',
+      );
+    });
+
+    it("passes the selected existing room's timezone, not the default", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      vi.mocked(adminApi.listRooms).mockResolvedValue({
+        items: [
+          buildRoom({
+            uid: 'room-2',
+            name: 'Room 202',
+            timezone: 'Asia/Tokyo',
+          }),
+        ],
+        nextCursor: null,
+      });
+      vi.mocked(adminApi.addDeviceToRoom).mockResolvedValue(null);
+      renderWithProviders(<KioskWizardPage />);
+      await registerDevice(user);
+      await clickNext(user);
+
+      // Act
+      await user.click(
+        screen.getByRole('radio', { name: /add to an existing room/i }),
+      );
+      await waitFor(() => {
+        expect(adminApi.listRooms).toHaveBeenCalled();
+      });
+      await user.click(screen.getByRole('combobox', { name: 'Room' }));
+      await user.click(screen.getByRole('option', { name: 'Room 202' }));
+      await user.click(screen.getByRole('button', { name: /add to room/i }));
+      await screen.findByText('room-2', { selector: 'strong' });
+      await clickNext(user);
+
+      // Assert: not the DEFAULT_TIMEZONE ('America/Chicago') fallback
+      expect(screen.getByTestId('schedule-step-room-timezone')).toHaveTextContent(
+        'Asia/Tokyo',
+      );
+    });
+  });
+
+  describe('Verify step polling', (it) => {
+    it(
+      'polls getDevice on an interval and stops polling after unmount',
+      async () => {
+        // Arrange: real timers throughout — mixing vitest fake timers with
+        // userEvent + RTL's waitFor is unreliable (waitFor's fake-timer
+        // detection only recognizes Jest's global `jest`, not vitest), so
+        // this exercises the wizard's real POLL_MS=3000ms interval directly.
+        const user = userEvent.setup();
+        vi.mocked(adminApi.getDevice).mockResolvedValue(
+          buildDevice({ uid: 'device-1', active: false }),
+        );
+        const { unmount } = renderWithProviders(<KioskWizardPage />);
+        await registerDevice(user);
+        await clickNext(user);
+        vi.mocked(adminApi.createRoom).mockResolvedValue(
+          buildRoom({ uid: 'room-1' }),
+        );
+        await user.type(screen.getByLabelText('Room name'), 'Room 101');
+        await user.click(
+          screen.getByRole('button', { name: /create room/i }),
+        );
+        await screen.findByText('room-1', { selector: 'strong' });
+        await clickNext(user);
+        await clickNextOrSkip(user);
+        await screen.findByText(/waiting for the kiosk to activate/i);
+
+        const callsAtVerify = vi.mocked(adminApi.getDevice).mock.calls.length;
+        expect(callsAtVerify).toBeGreaterThanOrEqual(1);
+
+        // Act
+        await new Promise((resolve) => setTimeout(resolve, 3400));
+        const callsAfterPolling = vi.mocked(adminApi.getDevice).mock.calls
+          .length;
+        expect(callsAfterPolling).toBeGreaterThan(callsAtVerify);
+
+        unmount();
+        const callsAtUnmount = vi.mocked(adminApi.getDevice).mock.calls
+          .length;
+        await new Promise((resolve) => setTimeout(resolve, 3400));
+
+        // Assert
+        expect(vi.mocked(adminApi.getDevice).mock.calls.length).toBe(
+          callsAtUnmount,
+        );
+      },
+      10_000,
+    );
+  });
+
+  describe('re-register', (it) => {
+    it('replaces the displayed activation code', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      renderWithProviders(<KioskWizardPage />);
+      await registerDevice(user);
+      expect(screen.getByText('ABC123')).toBeInTheDocument();
+      vi.mocked(adminApi.reregisterDevice).mockResolvedValue({
+        activationCode: 'ZZZ999',
+        expiry: new Date(Date.now() + 5 * 60_000).toISOString(),
+      });
+
+      // Act
+      await user.click(
+        screen.getByRole('button', { name: /code expired\? re-register/i }),
+      );
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText('ZZZ999')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('ABC123')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/admin-webapp/tests/features/kiosk-setup/schedule-form-utils.test.ts
+++ b/apps/admin-webapp/tests/features/kiosk-setup/schedule-form-utils.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+
+import type { CommonFormState } from '#src/features/kiosk-setup/schedule-form-utils';
+import {
+  START_LEAD_MS,
+  dateInputToLocalMidnight,
+  dateToInput,
+  describeSchedule,
+  describeWindow,
+  resolveActiveRange,
+} from '#src/features/kiosk-setup/schedule-form-utils';
+
+// Wall-clock "now" used by every fake-timer test: 2026-07-23 10:00:00 local,
+// safely away from a midnight rollover unless a test deliberately wants one.
+const NOW = new Date(2026, 6, 23, 10, 0, 0, 0);
+
+function buildForm(overrides: Partial<CommonFormState> = {}): CommonFormState {
+  return {
+    daysOfWeek: [],
+    localStartTime: '09:00',
+    localEndTime: '10:00',
+    startsOn: dateToInput(NOW),
+    indefinite: true,
+    endsOn: '',
+    joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+    transcriptionProviderId: 'whisper',
+    transcriptionStreamConfig: '{}',
+    ...overrides,
+  };
+}
+
+describe('dateToInput / dateInputToLocalMidnight', (it) => {
+  it('round-trips a local date through the input format', () => {
+    // Arrange
+    const d = new Date(2026, 7, 24, 15, 30);
+
+    // Act
+    const input = dateToInput(d);
+    const parsed = dateInputToLocalMidnight(input);
+
+    // Assert
+    expect(input).toBe('2026-08-24');
+    expect(parsed).not.toBeNull();
+    expect(parsed?.getFullYear()).toBe(2026);
+    expect(parsed?.getMonth()).toBe(7);
+    expect(parsed?.getDate()).toBe(24);
+    expect(parsed?.getHours()).toBe(0);
+    expect(parsed?.getMinutes()).toBe(0);
+    expect(parsed?.getSeconds()).toBe(0);
+  });
+
+  it('parses as local midnight, not UTC midnight', () => {
+    // Act
+    const parsed = dateInputToLocalMidnight('2026-08-24');
+
+    // Assert: `new Date('2026-08-24')` would read this as UTC midnight, which
+    // is the wrong calendar day in any zone west of Greenwich.
+    expect(parsed?.getHours()).toBe(0);
+    expect(parsed?.getFullYear()).toBe(2026);
+    expect(parsed?.getMonth()).toBe(7);
+    expect(parsed?.getDate()).toBe(24);
+  });
+
+  it('returns null for input that does not match the yyyy-mm-dd shape', () => {
+    expect(dateInputToLocalMidnight('')).toBeNull();
+    expect(dateInputToLocalMidnight('garbage')).toBeNull();
+    expect(dateInputToLocalMidnight('08/24/2026')).toBeNull();
+    expect(dateInputToLocalMidnight('2026-8-24')).toBeNull();
+  });
+
+  it('rolls over out-of-range month/day components rather than rejecting them', () => {
+    // The regex only checks shape, not calendar validity, so `Date`'s own
+    // rollover semantics apply — documented here so a tightening of the regex
+    // is a deliberate choice, not an accidental behavior change.
+    const parsed = dateInputToLocalMidnight('2026-13-01');
+    expect(parsed).not.toBeNull();
+    expect(parsed?.getFullYear()).toBe(2027);
+    expect(parsed?.getMonth()).toBe(0);
+  });
+});
+
+describe('resolveActiveRange', (it) => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects a start date before today', () => {
+    // Arrange
+    const yesterday = new Date(NOW);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const form = buildForm({ startsOn: dateToInput(yesterday) });
+
+    // Act
+    const result = resolveActiveRange(form, true);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.toLowerCase()).toMatch(/today|later/);
+    }
+  });
+
+  it('anchors a today start to now + lead time when anchorToFuture is true', () => {
+    // Arrange
+    const form = buildForm({ startsOn: dateToInput(NOW) });
+
+    // Act
+    const result = resolveActiveRange(form, true);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.activeStart).toBe(
+        new Date(NOW.getTime() + START_LEAD_MS).toISOString(),
+      );
+    }
+  });
+
+  it('anchors a future start to exactly local midnight when anchorToFuture is true', () => {
+    // Arrange
+    const tomorrow = new Date(NOW);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const midnight = new Date(
+      tomorrow.getFullYear(),
+      tomorrow.getMonth(),
+      tomorrow.getDate(),
+    );
+    const form = buildForm({ startsOn: dateToInput(tomorrow) });
+
+    // Act
+    const result = resolveActiveRange(form, true);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.activeStart).toBe(midnight.toISOString());
+    }
+  });
+
+  it('anchors a today start to exactly local midnight when anchorToFuture is false', () => {
+    // Arrange: this is the window-form regression guard — a kiosk configured
+    // mid-morning must not lose the rest of today's open hours to a
+    // now-based anchor the way schedules do.
+    const midnight = new Date(NOW.getFullYear(), NOW.getMonth(), NOW.getDate());
+    const form = buildForm({ startsOn: dateToInput(NOW) });
+
+    // Act
+    const result = resolveActiveRange(form, false);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.activeStart).toBe(midnight.toISOString());
+      expect(result.activeStart).not.toBe(
+        new Date(NOW.getTime() + START_LEAD_MS).toISOString(),
+      );
+    }
+  });
+
+  it('returns a null activeEnd when indefinite is true', () => {
+    // Arrange
+    const form = buildForm({ startsOn: dateToInput(NOW), indefinite: true });
+
+    // Act
+    const result = resolveActiveRange(form, false);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.activeEnd).toBeNull();
+    }
+  });
+
+  it('rejects an end date that has already fallen before the anchored start', () => {
+    // Arrange: with 10s left in the day, the anchorToFuture lead time rolls
+    // activeStart into tomorrow, so an end date equal to today's start date
+    // (even at its last inclusive instant, 23:59:59.999) is now too early.
+    // This guards the exact overlap between START_LEAD_MS and a day boundary.
+    const lateNow = new Date(2026, 6, 23, 23, 59, 50, 0);
+    vi.setSystemTime(lateNow);
+    const today = dateToInput(lateNow);
+    const form = buildForm({
+      startsOn: today,
+      indefinite: false,
+      endsOn: today,
+    });
+
+    // Act
+    const result = resolveActiveRange(form, true);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/end date must be after/i);
+    }
+  });
+
+  it('accepts an end date after the start date, inclusive through end of day', () => {
+    // Arrange
+    const start = dateToInput(NOW);
+    const endDate = new Date(NOW);
+    endDate.setDate(endDate.getDate() + 5);
+    const form = buildForm({
+      startsOn: start,
+      indefinite: false,
+      endsOn: dateToInput(endDate),
+    });
+
+    // Act
+    const result = resolveActiveRange(form, false);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.activeEnd).not.toBeNull();
+      const parsedEnd = new Date(result.activeEnd!);
+      expect(parsedEnd.getFullYear()).toBe(endDate.getFullYear());
+      expect(parsedEnd.getMonth()).toBe(endDate.getMonth());
+      expect(parsedEnd.getDate()).toBe(endDate.getDate());
+      expect(parsedEnd.getHours()).toBe(23);
+      expect(parsedEnd.getMinutes()).toBe(59);
+      expect(parsedEnd.getSeconds()).toBe(59);
+      expect(parsedEnd.getMilliseconds()).toBe(999);
+    }
+  });
+
+  it('rejects an empty startsOn without throwing', () => {
+    const form = buildForm({ startsOn: '' });
+    expect(() => resolveActiveRange(form, true)).not.toThrow();
+    expect(resolveActiveRange(form, true).ok).toBe(false);
+  });
+
+  it('rejects a garbage startsOn without throwing', () => {
+    const form = buildForm({ startsOn: 'garbage' });
+    expect(() => resolveActiveRange(form, true)).not.toThrow();
+    expect(resolveActiveRange(form, true).ok).toBe(false);
+  });
+
+  it('rejects a missing endsOn when not indefinite', () => {
+    const form = buildForm({
+      startsOn: dateToInput(NOW),
+      indefinite: false,
+      endsOn: '',
+    });
+    const result = resolveActiveRange(form, false);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/end date/i);
+    }
+  });
+});
+
+describe('describeSchedule / describeWindow', (it) => {
+  it('truncates seconds from the time-of-day', () => {
+    const schedule = {
+      uid: 's1',
+      name: 'CS 225 Lecture',
+      frequency: 'ONCE' as const,
+      daysOfWeek: null,
+      localStartTime: '09:00:00',
+      localEndTime: '09:50:00',
+    };
+
+    expect(describeSchedule(schedule as never)).toBe(
+      'CS 225 Lecture — ONCE 09:00–09:50',
+    );
+  });
+
+  it('renders with no stray separator when daysOfWeek is null (ONCE)', () => {
+    const schedule = {
+      uid: 's1',
+      name: 'One-off',
+      frequency: 'ONCE' as const,
+      daysOfWeek: null,
+      localStartTime: '13:00:00',
+      localEndTime: '14:00:00',
+    };
+
+    expect(describeSchedule(schedule as never)).toBe(
+      'One-off — ONCE 13:00–14:00',
+    );
+  });
+
+  it('lists days for a recurring schedule', () => {
+    const schedule = {
+      uid: 's1',
+      name: 'MWF Lecture',
+      frequency: 'WEEKLY' as const,
+      daysOfWeek: ['MON', 'WED', 'FRI'],
+      localStartTime: '09:00:00',
+      localEndTime: '09:50:00',
+    };
+
+    expect(describeSchedule(schedule as never)).toBe(
+      'MWF Lecture — WEEKLY MON, WED, FRI 09:00–09:50',
+    );
+  });
+
+  it('renders a window as a day list and time range', () => {
+    const window = {
+      uid: 'w1',
+      daysOfWeek: ['MON', 'TUE', 'WED', 'THU', 'FRI'],
+      localStartTime: '08:00:00',
+      localEndTime: '17:00:00',
+    };
+
+    expect(describeWindow(window as never)).toBe(
+      'MON, TUE, WED, THU, FRI 08:00–17:00',
+    );
+  });
+});

--- a/apps/admin-webapp/tests/features/kiosk-setup/schedule-step.test.tsx
+++ b/apps/admin-webapp/tests/features/kiosk-setup/schedule-step.test.tsx
@@ -1,0 +1,523 @@
+import { beforeEach, describe, expect, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ScheduleStep } from '#src/features/kiosk-setup/schedule-step';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
+
+import { renderWithProviders } from '../../utils/render-with-providers';
+import { buildRoomDetail, buildSchedule, buildWindow } from './fixtures';
+
+vi.mock('#src/lib/admin-api', () => ({
+  adminApi: {
+    listSchedules: vi.fn(),
+    listAutoWindows: vi.fn(),
+    roomDetail: vi.fn(),
+    createSchedule: vi.fn(),
+    createAutoWindow: vi.fn(),
+    updateRoomScheduleConfig: vi.fn(),
+  },
+}));
+
+const ROOM_UID = 'room-1';
+
+function mockDefaultLoad(roomOverrides: Parameters<typeof buildRoomDetail>[0] = {}) {
+  vi.mocked(adminApi.listSchedules).mockResolvedValue({ items: [] });
+  vi.mocked(adminApi.listAutoWindows).mockResolvedValue({ items: [] });
+  vi.mocked(adminApi.roomDetail).mockResolvedValue(
+    buildRoomDetail(roomOverrides),
+  );
+}
+
+async function waitForLoad() {
+  await waitFor(() => {
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+}
+
+function renderStep(onCreated = vi.fn()) {
+  renderWithProviders(
+    <ScheduleStep
+      roomUid={ROOM_UID}
+      roomTimezone="America/Chicago"
+      onCreated={onCreated}
+    />,
+  );
+  return { onCreated };
+}
+
+describe('ScheduleStep', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('roomUid is null', (it) => {
+    it('renders the attach-a-room message and issues no requests', () => {
+      // Arrange / Act
+      renderWithProviders(
+        <ScheduleStep
+          roomUid={null}
+          roomTimezone="America/Chicago"
+          onCreated={vi.fn()}
+        />,
+      );
+
+      // Assert
+      expect(
+        screen.getByText(/attach this device to a room first/i),
+      ).toBeInTheDocument();
+      expect(adminApi.listSchedules).not.toHaveBeenCalled();
+      expect(adminApi.listAutoWindows).not.toHaveBeenCalled();
+      expect(adminApi.roomDetail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('mode selection', (it) => {
+    it('defaults to "No schedule for now" with neither form mounted', async () => {
+      // Arrange
+      mockDefaultLoad();
+
+      // Act
+      renderStep();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        screen.getByRole('radio', { name: /no schedule for now/i }),
+      ).toBeChecked();
+      expect(screen.queryByLabelText('Name')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Opens at')).not.toBeInTheDocument();
+    });
+
+    it('reveals the schedule form and hides it again for open hours', async () => {
+      // Arrange
+      mockDefaultLoad();
+      renderStep();
+      await waitForLoad();
+      const user = userEvent.setup();
+
+      // Act
+      await user.click(
+        screen.getByRole('radio', { name: /recurring schedule/i }),
+      );
+
+      // Assert
+      expect(screen.getByLabelText('Name')).toBeInTheDocument();
+      expect(screen.getByLabelText('Start time')).toBeInTheDocument();
+
+      // Act: switch to open hours
+      await user.click(
+        screen.getByRole('radio', { name: /room open hours/i }),
+      );
+
+      // Assert
+      expect(screen.queryByLabelText('Name')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Opens at')).toBeInTheDocument();
+    });
+  });
+
+  describe('schedule path', (it) => {
+    async function openScheduleForm() {
+      mockDefaultLoad();
+      renderStep();
+      await waitForLoad();
+      const user = userEvent.setup();
+      await user.click(
+        screen.getByRole('radio', { name: /recurring schedule/i }),
+      );
+      return user;
+    }
+
+    it('disables Create schedule until a name is entered', async () => {
+      // Arrange
+      const user = await openScheduleForm();
+      const createButton = screen.getByRole('button', {
+        name: /create schedule/i,
+      });
+
+      // Assert
+      expect(createButton).toBeDisabled();
+
+      // Act
+      await user.type(screen.getByLabelText('Name'), 'CS 225 Lecture');
+
+      // Assert
+      expect(createButton).toBeEnabled();
+    });
+
+    it('rejects a WEEKLY schedule with no days picked, without calling the API', async () => {
+      // Arrange
+      const user = await openScheduleForm();
+      await user.type(screen.getByLabelText('Name'), 'CS 225 Lecture');
+
+      // Act
+      await user.click(
+        screen.getByRole('button', { name: /create schedule/i }),
+      );
+
+      // Assert
+      expect(
+        await screen.findByText(/pick at least one day of the week/i),
+      ).toBeInTheDocument();
+      expect(adminApi.createSchedule).not.toHaveBeenCalled();
+    });
+
+    it('creates a schedule with the exact body on the happy path', async () => {
+      // Arrange
+      const user = await openScheduleForm();
+      const created = buildSchedule();
+      vi.mocked(adminApi.createSchedule).mockResolvedValue(created);
+
+      await user.type(screen.getByLabelText('Name'), '  CS 225 Lecture  ');
+      await user.click(screen.getByRole('button', { name: 'Monday' }));
+      await user.click(screen.getByRole('button', { name: 'Wednesday' }));
+      await user.click(screen.getByRole('button', { name: 'Friday' }));
+      await user.click(screen.getByText('Advanced'));
+      const jsonField = screen.getByLabelText(
+        /transcription stream config/i,
+      );
+      fireEvent.change(jsonField, { target: { value: '{"foo":1}' } });
+
+      // Act
+      await user.click(
+        screen.getByRole('button', { name: /create schedule/i }),
+      );
+
+      // Assert
+      await waitFor(() => {
+        expect(adminApi.createSchedule).toHaveBeenCalledTimes(1);
+      });
+      const body = vi.mocked(adminApi.createSchedule).mock.calls[0]![0];
+      expect(body).toMatchObject({
+        roomUid: ROOM_UID,
+        name: 'CS 225 Lecture',
+        localStartTime: '09:00',
+        localEndTime: '10:00',
+        frequency: 'WEEKLY',
+        daysOfWeek: ['MON', 'WED', 'FRI'],
+        joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+        transcriptionProviderId: 'whisper',
+        transcriptionStreamConfig: { foo: 1 },
+      });
+      expect(body.activeEnd).toBeNull();
+      expect(typeof body.activeStart).toBe('string');
+    });
+
+    it('sends null daysOfWeek for a ONCE schedule', async () => {
+      // Arrange
+      const user = await openScheduleForm();
+      vi.mocked(adminApi.createSchedule).mockResolvedValue(buildSchedule());
+      await user.type(screen.getByLabelText('Name'), 'One-off');
+      await user.click(screen.getByText('Advanced'));
+      await user.click(
+        screen.getByRole('combobox', { name: /frequency/i }),
+      );
+      await user.click(screen.getByRole('option', { name: 'ONCE' }));
+
+      // Act
+      await user.click(
+        screen.getByRole('button', { name: /create schedule/i }),
+      );
+
+      // Assert
+      await waitFor(() => {
+        expect(adminApi.createSchedule).toHaveBeenCalledTimes(1);
+      });
+      const body = vi.mocked(adminApi.createSchedule).mock.calls[0]![0];
+      expect(body.daysOfWeek).toBeNull();
+      expect(body.frequency).toBe('ONCE');
+    });
+
+    it('shows an inline error for invalid JSON and does not call the API', async () => {
+      // Arrange
+      const user = await openScheduleForm();
+      await user.type(screen.getByLabelText('Name'), 'CS 225 Lecture');
+      await user.click(screen.getByRole('button', { name: 'Monday' }));
+      await user.click(screen.getByText('Advanced'));
+      const jsonField = screen.getByLabelText(
+        /transcription stream config/i,
+      );
+      fireEvent.change(jsonField, { target: { value: '{not json' } });
+
+      // Act
+      await user.click(
+        screen.getByRole('button', { name: /create schedule/i }),
+      );
+
+      // Assert
+      expect(await screen.findByText('Invalid JSON.')).toBeInTheDocument();
+      expect(adminApi.createSchedule).not.toHaveBeenCalled();
+    });
+
+    it('resets the form, returns to "none", fires onCreated once, and lists the new schedule', async () => {
+      // Arrange
+      mockDefaultLoad();
+      const onCreated = vi.fn();
+      const created = buildSchedule({
+        name: 'CS 225 Lecture',
+        daysOfWeek: ['MON'],
+      });
+      vi.mocked(adminApi.createSchedule).mockResolvedValue(created);
+      renderWithProviders(
+        <ScheduleStep
+          roomUid={ROOM_UID}
+          roomTimezone="America/Chicago"
+          onCreated={onCreated}
+        />,
+      );
+      await waitForLoad();
+      const user = userEvent.setup();
+      await user.click(
+        screen.getByRole('radio', { name: /recurring schedule/i }),
+      );
+      await user.type(screen.getByLabelText('Name'), 'CS 225 Lecture');
+      await user.click(screen.getByRole('button', { name: 'Monday' }));
+
+      // Act
+      await user.click(
+        screen.getByRole('button', { name: /create schedule/i }),
+      );
+
+      // Assert
+      await waitFor(() => {
+        expect(
+          screen.getByRole('radio', { name: /no schedule for now/i }),
+        ).toBeChecked();
+      });
+      expect(screen.queryByLabelText('Name')).not.toBeInTheDocument();
+      expect(onCreated).toHaveBeenCalledTimes(1);
+      expect(
+        screen.getByText(/CS 225 Lecture — WEEKLY MON 09:00–09:50/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('open-hours path', (it) => {
+    async function openWindowForm(
+      roomOverrides: Parameters<typeof buildRoomDetail>[0] = {},
+    ) {
+      mockDefaultLoad(roomOverrides);
+      renderStep();
+      await waitForLoad();
+      const user = userEvent.setup();
+      await user.click(
+        screen.getByRole('radio', { name: /room open hours/i }),
+      );
+      return user;
+    }
+
+    it('defaults to Mon–Fri 08:00–17:00', async () => {
+      // Arrange / Act
+      await openWindowForm();
+
+      // Assert
+      expect(screen.getByLabelText('Opens at')).toHaveValue('08:00');
+      expect(screen.getByLabelText('Closes at')).toHaveValue('17:00');
+      for (const day of ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']) {
+        expect(screen.getByRole('button', { name: day })).toHaveAttribute(
+          'aria-pressed',
+          'true',
+        );
+      }
+      for (const day of ['Saturday', 'Sunday']) {
+        expect(screen.getByRole('button', { name: day })).toHaveAttribute(
+          'aria-pressed',
+          'false',
+        );
+      }
+    });
+
+    it('shows the checkbox checked when auto-sessions are off, and enables it in that order', async () => {
+      // Arrange
+      const user = await openWindowForm({ autoSessionEnabled: false });
+      const window = buildWindow();
+      vi.mocked(adminApi.createAutoWindow).mockResolvedValue(window);
+      vi.mocked(adminApi.updateRoomScheduleConfig).mockResolvedValue(
+        buildRoomDetail({ autoSessionEnabled: true }).room,
+      );
+      const checkbox = screen.getByRole('checkbox', {
+        name: /enable auto-sessions for this room/i,
+      });
+      expect(checkbox).toBeChecked();
+
+      // Act
+      await user.click(
+        screen.getByRole('button', { name: /save open hours/i }),
+      );
+
+      // Assert
+      await waitFor(() => {
+        expect(adminApi.createAutoWindow).toHaveBeenCalledTimes(1);
+        expect(adminApi.updateRoomScheduleConfig).toHaveBeenCalledTimes(1);
+      });
+      expect(adminApi.updateRoomScheduleConfig).toHaveBeenCalledWith({
+        roomUid: ROOM_UID,
+        autoSessionEnabled: true,
+      });
+      const windowOrder = vi.mocked(adminApi.createAutoWindow).mock
+        .invocationCallOrder[0]!;
+      const configOrder = vi.mocked(adminApi.updateRoomScheduleConfig).mock
+        .invocationCallOrder[0]!;
+      expect(windowOrder).toBeLessThan(configOrder);
+    });
+
+    it('shows no checkbox and does not touch the master switch when auto-sessions are already on', async () => {
+      // Arrange
+      const user = await openWindowForm({ autoSessionEnabled: true });
+      vi.mocked(adminApi.createAutoWindow).mockResolvedValue(buildWindow());
+      expect(
+        screen.getByText(/auto-sessions are already enabled for this room/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('checkbox', {
+          name: /enable auto-sessions for this room/i,
+        }),
+      ).not.toBeInTheDocument();
+
+      // Act
+      await user.click(
+        screen.getByRole('button', { name: /save open hours/i }),
+      );
+
+      // Assert
+      await waitFor(() => {
+        expect(adminApi.createAutoWindow).toHaveBeenCalledTimes(1);
+      });
+      expect(adminApi.updateRoomScheduleConfig).not.toHaveBeenCalled();
+    });
+
+    it('leaves the master switch untouched and shows the warning caption when unticked', async () => {
+      // Arrange
+      const user = await openWindowForm({ autoSessionEnabled: false });
+      vi.mocked(adminApi.createAutoWindow).mockResolvedValue(buildWindow());
+      const checkbox = screen.getByRole('checkbox', {
+        name: /enable auto-sessions for this room/i,
+      });
+
+      // Act
+      await user.click(checkbox);
+
+      // Assert: warning caption visible before saving
+      expect(
+        screen.getByText(
+          /leaving this off saves the hours but produces no sessions/i,
+        ),
+      ).toBeInTheDocument();
+
+      // Act
+      await user.click(
+        screen.getByRole('button', { name: /save open hours/i }),
+      );
+
+      // Assert
+      await waitFor(() => {
+        expect(adminApi.createAutoWindow).toHaveBeenCalledTimes(1);
+      });
+      expect(adminApi.updateRoomScheduleConfig).not.toHaveBeenCalled();
+    });
+
+    it('still fires onCreated when createAutoWindow succeeds but the master-switch update fails', async () => {
+      // Arrange: documents current behavior per
+      // PLAN-Future-todo-wizard-tests.md 1e — the window itself was created,
+      // so onCreated firing is treated here as the intended outcome even
+      // though the master-switch enable failed.
+      mockDefaultLoad({ autoSessionEnabled: false });
+      const onCreated = vi.fn();
+      renderWithProviders(
+        <ScheduleStep
+          roomUid={ROOM_UID}
+          roomTimezone="America/Chicago"
+          onCreated={onCreated}
+        />,
+      );
+      await waitForLoad();
+      const user = userEvent.setup();
+      await user.click(
+        screen.getByRole('radio', { name: /room open hours/i }),
+      );
+      vi.mocked(adminApi.createAutoWindow).mockResolvedValue(buildWindow());
+      vi.mocked(adminApi.updateRoomScheduleConfig).mockRejectedValue(
+        new Error('boom'),
+      );
+
+      // Act
+      await user.click(
+        screen.getByRole('button', { name: /save open hours/i }),
+      );
+
+      // Assert
+      await waitFor(() => {
+        expect(onCreated).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('shared', (it) => {
+    it('shows the ADMIN_API_KEY alert instead of a toast on BACKEND_MISCONFIGURATION during load', async () => {
+      // Arrange
+      vi.mocked(adminApi.listSchedules).mockRejectedValue(
+        new ApiError('BACKEND_MISCONFIGURATION', 'nope', 502),
+      );
+      vi.mocked(adminApi.listAutoWindows).mockResolvedValue({ items: [] });
+      vi.mocked(adminApi.roomDetail).mockResolvedValue(buildRoomDetail());
+
+      // Act
+      renderStep();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText(/admin backend misconfiguration/i),
+      ).toBeInTheDocument();
+    });
+
+    it('renders existing schedules and windows, with the auto-sessions-off suffix only when the room flag is false', async () => {
+      // Arrange
+      vi.mocked(adminApi.listSchedules).mockResolvedValue({
+        items: [buildSchedule()],
+      });
+      vi.mocked(adminApi.listAutoWindows).mockResolvedValue({
+        items: [buildWindow()],
+      });
+      vi.mocked(adminApi.roomDetail).mockResolvedValue(
+        buildRoomDetail({ autoSessionEnabled: false }),
+      );
+
+      // Act
+      renderStep();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        screen.getByText(/CS 225 Lecture — WEEKLY MON, WED, FRI 09:00–09:50/),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /Open hours MON, TUE, WED, THU, FRI 08:00–17:00 \(auto-sessions are off for this room\)/,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('omits the auto-sessions-off suffix when the room flag is true', async () => {
+      // Arrange
+      vi.mocked(adminApi.listSchedules).mockResolvedValue({ items: [] });
+      vi.mocked(adminApi.listAutoWindows).mockResolvedValue({
+        items: [buildWindow()],
+      });
+      vi.mocked(adminApi.roomDetail).mockResolvedValue(
+        buildRoomDetail({ autoSessionEnabled: true }),
+      );
+
+      // Act
+      renderStep();
+      await waitForLoad();
+
+      // Assert
+      const windowLine = screen.getByText(
+        /Open hours MON, TUE, WED, THU, FRI 08:00–17:00/,
+      );
+      expect(windowLine.textContent).not.toMatch(/auto-sessions are off/);
+    });
+  });
+});

--- a/apps/admin-webapp/tests/features/kiosk-setup/schedule-step.test.tsx
+++ b/apps/admin-webapp/tests/features/kiosk-setup/schedule-step.test.tsx
@@ -156,10 +156,11 @@ describe('ScheduleStep', () => {
         screen.getByRole('button', { name: /create schedule/i }),
       );
 
-      // Assert
+      // Assert: shown both as a toast and as a persistent inline error tied
+      // to the day-toggle group (WCAG 3.3.1 — not just a transient toast).
       expect(
-        await screen.findByText(/pick at least one day of the week/i),
-      ).toBeInTheDocument();
+        await screen.findAllByText(/pick at least one day of the week/i),
+      ).toHaveLength(2);
       expect(adminApi.createSchedule).not.toHaveBeenCalled();
     });
 

--- a/apps/admin-webapp/tests/features/rooms/fixtures.ts
+++ b/apps/admin-webapp/tests/features/rooms/fixtures.ts
@@ -1,0 +1,41 @@
+import type { Device, Room } from '@scribear/session-manager-schema';
+
+import type { RoomDetail } from '#src/lib/admin-api';
+
+export function buildRoom(overrides: Partial<Room> = {}): Room {
+  return {
+    uid: 'room-1',
+    name: 'Room 101',
+    timezone: 'America/Chicago',
+    autoSessionEnabled: false,
+    roomScheduleVersion: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function buildDevice(overrides: Partial<Device> = {}): Device {
+  return {
+    uid: 'device-1',
+    name: 'Kiosk 1',
+    active: false,
+    roomUid: null,
+    isSource: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastSeenAt: null,
+    online: false,
+    ...overrides,
+  };
+}
+
+export function buildRoomDetail(
+  overrides: {
+    room?: Partial<Room>;
+    devices?: Device[];
+  } = {},
+): RoomDetail {
+  return {
+    room: buildRoom(overrides.room),
+    devices: overrides.devices ?? [],
+  };
+}

--- a/apps/admin-webapp/tests/features/rooms/room-detail-page.test.tsx
+++ b/apps/admin-webapp/tests/features/rooms/room-detail-page.test.tsx
@@ -1,0 +1,156 @@
+import type { ReactElement } from 'react';
+
+import { beforeEach, describe, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+
+import { Route, Routes } from 'react-router-dom';
+
+import { RoomDetailPage } from '#src/features/rooms/room-detail-page';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
+
+import { renderWithProviders } from '../../utils/render-with-providers';
+import { buildDevice, buildRoomDetail } from './fixtures';
+
+vi.mock('#src/lib/admin-api', () => ({
+  adminApi: {
+    roomDetail: vi.fn(),
+  },
+}));
+
+const ROOM_UID = 'room-1';
+
+function renderPage(ui: ReactElement = <RoomDetailPage />) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/rooms/:roomUid" element={ui} />
+    </Routes>,
+    { route: `/rooms/${ROOM_UID}` },
+  );
+}
+
+async function waitForLoad() {
+  await waitFor(() => {
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+}
+
+describe('RoomDetailPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('loading', (it) => {
+    it('shows a spinner while the initial load is in flight', () => {
+      // Arrange
+      vi.mocked(adminApi.roomDetail).mockReturnValue(
+        new Promise(() => {
+          /* never resolves */
+        }),
+      );
+
+      // Act
+      renderPage();
+
+      // Assert
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', (it) => {
+    it('shows "No devices assigned to this room." when the room has no devices', async () => {
+      // Arrange
+      vi.mocked(adminApi.roomDetail).mockResolvedValue(
+        buildRoomDetail({ devices: [] }),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        screen.getByText('No devices assigned to this room.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('error / not-found state', (it) => {
+    it('shows a toast and a "Room not found." fallback on a non-ApiError rejection', async () => {
+      // Arrange
+      vi.mocked(adminApi.roomDetail).mockRejectedValue(
+        new Error('network down'),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText('Failed to load room.'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Room not found.')).toBeInTheDocument();
+    });
+  });
+
+  describe('BACKEND_MISCONFIGURATION', (it) => {
+    it('shows the ADMIN_API_KEY alert as the entire page body', async () => {
+      // Arrange
+      vi.mocked(adminApi.roomDetail).mockRejectedValue(
+        new ApiError('BACKEND_MISCONFIGURATION', 'nope', 502),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText(/admin backend misconfiguration/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByText('Room not found.')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Show UUIDs setting', (it) => {
+    it('renders just the names when the setting is off', async () => {
+      // Arrange
+      vi.mocked(adminApi.roomDetail).mockResolvedValue(
+        buildRoomDetail({
+          room: { uid: ROOM_UID, name: 'Room 101' },
+          devices: [buildDevice({ uid: 'device-1', name: 'Kiosk 1' })],
+        }),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(screen.getByText('Room 101')).toBeInTheDocument();
+      expect(screen.getByText('Kiosk 1')).toBeInTheDocument();
+      expect(screen.queryByText(ROOM_UID)).not.toBeInTheDocument();
+      expect(screen.queryByText('device-1')).not.toBeInTheDocument();
+    });
+
+    it('renders the uids under the names when the setting is on', async () => {
+      // Arrange
+      localStorage.setItem('scribear-admin:show-uuids', 'true');
+      vi.mocked(adminApi.roomDetail).mockResolvedValue(
+        buildRoomDetail({
+          room: { uid: ROOM_UID, name: 'Room 101' },
+          devices: [buildDevice({ uid: 'device-1', name: 'Kiosk 1' })],
+        }),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(screen.getByText(ROOM_UID)).toBeInTheDocument();
+      expect(screen.getByText('device-1')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/admin-webapp/tests/features/rooms/rooms-list-page.test.tsx
+++ b/apps/admin-webapp/tests/features/rooms/rooms-list-page.test.tsx
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+
+import { RoomsListPage } from '#src/features/rooms/rooms-list-page';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
+
+import { renderWithProviders } from '../../utils/render-with-providers';
+import { buildRoom } from './fixtures';
+
+vi.mock('#src/lib/admin-api', () => ({
+  adminApi: {
+    listRooms: vi.fn(),
+  },
+}));
+
+async function waitForLoad() {
+  await waitFor(() => {
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+}
+
+describe('RoomsListPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('loading', (it) => {
+    it('shows a spinner while the initial load is in flight', () => {
+      // Arrange
+      vi.mocked(adminApi.listRooms).mockReturnValue(
+        new Promise(() => {
+          /* never resolves */
+        }),
+      );
+
+      // Act
+      renderWithProviders(<RoomsListPage />);
+
+      // Assert
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', (it) => {
+    it('shows "No rooms found." when the API returns an empty list', async () => {
+      // Arrange
+      vi.mocked(adminApi.listRooms).mockResolvedValue({
+        items: [],
+        nextCursor: null,
+      });
+
+      // Act
+      renderWithProviders(<RoomsListPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(screen.getByText('No rooms found.')).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', (it) => {
+    it('shows a toast and falls back to the empty state on a non-ApiError rejection', async () => {
+      // Arrange
+      vi.mocked(adminApi.listRooms).mockRejectedValue(
+        new Error('network down'),
+      );
+
+      // Act
+      renderWithProviders(<RoomsListPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText('Failed to load rooms.'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('No rooms found.')).toBeInTheDocument();
+    });
+
+    it("shows the ApiError's own message in the toast for a non-misconfiguration ApiError", async () => {
+      // Arrange
+      vi.mocked(adminApi.listRooms).mockRejectedValue(
+        new ApiError('SOME_OTHER_CODE', 'Something else went wrong.', 400),
+      );
+
+      // Act
+      renderWithProviders(<RoomsListPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText('Something else went wrong.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('BACKEND_MISCONFIGURATION', (it) => {
+    it('shows the ADMIN_API_KEY alert instead of a toast', async () => {
+      // Arrange
+      vi.mocked(adminApi.listRooms).mockRejectedValue(
+        new ApiError('BACKEND_MISCONFIGURATION', 'nope', 502),
+      );
+
+      // Act
+      renderWithProviders(<RoomsListPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText(/admin backend misconfiguration/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Show UUIDs setting', (it) => {
+    it('renders just the name when the setting is off', async () => {
+      // Arrange
+      vi.mocked(adminApi.listRooms).mockResolvedValue({
+        items: [buildRoom({ uid: 'room-1', name: 'Room 101' })],
+        nextCursor: null,
+      });
+
+      // Act
+      renderWithProviders(<RoomsListPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(screen.getByText('Room 101')).toBeInTheDocument();
+      expect(screen.queryByText('room-1')).not.toBeInTheDocument();
+    });
+
+    it('renders the uid under the name when the setting is on', async () => {
+      // Arrange
+      localStorage.setItem('scribear-admin:show-uuids', 'true');
+      vi.mocked(adminApi.listRooms).mockResolvedValue({
+        items: [buildRoom({ uid: 'room-1', name: 'Room 101' })],
+        nextCursor: null,
+      });
+
+      // Act
+      renderWithProviders(<RoomsListPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(screen.getByText('Room 101')).toBeInTheDocument();
+      expect(screen.getByText('room-1')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/admin-webapp/tests/features/scheduling/fixtures.ts
+++ b/apps/admin-webapp/tests/features/scheduling/fixtures.ts
@@ -1,0 +1,64 @@
+import type {
+  AutoSessionWindow,
+  Room,
+  SessionSchedule,
+} from '@scribear/session-manager-schema';
+
+import type { RoomDetail } from '#src/lib/admin-api';
+
+export function buildRoom(overrides: Partial<Room> = {}): Room {
+  return {
+    uid: 'room-1',
+    name: 'Room 101',
+    timezone: 'America/Chicago',
+    autoSessionEnabled: false,
+    roomScheduleVersion: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function buildRoomDetail(overrides: Partial<Room> = {}): RoomDetail {
+  return { room: buildRoom(overrides), devices: [] };
+}
+
+export function buildSchedule(
+  overrides: Partial<SessionSchedule> = {},
+): SessionSchedule {
+  return {
+    uid: 'schedule-1',
+    roomUid: 'room-1',
+    name: 'CS 225 Lecture',
+    activeStart: '2026-08-01T14:00:00.000Z',
+    activeEnd: null,
+    anchorStart: '2026-08-01T14:00:00.000Z',
+    localStartTime: '09:00:00',
+    localEndTime: '09:50:00',
+    frequency: 'WEEKLY',
+    daysOfWeek: ['MON', 'WED', 'FRI'],
+    joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+    transcriptionProviderId: 'whisper',
+    transcriptionStreamConfig: {},
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function buildWindow(
+  overrides: Partial<AutoSessionWindow> = {},
+): AutoSessionWindow {
+  return {
+    uid: 'window-1',
+    roomUid: 'room-1',
+    localStartTime: '08:00:00',
+    localEndTime: '17:00:00',
+    daysOfWeek: ['MON', 'TUE', 'WED', 'THU', 'FRI'],
+    joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+    transcriptionProviderId: 'whisper',
+    transcriptionStreamConfig: {},
+    activeStart: '2026-08-01T00:00:00.000Z',
+    activeEnd: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}

--- a/apps/admin-webapp/tests/features/scheduling/room-scheduling-form-utils.test.ts
+++ b/apps/admin-webapp/tests/features/scheduling/room-scheduling-form-utils.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect } from 'vitest';
+
+import {
+  diffAutoWindowUpdate,
+  diffScheduleUpdate,
+  sameStringArray,
+} from '#src/features/scheduling/room-scheduling-form-utils';
+import type { DayOfWeek, SessionScope } from '#src/lib/admin-api';
+
+import { buildSchedule, buildWindow } from './fixtures';
+
+/** The exact "resolved next state" `diffScheduleUpdate` expects, built from
+ * a schedule so that "no changes" is the starting point for each test. */
+function resolvedFromSchedule(
+  schedule: ReturnType<typeof buildSchedule>,
+): Parameters<typeof diffScheduleUpdate>[1] {
+  return {
+    name: schedule.name,
+    activeStart: schedule.activeStart,
+    activeEnd: schedule.activeEnd,
+    localStartTime: schedule.localStartTime.slice(0, 5),
+    localEndTime: schedule.localEndTime.slice(0, 5),
+    frequency: schedule.frequency,
+    daysOfWeek: schedule.daysOfWeek,
+    joinCodeScopes: schedule.joinCodeScopes,
+    transcriptionProviderId: schedule.transcriptionProviderId ?? '',
+    transcriptionStreamConfig: schedule.transcriptionStreamConfig ?? {},
+  };
+}
+
+function resolvedFromWindow(
+  w: ReturnType<typeof buildWindow>,
+): Parameters<typeof diffAutoWindowUpdate>[1] {
+  return {
+    localStartTime: w.localStartTime.slice(0, 5),
+    localEndTime: w.localEndTime.slice(0, 5),
+    daysOfWeek: w.daysOfWeek,
+    activeStart: w.activeStart,
+    activeEnd: w.activeEnd,
+    joinCodeScopes: w.joinCodeScopes,
+    transcriptionProviderId: w.transcriptionProviderId,
+    transcriptionStreamConfig: w.transcriptionStreamConfig,
+  };
+}
+
+describe('sameStringArray', (it) => {
+  it('is true for the same elements regardless of order', () => {
+    // Assert
+    expect(sameStringArray(['MON', 'WED', 'FRI'], ['FRI', 'MON', 'WED'])).toBe(
+      true,
+    );
+  });
+
+  it('is false when lengths differ or elements differ', () => {
+    // Assert
+    expect(sameStringArray(['MON'], ['MON', 'TUE'])).toBe(false);
+    expect(sameStringArray(['MON'], ['TUE'])).toBe(false);
+  });
+});
+
+describe('diffScheduleUpdate', (it) => {
+  it('returns an empty body when nothing changed', () => {
+    // Arrange
+    const schedule = buildSchedule();
+
+    // Act
+    const body = diffScheduleUpdate(schedule, resolvedFromSchedule(schedule));
+
+    // Assert
+    expect(body).toEqual({});
+  });
+
+  it('includes only name when only name changed', () => {
+    // Arrange
+    const schedule = buildSchedule();
+    const next = { ...resolvedFromSchedule(schedule), name: 'New name' };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({ name: 'New name' });
+  });
+
+  it('includes only activeStart when only activeStart changed', () => {
+    // Arrange
+    const schedule = buildSchedule();
+    const next = {
+      ...resolvedFromSchedule(schedule),
+      activeStart: '2027-01-01T00:00:00.000Z',
+    };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({ activeStart: '2027-01-01T00:00:00.000Z' });
+  });
+
+  it('includes only activeEnd when only activeEnd changed', () => {
+    // Arrange
+    const schedule = buildSchedule({ activeEnd: null });
+    const next = {
+      ...resolvedFromSchedule(schedule),
+      activeEnd: '2027-01-01T00:00:00.000Z',
+    };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({ activeEnd: '2027-01-01T00:00:00.000Z' });
+  });
+
+  it('includes only localStartTime when only localStartTime changed', () => {
+    // Arrange
+    const schedule = buildSchedule();
+    const next = {
+      ...resolvedFromSchedule(schedule),
+      localStartTime: '10:00',
+    };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({ localStartTime: '10:00' });
+  });
+
+  it('includes only localEndTime when only localEndTime changed', () => {
+    // Arrange
+    const schedule = buildSchedule();
+    const next = { ...resolvedFromSchedule(schedule), localEndTime: '11:00' };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({ localEndTime: '11:00' });
+  });
+
+  it('includes only frequency when only frequency changed', () => {
+    // Arrange
+    const schedule = buildSchedule({ frequency: 'WEEKLY' });
+    const next = {
+      ...resolvedFromSchedule(schedule),
+      frequency: 'ONCE' as const,
+    };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({ frequency: 'ONCE' });
+  });
+
+  it('includes only daysOfWeek when only daysOfWeek changed', () => {
+    // Arrange
+    const schedule = buildSchedule({ daysOfWeek: ['MON'] });
+    const next = {
+      ...resolvedFromSchedule(schedule),
+      daysOfWeek: ['MON', 'TUE'] as DayOfWeek[],
+    };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({ daysOfWeek: ['MON', 'TUE'] });
+  });
+
+  it('includes only joinCodeScopes when only joinCodeScopes changed', () => {
+    // Arrange
+    const schedule = buildSchedule({ joinCodeScopes: ['SEND_AUDIO'] });
+    const next = {
+      ...resolvedFromSchedule(schedule),
+      joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'] as SessionScope[],
+    };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({ joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'] });
+  });
+
+  it('includes only transcriptionProviderId when only that changed', () => {
+    // Arrange
+    const schedule = buildSchedule({ transcriptionProviderId: 'whisper' });
+    const next = {
+      ...resolvedFromSchedule(schedule),
+      transcriptionProviderId: 'other-provider',
+    };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({ transcriptionProviderId: 'other-provider' });
+  });
+
+  it('treats a null transcriptionProviderId as unchanged against an empty-string next value', () => {
+    // Arrange
+    const schedule = buildSchedule({ transcriptionProviderId: null });
+    const next = { ...resolvedFromSchedule(schedule), transcriptionProviderId: '' };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({});
+  });
+
+  it('includes only transcriptionStreamConfig when only that changed', () => {
+    // Arrange
+    const schedule = buildSchedule({ transcriptionStreamConfig: { a: 1 } });
+    const next = {
+      ...resolvedFromSchedule(schedule),
+      transcriptionStreamConfig: { a: 2 },
+    };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({ transcriptionStreamConfig: { a: 2 } });
+  });
+
+  it('treats a null transcriptionStreamConfig as unchanged against an empty-object next value', () => {
+    // Arrange
+    const schedule = buildSchedule({ transcriptionStreamConfig: null });
+    const next = {
+      ...resolvedFromSchedule(schedule),
+      transcriptionStreamConfig: {},
+    };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({});
+  });
+
+  it('combines several changed fields, and only those, into one body', () => {
+    // Arrange
+    const schedule = buildSchedule();
+    const next = {
+      ...resolvedFromSchedule(schedule),
+      name: 'Renamed',
+      localEndTime: '12:00',
+    };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({ name: 'Renamed', localEndTime: '12:00' });
+  });
+
+  it(
+    // LOCKED-IN AMBIGUITY: daysOfWeek is diffed with a plain JSON.stringify
+    // comparison (order-sensitive), unlike joinCodeScopes just above it in
+    // the same function (and unlike the auto-window dialog's own daysOfWeek,
+    // see diffAutoWindowUpdate below), both of which use the order-insensitive
+    // sameStringArray. Whether a same-set-but-reordered daysOfWeek "counts" as
+    // a user edit is not something this test suite decides — it locks in the
+    // current behavior (treated as changed) rather than picking a side.
+    'treats a same-set-but-reordered daysOfWeek as changed (order-sensitive, unlike joinCodeScopes)',
+    () => {
+      // Arrange
+      const schedule = buildSchedule({ daysOfWeek: ['MON', 'WED', 'FRI'] });
+      const next = {
+        ...resolvedFromSchedule(schedule),
+        daysOfWeek: ['FRI', 'MON', 'WED'] as DayOfWeek[],
+      };
+
+      // Act
+      const body = diffScheduleUpdate(schedule, next);
+
+      // Assert
+      expect(body).toEqual({ daysOfWeek: ['FRI', 'MON', 'WED'] });
+    },
+  );
+
+  it('treats a same-set-but-reordered joinCodeScopes as unchanged (order-insensitive)', () => {
+    // Arrange
+    const schedule = buildSchedule({
+      joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+    });
+    const next = {
+      ...resolvedFromSchedule(schedule),
+      joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS', 'SEND_AUDIO'] as SessionScope[],
+    };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({});
+  });
+});
+
+describe('diffAutoWindowUpdate', (it) => {
+  it('returns an empty body when nothing changed', () => {
+    // Arrange
+    const w = buildWindow();
+
+    // Act
+    const body = diffAutoWindowUpdate(w, resolvedFromWindow(w));
+
+    // Assert
+    expect(body).toEqual({});
+  });
+
+  it('includes only localStartTime when only localStartTime changed', () => {
+    // Arrange
+    const w = buildWindow();
+    const next = { ...resolvedFromWindow(w), localStartTime: '10:00' };
+
+    // Act
+    const body = diffAutoWindowUpdate(w, next);
+
+    // Assert
+    expect(body).toEqual({ localStartTime: '10:00' });
+  });
+
+  it('includes only localEndTime when only localEndTime changed', () => {
+    // Arrange
+    const w = buildWindow();
+    const next = { ...resolvedFromWindow(w), localEndTime: '18:00' };
+
+    // Act
+    const body = diffAutoWindowUpdate(w, next);
+
+    // Assert
+    expect(body).toEqual({ localEndTime: '18:00' });
+  });
+
+  it('includes only daysOfWeek when the set of days actually changed', () => {
+    // Arrange
+    const w = buildWindow({ daysOfWeek: ['MON', 'TUE'] });
+    const next = {
+      ...resolvedFromWindow(w),
+      daysOfWeek: ['MON', 'TUE', 'WED'] as DayOfWeek[],
+    };
+
+    // Act
+    const body = diffAutoWindowUpdate(w, next);
+
+    // Assert
+    expect(body).toEqual({ daysOfWeek: ['MON', 'TUE', 'WED'] });
+  });
+
+  it('treats a same-set-but-reordered daysOfWeek as unchanged (order-insensitive, unlike the schedule dialog)', () => {
+    // Arrange
+    const w = buildWindow({ daysOfWeek: ['MON', 'TUE', 'WED'] });
+    const next = {
+      ...resolvedFromWindow(w),
+      daysOfWeek: ['WED', 'MON', 'TUE'] as DayOfWeek[],
+    };
+
+    // Act
+    const body = diffAutoWindowUpdate(w, next);
+
+    // Assert
+    expect(body).toEqual({});
+  });
+
+  it('includes only activeStart when only activeStart changed', () => {
+    // Arrange
+    const w = buildWindow();
+    const next = {
+      ...resolvedFromWindow(w),
+      activeStart: '2027-01-01T00:00:00.000Z',
+    };
+
+    // Act
+    const body = diffAutoWindowUpdate(w, next);
+
+    // Assert
+    expect(body).toEqual({ activeStart: '2027-01-01T00:00:00.000Z' });
+  });
+
+  it('includes only activeEnd when only activeEnd changed', () => {
+    // Arrange
+    const w = buildWindow({ activeEnd: null });
+    const next = {
+      ...resolvedFromWindow(w),
+      activeEnd: '2027-01-01T00:00:00.000Z',
+    };
+
+    // Act
+    const body = diffAutoWindowUpdate(w, next);
+
+    // Assert
+    expect(body).toEqual({ activeEnd: '2027-01-01T00:00:00.000Z' });
+  });
+
+  it('includes only joinCodeScopes when the set of scopes actually changed', () => {
+    // Arrange
+    const w = buildWindow({ joinCodeScopes: ['SEND_AUDIO'] });
+    const next = {
+      ...resolvedFromWindow(w),
+      joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'] as SessionScope[],
+    };
+
+    // Act
+    const body = diffAutoWindowUpdate(w, next);
+
+    // Assert
+    expect(body).toEqual({
+      joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+    });
+  });
+
+  it('treats a same-set-but-reordered joinCodeScopes as unchanged (order-insensitive)', () => {
+    // Arrange
+    const w = buildWindow({
+      joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+    });
+    const next = {
+      ...resolvedFromWindow(w),
+      joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS', 'SEND_AUDIO'] as SessionScope[],
+    };
+
+    // Act
+    const body = diffAutoWindowUpdate(w, next);
+
+    // Assert
+    expect(body).toEqual({});
+  });
+
+  it('includes only transcriptionProviderId when only that changed', () => {
+    // Arrange
+    const w = buildWindow({ transcriptionProviderId: 'whisper' });
+    const next = {
+      ...resolvedFromWindow(w),
+      transcriptionProviderId: 'other-provider',
+    };
+
+    // Act
+    const body = diffAutoWindowUpdate(w, next);
+
+    // Assert
+    expect(body).toEqual({ transcriptionProviderId: 'other-provider' });
+  });
+
+  it('includes only transcriptionStreamConfig when only that changed', () => {
+    // Arrange
+    const w = buildWindow({ transcriptionStreamConfig: { a: 1 } });
+    const next = {
+      ...resolvedFromWindow(w),
+      transcriptionStreamConfig: { a: 2 },
+    };
+
+    // Act
+    const body = diffAutoWindowUpdate(w, next);
+
+    // Assert
+    expect(body).toEqual({ transcriptionStreamConfig: { a: 2 } });
+  });
+
+  it('combines several changed fields, and only those, into one body', () => {
+    // Arrange
+    const w = buildWindow();
+    const next = {
+      ...resolvedFromWindow(w),
+      localStartTime: '07:00',
+      transcriptionProviderId: 'other-provider',
+    };
+
+    // Act
+    const body = diffAutoWindowUpdate(w, next);
+
+    // Assert
+    expect(body).toEqual({
+      localStartTime: '07:00',
+      transcriptionProviderId: 'other-provider',
+    });
+  });
+});

--- a/apps/admin-webapp/tests/features/scheduling/room-scheduling-form-utils.test.ts
+++ b/apps/admin-webapp/tests/features/scheduling/room-scheduling-form-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect } from 'vitest';
 import {
   diffAutoWindowUpdate,
   diffScheduleUpdate,
+  sameDaysOfWeek,
   sameStringArray,
 } from '#src/features/scheduling/room-scheduling-form-utils';
 import type { DayOfWeek, SessionScope } from '#src/lib/admin-api';
@@ -55,6 +56,27 @@ describe('sameStringArray', (it) => {
     // Assert
     expect(sameStringArray(['MON'], ['MON', 'TUE'])).toBe(false);
     expect(sameStringArray(['MON'], ['TUE'])).toBe(false);
+  });
+});
+
+describe('sameDaysOfWeek', (it) => {
+  it('is true for the same elements regardless of order, like sameStringArray', () => {
+    // Assert
+    expect(sameDaysOfWeek(['MON', 'WED', 'FRI'], ['FRI', 'MON', 'WED'])).toBe(
+      true,
+    );
+  });
+
+  it('is true when both sides are null', () => {
+    // Assert
+    expect(sameDaysOfWeek(null, null)).toBe(true);
+  });
+
+  it('is false when one side is null and the other is an array, even an empty one', () => {
+    // Assert
+    expect(sameDaysOfWeek(null, [])).toBe(false);
+    expect(sameDaysOfWeek([], null)).toBe(false);
+    expect(sameDaysOfWeek(null, ['MON'])).toBe(false);
   });
 });
 
@@ -257,30 +279,47 @@ describe('diffScheduleUpdate', (it) => {
     expect(body).toEqual({ name: 'Renamed', localEndTime: '12:00' });
   });
 
-  it(
-    // LOCKED-IN AMBIGUITY: daysOfWeek is diffed with a plain JSON.stringify
-    // comparison (order-sensitive), unlike joinCodeScopes just above it in
-    // the same function (and unlike the auto-window dialog's own daysOfWeek,
-    // see diffAutoWindowUpdate below), both of which use the order-insensitive
-    // sameStringArray. Whether a same-set-but-reordered daysOfWeek "counts" as
-    // a user edit is not something this test suite decides — it locks in the
-    // current behavior (treated as changed) rather than picking a side.
-    'treats a same-set-but-reordered daysOfWeek as changed (order-sensitive, unlike joinCodeScopes)',
-    () => {
-      // Arrange
-      const schedule = buildSchedule({ daysOfWeek: ['MON', 'WED', 'FRI'] });
-      const next = {
-        ...resolvedFromSchedule(schedule),
-        daysOfWeek: ['FRI', 'MON', 'WED'] as DayOfWeek[],
-      };
+  it('treats a same-set-but-reordered daysOfWeek as unchanged (order-insensitive, consistent with joinCodeScopes)', () => {
+    // Arrange
+    const schedule = buildSchedule({ daysOfWeek: ['MON', 'WED', 'FRI'] });
+    const next = {
+      ...resolvedFromSchedule(schedule),
+      daysOfWeek: ['FRI', 'MON', 'WED'] as DayOfWeek[],
+    };
 
-      // Act
-      const body = diffScheduleUpdate(schedule, next);
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
 
-      // Assert
-      expect(body).toEqual({ daysOfWeek: ['FRI', 'MON', 'WED'] });
-    },
-  );
+    // Assert
+    expect(body).toEqual({});
+  });
+
+  it('treats a null daysOfWeek as unchanged against a null next value', () => {
+    // Arrange
+    const schedule = buildSchedule({ daysOfWeek: null });
+    const next = { ...resolvedFromSchedule(schedule), daysOfWeek: null };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({});
+  });
+
+  it('treats null vs. an actual daysOfWeek array as changed, not equivalent to empty', () => {
+    // Arrange
+    const schedule = buildSchedule({ daysOfWeek: null });
+    const next = {
+      ...resolvedFromSchedule(schedule),
+      daysOfWeek: ['MON'] as DayOfWeek[],
+    };
+
+    // Act
+    const body = diffScheduleUpdate(schedule, next);
+
+    // Assert
+    expect(body).toEqual({ daysOfWeek: ['MON'] });
+  });
 
   it('treats a same-set-but-reordered joinCodeScopes as unchanged (order-insensitive)', () => {
     // Arrange

--- a/apps/admin-webapp/tests/features/scheduling/room-scheduling-page.test.tsx
+++ b/apps/admin-webapp/tests/features/scheduling/room-scheduling-page.test.tsx
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, vi } from 'vitest';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Route, Routes } from 'react-router-dom';
+
+import { RoomSchedulingPage } from '#src/features/scheduling/room-scheduling-page';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
+
+import { renderWithProviders } from '../../utils/render-with-providers';
+import { buildRoomDetail, buildSchedule, buildWindow } from './fixtures';
+
+vi.mock('#src/lib/admin-api', () => ({
+  adminApi: {
+    roomDetail: vi.fn(),
+    listSchedules: vi.fn(),
+    listAutoWindows: vi.fn(),
+    createSchedule: vi.fn(),
+    updateSchedule: vi.fn(),
+    createAutoWindow: vi.fn(),
+    updateAutoWindow: vi.fn(),
+    deleteSchedule: vi.fn(),
+    deleteAutoWindow: vi.fn(),
+    updateRoomScheduleConfig: vi.fn(),
+  },
+}));
+
+const ROOM_UID = 'room-1';
+
+function mockDefaultLoad(options: {
+  schedules?: ReturnType<typeof buildSchedule>[];
+  windows?: ReturnType<typeof buildWindow>[];
+  roomOverrides?: Parameters<typeof buildRoomDetail>[0];
+} = {}) {
+  const { schedules = [], windows = [], roomOverrides = {} } = options;
+  vi.mocked(adminApi.roomDetail).mockResolvedValue(
+    buildRoomDetail(roomOverrides),
+  );
+  vi.mocked(adminApi.listSchedules).mockResolvedValue({ items: schedules });
+  vi.mocked(adminApi.listAutoWindows).mockResolvedValue({ items: windows });
+}
+
+async function waitForLoad() {
+  await waitFor(() => {
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+}
+
+function renderPage() {
+  renderWithProviders(
+    <Routes>
+      <Route
+        path="/rooms/:roomUid/scheduling"
+        element={<RoomSchedulingPage />}
+      />
+    </Routes>,
+    { route: `/rooms/${ROOM_UID}/scheduling` },
+  );
+}
+
+/** Finds the table row containing `text` and returns the "Edit" button
+ * inside it, disambiguating the schedules table from the windows table
+ * (both render an "Edit"/"Delete" button pair). */
+function editButtonForRow(text: string) {
+  const row = screen.getByText(text).closest('tr');
+  if (row === null) throw new Error(`no row found for "${text}"`);
+  return within(row).getByRole('button', { name: 'Edit' });
+}
+
+/** Opens a MultiSelectField's dropdown and toggles one option, then closes
+ * it with Escape (MUI's multi-select keeps the listbox open across clicks). */
+async function toggleMultiSelectOption(
+  user: ReturnType<typeof userEvent.setup>,
+  fieldLabel: string,
+  optionName: string,
+) {
+  await user.click(screen.getByLabelText(fieldLabel));
+  await user.click(
+    await screen.findByRole('option', { name: new RegExp(optionName) }),
+  );
+  await user.keyboard('{Escape}');
+}
+
+describe('RoomSchedulingPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('ScheduleDialog edit-mode diffing', (it) => {
+    it('sends only the fields the user actually changed', async () => {
+      // Arrange
+      const schedule = buildSchedule({
+        uid: 'schedule-1',
+        name: 'CS 225 Lecture',
+        localStartTime: '09:00:00',
+        localEndTime: '09:50:00',
+      });
+      mockDefaultLoad({ schedules: [schedule] });
+      renderPage();
+      await waitForLoad();
+      const user = userEvent.setup();
+      await user.click(editButtonForRow('CS 225 Lecture'));
+
+      const nameField = await screen.findByLabelText('Name');
+      expect(nameField).toHaveValue('CS 225 Lecture');
+      await user.clear(nameField);
+      await user.type(nameField, 'CS 225 Lecture (renamed)');
+      fireEvent.change(screen.getByLabelText('Local end time'), {
+        target: { value: '10:30' },
+      });
+
+      const created = buildSchedule();
+      vi.mocked(adminApi.updateSchedule).mockResolvedValue(created);
+
+      // Act
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      await waitFor(() => {
+        expect(adminApi.updateSchedule).toHaveBeenCalledTimes(1);
+      });
+      const body = vi.mocked(adminApi.updateSchedule).mock.calls[0]![0];
+      expect(body).toEqual({
+        scheduleUid: 'schedule-1',
+        name: 'CS 225 Lecture (renamed)',
+        localEndTime: '10:30',
+      });
+    });
+
+    it('sends only {scheduleUid} when nothing was changed before Save', async () => {
+      // Arrange: locks in current behavior — handleSubmit has no
+      // "anything actually changed?" guard, so an untouched edit still
+      // issues an update call with an effectively-empty diff.
+      const schedule = buildSchedule({
+        uid: 'schedule-1',
+        name: 'CS 225 Lecture',
+      });
+      mockDefaultLoad({ schedules: [schedule] });
+      renderPage();
+      await waitForLoad();
+      const user = userEvent.setup();
+      await user.click(editButtonForRow('CS 225 Lecture'));
+      await screen.findByLabelText('Name');
+      vi.mocked(adminApi.updateSchedule).mockResolvedValue(schedule);
+
+      // Act
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      await waitFor(() => {
+        expect(adminApi.updateSchedule).toHaveBeenCalledTimes(1);
+      });
+      expect(adminApi.updateSchedule).toHaveBeenCalledWith({
+        scheduleUid: 'schedule-1',
+      });
+    });
+  });
+
+  describe('ScheduleDialog create-mode', (it) => {
+    it('sends a full body, not a partial diff', async () => {
+      // Arrange
+      mockDefaultLoad();
+      renderPage();
+      await waitForLoad();
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: /new schedule/i }));
+
+      await user.type(await screen.findByLabelText('Name'), 'New Schedule');
+      fireEvent.change(screen.getByLabelText('Active start'), {
+        target: { value: '2030-01-01T09:00' },
+      });
+      vi.mocked(adminApi.createSchedule).mockResolvedValue(buildSchedule());
+
+      // Act
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      await waitFor(() => {
+        expect(adminApi.createSchedule).toHaveBeenCalledTimes(1);
+      });
+      const body = vi.mocked(adminApi.createSchedule).mock.calls[0]![0];
+      expect(body).toEqual({
+        roomUid: ROOM_UID,
+        name: 'New Schedule',
+        activeStart: new Date('2030-01-01T09:00').toISOString(),
+        activeEnd: null,
+        localStartTime: '09:00',
+        localEndTime: '10:00',
+        frequency: 'ONCE',
+        daysOfWeek: null,
+        joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+        transcriptionProviderId: 'whisper',
+        transcriptionStreamConfig: {},
+      });
+    });
+  });
+
+  describe('AutoWindowDialog edit-mode diffing', (it) => {
+    it('sends only the fields the user actually changed', async () => {
+      // Arrange
+      const w = buildWindow({
+        uid: 'window-1',
+        localStartTime: '08:00:00',
+        localEndTime: '17:00:00',
+        transcriptionProviderId: 'whisper',
+      });
+      mockDefaultLoad({ windows: [w] });
+      renderPage();
+      await waitForLoad();
+      const user = userEvent.setup();
+      await user.click(editButtonForRow('MON, TUE, WED, THU, FRI'));
+
+      fireEvent.change(await screen.findByLabelText('Local start time'), {
+        target: { value: '07:00' },
+      });
+      const providerField = screen.getByLabelText(
+        'Transcription provider ID',
+      );
+      await user.clear(providerField);
+      await user.type(providerField, 'other-provider');
+
+      vi.mocked(adminApi.updateAutoWindow).mockResolvedValue(w);
+
+      // Act
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      await waitFor(() => {
+        expect(adminApi.updateAutoWindow).toHaveBeenCalledTimes(1);
+      });
+      const body = vi.mocked(adminApi.updateAutoWindow).mock.calls[0]![0];
+      expect(body).toEqual({
+        windowUid: 'window-1',
+        localStartTime: '07:00',
+        transcriptionProviderId: 'other-provider',
+      });
+    });
+  });
+
+  describe('AutoWindowDialog create-mode', (it) => {
+    it('sends a full body, not a partial diff', async () => {
+      // Arrange
+      mockDefaultLoad();
+      renderPage();
+      await waitForLoad();
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: /new window/i }));
+      await screen.findByLabelText('Local start time');
+
+      // The window form starts with no days picked, so at least one must be
+      // chosen for Save to pass validation.
+      await toggleMultiSelectOption(user, 'Days of week', 'MON');
+      fireEvent.change(screen.getByLabelText('Active start'), {
+        target: { value: '2030-01-01T09:00' },
+      });
+      vi.mocked(adminApi.createAutoWindow).mockResolvedValue(buildWindow());
+
+      // Act
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      await waitFor(() => {
+        expect(adminApi.createAutoWindow).toHaveBeenCalledTimes(1);
+      });
+      const body = vi.mocked(adminApi.createAutoWindow).mock.calls[0]![0];
+      expect(body).toEqual({
+        roomUid: ROOM_UID,
+        localStartTime: '09:00',
+        localEndTime: '10:00',
+        daysOfWeek: ['MON'],
+        activeStart: new Date('2030-01-01T09:00').toISOString(),
+        activeEnd: null,
+        joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+        transcriptionProviderId: 'whisper',
+        transcriptionStreamConfig: {},
+      });
+    });
+  });
+
+  describe('BACKEND_MISCONFIGURATION handling', (it) => {
+    it('shows the in-dialog alert instead of a toast when updating a schedule hits BACKEND_MISCONFIGURATION', async () => {
+      // Arrange
+      const schedule = buildSchedule({
+        uid: 'schedule-1',
+        name: 'CS 225 Lecture',
+      });
+      mockDefaultLoad({ schedules: [schedule] });
+      renderPage();
+      await waitForLoad();
+      const user = userEvent.setup();
+      await user.click(editButtonForRow('CS 225 Lecture'));
+      await screen.findByLabelText('Name');
+      vi.mocked(adminApi.updateSchedule).mockRejectedValue(
+        new ApiError('BACKEND_MISCONFIGURATION', 'nope', 502),
+      );
+
+      // Act
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      expect(
+        await screen.findByText(
+          /admin backend misconfiguration.*ADMIN_API_KEY/i,
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/failed to update schedule/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/admin-webapp/tests/features/sessions/fixtures.ts
+++ b/apps/admin-webapp/tests/features/sessions/fixtures.ts
@@ -1,0 +1,23 @@
+import type { Session } from '@scribear/session-manager-schema';
+
+export function buildSession(overrides: Partial<Session> = {}): Session {
+  return {
+    uid: 'session-1',
+    roomUid: 'room-1',
+    name: 'CS 225 Lecture',
+    type: 'SCHEDULED',
+    scheduledSessionUid: null,
+    scheduledStartTime: '2026-08-01T14:00:00.000Z',
+    scheduledEndTime: '2026-08-01T14:50:00.000Z',
+    startOverride: null,
+    endOverride: null,
+    effectiveStart: '2026-08-01T14:00:00.000Z',
+    effectiveEnd: '2026-08-01T14:50:00.000Z',
+    joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+    transcriptionProviderId: 'whisper',
+    transcriptionStreamConfig: {},
+    sessionConfigVersion: 1,
+    createdAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  };
+}

--- a/apps/admin-webapp/tests/features/sessions/session-detail-page.test.tsx
+++ b/apps/admin-webapp/tests/features/sessions/session-detail-page.test.tsx
@@ -1,0 +1,134 @@
+import type { ReactElement } from 'react';
+
+import { beforeEach, describe, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+
+import { Route, Routes } from 'react-router-dom';
+
+import { SessionDetailPage } from '#src/features/sessions/session-detail-page';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
+
+import { renderWithProviders } from '../../utils/render-with-providers';
+import { buildSession } from './fixtures';
+
+vi.mock('#src/lib/admin-api', () => ({
+  adminApi: {
+    getSession: vi.fn(),
+  },
+}));
+
+const SESSION_UID = 'session-1';
+
+function renderPage(ui: ReactElement = <SessionDetailPage />) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/sessions/:sessionUid" element={ui} />
+    </Routes>,
+    { route: `/sessions/${SESSION_UID}` },
+  );
+}
+
+async function waitForLoad() {
+  await waitFor(() => {
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+}
+
+describe('SessionDetailPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('loading', (it) => {
+    it('shows a spinner while the initial load is in flight', () => {
+      // Arrange
+      vi.mocked(adminApi.getSession).mockReturnValue(
+        new Promise(() => {
+          /* never resolves */
+        }),
+      );
+
+      // Act
+      renderPage();
+
+      // Assert
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+  });
+
+  describe('not-found state', (it) => {
+    it('shows "Session not found." on a 404 ApiError', async () => {
+      // Arrange
+      vi.mocked(adminApi.getSession).mockRejectedValue(
+        new ApiError('NOT_FOUND', 'no such session', 404),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText('Session not found.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', (it) => {
+    it('shows a toast and the not-found fallback on a non-404, non-ApiError rejection', async () => {
+      // Arrange
+      vi.mocked(adminApi.getSession).mockRejectedValue(
+        new Error('network down'),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText('Failed to load session.'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Session not found.')).toBeInTheDocument();
+    });
+  });
+
+  describe('BACKEND_MISCONFIGURATION', (it) => {
+    it('shows the ADMIN_API_KEY alert as the entire page body', async () => {
+      // Arrange
+      vi.mocked(adminApi.getSession).mockRejectedValue(
+        new ApiError('BACKEND_MISCONFIGURATION', 'nope', 502),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText(/admin backend misconfiguration/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('Session not found.'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('loaded state', (it) => {
+    it('renders the session fields once loaded', async () => {
+      // Arrange
+      vi.mocked(adminApi.getSession).mockResolvedValue(
+        buildSession({ name: 'CS 225 Lecture', roomUid: 'room-1' }),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(screen.getByText('CS 225 Lecture')).toBeInTheDocument();
+      expect(screen.getByText('room-1')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/admin-webapp/tests/lib/admin-api.test.ts
+++ b/apps/admin-webapp/tests/lib/admin-api.test.ts
@@ -1,0 +1,491 @@
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+
+import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { AdminApiClient, FLEET_STREAM_URL } from '#src/lib/admin-api';
+
+const BASE = '/api/admin/v1';
+
+/** Minimal stand-in for `Response` — `_request` only ever touches `.ok`,
+ *  `.status`, and `.json()`. */
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+/** A `Response` whose body can't be parsed as JSON (e.g. an empty 204, or an
+ *  upstream proxy error page). */
+function unparseableResponse(status: number): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.reject(new Error('Unexpected end of JSON input')),
+  } as unknown as Response;
+}
+
+describe('AdminApiClient', () => {
+  let client: AdminApiClient;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new AdminApiClient();
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('request construction', (it) => {
+    it('sends a GET request with no content-type or csrf header', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(
+        jsonResponse(200, { ok: true, data: { local: true, sso: false } }),
+      );
+
+      // Act
+      await client.getAuthConfig();
+
+      // Assert
+      expect(fetchMock).toHaveBeenCalledWith(`${BASE}/auth/config`, {
+        method: 'GET',
+        credentials: 'include',
+        headers: {},
+      });
+    });
+
+    it('attaches the csrf token header on a mutating POST request', async () => {
+      // Arrange
+      client.setCsrfToken('tok-123');
+      fetchMock.mockResolvedValue(jsonResponse(200, { ok: true, data: null }));
+
+      // Act
+      await client.logout();
+
+      // Assert
+      expect(fetchMock).toHaveBeenCalledWith(`${BASE}/auth/logout`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'x-csrf-token': 'tok-123' },
+      });
+    });
+
+    it('sends an empty csrf header (never omits it) when no token has been set', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(jsonResponse(200, { ok: true, data: null }));
+
+      // Act
+      await client.logout();
+
+      // Assert
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ headers: { 'x-csrf-token': '' } }),
+      );
+    });
+
+    it('reads the csrf token at call time, not at construction time', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(jsonResponse(200, { ok: true, data: null }));
+
+      // Act
+      client.setCsrfToken('first');
+      await client.logout();
+      client.setCsrfToken('second');
+      await client.logout();
+
+      // Assert
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        expect.any(String),
+        expect.objectContaining({ headers: { 'x-csrf-token': 'first' } }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        expect.any(String),
+        expect.objectContaining({ headers: { 'x-csrf-token': 'second' } }),
+      );
+    });
+
+    it('adds a content-type header and a JSON-serialized body for a mutation with a body', async () => {
+      // Arrange
+      client.setCsrfToken('tok');
+      fetchMock.mockResolvedValue(
+        jsonResponse(200, {
+          ok: true,
+          data: {
+            identity: {
+              subject: 'alice',
+              displayName: 'Alice',
+              provider: 'local',
+              roles: [],
+            },
+            csrfToken: 'new-tok',
+          },
+        }),
+      );
+
+      // Act
+      await client.login('alice', 'hunter2');
+
+      // Assert
+      expect(fetchMock).toHaveBeenCalledWith(`${BASE}/auth/login`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json', 'x-csrf-token': 'tok' },
+        body: JSON.stringify({ username: 'alice', password: 'hunter2' }),
+      });
+    });
+
+    it('omits the body field entirely for a bodyless mutation (not `body: undefined`)', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(jsonResponse(200, { ok: true, data: null }));
+
+      // Act
+      await client.logout();
+
+      // Assert
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(init).not.toHaveProperty('body');
+      expect(init).not.toHaveProperty('content-type');
+    });
+
+    it('always sends credentials: include, on GET and on mutations alike', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(jsonResponse(200, { ok: true, data: null }));
+
+      // Act
+      await client.health();
+      await client.deleteRoom('room-1');
+
+      // Assert
+      for (const call of fetchMock.mock.calls) {
+        const init = call[1] as RequestInit;
+        expect(init.credentials).toBe('include');
+      }
+    });
+  });
+
+  describe('query string construction', (it) => {
+    it('builds listRooms with no query string when called with no filters', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(
+        jsonResponse(200, { ok: true, data: { items: [], nextCursor: null } }),
+      );
+
+      // Act
+      await client.listRooms();
+
+      // Assert
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(`${BASE}/rooms/list`);
+    });
+
+    it('serializes search/cursor/limit for listRooms', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(
+        jsonResponse(200, { ok: true, data: { items: [], nextCursor: null } }),
+      );
+
+      // Act
+      await client.listRooms({ search: 'foo', cursor: 'c1', limit: 10 });
+
+      // Assert
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(
+        `${BASE}/rooms/list?search=foo&cursor=c1&limit=10`,
+      );
+    });
+
+    it('omits an empty-string search rather than sending search=', async () => {
+      // Arrange: an empty string is what a cleared MUI text field sends, and
+      // the client treats it the same as "no filter" rather than searching
+      // for the literal empty string.
+      fetchMock.mockResolvedValue(
+        jsonResponse(200, { ok: true, data: { items: [], nextCursor: null } }),
+      );
+
+      // Act
+      await client.listRooms({ search: '' });
+
+      // Assert
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(`${BASE}/rooms/list`);
+    });
+
+    it('serializes a boolean active=false for listDevices rather than omitting it', async () => {
+      // Arrange: `false` is a meaningful filter value, distinct from
+      // "unset" — only `undefined`/`null`/`''` are dropped by toQueryString.
+      fetchMock.mockResolvedValue(
+        jsonResponse(200, { ok: true, data: { items: [], nextCursor: null } }),
+      );
+
+      // Act
+      await client.listDevices({ active: false });
+
+      // Assert
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(
+        `${BASE}/devices/list?active=false`,
+      );
+    });
+
+    it('serializes roomUid/from/to for a schedules TimeRangeQuery', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(jsonResponse(200, { ok: true, data: { items: [] } }));
+
+      // Act
+      await client.listSchedules({
+        roomUid: 'room-1',
+        from: '2026-01-01',
+        to: '2026-01-31',
+      });
+
+      // Assert
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(
+        `${BASE}/schedules/list?roomUid=room-1&from=2026-01-01&to=2026-01-31`,
+      );
+    });
+
+    it('omits from/to on listAutoWindows when not given, keeping roomUid', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(jsonResponse(200, { ok: true, data: { items: [] } }));
+
+      // Act
+      await client.listAutoWindows({ roomUid: 'room-1' });
+
+      // Assert
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(
+        `${BASE}/auto-windows/list?roomUid=room-1`,
+      );
+    });
+
+    it('defaults listAudit to limit=50 when called with no argument', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(jsonResponse(200, { ok: true, data: { items: [] } }));
+
+      // Act
+      await client.listAudit();
+
+      // Assert
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(`${BASE}/audit?limit=50`);
+    });
+
+    it('serializes an explicit listAudit limit', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(jsonResponse(200, { ok: true, data: { items: [] } }));
+
+      // Act
+      await client.listAudit(5);
+
+      // Assert
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(`${BASE}/audit?limit=5`);
+    });
+
+    it('URL-encodes a path segment id (get-by-id routes, not query params)', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(
+        jsonResponse(200, { ok: true, data: { roomUid: 'room a/b' } }),
+      );
+
+      // Act
+      await client.getRoom('room a/b');
+
+      // Assert
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(
+        `${BASE}/rooms/get/room%20a%2Fb`,
+      );
+    });
+  });
+
+  describe('error mapping', (it) => {
+    it('resolves with the unwrapped data on an ok envelope', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(
+        jsonResponse(200, { ok: true, data: { bff: 'ok', components: [], checkedAt: 'now' } }),
+      );
+
+      // Act
+      const result = await client.health();
+
+      // Assert
+      expect(result).toEqual({ bff: 'ok', components: [], checkedAt: 'now' });
+    });
+
+    it('throws an ApiError carrying the server code/message/status/requestId on a declared 404', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(
+        jsonResponse(404, {
+          ok: false,
+          error: {
+            code: 'ROOM_NOT_FOUND',
+            message: 'No such room.',
+            requestId: 'req-1',
+          },
+        }),
+      );
+
+      // Act
+      const promise = client.getRoom('missing');
+
+      // Assert
+      await expect(promise).rejects.toMatchObject({
+        code: 'ROOM_NOT_FOUND',
+        message: 'No such room.',
+        status: 404,
+        requestId: 'req-1',
+      });
+      await expect(promise).rejects.toBeInstanceOf(ApiError);
+    });
+
+    it('passes through a 502 BACKEND_MISCONFIGURATION envelope error unchanged', async () => {
+      // Arrange: the client applies no special-casing for this code — it's
+      // just another declared envelope error. The interesting mapping (a
+      // rejected admin key becoming 502 BACKEND_MISCONFIGURATION) happens
+      // server-side in admin-server; see
+      // session-manager-gateway.service.test.ts for that half.
+      fetchMock.mockResolvedValue(
+        jsonResponse(502, {
+          ok: false,
+          error: {
+            code: 'BACKEND_MISCONFIGURATION',
+            message: 'The admin API key was rejected upstream.',
+          },
+        }),
+      );
+
+      // Act
+      const promise = client.fleet();
+
+      // Assert
+      await expect(promise).rejects.toMatchObject({
+        code: 'BACKEND_MISCONFIGURATION',
+        status: 502,
+      });
+    });
+
+    it('invokes onUnauthorized and still throws on a 401', async () => {
+      // Arrange
+      const onUnauthorized = vi.fn();
+      client.setOnUnauthorized(onUnauthorized);
+      fetchMock.mockResolvedValue(
+        jsonResponse(401, {
+          ok: false,
+          error: { code: 'UNAUTHENTICATED', message: 'Not logged in.' },
+        }),
+      );
+
+      // Act
+      const promise = client.me();
+
+      // Assert
+      await expect(promise).rejects.toMatchObject({
+        code: 'UNAUTHENTICATED',
+        status: 401,
+      });
+      expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not throw from the 401 handling itself when no onUnauthorized callback was registered', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(
+        jsonResponse(401, {
+          ok: false,
+          error: { code: 'UNAUTHENTICATED', message: 'Not logged in.' },
+        }),
+      );
+
+      // Act / Assert
+      await expect(client.me()).rejects.toMatchObject({ status: 401 });
+    });
+
+    it('maps a rejected fetch (offline / DNS failure) to a NETWORK ApiError with status 0', async () => {
+      // Arrange
+      fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+
+      // Act
+      const promise = client.health();
+
+      // Assert
+      await expect(promise).rejects.toMatchObject({
+        code: 'NETWORK',
+        status: 0,
+      });
+      await expect(promise).rejects.toBeInstanceOf(ApiError);
+    });
+
+    it('maps a non-ok response with an unparseable body to an UNKNOWN ApiError', async () => {
+      // Arrange
+      fetchMock.mockResolvedValue(unparseableResponse(500));
+
+      // Act
+      const promise = client.health();
+
+      // Assert
+      await expect(promise).rejects.toMatchObject({
+        code: 'UNKNOWN',
+        message: 'The request failed.',
+        status: 500,
+      });
+    });
+
+    it('surprising case: a 200 response with an unparseable body is still thrown as an ApiError, not returned', async () => {
+      // Arrange: `_request` treats `res.ok && json?.ok` as the only success
+      // path. A 200 whose body fails to parse as JSON falls through to the
+      // error branch with the generic UNKNOWN code, at the *original* 200
+      // status — i.e. a malformed-but-otherwise-successful response reads
+      // exactly like a real server error to every caller. Documented here
+      // since it's easy to assume any 2xx short-circuits to success.
+      fetchMock.mockResolvedValue(unparseableResponse(200));
+
+      // Act
+      const promise = client.health();
+
+      // Assert
+      await expect(promise).rejects.toMatchObject({
+        code: 'UNKNOWN',
+        status: 200,
+      });
+    });
+  });
+
+  describe('FLEET_STREAM_URL', (it) => {
+    it('builds the fleet SSE endpoint under the admin API base path', () => {
+      // Assert: EventSource can't reuse `_request` (no cookie header — it
+      // relies on `withCredentials`), so this is a plain exported constant
+      // rather than a method on the client.
+      expect(FLEET_STREAM_URL).toBe(`${BASE}/fleet/stream`);
+    });
+  });
+});
+
+describe('isApiErrorCode', (it) => {
+  it('returns true when the error is an ApiError with the matching code', () => {
+    // Arrange
+    const err = new ApiError('ROOM_NOT_FOUND', 'nope', 404);
+
+    // Act / Assert
+    expect(isApiErrorCode(err, 'ROOM_NOT_FOUND')).toBe(true);
+  });
+
+  it('returns false when the error is an ApiError with a different code', () => {
+    // Arrange
+    const err = new ApiError('ROOM_NOT_FOUND', 'nope', 404);
+
+    // Act / Assert
+    expect(isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')).toBe(false);
+  });
+
+  it('returns false for a plain Error that is not an ApiError', () => {
+    // Arrange
+    const err = new Error('boom');
+
+    // Act / Assert
+    expect(isApiErrorCode(err, 'ROOM_NOT_FOUND')).toBe(false);
+  });
+
+  it('returns false for non-error values such as null or a string', () => {
+    // Act / Assert
+    expect(isApiErrorCode(null, 'ROOM_NOT_FOUND')).toBe(false);
+    expect(isApiErrorCode('ROOM_NOT_FOUND', 'ROOM_NOT_FOUND')).toBe(false);
+  });
+});

--- a/apps/admin-webapp/tests/lib/admin-api.test.ts
+++ b/apps/admin-webapp/tests/lib/admin-api.test.ts
@@ -428,13 +428,12 @@ describe('AdminApiClient', () => {
       });
     });
 
-    it('surprising case: a 200 response with an unparseable body is still thrown as an ApiError, not returned', async () => {
+    it('maps a 200 response with an unparseable body to a distinct INVALID_RESPONSE ApiError', async () => {
       // Arrange: `_request` treats `res.ok && json?.ok` as the only success
       // path. A 200 whose body fails to parse as JSON falls through to the
-      // error branch with the generic UNKNOWN code, at the *original* 200
-      // status — i.e. a malformed-but-otherwise-successful response reads
-      // exactly like a real server error to every caller. Documented here
-      // since it's easy to assume any 2xx short-circuits to success.
+      // error branch, but gets its own INVALID_RESPONSE code (rather than the
+      // generic UNKNOWN used for a declared backend error) so callers can
+      // tell "the server sent 2xx but garbage" apart from a real error.
       fetchMock.mockResolvedValue(unparseableResponse(200));
 
       // Act
@@ -442,7 +441,28 @@ describe('AdminApiClient', () => {
 
       // Assert
       await expect(promise).rejects.toMatchObject({
-        code: 'UNKNOWN',
+        code: 'INVALID_RESPONSE',
+        status: 200,
+      });
+    });
+
+    it('maps a 200 response with an ok:false envelope to INVALID_RESPONSE rather than passing the envelope error through', async () => {
+      // Arrange: a 2xx status paired with a declared `ok: false` envelope
+      // never happens in the real BFF contract, but if it did, it should read
+      // as an unexpected-response bug, not a trustworthy declared error.
+      fetchMock.mockResolvedValue(
+        jsonResponse(200, {
+          ok: false,
+          error: { code: 'ROOM_NOT_FOUND', message: 'No such room.' },
+        }),
+      );
+
+      // Act
+      const promise = client.health();
+
+      // Assert
+      await expect(promise).rejects.toMatchObject({
+        code: 'INVALID_RESPONSE',
         status: 200,
       });
     });

--- a/apps/admin-webapp/tests/lib/session-rules.test.ts
+++ b/apps/admin-webapp/tests/lib/session-rules.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { sessionTypeColor } from '#src/lib/session-rules';
+
+describe('sessionTypeColor', () => {
+  it('returns info for SCHEDULED', () => {
+    expect(sessionTypeColor('SCHEDULED')).toBe('info');
+  });
+
+  it('returns success for ON_DEMAND', () => {
+    expect(sessionTypeColor('ON_DEMAND')).toBe('success');
+  });
+
+  it('returns default for AUTO', () => {
+    expect(sessionTypeColor('AUTO')).toBe('default');
+  });
+});

--- a/apps/admin-webapp/tests/setup.ts
+++ b/apps/admin-webapp/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/apps/admin-webapp/tests/setup.ts
+++ b/apps/admin-webapp/tests/setup.ts
@@ -9,4 +9,8 @@ import '@testing-library/jest-dom/vitest';
 // component test file leaks its DOM into the next test in the same file.
 afterEach(() => {
   cleanup();
+  // SettingsProvider (now part of renderWithProviders) persists the
+  // "Show UUIDs" preference to localStorage; clear it so one test's toggle
+  // doesn't leak into the next.
+  localStorage.clear();
 });

--- a/apps/admin-webapp/tests/setup.ts
+++ b/apps/admin-webapp/tests/setup.ts
@@ -1,1 +1,12 @@
+import { afterEach } from 'vitest';
+
+import { cleanup } from '@testing-library/react';
+
 import '@testing-library/jest-dom/vitest';
+
+// Vitest's `globals` is off (per vitest.shared.ts), so RTL's own auto-cleanup
+// never registers — it looks for a global `afterEach`. Without this, every
+// component test file leaks its DOM into the next test in the same file.
+afterEach(() => {
+  cleanup();
+});

--- a/apps/admin-webapp/tests/utils/render-with-providers.tsx
+++ b/apps/admin-webapp/tests/utils/render-with-providers.tsx
@@ -1,0 +1,22 @@
+import type { ReactElement } from 'react';
+
+import { render, type RenderOptions } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { ToastProvider } from '#src/lib/toast-provider';
+
+export const renderWithProviders = (
+  ui: ReactElement,
+  options?: RenderOptions & { route?: string },
+) => {
+  const { route = '/', ...renderOptions } = options ?? {};
+
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <MemoryRouter initialEntries={[route]}>
+        <ToastProvider>{children}</ToastProvider>
+      </MemoryRouter>
+    ),
+    ...renderOptions,
+  });
+};

--- a/apps/admin-webapp/tests/utils/render-with-providers.tsx
+++ b/apps/admin-webapp/tests/utils/render-with-providers.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react';
 import { render, type RenderOptions } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
+import { SettingsProvider } from '#src/lib/settings-provider';
 import { ToastProvider } from '#src/lib/toast-provider';
 
 export const renderWithProviders = (
@@ -14,7 +15,9 @@ export const renderWithProviders = (
   return render(ui, {
     wrapper: ({ children }) => (
       <MemoryRouter initialEntries={[route]}>
-        <ToastProvider>{children}</ToastProvider>
+        <ToastProvider>
+          <SettingsProvider>{children}</SettingsProvider>
+        </ToastProvider>
       </MemoryRouter>
     ),
     ...renderOptions,

--- a/apps/admin-webapp/vitest.config.ts
+++ b/apps/admin-webapp/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import sharedConfig from '../../vitest.shared.js';
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      include: ['./tests/**/*.test.{ts,tsx}'],
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'unit',
+            environment: 'jsdom',
+            setupFiles: ['./tests/setup.ts'],
+          },
+        },
+      ],
+    },
+  }),
+);

--- a/apps/monitoring-sidecar/src/server/dependency-injection/resolve-handler.ts
+++ b/apps/monitoring-sidecar/src/server/dependency-injection/resolve-handler.ts
@@ -11,9 +11,7 @@ function resolveHandler<
   M extends keyof AppDependencies[C],
 >(controller: C, method: M): AppDependencies[C][M] {
   const wrapper = async (req: FastifyRequest, res: FastifyReply) => {
-    const routeController = req.diScope.resolve(
-      controller,
-    );
+    const routeController = req.diScope.resolve(controller);
 
     if (
       !(method in routeController) ||

--- a/apps/node-server/.env.example
+++ b/apps/node-server/.env.example
@@ -23,3 +23,18 @@ SESSION_MANAGER_SERVICE_API_KEY=CHANGEME
 #### Transcription Service this Node Server forwards audio to
 TRANSCRIPTION_SERVICE_BASE_URL=http://localhost:8000
 TRANSCRIPTION_SERVICE_API_KEY=CHANGEME
+
+#### Demo caption room (dev/staging only). When enabled, this Node Server
+#### auto-emits a never-ending, looping caption stream - the dialogue of
+#### Alice's Adventures in Wonderland, Chapter V - to DEMO_SESSION_UID below,
+#### so the client, kiosk, and standalone webapps can be exercised end-to-end
+#### with no microphone, source device, or Python transcription service
+#### running. OFF by default. Must stay "false" in production: this publishes
+#### fixture captions into a real, joinable session.
+DEMO_ROOM_ENABLED=false
+
+#### Fixed UUID identifying the demo session above. Must be identical to the
+#### Session Manager's DEMO_SESSION_UID (apps/session-manager/.env.example),
+#### which seeds the joinable session with this same uid - the two only work
+#### together.
+DEMO_SESSION_UID=deadbeef-0000-4000-8000-000000000001

--- a/apps/node-server/PLAN-Demo-CAPTION_ROOM.md
+++ b/apps/node-server/PLAN-Demo-CAPTION_ROOM.md
@@ -1,0 +1,385 @@
+# PLAN: Demo caption room
+
+Status: **node-server side implemented and tested; Session Manager seeding is
+the remaining half.**
+
+Implemented: the utterance fixture
+(`src/server/features/demo-room/fixtures/alice-chapter-v.utterances.json` + its
+regenerator and JSON Schema), the `DemoCaptionSource` emitter and its loop, the
+`DEMO_ROOM_ENABLED` / `DEMO_SESSION_UID` config, DI wiring, the orchestrator's
+`registerSyntheticSession`, unit tests (fragment/schedule/loop/fixture/config)
+and a WS-level integration test that a client joining the demo session receives
+looping interim-then-final captions with no source or Python service. Env vars
+are documented in `.env.example` (node-server + session-manager + deployment)
+and defaulted off in `deployment/compose.yml`.
+
+Remaining: the Session Manager must seed a joinable session whose `uid` equals
+`DEMO_SESSION_UID` (see "Component B" — note the confirmed constraint that
+on-demand sessions are open-ended but DB-generate their uid, so a fixed-uid
+insert is required, and join codes rotate so the seeder logs the current one).
+The rest below is the design as built.
+
+Goal: in **dev and staging only**, a caption room comes up on its own and emits
+a never-ending, human-paced caption stream — interim (partial) captions that
+arrive first and are then corrected by a final — so the client, kiosk, and
+standalone webapps can be exercised end-to-end without a microphone, a source
+device, or the Python transcription service running.
+
+Read the two "How it actually works today" sections before the design; the
+design is shaped entirely by two facts they establish: **captions fan out per
+`sessionUid`, not per room**, and **the wire caption has no speaker field**.
+
+---
+
+## How captions actually reach a browser today
+
+The path, most load-bearing first (all in `apps/node-server` unless noted):
+
+1. A **client** browser opens a WebSocket to
+   `…/transcription-stream/:sessionUid/client`
+   (`libs/schemas/node-server-schema/…/routes/transcription-stream.schema.ts:123`),
+   sends one `auth` message with a session token, and thereafter *only receives*
+   `transcript` messages. It never talks to the orchestrator
+   (`transcription-stream.service.ts:110-121` subscribes it to the bus and
+   nothing else).
+
+2. Transcripts are delivered over an **in-process pub/sub**,
+   `EventBusService`, on the channel `transcript:${sessionUid}`
+   (`shared/services/event-bus.service.ts`, `events/transcript.events.ts:29`).
+   The per-connection service turns each bus event into the wire message:
+
+   ```ts
+   // transcription-stream.service.ts:110
+   this._eventBusService.subscribe(TranscriptChannel, (transcript) => {
+     this.emit('send', {
+       type: TranscriptionStreamServerMessageType.TRANSCRIPT,
+       final: transcript.final,
+       inProgress: transcript.inProgress,
+     });
+   }, this._sessionUid);
+   ```
+
+3. In production the **only** publisher of that channel is the orchestrator,
+   relaying the upstream Python service:
+
+   ```ts
+   // transcription-orchestrator.service.ts:403
+   upstream.on('message', (msg) => {
+     this._eventBus.publish(TranscriptChannel,
+       { final: msg.final, inProgress: msg.in_progress }, sessionUid);
+   });
+   ```
+
+**This is the seam the demo exploits.** Anything that publishes to
+`TranscriptChannel` for a `sessionUid` reaches every client subscribed to that
+session, with zero changes to the client-facing socket, the schema, or the
+webapps. The demo does not need audio, a source device, or the Python service —
+it needs a publisher.
+
+### The wire caption schema (what a browser gets)
+
+`serverMessage` union member `transcript`
+(`…/routes/transcription-stream.schema.ts:62`):
+
+```ts
+{ type: "transcript",
+  final:      TranscriptFragment | null,
+  inProgress: TranscriptFragment | null }
+```
+
+`TranscriptFragment` (`…/entities/transcript.schema.ts:10`):
+
+```ts
+{ text: string[], starts: number[] | null, ends: number[] | null }
+```
+
+Partial vs final is **structural, not a flag**, and the two fields have
+different semantics on the client, confirmed in
+`libs/store/transcription-content-store/src/transcription-content-slice.ts:238`
+(`handleTranscript`):
+
+- `inProgress` **replaces** the currently displayed partial.
+- `final` is **appended** to the finalized log and **clears** the partial.
+
+That is exactly the "guess, then correct it" behavior the demo wants: emit
+`inProgress = progresstxt`, later emit `final = spoken`. No new client code.
+
+**There is no speaker field anywhere on the wire.** `roomUid`/`sessionUid` are
+connection metadata (the orchestrator forwards `room_uid` *upstream* to Python
+at `transcription-orchestrator.service.ts:454`, but it never comes back down and
+never tags a caption). Speaker identity has to be carried *inside* `text` — see
+"Speaker handling" below.
+
+### How a browser is allowed to join a session
+
+A client cannot connect to an arbitrary `sessionUid`; the socket runs a 5s auth
+watchdog and verifies a **session token** (signed with
+`SESSION_TOKEN_SIGNING_KEY`) against the URL's `sessionUid`, requiring the
+`RECEIVE_TRANSCRIPTIONS` scope (`transcription-stream.auth.ts:7`,
+`transcription-stream.controller.ts:66`). Tokens are obtained by exchanging a
+**join code** through the Session Manager
+(`client-session-service.ts:190`, `sessionAuth.exchangeJoinCode`). Join codes
+are minted/rotated by the Session Manager
+(`session-auth.service.ts:108`).
+
+So "a room the frontends can join" is really "a **Session Manager session** with
+a stable join code, whose `sessionUid` something is publishing captions for."
+Both halves are required; a publisher alone is unreachable.
+
+### Session lifecycle & the dev/prod signal
+
+- Sessions are **not** created at node-server startup. Session state is built
+  lazily on the first *source* connection (`registerSource` → `_openSession`,
+  `transcription-orchestrator.service.ts:175/376`) and torn down at ref-count 0.
+  There is no seed data and no pre-existing demo/mock room in runtime code
+  (only a test helper, `tests/utils/seed-session.ts`).
+- The node server has **no `NODE_ENV`**. "Dev" is a CLI flag,
+  `process.argv.includes('--dev')` (`app-config.ts:127`), and there is no
+  staging notion at all. Config is env-var driven via `CONFIG_SCHEMA`
+  (`app-config.ts:11`). A new explicit flag is therefore cleaner than
+  overloading `--dev`, because staging is not `--dev`.
+
+---
+
+## How the Python transcription endpoint produces partials (for fidelity)
+
+Not on the demo's critical path — the demo replaces this service — but it is the
+behavior the fixture imitates, so the demo looks like the real thing.
+
+- Endpoint: WebSocket `GET /transcription_stream/{provider_key}`
+  (`transcription_service/src/webserver/features/transcription_stream/…`). Client
+  sends `auth` → `config` → binary audio; server pushes JSON `transcript`
+  messages with the same `{final, in_progress}` shape (snake_case upstream;
+  the node boundary renames `in_progress` → `inProgress`).
+- Partial vs final is decided by **LocalAgree** (Liu et al. 2020) in
+  `shared/utils/local_agree/local_agree.py`: a segment is promoted to `final`
+  only once the last *N* Whisper hypotheses agree on it **and** it forms a
+  complete sentence; everything committed-but-not-yet-final, plus the newest raw
+  hypothesis, is emitted as `in_progress`. The newest hypothesis is the part
+  that visibly churns and rewrites itself between frames.
+
+The fixture emulates this at the utterance level: `progresstxt` is a **shorter,
+sometimes slightly wrong** hypothesis (heard ~halfway through), and `spoken` is
+the corrected final — mirroring "interim churns, final commits."
+
+---
+
+## The fixture (built)
+
+`fixtures/alice-chapter-v.utterances.json` — the spoken dialogue of *Alice's
+Adventures in Wonderland*, **Chapter V, "Advice from a Caterpillar"** (Project
+Gutenberg eBook #11, public domain), extracted from `#chap05` up to where
+`#chap06` begins. 121 utterances, ~6.7 min per loop, speakers
+`caterpillar` (24), `alice` (70, incl. her recital of *"You are old, Father
+William"*), `pigeon` (27).
+
+Each utterance is exactly the shape the request asked for:
+
+```json
+{ "start": 4.77, "end": 9.10, "speaker": "alice",
+  "spoken": "at least I know who I was when I got up this morning,",
+  "progresstxt": "at least I know who I was when I got" }
+```
+
+- `start`/`end` — seconds on the loop's virtual timeline.
+- Long speeches are split into ~2–5 s fragments at ~**3 words/second**
+  (`end-start = words/3`, min 1 s). A 0.3 s gap separates fragments of one turn;
+  a 0.8 s gap separates turns. Those gaps are the inter-phrase **pauses** — the
+  emitter sends nothing during them.
+- `progresstxt` is hand-authored per fragment: a truncated guess with occasional
+  realistic STT errors that the final corrects — e.g. *chrysalis* →
+  "crystal is", *size* → "sighs", *doth* → "does". Very short fragments
+  (`"No."`, `"Why?"`) have `progresstxt: ""` → no interim, just a final.
+
+The file carries its Gutenberg attribution in a top-level `source` block, and
+`generate-alice-chapter-v.py` (same dir) can regenerate it; the header of both
+credits Project Gutenberg. **Regenerating requires no network** — the dialogue
+is inlined in the generator.
+
+---
+
+## Design
+
+### One sentence
+
+At boot, **iff a demo flag is set**, the node server starts a `DemoCaptionSource`
+that loops the fixture forever and **publishes to `TranscriptChannel` for a
+fixed demo `sessionUid`**, while the Session Manager seeds a matching,
+open-ended session with a **stable join code** so the webapps can actually join
+that `sessionUid`.
+
+### Why publish at the orchestrator seam, not elsewhere
+
+- **Not** a fake source device streaming audio → that needs real audio + real
+  Whisper, i.e. the exact thing we're trying to avoid.
+- **Not** the Python `debug` provider → still needs a source connection to open
+  the session, and puts timing under Python's control.
+- Publishing `{final, inProgress}` to `transcript:${demoSessionUid}` is byte-for-
+  byte what the orchestrator already does (`…:403`). Client sockets, schema, and
+  all three webapps are untouched. This is the smallest honest seam.
+
+### Component A — node-server: `DemoCaptionSource` (new feature `demo-room/`)
+
+A singleton started from `create-server.ts` when the flag is on. It:
+
+1. Loads and validates the fixture once at boot (schema-checked;
+   monotonic non-overlapping `start`/`end`; `speaker ∈ {caterpillar,alice,pigeon}`).
+2. Runs a **virtual-clock scheduler**. For each utterance `u`, two events:
+   - at `u.start + (u.end - u.start) * 0.5` →
+     `publish(TranscriptChannel, { final: null, inProgress: frag(u.progresstxt, u) }, DEMO_SESSION_UID)`
+     (skipped when `progresstxt === ""`).
+   - at `u.end` →
+     `publish(TranscriptChannel, { final: frag(u.spoken, u), inProgress: null }, DEMO_SESSION_UID)`.
+   The gaps between utterances are dead air (the pauses). After the last
+   utterance, wait a short reset (~2 s) and restart at virtual `t=0`. **Infinite
+   repeat.**
+   - Use a self-correcting timer (compare against a monotonic base, `setTimeout`
+     to the next event's absolute deadline) rather than a fixed interval, so the
+     loop doesn't drift over hours.
+3. Makes the session look *healthy* to a joining client. The controller calls
+   `orchestrator.getStatus(sessionUid)` once on connect and renders
+   `transcriptionServiceConnected` / `sourceDeviceConnected`
+   (`transcription-stream.controller.ts`, then `client-session-service.ts:287`).
+   With no real source, a demo session reports "disconnected" and the UI shows
+   "waiting for source". Fix: give the orchestrator a
+   `registerSyntheticSession(sessionUid)` that installs a status-only entry so
+   `getStatus` returns both-true, and have `DemoCaptionSource` also publish
+   `SessionStatusChannel {transcriptionServiceConnected:true,
+   sourceDeviceConnected:true}` once at start. (Do **not** route the demo session
+   through `_openSession` — it must never dial the Python service.)
+
+`frag(text, u)` tokenizes `text` into word tokens (whitespace split, punctuation
+kept on the token, matching real fragments' word granularity) and returns
+`{ text, starts, ends }`. Recommended: fill `starts`/`ends` with per-token times
+spread evenly across the utterance window (`[start, mid]` for interim,
+`[mid, end]` for final) so word-timing displays and the latency panel have
+something real to show; `null` is an acceptable v1 shortcut.
+
+**Speaker handling (the schema gap).** Because no wire field carries a speaker,
+the demo prefixes the speaker onto the first token of each turn's first
+fragment, e.g. `text = ["Caterpillar: ", "Who", " are", " you?"]`. This is a
+demo-only convention, documented in the source; it is the honest way to make
+speaker changes visible given the current protocol. (If per-speaker rendering
+ever becomes a real product need, it belongs in the schema, not here — out of
+scope.)
+
+### Component B — Session Manager: seed a joinable demo session
+
+Gated by the same flag, at Session Manager boot, idempotently ensure:
+`registerDevice` → `createRoom("Demo — Alice in Wonderland")` →
+`createOnDemandSession` with `joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS']` (add
+`SEND_AUDIO` only if you also want to demo a source), reusing the exact recipe
+already proven in `tests/utils/seed-session.ts`. Two demo-specific requirements:
+
+- The session's `uid` must equal the node server's `DEMO_SESSION_UID` (shared
+  constant/env on both services — the token is verified against the URL
+  `sessionUid`, so they must match).
+- The session must be **open-ended / perpetually current** (no near
+  `effectiveEnd`), or the orchestrator's end timer / the join path will retire
+  it. Confirm `createOnDemandSession` supports an open-ended window; if not, the
+  seed re-materializes it, or a small "always-current demo session" affordance is
+  added. **(Open question — verify against schedule-management before building.)**
+- Publish a **stable, well-known join code** for dev/staging (e.g. `DEMO-ALICE`)
+  so the webapps can hardcode/prefill it. Since join codes normally rotate
+  (`session-auth.service.ts:108`), this needs either a fixed demo code path or a
+  dev endpoint/log line that surfaces the current code at boot.
+
+### Component C — the dev/staging flag
+
+Add `DEMO_ROOM_ENABLED: Type.Boolean({ default: false })` to node-server
+`CONFIG_SCHEMA` (`app-config.ts:11`) and an equivalent in the Session Manager
+config. Set it **true** in the dev compose / `.env.example` and in the
+**staging** deployment manifest under `deployment/`; leave it unset (false) in
+production. This keeps prod bytes unreachable by a real user and is independent
+of the `--dev` Swagger flag. A shared `DEMO_SESSION_UID` (fixed UUID) is set on
+both services in the same environments.
+
+### Emission cadence sanity check
+
+Most fragments are 1–5 s, each producing an interim at its midpoint and a final
+at its end — so a browser sees a new caption event **roughly every second**,
+punctuated by the 0.3–0.8 s inter-phrase pauses, which is exactly the requested
+"every second or so, with intermittent pauses."
+
+---
+
+## Files
+
+New (node-server) — **all built**:
+- `src/server/features/demo-room/demo-caption-source.ts` — scheduler + publisher.
+- `src/server/features/demo-room/demo-room.constants.ts` — `DEFAULT_DEMO_SESSION_UID`, tail-gap, speaker-prefix labels.
+- `src/server/features/demo-room/fixtures/alice-chapter-v.utterances.json` — the fixture.
+- `src/server/features/demo-room/fixtures/generate-alice-chapter-v.py` — regenerator (prettier the JSON after regenerating).
+- `src/server/features/demo-room/fixtures/alice-chapter-v.utterances.schema.json` — fixture JSON Schema (referenced by `$schema`).
+- `tests/unit/features/demo-room/demo-caption-source.test.ts`, `tests/unit/features/demo-room/demo-fixture.test.ts`, `tests/integration/features/demo-room/demo-room.routes.test.ts`.
+
+Changed (node-server) — **all built**:
+- `src/app-config/app-config.ts` — `DEMO_ROOM_ENABLED`, `DEMO_SESSION_UID`, `demoRoomConfig`.
+- `src/server/create-server.ts` — start/stop `DemoCaptionSource` on onReady/onClose when enabled.
+- `src/server/dependency-injection/{app-dependencies,register-dependencies}.ts` — register `demoRoomConfig` + `demoCaptionSource`.
+- `src/server/features/transcription-stream/transcription-orchestrator.service.ts`
+  — `registerSyntheticSession` + a `_syntheticStatuses` map so `getStatus` reports the demo session healthy without a fake `_sessions` entry.
+- `tsconfig.json` — `resolveJsonModule` + a fixtures JSON glob in `include` (esbuild inlines the fixture into `dist/bundle.mjs`).
+- `vitest.config.ts` — exclude `**/*.py` from coverage (the generator lives beside the fixture).
+- `tests/utils/use-server.ts` — default `demoRoomConfig` (off) so existing integration servers still boot.
+- `.env.example` — document the new vars.
+
+Session Manager — **remaining** (see Component B; delegated):
+- Config schema + `demoRoomConfig` getter; `.env.example` (vars already documented).
+- A boot-time seeder gated on the flag that inserts an open-ended `ON_DEMAND`
+  session with `uid === DEMO_SESSION_UID` (fixed-uid insert, since the normal
+  create path DB-generates the uid), ensures a current join code, and logs it.
+
+Deployment — **built**:
+- `deployment/compose.yml` passes `DEMO_ROOM_ENABLED` (default false) +
+  `DEMO_SESSION_UID` to both services; `deployment/.env.example` documents them.
+  The repo has a single compose for all environments, so dev/staging enable it
+  via their own untracked `.env`; prod never sets it.
+
+---
+
+## Tests
+
+- **Fixture validation (unit):** parses; `start < end`; non-overlapping and
+  monotonic; every `speaker` in the allowed set; `spoken` non-empty. (The
+  generator already asserts no overlaps — mirror it as a committed test so the
+  checked-in JSON can't rot.)
+- **Scheduler (unit, fake clock):** for a 2–3 utterance fixture, asserts the
+  event order interim(progresstxt)→final(spoken) per utterance; that
+  `inProgress` is null on the final and `final` is null on the interim; that
+  empty `progresstxt` emits no interim; and that the loop wraps back to `t=0`.
+- **Speaker prefix (unit):** first fragment of a turn carries the
+  `"Speaker: "` token; continuations do not.
+- **Integration:** with the flag on, a client socket authed for
+  `DEMO_SESSION_UID` receives `transcript` messages and a healthy
+  `sessionStatus`, without any source connection or Python service — the demo's
+  whole point, asserted.
+
+---
+
+## Risks & limitations
+
+1. **No speaker field on the wire.** Speaker is folded into `text`. Anything
+   wanting structured per-speaker data needs a schema change; explicitly out of
+   scope.
+2. **Multi-instance.** Client sockets are sticky-routed by `sessionUid`, so a
+   joining browser lands on one node instance and sees that instance's loop.
+   Every instance runs its own loop, so different instances are **not** phase-
+   aligned — acceptable for a demo, but note it (a viewer who reconnects and is
+   rerouted may jump in the script).
+3. **Stable join code vs rotation.** Join codes normally rotate; a fixed demo
+   code is a dev/staging-only affordance and must not leak into prod (the flag
+   guards it).
+4. **Open-ended session.** The seeded session must not hit `effectiveEnd`.
+   Verify `createOnDemandSession` supports this before building (open question
+   above).
+5. **Prod safety.** The entire feature is unreachable unless `DEMO_ROOM_ENABLED`
+   is set; default false on both services. No prod code path publishes to
+   `TranscriptChannel` except the real orchestrator.
+
+## Attribution
+
+Source text: *Alice's Adventures in Wonderland* by Lewis Carroll, Chapter V,
+**Project Gutenberg eBook #11** — public domain. Attribution is carried in the
+fixture's `source` block, in the generator header, and must be repeated in the
+`DemoCaptionSource` source file header.

--- a/apps/node-server/package.json
+++ b/apps/node-server/package.json
@@ -15,8 +15,8 @@
     "dev": "tsc --build && concurrently -k \"tsc --build --watch\" \"node --watch-path=dist dist/src/index.js --dev | pino-pretty\"",
     "format": "prettier --check ./src",
     "format:fix": "prettier --write ./src",
-    "lint": "eslint ./src",
-    "lint:fix": "eslint ./src --fix",
+    "lint": "eslint ./src ./tests",
+    "lint:fix": "eslint ./src ./tests --fix",
     "test:dev": "vitest --ui --coverage",
     "test:integration": "vitest run --project integration",
     "test:unit": "vitest run --project unit"

--- a/apps/node-server/src/app-config/app-config.ts
+++ b/apps/node-server/src/app-config/app-config.ts
@@ -5,6 +5,7 @@ import type { Static } from 'typebox';
 
 import { LogLevel } from '@scribear/base-fastify-server';
 
+import { DEFAULT_DEMO_SESSION_UID } from '#src/server/features/demo-room/demo-room.constants.js';
 import type { ServiceAuthConfig } from '#src/server/shared/services/service-auth.service.js';
 import type { SessionTokenConfig } from '#src/server/shared/services/session-token.service.js';
 
@@ -23,6 +24,15 @@ const CONFIG_SCHEMA = Type.Object({
   // is what keeps a deployment that predates B1.7 booting unchanged.
   REDIS_URL: Type.String({ default: '' }),
   NODE_INSTANCE_ID: Type.String({ default: '' }),
+  // Dev/staging-only demo caption room (see PLAN-Demo-CAPTION_ROOM.md). Off by
+  // default so a production instance never emits synthetic captions; enabled
+  // explicitly in the dev and staging deployments. env-schema coerces the
+  // strings "true"/"false" only - "1"/"0"/"" are rejected at boot.
+  DEMO_ROOM_ENABLED: Type.Boolean({ default: false }),
+  // Session UID the demo captions are published for. Must match the session the
+  // Session Manager seeds, so both services default to (and are configured
+  // with) the same value.
+  DEMO_SESSION_UID: Type.String({ default: DEFAULT_DEMO_SESSION_UID }),
 });
 
 export interface BaseConfig {
@@ -40,6 +50,13 @@ export interface SessionManagerClientConfig {
 export interface TranscriptionServiceClientConfig {
   baseUrl: string;
   apiKey: string;
+}
+
+export interface DemoRoomConfig {
+  /** When false, the demo caption source is never constructed or started. */
+  enabled: boolean;
+  /** Session UID captions are published for; matches the seeded session. */
+  sessionUid: string;
 }
 
 export interface TelemetryPublisherConfig {
@@ -75,6 +92,13 @@ export class AppConfig {
   get serviceAuthConfig(): ServiceAuthConfig {
     return {
       serviceApiKey: this._env.NODE_SERVER_SERVICE_API_KEY,
+    };
+  }
+
+  get demoRoomConfig(): DemoRoomConfig {
+    return {
+      enabled: this._env.DEMO_ROOM_ENABLED,
+      sessionUid: this._env.DEMO_SESSION_UID,
     };
   }
 

--- a/apps/node-server/src/server/create-server.ts
+++ b/apps/node-server/src/server/create-server.ts
@@ -53,6 +53,22 @@ async function createServer(config: AppConfig) {
     );
   }
 
+  // Demo caption room (dev/staging only). Resolved solely when enabled so a
+  // production instance never constructs it. It publishes a looping synthetic
+  // caption stream for the demo session; see PLAN-Demo-CAPTION_ROOM.md.
+  if (config.demoRoomConfig.enabled) {
+    const demoCaptionSource =
+      dependencyContainer.resolve<AppDependencies['demoCaptionSource']>(
+        'demoCaptionSource',
+      );
+    fastify.addHook('onReady', () => {
+      demoCaptionSource.start();
+    });
+    fastify.addHook('onClose', () => {
+      demoCaptionSource.stop();
+    });
+  }
+
   return { logger, fastify };
 }
 

--- a/apps/node-server/src/server/dependency-injection/app-dependencies.ts
+++ b/apps/node-server/src/server/dependency-injection/app-dependencies.ts
@@ -9,10 +9,12 @@ import type { TranscriptionServiceClient } from '@scribear/transcription-service
 import type {
   AppConfig,
   BaseConfig,
+  DemoRoomConfig,
   SessionManagerClientConfig,
   TelemetryPublisherConfig,
   TranscriptionServiceClientConfig,
 } from '#src/app-config/app-config.js';
+import type { DemoCaptionSource } from '#src/server/features/demo-room/demo-caption-source.js';
 import type { LivenessController } from '#src/server/features/probes/liveness.controller.js';
 import type { ReadinessController } from '#src/server/features/probes/readiness.controller.js';
 import type { StatusController } from '#src/server/features/status/status.controller.js';
@@ -45,6 +47,7 @@ interface AppDependencies extends BaseDependencies {
   sessionManagerClientConfig: SessionManagerClientConfig;
   transcriptionServiceClientConfig: TranscriptionServiceClientConfig;
   telemetryPublisherConfig: TelemetryPublisherConfig;
+  demoRoomConfig: DemoRoomConfig;
 
   // Shared services
   serviceAuthService: ServiceAuthService;
@@ -72,6 +75,9 @@ interface AppDependencies extends BaseDependencies {
   sessionConfigPollFactory: SessionConfigPollFactory;
   transcriptionOrchestratorService: TranscriptionOrchestratorService;
   transcriptionStreamController: TranscriptionStreamController;
+
+  // Demo caption room (dev/staging only)
+  demoCaptionSource: DemoCaptionSource;
 }
 
 /**

--- a/apps/node-server/src/server/dependency-injection/register-dependencies.ts
+++ b/apps/node-server/src/server/dependency-injection/register-dependencies.ts
@@ -16,6 +16,7 @@ import {
 } from '@scribear/session-manager-schema';
 import { createTranscriptionServiceClient } from '@scribear/transcription-service-client';
 
+import { DemoCaptionSource } from '#src/server/features/demo-room/demo-caption-source.js';
 import { LivenessController } from '#src/server/features/probes/liveness.controller.js';
 import { ReadinessController } from '#src/server/features/probes/readiness.controller.js';
 import { StatusController } from '#src/server/features/status/status.controller.js';
@@ -51,6 +52,7 @@ function registerDependencies(
       config.transcriptionServiceClientConfig,
     ),
     telemetryPublisherConfig: asValue(config.telemetryPublisherConfig),
+    demoRoomConfig: asValue(config.demoRoomConfig),
 
     // Shared services
     serviceAuthService: asClass(ServiceAuthService, {
@@ -151,6 +153,13 @@ function registerDependencies(
     ),
     transcriptionStreamController: asClass(TranscriptionStreamController, {
       lifetime: Lifetime.SCOPED,
+    }),
+
+    // Demo caption room (dev/staging only). Constructed regardless, but a no-op
+    // unless `demoRoomConfig.enabled`; `createServer` only resolves and starts
+    // it when the flag is set.
+    demoCaptionSource: asClass(DemoCaptionSource, {
+      lifetime: Lifetime.SINGLETON,
     }),
   } as NameAndRegistrationPair<AppDependencies>);
 }

--- a/apps/node-server/src/server/features/demo-room/demo-caption-source.ts
+++ b/apps/node-server/src/server/features/demo-room/demo-caption-source.ts
@@ -1,0 +1,263 @@
+import type { TranscriptFragment } from '@scribear/node-server-schema';
+
+import type { DemoRoomConfig } from '#src/app-config/app-config.js';
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+import { SessionStatusChannel } from '#src/server/features/transcription-stream/events/session-status.events.js';
+import {
+  TranscriptChannel,
+  type TranscriptMessage,
+} from '#src/server/features/transcription-stream/events/transcript.events.js';
+
+import {
+  DEMO_LOOP_TAIL_GAP_MS,
+  DEMO_SPEAKER_LABELS,
+} from './demo-room.constants.js';
+// The fixture is inlined into the bundle by esbuild at build time (only
+// `dist/bundle.mjs` ships), so no file is read at runtime. Source & licence:
+// Alice's Adventures in Wonderland, Chapter V, Project Gutenberg eBook #11
+// (public domain). See the fixture's `source` block and PLAN-Demo-CAPTION_ROOM.md.
+import demoFixture from './fixtures/alice-chapter-v.utterances.json' with { type: 'json' };
+
+/** One utterance from the fixture (the fields the emitter reads). */
+interface DemoUtterance {
+  start: number;
+  end: number;
+  speaker: string;
+  spoken: string;
+  progresstxt: string;
+}
+
+/** A single caption publish scheduled at `atMs` on the loop's virtual clock. */
+interface ScheduledEvent {
+  atMs: number;
+  message: TranscriptMessage;
+}
+
+const UTTERANCES =
+  demoFixture.utterances as unknown as readonly DemoUtterance[];
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/** Display label for a speaker, capitalized as a fallback for unknown names. */
+function speakerLabel(speaker: string): string {
+  return (
+    DEMO_SPEAKER_LABELS[speaker] ??
+    speaker.charAt(0).toUpperCase() + speaker.slice(1)
+  );
+}
+
+/**
+ * Turn one utterance's text into a wire {@link TranscriptFragment}: word tokens
+ * (each carrying its leading space, so `text.join('')` reconstructs the string)
+ * with per-token times spread evenly across `[startS, endS]`.
+ *
+ * On the first fragment of a speaker turn the speaker label is folded into the
+ * leading token (`"Caterpillar: "`), because the wire schema carries no speaker
+ * field - a demo-only convention documented in PLAN-Demo-CAPTION_ROOM.md.
+ */
+export function buildFragment(
+  text: string,
+  speaker: string,
+  turnStart: boolean,
+  startS: number,
+  endS: number,
+): TranscriptFragment {
+  const display = turnStart ? `${speakerLabel(speaker)}: ${text}` : text;
+  const words = display.split(/\s+/).filter((word) => word.length > 0);
+  const tokens = words.map((word, index) => (index === 0 ? word : ` ${word}`));
+
+  const span = Math.max(0.001, endS - startS);
+  const starts: number[] = [];
+  const ends: number[] = [];
+  for (let index = 0; index < tokens.length; index++) {
+    starts.push(round2(startS + (span * index) / tokens.length));
+    ends.push(round2(startS + (span * (index + 1)) / tokens.length));
+  }
+
+  return { text: tokens, starts, ends };
+}
+
+/**
+ * Compile the fixture into a time-ordered list of caption publishes for one
+ * pass, plus the total loop length.
+ *
+ * Per utterance: an interim caption (`inProgress = progresstxt`) at the halfway
+ * point - skipped when `progresstxt` is empty - then a final caption
+ * (`final = spoken`, `inProgress = null`) at `end`. This mirrors the real
+ * pipeline's "interim replaces, final commits" contract
+ * (`transcription-content-store`), so the browser sees a guess that is then
+ * corrected. The gaps between utterances are dead air: the inter-phrase pauses.
+ */
+export function buildDemoSchedule(utterances: readonly DemoUtterance[]): {
+  events: ScheduledEvent[];
+  loopMs: number;
+} {
+  const events: ScheduledEvent[] = [];
+  let previousSpeaker: string | null = null;
+
+  for (const utterance of utterances) {
+    const turnStart = utterance.speaker !== previousSpeaker;
+    previousSpeaker = utterance.speaker;
+
+    const durationS = Math.max(0, utterance.end - utterance.start);
+    const midpointS = utterance.start + durationS / 2;
+
+    if (utterance.progresstxt.trim() !== '') {
+      events.push({
+        atMs: Math.round(midpointS * 1000),
+        message: {
+          final: null,
+          inProgress: buildFragment(
+            utterance.progresstxt,
+            utterance.speaker,
+            turnStart,
+            utterance.start,
+            midpointS,
+          ),
+        },
+      });
+    }
+
+    events.push({
+      atMs: Math.round(utterance.end * 1000),
+      message: {
+        final: buildFragment(
+          utterance.spoken,
+          utterance.speaker,
+          turnStart,
+          utterance.start,
+          utterance.end,
+        ),
+        inProgress: null,
+      },
+    });
+  }
+
+  events.sort((a, b) => a.atMs - b.atMs);
+  const lastAtMs = events.reduce((max, event) => Math.max(max, event.atMs), 0);
+  return { events, loopMs: lastAtMs + DEMO_LOOP_TAIL_GAP_MS };
+}
+
+/**
+ * Dev/staging-only source of a self-contained, looping caption stream.
+ *
+ * When enabled, it publishes the compiled fixture to `TranscriptChannel` for
+ * the demo session on a self-correcting virtual clock - exactly the channel the
+ * orchestrator publishes real transcripts on - so every client subscribed to
+ * the demo session receives captions with no audio, no source device, and no
+ * upstream transcription service. It also registers a synthetic "healthy"
+ * status for the session so a joining browser is not told to wait for a source.
+ *
+ * The loop repeats forever. It is never constructed when the feature is off
+ * (see `create-server.ts`), so a production instance carries no demo behaviour.
+ */
+export class DemoCaptionSource {
+  private readonly _logger: AppDependencies['logger'];
+  private readonly _eventBus: AppDependencies['eventBusService'];
+  private readonly _orchestrator: AppDependencies['transcriptionOrchestratorService'];
+  private readonly _config: DemoRoomConfig;
+
+  private _events: ScheduledEvent[] = [];
+  private _loopMs = 0;
+  /** Wall-clock ms mapped to virtual time 0 for the current loop pass. */
+  private _baseMs = 0;
+  private _timer: ReturnType<typeof setTimeout> | null = null;
+  private _stopped = false;
+
+  constructor(
+    logger: AppDependencies['logger'],
+    eventBusService: AppDependencies['eventBusService'],
+    transcriptionOrchestratorService: AppDependencies['transcriptionOrchestratorService'],
+    demoRoomConfig: DemoRoomConfig,
+  ) {
+    this._logger = logger;
+    this._eventBus = eventBusService;
+    this._orchestrator = transcriptionOrchestratorService;
+    this._config = demoRoomConfig;
+  }
+
+  /**
+   * Begin looping the fixture. No-op when the feature is disabled or the
+   * fixture compiles to no events. Safe to call once at boot.
+   */
+  start(): void {
+    if (!this._config.enabled) return;
+
+    const { events, loopMs } = buildDemoSchedule(UTTERANCES);
+    if (events.length === 0) {
+      this._logger.warn(
+        'demo caption room enabled but the fixture produced no events; not starting',
+      );
+      return;
+    }
+    this._events = events;
+    this._loopMs = loopMs;
+
+    // Make the session report healthy to clients that authenticate after the
+    // loop starts (the controller reads getStatus once on connect) and to any
+    // already-connected client (via the bus).
+    const status = {
+      transcriptionServiceConnected: true,
+      sourceDeviceConnected: true,
+    };
+    this._orchestrator.registerSyntheticSession(
+      this._config.sessionUid,
+      status,
+    );
+    this._eventBus.publish(
+      SessionStatusChannel,
+      status,
+      this._config.sessionUid,
+    );
+
+    this._baseMs = Date.now();
+    this._logger.info(
+      {
+        sessionUid: this._config.sessionUid,
+        utterances: UTTERANCES.length,
+        events: events.length,
+        loopSeconds: round2(loopMs / 1000),
+      },
+      'demo caption room started (Alice in Wonderland Ch. V, Project Gutenberg #11)',
+    );
+    this._run(0);
+  }
+
+  /** Stop the loop and release the pending timer. Idempotent. */
+  stop(): void {
+    this._stopped = true;
+    if (this._timer !== null) {
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+  }
+
+  /**
+   * Schedule event `index` (or the loop wrap when `index` is past the end)
+   * against `_baseMs`, so per-event delays never accumulate drift.
+   */
+  private _run(index: number): void {
+    if (this._stopped) return;
+
+    const event = this._events[index]; // undefined at the loop-wrap boundary
+    const targetMs = event ? event.atMs : this._loopMs;
+    const delayMs = Math.max(0, this._baseMs + targetMs - Date.now());
+
+    this._timer = setTimeout(() => {
+      if (this._stopped) return;
+      if (event) {
+        this._eventBus.publish(
+          TranscriptChannel,
+          event.message,
+          this._config.sessionUid,
+        );
+        this._run(index + 1);
+      } else {
+        this._baseMs += this._loopMs;
+        this._run(0);
+      }
+    }, delayMs);
+  }
+}

--- a/apps/node-server/src/server/features/demo-room/demo-room.constants.ts
+++ b/apps/node-server/src/server/features/demo-room/demo-room.constants.ts
@@ -1,0 +1,33 @@
+/**
+ * Fixed identity of the demo caption session.
+ *
+ * The Session Manager seeds a session whose `uid` is exactly this value (see
+ * `apps/node-server/PLAN-Demo-CAPTION_ROOM.md`), so a browser can join it
+ * through the normal join-code flow, and {@link DemoCaptionSource} publishes
+ * captions on the matching `transcript:${sessionUid}` bus channel. The two
+ * services are kept in sync by the `DEMO_SESSION_UID` env var, which defaults
+ * to this literal on both.
+ *
+ * `deadbeef` is a memorable, valid hex UUID node; the `4` and `8` nibbles keep
+ * it a well-formed v4 UUID so it passes the `format: 'uuid'` param check on the
+ * transcription-stream route.
+ */
+export const DEFAULT_DEMO_SESSION_UID = 'deadbeef-0000-4000-8000-000000000001';
+
+/**
+ * Gap after the final utterance of a loop before the fixture restarts, so a
+ * viewer perceives a natural pause rather than an instant jump back to the top.
+ */
+export const DEMO_LOOP_TAIL_GAP_MS = 2_000;
+
+/**
+ * Display labels prefixed onto the first token of each speaker turn. The wire
+ * caption schema has no speaker field, so speaker identity is carried inside
+ * the caption text; this is a demo-only convention. Speakers not listed fall
+ * back to a capitalized form of the raw speaker string.
+ */
+export const DEMO_SPEAKER_LABELS: Record<string, string> = {
+  caterpillar: 'Caterpillar',
+  alice: 'Alice',
+  pigeon: 'Pigeon',
+};

--- a/apps/node-server/src/server/features/demo-room/fixtures/alice-chapter-v.utterances.json
+++ b/apps/node-server/src/server/features/demo-room/fixtures/alice-chapter-v.utterances.json
@@ -1,0 +1,870 @@
+{
+  "$schema": "./alice-chapter-v.utterances.schema.json",
+  "source": {
+    "title": "Alice's Adventures in Wonderland",
+    "author": "Lewis Carroll",
+    "chapter": "Chapter V — Advice from a Caterpillar",
+    "attribution": "Project Gutenberg eBook #11 (public domain).",
+    "url": "https://www.gutenberg.org/files/11/11-h/11-h.htm#chap05",
+    "note": "Spoken dialogue only, extracted from #chap05 up to where #chap06 begins. Text is in the public domain; this fixture is for local/dev caption playback."
+  },
+  "timing": {
+    "wordsPerSecond": 3.0,
+    "gapWithinTurnSeconds": 0.3,
+    "gapBetweenTurnsSeconds": 0.8,
+    "progressEmittedAtFractionOfDuration": 0.5
+  },
+  "speakers": ["caterpillar", "alice", "pigeon"],
+  "loop": true,
+  "totalDurationSeconds": 404.97,
+  "utteranceCount": 121,
+  "utterances": [
+    {
+      "start": 0.0,
+      "end": 1.0,
+      "speaker": "caterpillar",
+      "spoken": "Who are you?",
+      "progresstxt": "who are"
+    },
+    {
+      "start": 1.8,
+      "end": 4.47,
+      "speaker": "alice",
+      "spoken": "I—I hardly know, sir, just at present—",
+      "progresstxt": "I hardly know sir just at"
+    },
+    {
+      "start": 4.77,
+      "end": 9.1,
+      "speaker": "alice",
+      "spoken": "at least I know who I was when I got up this morning,",
+      "progresstxt": "at least I know who I was when I got"
+    },
+    {
+      "start": 9.4,
+      "end": 13.4,
+      "speaker": "alice",
+      "spoken": "but I think I must have been changed several times since then.",
+      "progresstxt": "but I think I must have been changed"
+    },
+    {
+      "start": 14.2,
+      "end": 16.87,
+      "speaker": "caterpillar",
+      "spoken": "What do you mean by that? Explain yourself!",
+      "progresstxt": "what do you mean by that"
+    },
+    {
+      "start": 17.67,
+      "end": 20.0,
+      "speaker": "alice",
+      "spoken": "I can't explain myself, I'm afraid, sir,",
+      "progresstxt": "I can't explain myself I'm afraid"
+    },
+    {
+      "start": 20.3,
+      "end": 22.3,
+      "speaker": "alice",
+      "spoken": "because I'm not myself, you see.",
+      "progresstxt": "because I'm not myself you"
+    },
+    {
+      "start": 23.1,
+      "end": 24.1,
+      "speaker": "caterpillar",
+      "spoken": "I don't see.",
+      "progresstxt": "I don't"
+    },
+    {
+      "start": 24.9,
+      "end": 27.57,
+      "speaker": "alice",
+      "spoken": "I'm afraid I can't put it more clearly,",
+      "progresstxt": "I'm afraid I can't put it more"
+    },
+    {
+      "start": 27.87,
+      "end": 30.87,
+      "speaker": "alice",
+      "spoken": "for I can't understand it myself to begin with;",
+      "progresstxt": "for I can't understand it myself to"
+    },
+    {
+      "start": 31.17,
+      "end": 35.17,
+      "speaker": "alice",
+      "spoken": "and being so many different sizes in a day is very confusing.",
+      "progresstxt": "and being so many different sizes in a day"
+    },
+    {
+      "start": 35.97,
+      "end": 36.97,
+      "speaker": "caterpillar",
+      "spoken": "It isn't.",
+      "progresstxt": ""
+    },
+    {
+      "start": 37.77,
+      "end": 40.44,
+      "speaker": "alice",
+      "spoken": "Well, perhaps you haven't found it so yet,",
+      "progresstxt": "well perhaps you haven't found it so"
+    },
+    {
+      "start": 40.74,
+      "end": 45.74,
+      "speaker": "alice",
+      "spoken": "but when you have to turn into a chrysalis—you will some day, you know—",
+      "progresstxt": "but when you have to turn into a crystal is you will"
+    },
+    {
+      "start": 46.04,
+      "end": 48.37,
+      "speaker": "alice",
+      "spoken": "and then after that into a butterfly,",
+      "progresstxt": "and then after that into a butter"
+    },
+    {
+      "start": 48.67,
+      "end": 52.34,
+      "speaker": "alice",
+      "spoken": "I should think you'll feel it a little queer, won't you?",
+      "progresstxt": "I should think you'll feel it a little queer"
+    },
+    {
+      "start": 53.14,
+      "end": 54.14,
+      "speaker": "caterpillar",
+      "spoken": "Not a bit.",
+      "progresstxt": "not a"
+    },
+    {
+      "start": 54.94,
+      "end": 57.27,
+      "speaker": "alice",
+      "spoken": "Well, perhaps your feelings may be different,",
+      "progresstxt": "well perhaps your feelings may be"
+    },
+    {
+      "start": 57.57,
+      "end": 61.24,
+      "speaker": "alice",
+      "spoken": "all I know is, it would feel very queer to me.",
+      "progresstxt": "all I know is it would feel very"
+    },
+    {
+      "start": 62.04,
+      "end": 63.37,
+      "speaker": "caterpillar",
+      "spoken": "You! Who are you?",
+      "progresstxt": "you who are"
+    },
+    {
+      "start": 64.17,
+      "end": 67.84,
+      "speaker": "alice",
+      "spoken": "I think, you ought to tell me who you are, first.",
+      "progresstxt": "I think you ought to tell me who you"
+    },
+    {
+      "start": 68.64,
+      "end": 69.64,
+      "speaker": "caterpillar",
+      "spoken": "Why?",
+      "progresstxt": ""
+    },
+    {
+      "start": 70.44,
+      "end": 71.44,
+      "speaker": "caterpillar",
+      "spoken": "Come back!",
+      "progresstxt": ""
+    },
+    {
+      "start": 71.74,
+      "end": 73.41,
+      "speaker": "caterpillar",
+      "spoken": "I've something important to say!",
+      "progresstxt": "I've something important to"
+    },
+    {
+      "start": 74.21,
+      "end": 75.21,
+      "speaker": "caterpillar",
+      "spoken": "Keep your temper.",
+      "progresstxt": "keep your"
+    },
+    {
+      "start": 76.01,
+      "end": 77.01,
+      "speaker": "alice",
+      "spoken": "Is that all?",
+      "progresstxt": "is that"
+    },
+    {
+      "start": 77.81,
+      "end": 78.81,
+      "speaker": "caterpillar",
+      "spoken": "No.",
+      "progresstxt": ""
+    },
+    {
+      "start": 79.61,
+      "end": 81.94,
+      "speaker": "caterpillar",
+      "spoken": "So you think you're changed, do you?",
+      "progresstxt": "so you think you're changed"
+    },
+    {
+      "start": 82.74,
+      "end": 84.41,
+      "speaker": "alice",
+      "spoken": "I'm afraid I am, sir,",
+      "progresstxt": "I'm afraid I am"
+    },
+    {
+      "start": 84.71,
+      "end": 87.04,
+      "speaker": "alice",
+      "spoken": "I can't remember things as I used—",
+      "progresstxt": "I can't remember things as I"
+    },
+    {
+      "start": 87.34,
+      "end": 91.01,
+      "speaker": "alice",
+      "spoken": "and I don't keep the same size for ten minutes together!",
+      "progresstxt": "and I don't keep the same sighs for ten"
+    },
+    {
+      "start": 91.81,
+      "end": 93.14,
+      "speaker": "caterpillar",
+      "spoken": "Can't remember what things?",
+      "progresstxt": "can't remember what"
+    },
+    {
+      "start": 93.94,
+      "end": 97.61,
+      "speaker": "alice",
+      "spoken": "Well, I've tried to say \"How doth the little busy bee,\"",
+      "progresstxt": "well I've tried to say how does the little busy"
+    },
+    {
+      "start": 97.91,
+      "end": 99.58,
+      "speaker": "alice",
+      "spoken": "but it all came different!",
+      "progresstxt": "but it all came"
+    },
+    {
+      "start": 100.38,
+      "end": 102.38,
+      "speaker": "caterpillar",
+      "spoken": "Repeat, 'You are old, Father William,'",
+      "progresstxt": "repeat you are old father"
+    },
+    {
+      "start": 103.18,
+      "end": 108.51,
+      "speaker": "alice",
+      "spoken": "\"You are old, Father William,\" the young man said, \"And your hair has become very white;",
+      "progresstxt": "you are old father william the young man said and your"
+    },
+    {
+      "start": 108.81,
+      "end": 114.48,
+      "speaker": "alice",
+      "spoken": "And yet you incessantly stand on your head— Do you think, at your age, it is right?\"",
+      "progresstxt": "and yet you incessantly stand on your head do you think"
+    },
+    {
+      "start": 114.78,
+      "end": 120.11,
+      "speaker": "alice",
+      "spoken": "\"In my youth,\" Father William replied to his son, \"I feared it might injure the brain;",
+      "progresstxt": "in my youth father william replied to his son I feared"
+    },
+    {
+      "start": 120.41,
+      "end": 125.74,
+      "speaker": "alice",
+      "spoken": "But, now that I'm perfectly sure I have none, Why, I do it again and again.\"",
+      "progresstxt": "but now that I'm perfectly sure I have none why I"
+    },
+    {
+      "start": 126.04,
+      "end": 131.37,
+      "speaker": "alice",
+      "spoken": "\"You are old,\" said the youth, \"as I mentioned before, And have grown most uncommonly fat;",
+      "progresstxt": "you are old said the youth as I mentioned before and"
+    },
+    {
+      "start": 131.67,
+      "end": 137.0,
+      "speaker": "alice",
+      "spoken": "Yet you turned a back-somersault in at the door— Pray, what is the reason of that?\"",
+      "progresstxt": "yet you turned a back somersault in at the door pray"
+    },
+    {
+      "start": 137.3,
+      "end": 143.63,
+      "speaker": "alice",
+      "spoken": "\"In my youth,\" said the sage, as he shook his grey locks, \"I kept all my limbs very supple",
+      "progresstxt": "in my youth said the sage as he shook his grey"
+    },
+    {
+      "start": 143.93,
+      "end": 149.6,
+      "speaker": "alice",
+      "spoken": "By the use of this ointment—one shilling the box— Allow me to sell you a couple?\"",
+      "progresstxt": "by the use of this ointment one shilling the box allow"
+    },
+    {
+      "start": 149.9,
+      "end": 155.57,
+      "speaker": "alice",
+      "spoken": "\"You are old,\" said the youth, \"and your jaws are too weak For anything tougher than suet;",
+      "progresstxt": "you are old said the youth and your jaws are too"
+    },
+    {
+      "start": 155.87,
+      "end": 162.2,
+      "speaker": "alice",
+      "spoken": "Yet you finished the goose, with the bones and the beak— Pray, how did you manage to do it?\"",
+      "progresstxt": "yet you finished the goose with the bones and the beak"
+    },
+    {
+      "start": 162.5,
+      "end": 168.5,
+      "speaker": "alice",
+      "spoken": "\"In my youth,\" said his father, \"I took to the law, And argued each case with my wife;",
+      "progresstxt": "in my youth said his father I took to the law"
+    },
+    {
+      "start": 168.8,
+      "end": 174.47,
+      "speaker": "alice",
+      "spoken": "And the muscular strength, which it gave to my jaw, Has lasted the rest of my life.\"",
+      "progresstxt": "and the muscular strength which it gave to my jaw has"
+    },
+    {
+      "start": 174.77,
+      "end": 180.77,
+      "speaker": "alice",
+      "spoken": "\"You are old,\" said the youth, \"one would hardly suppose That your eye was as steady as ever;",
+      "progresstxt": "you are old said the youth one would hardly suppose that"
+    },
+    {
+      "start": 181.07,
+      "end": 186.74,
+      "speaker": "alice",
+      "spoken": "Yet you balanced an eel on the end of your nose— What made you so awfully clever?\"",
+      "progresstxt": "yet you balanced an eel on the end of your nose"
+    },
+    {
+      "start": 187.04,
+      "end": 192.37,
+      "speaker": "alice",
+      "spoken": "\"I have answered three questions, and that is enough,\" Said his father; \"don't give yourself airs!",
+      "progresstxt": "I have answered three questions and that is enough said his"
+    },
+    {
+      "start": 192.67,
+      "end": 199.0,
+      "speaker": "alice",
+      "spoken": "Do you think I can listen all day to such stuff? Be off, or I'll kick you down stairs!\"",
+      "progresstxt": "do you think I can listen all day to such stuff"
+    },
+    {
+      "start": 199.8,
+      "end": 201.47,
+      "speaker": "caterpillar",
+      "spoken": "That is not said right.",
+      "progresstxt": "that is not said"
+    },
+    {
+      "start": 202.27,
+      "end": 203.94,
+      "speaker": "alice",
+      "spoken": "Not quite right, I'm afraid,",
+      "progresstxt": "not quite right I'm"
+    },
+    {
+      "start": 204.24,
+      "end": 206.57,
+      "speaker": "alice",
+      "spoken": "some of the words have got altered.",
+      "progresstxt": "some of the words have got"
+    },
+    {
+      "start": 207.37,
+      "end": 209.7,
+      "speaker": "caterpillar",
+      "spoken": "It is wrong from beginning to end.",
+      "progresstxt": "it is wrong from beginning"
+    },
+    {
+      "start": 210.5,
+      "end": 212.83,
+      "speaker": "caterpillar",
+      "spoken": "What size do you want to be?",
+      "progresstxt": "what size do you want"
+    },
+    {
+      "start": 213.63,
+      "end": 215.96,
+      "speaker": "alice",
+      "spoken": "Oh, I'm not particular as to size,",
+      "progresstxt": "oh I'm not particular as to"
+    },
+    {
+      "start": 216.26,
+      "end": 219.26,
+      "speaker": "alice",
+      "spoken": "only one doesn't like changing so often, you know.",
+      "progresstxt": "only one doesn't like changing so often"
+    },
+    {
+      "start": 220.06,
+      "end": 221.06,
+      "speaker": "caterpillar",
+      "spoken": "I don't know.",
+      "progresstxt": "I don't"
+    },
+    {
+      "start": 221.86,
+      "end": 223.19,
+      "speaker": "caterpillar",
+      "spoken": "Are you content now?",
+      "progresstxt": "are you content"
+    },
+    {
+      "start": 223.99,
+      "end": 227.32,
+      "speaker": "alice",
+      "spoken": "Well, I should like to be a little larger, sir,",
+      "progresstxt": "well I should like to be a little larger"
+    },
+    {
+      "start": 227.62,
+      "end": 228.95,
+      "speaker": "alice",
+      "spoken": "if you wouldn't mind,",
+      "progresstxt": "if you wouldn't"
+    },
+    {
+      "start": 229.25,
+      "end": 232.25,
+      "speaker": "alice",
+      "spoken": "three inches is such a wretched height to be.",
+      "progresstxt": "three inches is such a wretched height"
+    },
+    {
+      "start": 233.05,
+      "end": 235.38,
+      "speaker": "caterpillar",
+      "spoken": "It is a very good height indeed!",
+      "progresstxt": "it is a very good height"
+    },
+    {
+      "start": 236.18,
+      "end": 238.18,
+      "speaker": "alice",
+      "spoken": "But I'm not used to it!",
+      "progresstxt": "but I'm not used to"
+    },
+    {
+      "start": 238.98,
+      "end": 241.31,
+      "speaker": "caterpillar",
+      "spoken": "You'll get used to it in time.",
+      "progresstxt": "you'll get used to it in"
+    },
+    {
+      "start": 242.11,
+      "end": 244.44,
+      "speaker": "caterpillar",
+      "spoken": "One side will make you grow taller,",
+      "progresstxt": "one side will make you grow"
+    },
+    {
+      "start": 244.74,
+      "end": 247.74,
+      "speaker": "caterpillar",
+      "spoken": "and the other side will make you grow shorter.",
+      "progresstxt": "and the other side will make you grow"
+    },
+    {
+      "start": 248.54,
+      "end": 249.54,
+      "speaker": "caterpillar",
+      "spoken": "Of the mushroom.",
+      "progresstxt": "of the"
+    },
+    {
+      "start": 250.34,
+      "end": 252.01,
+      "speaker": "alice",
+      "spoken": "And now which is which?",
+      "progresstxt": "and now which is"
+    },
+    {
+      "start": 252.81,
+      "end": 254.81,
+      "speaker": "alice",
+      "spoken": "Come, my head's free at last!",
+      "progresstxt": "come my head's free at"
+    },
+    {
+      "start": 255.61,
+      "end": 257.94,
+      "speaker": "alice",
+      "spoken": "What can all that green stuff be?",
+      "progresstxt": "what can all that green stuff"
+    },
+    {
+      "start": 258.24,
+      "end": 260.57,
+      "speaker": "alice",
+      "spoken": "And where have my shoulders got to?",
+      "progresstxt": "and where have my shoulders got"
+    },
+    {
+      "start": 260.87,
+      "end": 262.54,
+      "speaker": "alice",
+      "spoken": "And oh, my poor hands,",
+      "progresstxt": "and oh my poor"
+    },
+    {
+      "start": 262.84,
+      "end": 265.17,
+      "speaker": "alice",
+      "spoken": "how is it I can't see you?",
+      "progresstxt": "how is it I can't see"
+    },
+    {
+      "start": 265.97,
+      "end": 266.97,
+      "speaker": "pigeon",
+      "spoken": "Serpent!",
+      "progresstxt": ""
+    },
+    {
+      "start": 267.77,
+      "end": 269.1,
+      "speaker": "alice",
+      "spoken": "I'm not a serpent!",
+      "progresstxt": "I'm not a"
+    },
+    {
+      "start": 269.4,
+      "end": 270.4,
+      "speaker": "alice",
+      "spoken": "Let me alone!",
+      "progresstxt": "let me"
+    },
+    {
+      "start": 271.2,
+      "end": 272.53,
+      "speaker": "pigeon",
+      "spoken": "Serpent, I say again!",
+      "progresstxt": "serpent I say"
+    },
+    {
+      "start": 272.83,
+      "end": 274.16,
+      "speaker": "pigeon",
+      "spoken": "I've tried every way,",
+      "progresstxt": "I've tried every"
+    },
+    {
+      "start": 274.46,
+      "end": 276.46,
+      "speaker": "pigeon",
+      "spoken": "and nothing seems to suit them!",
+      "progresstxt": "and nothing seems to suit"
+    },
+    {
+      "start": 277.26,
+      "end": 280.26,
+      "speaker": "alice",
+      "spoken": "I haven't the least idea what you're talking about.",
+      "progresstxt": "I haven't the least idea what you're"
+    },
+    {
+      "start": 281.06,
+      "end": 283.06,
+      "speaker": "pigeon",
+      "spoken": "I've tried the roots of trees,",
+      "progresstxt": "I've tried the roots of"
+    },
+    {
+      "start": 283.36,
+      "end": 286.03,
+      "speaker": "pigeon",
+      "spoken": "and I've tried banks, and I've tried hedges,",
+      "progresstxt": "and I've tried banks and I've tried"
+    },
+    {
+      "start": 286.33,
+      "end": 288.66,
+      "speaker": "pigeon",
+      "spoken": "but those serpents! There's no pleasing them!",
+      "progresstxt": "but those serpents there's no pleasing"
+    },
+    {
+      "start": 289.46,
+      "end": 292.46,
+      "speaker": "pigeon",
+      "spoken": "As if it wasn't trouble enough hatching the eggs,",
+      "progresstxt": "as if it wasn't trouble enough hatching"
+    },
+    {
+      "start": 292.76,
+      "end": 296.76,
+      "speaker": "pigeon",
+      "spoken": "but I must be on the look-out for serpents night and day!",
+      "progresstxt": "but I must be on the lookout for serpents night"
+    },
+    {
+      "start": 297.06,
+      "end": 300.73,
+      "speaker": "pigeon",
+      "spoken": "Why, I haven't had a wink of sleep these three weeks!",
+      "progresstxt": "why I haven't had a wink of sleep these"
+    },
+    {
+      "start": 301.53,
+      "end": 303.53,
+      "speaker": "alice",
+      "spoken": "I'm very sorry you've been annoyed.",
+      "progresstxt": "I'm very sorry you've been"
+    },
+    {
+      "start": 304.33,
+      "end": 308.0,
+      "speaker": "pigeon",
+      "spoken": "And just as I'd taken the highest tree in the wood,",
+      "progresstxt": "and just as I'd taken the highest tree in"
+    },
+    {
+      "start": 308.3,
+      "end": 312.97,
+      "speaker": "pigeon",
+      "spoken": "and just as I was thinking I should be free of them at last,",
+      "progresstxt": "and just as I was thinking I should be free of"
+    },
+    {
+      "start": 313.27,
+      "end": 316.94,
+      "speaker": "pigeon",
+      "spoken": "they must needs come wriggling down from the sky! Ugh, Serpent!",
+      "progresstxt": "they must needs come wriggling down from the sky"
+    },
+    {
+      "start": 317.74,
+      "end": 320.41,
+      "speaker": "alice",
+      "spoken": "But I'm not a serpent, I tell you!",
+      "progresstxt": "but I'm not a serpent I tell"
+    },
+    {
+      "start": 320.71,
+      "end": 322.04,
+      "speaker": "alice",
+      "spoken": "I'm a—I'm a—",
+      "progresstxt": "I'm a"
+    },
+    {
+      "start": 322.84,
+      "end": 324.17,
+      "speaker": "pigeon",
+      "spoken": "Well! What are you?",
+      "progresstxt": "well what are"
+    },
+    {
+      "start": 324.47,
+      "end": 327.14,
+      "speaker": "pigeon",
+      "spoken": "I can see you're trying to invent something!",
+      "progresstxt": "I can see you're trying to invent"
+    },
+    {
+      "start": 327.94,
+      "end": 329.61,
+      "speaker": "alice",
+      "spoken": "I—I'm a little girl,",
+      "progresstxt": "I'm a little"
+    },
+    {
+      "start": 330.41,
+      "end": 331.74,
+      "speaker": "pigeon",
+      "spoken": "A likely story indeed!",
+      "progresstxt": "a likely story"
+    },
+    {
+      "start": 332.04,
+      "end": 335.37,
+      "speaker": "pigeon",
+      "spoken": "I've seen a good many little girls in my time,",
+      "progresstxt": "I've seen a good many little girls in my"
+    },
+    {
+      "start": 335.67,
+      "end": 338.67,
+      "speaker": "pigeon",
+      "spoken": "but never one with such a neck as that!",
+      "progresstxt": "but never one with such a neck as"
+    },
+    {
+      "start": 338.97,
+      "end": 342.64,
+      "speaker": "pigeon",
+      "spoken": "No, no! You're a serpent; and there's no use denying it.",
+      "progresstxt": "no no you're a serpent and there's no use"
+    },
+    {
+      "start": 342.94,
+      "end": 347.27,
+      "speaker": "pigeon",
+      "spoken": "I suppose you'll be telling me next that you never tasted an egg!",
+      "progresstxt": "I suppose you'll be telling me next that you never"
+    },
+    {
+      "start": 348.07,
+      "end": 349.74,
+      "speaker": "alice",
+      "spoken": "I have tasted eggs, certainly,",
+      "progresstxt": "I have tasted eggs"
+    },
+    {
+      "start": 350.04,
+      "end": 354.37,
+      "speaker": "alice",
+      "spoken": "but little girls eat eggs quite as much as serpents do, you know.",
+      "progresstxt": "but little girls eat eggs quite as much as serpents"
+    },
+    {
+      "start": 355.17,
+      "end": 356.5,
+      "speaker": "pigeon",
+      "spoken": "I don't believe it,",
+      "progresstxt": "I don't believe"
+    },
+    {
+      "start": 356.8,
+      "end": 360.47,
+      "speaker": "pigeon",
+      "spoken": "but if they do, why then they're a kind of serpent,",
+      "progresstxt": "but if they do why then they're a kind of"
+    },
+    {
+      "start": 360.77,
+      "end": 362.44,
+      "speaker": "pigeon",
+      "spoken": "that's all I can say.",
+      "progresstxt": "that's all I can"
+    },
+    {
+      "start": 363.24,
+      "end": 366.24,
+      "speaker": "pigeon",
+      "spoken": "You're looking for eggs, I know that well enough;",
+      "progresstxt": "you're looking for eggs I know that well"
+    },
+    {
+      "start": 366.54,
+      "end": 368.87,
+      "speaker": "pigeon",
+      "spoken": "and what does it matter to me",
+      "progresstxt": "and what does it matter to"
+    },
+    {
+      "start": 369.17,
+      "end": 371.84,
+      "speaker": "pigeon",
+      "spoken": "whether you're a little girl or a serpent?",
+      "progresstxt": "whether you're a little girl or a"
+    },
+    {
+      "start": 372.64,
+      "end": 374.97,
+      "speaker": "alice",
+      "spoken": "It matters a good deal to me,",
+      "progresstxt": "it matters a good deal to"
+    },
+    {
+      "start": 375.27,
+      "end": 378.27,
+      "speaker": "alice",
+      "spoken": "but I'm not looking for eggs, as it happens;",
+      "progresstxt": "but I'm not looking for eggs as it"
+    },
+    {
+      "start": 378.57,
+      "end": 381.24,
+      "speaker": "alice",
+      "spoken": "and if I was, I shouldn't want yours:",
+      "progresstxt": "and if I was I shouldn't want"
+    },
+    {
+      "start": 381.54,
+      "end": 383.21,
+      "speaker": "alice",
+      "spoken": "I don't like them raw.",
+      "progresstxt": "I don't like them"
+    },
+    {
+      "start": 384.01,
+      "end": 385.34,
+      "speaker": "pigeon",
+      "spoken": "Well, be off, then!",
+      "progresstxt": "well be off"
+    },
+    {
+      "start": 386.14,
+      "end": 388.47,
+      "speaker": "alice",
+      "spoken": "Come, there's half my plan done now!",
+      "progresstxt": "come there's half my plan done"
+    },
+    {
+      "start": 388.77,
+      "end": 390.77,
+      "speaker": "alice",
+      "spoken": "How puzzling all these changes are!",
+      "progresstxt": "how puzzling all these changes"
+    },
+    {
+      "start": 391.07,
+      "end": 395.4,
+      "speaker": "alice",
+      "spoken": "I'm never sure what I'm going to be, from one minute to another!",
+      "progresstxt": "I'm never sure what I'm going to be from one"
+    },
+    {
+      "start": 395.7,
+      "end": 398.37,
+      "speaker": "alice",
+      "spoken": "However, I've got back to my right size:",
+      "progresstxt": "however I've got back to my right"
+    },
+    {
+      "start": 398.67,
+      "end": 402.0,
+      "speaker": "alice",
+      "spoken": "the next thing is, to get into that beautiful garden—",
+      "progresstxt": "the next thing is to get into that beautiful"
+    },
+    {
+      "start": 402.3,
+      "end": 404.97,
+      "speaker": "alice",
+      "spoken": "how is that to be done, I wonder?",
+      "progresstxt": "how is that to be done I"
+    }
+  ]
+}

--- a/apps/node-server/src/server/features/demo-room/fixtures/alice-chapter-v.utterances.schema.json
+++ b/apps/node-server/src/server/features/demo-room/fixtures/alice-chapter-v.utterances.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "./alice-chapter-v.utterances.schema.json",
+  "title": "Alice's Adventures in Wonderland — Chapter V utterances fixture",
+  "description": "Schema for the demo caption-room utterance fixture derived from Alice's Adventures in Wonderland, Chapter V (Project Gutenberg eBook #11, public domain). Describes the timed, per-speaker spoken lines used to simulate live captioning in the demo room.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Self-reference to this schema file."
+    },
+    "source": {
+      "type": "object",
+      "description": "Attribution and provenance information for the source text.",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Title of the source work."
+        },
+        "author": {
+          "type": "string",
+          "description": "Author of the source work."
+        },
+        "chapter": {
+          "type": "string",
+          "description": "Chapter title/label the utterances are drawn from."
+        },
+        "attribution": {
+          "type": "string",
+          "description": "Attribution statement for the source text."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL to the source text."
+        },
+        "note": {
+          "type": "string",
+          "description": "Additional notes about how the fixture text was extracted or is intended to be used."
+        }
+      },
+      "required": ["title", "author", "chapter", "attribution", "url", "note"],
+      "additionalProperties": false
+    },
+    "timing": {
+      "type": "object",
+      "description": "Parameters used to derive/simulate the timing of utterances and caption progress.",
+      "properties": {
+        "wordsPerSecond": {
+          "type": "number",
+          "description": "Assumed speaking rate in words per second used to compute utterance durations."
+        },
+        "gapWithinTurnSeconds": {
+          "type": "number",
+          "description": "Gap in seconds inserted between consecutive utterances from the same speaker's turn."
+        },
+        "gapBetweenTurnsSeconds": {
+          "type": "number",
+          "description": "Gap in seconds inserted between utterances when the speaker changes."
+        },
+        "progressEmittedAtFractionOfDuration": {
+          "type": "number",
+          "description": "Fraction of an utterance's duration at which an in-progress caption update (progresstxt) is emitted."
+        }
+      },
+      "required": [
+        "wordsPerSecond",
+        "gapWithinTurnSeconds",
+        "gapBetweenTurnsSeconds",
+        "progressEmittedAtFractionOfDuration"
+      ],
+      "additionalProperties": false
+    },
+    "speakers": {
+      "type": "array",
+      "description": "List of distinct speakers appearing in the utterances.",
+      "items": {
+        "type": "string",
+        "enum": ["caterpillar", "alice", "pigeon"]
+      }
+    },
+    "loop": {
+      "type": "boolean",
+      "description": "Whether the demo playback should loop back to the start after the last utterance."
+    },
+    "totalDurationSeconds": {
+      "type": "number",
+      "description": "Total duration in seconds of the full utterance sequence."
+    },
+    "utteranceCount": {
+      "type": "integer",
+      "description": "Total number of utterances in the utterances array."
+    },
+    "utterances": {
+      "type": "array",
+      "description": "Ordered list of timed spoken lines used to drive the demo caption playback.",
+      "items": {
+        "type": "object",
+        "description": "A single timed utterance spoken by one of the enumerated speakers.",
+        "properties": {
+          "start": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Start time in seconds, relative to the beginning of playback."
+          },
+          "end": {
+            "type": "number",
+            "minimum": 0,
+            "description": "End time in seconds, relative to the beginning of playback."
+          },
+          "speaker": {
+            "type": "string",
+            "enum": ["caterpillar", "alice", "pigeon"],
+            "description": "The speaker of this utterance."
+          },
+          "spoken": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The full spoken line of dialogue."
+          },
+          "progresstxt": {
+            "type": "string",
+            "description": "Partial/in-progress text emitted mid-utterance to simulate live captioning; may be empty for very short utterances."
+          }
+        },
+        "required": ["start", "end", "speaker", "spoken", "progresstxt"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "source",
+    "timing",
+    "speakers",
+    "loop",
+    "totalDurationSeconds",
+    "utteranceCount",
+    "utterances"
+  ]
+}

--- a/apps/node-server/src/server/features/demo-room/fixtures/generate-alice-chapter-v.py
+++ b/apps/node-server/src/server/features/demo-room/fixtures/generate-alice-chapter-v.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Generate the Alice-Chapter-V demo utterance fixture.
+
+Source text: Alice's Adventures in Wonderland by Lewis Carroll, Chapter V
+("Advice from a Caterpillar"), Project Gutenberg eBook #11.
+https://www.gutenberg.org/files/11/11-h/11-h.htm#chap05
+Public domain. This file only stores the *spoken dialogue* (quoted speech)
+of the chapter, split into short utterances and attributed to a speaker.
+
+Timing model: ~3 spoken words per second. Each utterance's duration is
+words/3 (min 1.0s). A 0.3s pause separates consecutive fragments of the same
+turn; a 0.8s pause separates turns (emulates the gap between speakers/phrases).
+`progresstxt` is a hand-authored mock interim hypothesis a speech-to-text
+engine might emit at the half-way point: a shortened, sometimes slightly wrong
+guess that the final `spoken` text corrects.
+"""
+import json
+
+WPS = 3.0
+GAP_WITHIN_TURN = 0.3
+GAP_BETWEEN_TURNS = 0.8
+
+# Each turn: (speaker, [(spoken, progresstxt), ...])
+# progresstxt "" means no interim is shown for that (very short) fragment.
+TURNS = [
+    ("caterpillar", [("Who are you?", "who are")]),
+    ("alice", [
+        ("I—I hardly know, sir, just at present—", "I hardly know sir just at"),
+        ("at least I know who I was when I got up this morning,", "at least I know who I was when I got"),
+        ("but I think I must have been changed several times since then.", "but I think I must have been changed"),
+    ]),
+    ("caterpillar", [("What do you mean by that? Explain yourself!", "what do you mean by that")]),
+    ("alice", [
+        ("I can't explain myself, I'm afraid, sir,", "I can't explain myself I'm afraid"),
+        ("because I'm not myself, you see.", "because I'm not myself you"),
+    ]),
+    ("caterpillar", [("I don't see.", "I don't")]),
+    ("alice", [
+        ("I'm afraid I can't put it more clearly,", "I'm afraid I can't put it more"),
+        ("for I can't understand it myself to begin with;", "for I can't understand it myself to"),
+        ("and being so many different sizes in a day is very confusing.", "and being so many different sizes in a day"),
+    ]),
+    ("caterpillar", [("It isn't.", "")]),
+    ("alice", [
+        ("Well, perhaps you haven't found it so yet,", "well perhaps you haven't found it so"),
+        ("but when you have to turn into a chrysalis—you will some day, you know—", "but when you have to turn into a crystal is you will"),
+        ("and then after that into a butterfly,", "and then after that into a butter"),
+        ("I should think you'll feel it a little queer, won't you?", "I should think you'll feel it a little queer"),
+    ]),
+    ("caterpillar", [("Not a bit.", "not a")]),
+    ("alice", [
+        ("Well, perhaps your feelings may be different,", "well perhaps your feelings may be"),
+        ("all I know is, it would feel very queer to me.", "all I know is it would feel very"),
+    ]),
+    ("caterpillar", [("You! Who are you?", "you who are")]),
+    ("alice", [("I think, you ought to tell me who you are, first.", "I think you ought to tell me who you")]),
+    ("caterpillar", [("Why?", "")]),
+    ("caterpillar", [
+        ("Come back!", ""),
+        ("I've something important to say!", "I've something important to"),
+    ]),
+    ("caterpillar", [("Keep your temper.", "keep your")]),
+    ("alice", [("Is that all?", "is that")]),
+    ("caterpillar", [("No.", "")]),
+    ("caterpillar", [("So you think you're changed, do you?", "so you think you're changed")]),
+    ("alice", [
+        ("I'm afraid I am, sir,", "I'm afraid I am"),
+        ("I can't remember things as I used—", "I can't remember things as I"),
+        ("and I don't keep the same size for ten minutes together!", "and I don't keep the same sighs for ten"),
+    ]),
+    ("caterpillar", [("Can't remember what things?", "can't remember what")]),
+    ("alice", [
+        ("Well, I've tried to say \"How doth the little busy bee,\"", "well I've tried to say how does the little busy"),
+        ("but it all came different!", "but it all came"),
+    ]),
+    ("caterpillar", [("Repeat, 'You are old, Father William,'", "repeat you are old father")]),
+    # Alice recites the poem "You are old, Father William" (8 stanzas).
+    ("alice", [
+        ("\"You are old, Father William,\" the young man said, \"And your hair has become very white;",
+         "you are old father william the young man said and your"),
+        ("And yet you incessantly stand on your head— Do you think, at your age, it is right?\"",
+         "and yet you incessantly stand on your head do you think"),
+        ("\"In my youth,\" Father William replied to his son, \"I feared it might injure the brain;",
+         "in my youth father william replied to his son I feared"),
+        ("But, now that I'm perfectly sure I have none, Why, I do it again and again.\"",
+         "but now that I'm perfectly sure I have none why I"),
+        ("\"You are old,\" said the youth, \"as I mentioned before, And have grown most uncommonly fat;",
+         "you are old said the youth as I mentioned before and"),
+        ("Yet you turned a back-somersault in at the door— Pray, what is the reason of that?\"",
+         "yet you turned a back somersault in at the door pray"),
+        ("\"In my youth,\" said the sage, as he shook his grey locks, \"I kept all my limbs very supple",
+         "in my youth said the sage as he shook his grey"),
+        ("By the use of this ointment—one shilling the box— Allow me to sell you a couple?\"",
+         "by the use of this ointment one shilling the box allow"),
+        ("\"You are old,\" said the youth, \"and your jaws are too weak For anything tougher than suet;",
+         "you are old said the youth and your jaws are too"),
+        ("Yet you finished the goose, with the bones and the beak— Pray, how did you manage to do it?\"",
+         "yet you finished the goose with the bones and the beak"),
+        ("\"In my youth,\" said his father, \"I took to the law, And argued each case with my wife;",
+         "in my youth said his father I took to the law"),
+        ("And the muscular strength, which it gave to my jaw, Has lasted the rest of my life.\"",
+         "and the muscular strength which it gave to my jaw has"),
+        ("\"You are old,\" said the youth, \"one would hardly suppose That your eye was as steady as ever;",
+         "you are old said the youth one would hardly suppose that"),
+        ("Yet you balanced an eel on the end of your nose— What made you so awfully clever?\"",
+         "yet you balanced an eel on the end of your nose"),
+        ("\"I have answered three questions, and that is enough,\" Said his father; \"don't give yourself airs!",
+         "I have answered three questions and that is enough said his"),
+        ("Do you think I can listen all day to such stuff? Be off, or I'll kick you down stairs!\"",
+         "do you think I can listen all day to such stuff"),
+    ]),
+    ("caterpillar", [("That is not said right.", "that is not said")]),
+    ("alice", [
+        ("Not quite right, I'm afraid,", "not quite right I'm"),
+        ("some of the words have got altered.", "some of the words have got"),
+    ]),
+    ("caterpillar", [("It is wrong from beginning to end.", "it is wrong from beginning")]),
+    ("caterpillar", [("What size do you want to be?", "what size do you want")]),
+    ("alice", [
+        ("Oh, I'm not particular as to size,", "oh I'm not particular as to"),
+        ("only one doesn't like changing so often, you know.", "only one doesn't like changing so often"),
+    ]),
+    ("caterpillar", [("I don't know.", "I don't")]),
+    ("caterpillar", [("Are you content now?", "are you content")]),
+    ("alice", [
+        ("Well, I should like to be a little larger, sir,", "well I should like to be a little larger"),
+        ("if you wouldn't mind,", "if you wouldn't"),
+        ("three inches is such a wretched height to be.", "three inches is such a wretched height"),
+    ]),
+    ("caterpillar", [("It is a very good height indeed!", "it is a very good height")]),
+    ("alice", [("But I'm not used to it!", "but I'm not used to")]),
+    ("caterpillar", [("You'll get used to it in time.", "you'll get used to it in")]),
+    ("caterpillar", [
+        ("One side will make you grow taller,", "one side will make you grow"),
+        ("and the other side will make you grow shorter.", "and the other side will make you grow"),
+    ]),
+    ("caterpillar", [("Of the mushroom.", "of the")]),
+    ("alice", [("And now which is which?", "and now which is")]),
+    ("alice", [("Come, my head's free at last!", "come my head's free at")]),
+    ("alice", [
+        ("What can all that green stuff be?", "what can all that green stuff"),
+        ("And where have my shoulders got to?", "and where have my shoulders got"),
+        ("And oh, my poor hands,", "and oh my poor"),
+        ("how is it I can't see you?", "how is it I can't see"),
+    ]),
+    ("pigeon", [("Serpent!", "")]),
+    ("alice", [
+        ("I'm not a serpent!", "I'm not a"),
+        ("Let me alone!", "let me"),
+    ]),
+    ("pigeon", [
+        ("Serpent, I say again!", "serpent I say"),
+        ("I've tried every way,", "I've tried every"),
+        ("and nothing seems to suit them!", "and nothing seems to suit"),
+    ]),
+    ("alice", [("I haven't the least idea what you're talking about.", "I haven't the least idea what you're")]),
+    ("pigeon", [
+        ("I've tried the roots of trees,", "I've tried the roots of"),
+        ("and I've tried banks, and I've tried hedges,", "and I've tried banks and I've tried"),
+        ("but those serpents! There's no pleasing them!", "but those serpents there's no pleasing"),
+    ]),
+    ("pigeon", [
+        ("As if it wasn't trouble enough hatching the eggs,", "as if it wasn't trouble enough hatching"),
+        ("but I must be on the look-out for serpents night and day!", "but I must be on the lookout for serpents night"),
+        ("Why, I haven't had a wink of sleep these three weeks!", "why I haven't had a wink of sleep these"),
+    ]),
+    ("alice", [("I'm very sorry you've been annoyed.", "I'm very sorry you've been")]),
+    ("pigeon", [
+        ("And just as I'd taken the highest tree in the wood,", "and just as I'd taken the highest tree in"),
+        ("and just as I was thinking I should be free of them at last,", "and just as I was thinking I should be free of"),
+        ("they must needs come wriggling down from the sky! Ugh, Serpent!", "they must needs come wriggling down from the sky"),
+    ]),
+    ("alice", [
+        ("But I'm not a serpent, I tell you!", "but I'm not a serpent I tell"),
+        ("I'm a—I'm a—", "I'm a"),
+    ]),
+    ("pigeon", [
+        ("Well! What are you?", "well what are"),
+        ("I can see you're trying to invent something!", "I can see you're trying to invent"),
+    ]),
+    ("alice", [("I—I'm a little girl,", "I'm a little")]),
+    ("pigeon", [
+        ("A likely story indeed!", "a likely story"),
+        ("I've seen a good many little girls in my time,", "I've seen a good many little girls in my"),
+        ("but never one with such a neck as that!", "but never one with such a neck as"),
+        ("No, no! You're a serpent; and there's no use denying it.", "no no you're a serpent and there's no use"),
+        ("I suppose you'll be telling me next that you never tasted an egg!", "I suppose you'll be telling me next that you never"),
+    ]),
+    ("alice", [
+        ("I have tasted eggs, certainly,", "I have tasted eggs"),
+        ("but little girls eat eggs quite as much as serpents do, you know.", "but little girls eat eggs quite as much as serpents"),
+    ]),
+    ("pigeon", [
+        ("I don't believe it,", "I don't believe"),
+        ("but if they do, why then they're a kind of serpent,", "but if they do why then they're a kind of"),
+        ("that's all I can say.", "that's all I can"),
+    ]),
+    ("pigeon", [
+        ("You're looking for eggs, I know that well enough;", "you're looking for eggs I know that well"),
+        ("and what does it matter to me", "and what does it matter to"),
+        ("whether you're a little girl or a serpent?", "whether you're a little girl or a"),
+    ]),
+    ("alice", [
+        ("It matters a good deal to me,", "it matters a good deal to"),
+        ("but I'm not looking for eggs, as it happens;", "but I'm not looking for eggs as it"),
+        ("and if I was, I shouldn't want yours:", "and if I was I shouldn't want"),
+        ("I don't like them raw.", "I don't like them"),
+    ]),
+    ("pigeon", [("Well, be off, then!", "well be off")]),
+    ("alice", [
+        ("Come, there's half my plan done now!", "come there's half my plan done"),
+        ("How puzzling all these changes are!", "how puzzling all these changes"),
+        ("I'm never sure what I'm going to be, from one minute to another!", "I'm never sure what I'm going to be from one"),
+        ("However, I've got back to my right size:", "however I've got back to my right"),
+        ("the next thing is, to get into that beautiful garden—", "the next thing is to get into that beautiful"),
+        ("how is that to be done, I wonder?", "how is that to be done I"),
+    ]),
+]
+
+
+def word_count(s):
+    return len([w for w in s.replace("—", " ").split() if w.strip()])
+
+
+utterances = []
+t = 0.0
+for ti, (speaker, chunks) in enumerate(TURNS):
+    if ti > 0:
+        t += GAP_BETWEEN_TURNS
+    for ci, (spoken, progress) in enumerate(chunks):
+        if ci > 0:
+            t += GAP_WITHIN_TURN
+        dur = max(1.0, word_count(spoken) / WPS)
+        start = round(t, 2)
+        end = round(t + dur, 2)
+        utterances.append({
+            "start": start,
+            "end": end,
+            "speaker": speaker,
+            "spoken": spoken,
+            "progresstxt": progress,
+        })
+        t = end
+
+doc = {
+    "$schema": "./alice-chapter-v.utterances.schema.json",
+    "source": {
+        "title": "Alice's Adventures in Wonderland",
+        "author": "Lewis Carroll",
+        "chapter": "Chapter V — Advice from a Caterpillar",
+        "attribution": "Project Gutenberg eBook #11 (public domain).",
+        "url": "https://www.gutenberg.org/files/11/11-h/11-h.htm#chap05",
+        "note": "Spoken dialogue only, extracted from #chap05 up to where #chap06 begins. Text is in the public domain; this fixture is for local/dev caption playback.",
+    },
+    "timing": {
+        "wordsPerSecond": WPS,
+        "gapWithinTurnSeconds": GAP_WITHIN_TURN,
+        "gapBetweenTurnsSeconds": GAP_BETWEEN_TURNS,
+        "progressEmittedAtFractionOfDuration": 0.5,
+    },
+    "speakers": ["caterpillar", "alice", "pigeon"],
+    "loop": True,
+    "totalDurationSeconds": round(utterances[-1]["end"], 2),
+    "utteranceCount": len(utterances),
+    "utterances": utterances,
+}
+
+print(json.dumps(doc, indent=2, ensure_ascii=False))

--- a/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
@@ -141,6 +141,14 @@ interface SessionState {
  */
 export class TranscriptionOrchestratorService {
   private _sessions = new Map<string, SessionState>();
+  /**
+   * Status overrides for sessions that have no real upstream - only the
+   * dev/staging demo caption room (see `demo-room/`). Kept separate from
+   * `_sessions` so nothing that iterates real session state (e.g.
+   * `sessionSnapshots`, which dereferences `state.upstream`) ever sees a
+   * session without an upstream connection.
+   */
+  private _syntheticStatuses = new Map<string, SessionStatusMessage>();
   private _logger: AppDependencies['logger'];
   private _eventBus: AppDependencies['eventBusService'];
   private _transcriptionServiceClient: AppDependencies['transcriptionServiceClient'];
@@ -186,6 +194,21 @@ export class TranscriptionOrchestratorService {
   }
 
   /**
+   * Register a status override for a session with no real upstream. Used only
+   * by the dev/staging demo caption room, which publishes transcripts to
+   * {@link TranscriptChannel} directly and needs joining clients to see the
+   * session as connected rather than "waiting for source". Ignored for any
+   * session that also has real source connections (`_sessions` wins in
+   * {@link getStatus}). No-op semantics otherwise.
+   */
+  registerSyntheticSession(
+    sessionUid: string,
+    status: SessionStatusMessage,
+  ): void {
+    this._syntheticStatuses.set(sessionUid, status);
+  }
+
+  /**
    * Current connectivity snapshot for a session. Sessions that have never had
    * a source register (or whose last source has unregistered) are reported as
    * fully disconnected.
@@ -197,6 +220,8 @@ export class TranscriptionOrchestratorService {
   getStatus(sessionUid: string): SessionStatusMessage {
     const state = this._sessions.get(sessionUid);
     if (state === undefined) {
+      const synthetic = this._syntheticStatuses.get(sessionUid);
+      if (synthetic !== undefined) return synthetic;
       return {
         transcriptionServiceConnected: false,
         sourceDeviceConnected: false,

--- a/apps/node-server/tests/integration/features/demo-room/demo-room.routes.test.ts
+++ b/apps/node-server/tests/integration/features/demo-room/demo-room.routes.test.ts
@@ -1,0 +1,149 @@
+import crypto from 'node:crypto';
+import { describe, expect, inject } from 'vitest';
+import type WebSocket from 'ws';
+
+import {
+  TranscriptionStreamClientMessageType,
+  TranscriptionStreamServerMessageType,
+} from '@scribear/node-server-schema';
+import type { SessionTokenPayload } from '@scribear/session-manager-schema';
+
+import { DEFAULT_DEMO_SESSION_UID } from '#src/server/features/demo-room/demo-room.constants.js';
+import { useServer } from '#tests/utils/use-server.js';
+
+const FAR_FUTURE = Math.floor(Date.now() / 1000) + 3600;
+
+interface ServerMessage {
+  type: TranscriptionStreamServerMessageType;
+  [key: string]: unknown;
+}
+
+/** HMAC-sign a session token the way the Session Manager does. */
+function signToken(payload: SessionTokenPayload): string {
+  const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString(
+    'base64url',
+  );
+  const signature = crypto
+    .createHmac('sha256', inject('sessionTokenSigningKey'))
+    .update(encoded)
+    .digest('base64url');
+  return `${encoded}.${signature}`;
+}
+
+function bufferOf(data: Buffer | ArrayBuffer | Buffer[]): Buffer {
+  if (Buffer.isBuffer(data)) return data;
+  if (Array.isArray(data)) return Buffer.concat(data);
+  return Buffer.from(data);
+}
+
+/**
+ * Attach one persistent listener that records every JSON server message into a
+ * growing array. A single collector (rather than sequential one-shot waiters)
+ * is essential here: `sessionStatus` is emitted once, right after `authOk`, so
+ * a second listener attached later would miss it.
+ */
+function collectMessages(ws: WebSocket): ServerMessage[] {
+  const messages: ServerMessage[] = [];
+  ws.on('message', (data: Buffer | ArrayBuffer | Buffer[]) => {
+    try {
+      messages.push(
+        JSON.parse(bufferOf(data).toString('utf8')) as ServerMessage,
+      );
+    } catch {
+      /* ignore non-JSON frames */
+    }
+  });
+  return messages;
+}
+
+/** Poll until `predicate` holds over the collected messages, or time out. */
+async function waitUntil(
+  predicate: () => boolean,
+  timeoutMs = 5000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error('timed out waiting for the expected server messages');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+describe('Demo caption room', () => {
+  // Boot a server with the demo room enabled. It needs no source device and no
+  // upstream transcription service - the whole point of the feature.
+  const server = useServer({ demoRoomConfig: { enabled: true } });
+
+  const clientPath = `/api/node-server/v1/transcription-stream/${DEFAULT_DEMO_SESSION_UID}/client`;
+
+  function authAsClient(ws: WebSocket): void {
+    ws.send(
+      JSON.stringify({
+        type: TranscriptionStreamClientMessageType.AUTH,
+        sessionToken: signToken({
+          sessionUid: DEFAULT_DEMO_SESSION_UID,
+          clientId: 'demo-client-1',
+          scopes: ['RECEIVE_TRANSCRIPTIONS'],
+          exp: FAR_FUTURE,
+        }),
+      }),
+    );
+  }
+
+  describe('a joining client', (it) => {
+    it('authenticates, is told the session is healthy, and receives looping captions', async () => {
+      // Arrange
+      const ws = await server.fastify.injectWS(clientPath);
+      const messages = collectMessages(ws);
+
+      // Act
+      authAsClient(ws);
+
+      // Assert - auth acknowledged.
+      await waitUntil(() =>
+        messages.some(
+          (m) => m.type === TranscriptionStreamServerMessageType.AUTH_OK,
+        ),
+      );
+
+      // Synthetic status: connected even though there is no source or upstream.
+      await waitUntil(() =>
+        messages.some(
+          (m) =>
+            m.type === TranscriptionStreamServerMessageType.SESSION_STATUS &&
+            m['transcriptionServiceConnected'] === true &&
+            m['sourceDeviceConnected'] === true,
+        ),
+      );
+
+      // A transcript with an interim (partial) fragment, and one with a final.
+      await waitUntil(() =>
+        messages.some(
+          (m) =>
+            m.type === TranscriptionStreamServerMessageType.TRANSCRIPT &&
+            m['inProgress'] !== null,
+        ),
+      );
+      await waitUntil(() =>
+        messages.some(
+          (m) =>
+            m.type === TranscriptionStreamServerMessageType.TRANSCRIPT &&
+            m['final'] !== null,
+        ),
+      );
+
+      // Fragments are word-token arrays, as the wire schema promises.
+      const interimMsg = messages.find(
+        (m) =>
+          m.type === TranscriptionStreamServerMessageType.TRANSCRIPT &&
+          m['inProgress'] !== null,
+      );
+      const interim = interimMsg?.['inProgress'] as { text: string[] };
+      expect(Array.isArray(interim.text)).toBe(true);
+      expect(interim.text.length).toBeGreaterThan(0);
+
+      ws.terminate();
+    });
+  });
+});

--- a/apps/node-server/tests/integration/features/telemetry/redis-telemetry-publisher.test.ts
+++ b/apps/node-server/tests/integration/features/telemetry/redis-telemetry-publisher.test.ts
@@ -220,9 +220,9 @@ describe('Redis telemetry publisher — fleet event deltas', () => {
     it('round-trips a session status delta through real Redis pub/sub', async () => {
       // Arrange
       const received = new Promise<string>((resolve) => {
-        subscriber.once('message', (_channel, message: string) =>
-          resolve(message),
-        );
+        subscriber.once('message', (_channel, message: string) => {
+          resolve(message);
+        });
       });
       await subscriber.subscribe(FLEET_EVENTS_CHANNEL_KEY);
 

--- a/apps/node-server/tests/unit/app-config/app-config.test.ts
+++ b/apps/node-server/tests/unit/app-config/app-config.test.ts
@@ -24,7 +24,12 @@ const VALID_ENV: Record<string, string> = {
  * cleared before each test so the defaults are what is exercised, and restored
  * afterwards like the rest.
  */
-const OPTIONAL_ENV_KEYS = ['REDIS_URL', 'NODE_INSTANCE_ID'];
+const OPTIONAL_ENV_KEYS = [
+  'REDIS_URL',
+  'NODE_INSTANCE_ID',
+  'DEMO_ROOM_ENABLED',
+  'DEMO_SESSION_UID',
+];
 const ENV_KEYS = [...Object.keys(VALID_ENV), ...OPTIONAL_ENV_KEYS];
 
 // A path that does not exist, used to disable dotenv file loading so validation
@@ -176,6 +181,42 @@ describe('AppConfig', () => {
 
       // Assert
       expect(config.baseConfig.isDevelopment).toBe(false);
+    });
+  });
+
+  describe('demo room configuration', (it) => {
+    it('is disabled with the default session uid when unset', () => {
+      // Act - both vars are absent, the production default.
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert
+      expect(config.demoRoomConfig).toStrictEqual({
+        enabled: false,
+        sessionUid: 'deadbeef-0000-4000-8000-000000000001',
+      });
+    });
+
+    it('maps an explicit enable flag and session uid', () => {
+      // Arrange
+      process.env['DEMO_ROOM_ENABLED'] = 'true';
+      process.env['DEMO_SESSION_UID'] = 'aaaaaaaa-0000-4000-8000-000000000002';
+
+      // Act
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert
+      expect(config.demoRoomConfig).toStrictEqual({
+        enabled: true,
+        sessionUid: 'aaaaaaaa-0000-4000-8000-000000000002',
+      });
+    });
+
+    it('rejects a non-boolean enable flag (only true/false are accepted)', () => {
+      // Arrange - env-schema coerces "true"/"false" but not "1".
+      process.env['DEMO_ROOM_ENABLED'] = '1';
+
+      // Act / Assert
+      expect(() => new AppConfig(NO_DOTENV_FILE)).toThrow();
     });
   });
 

--- a/apps/node-server/tests/unit/features/demo-room/demo-caption-source.test.ts
+++ b/apps/node-server/tests/unit/features/demo-room/demo-caption-source.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+
+import type { DemoRoomConfig } from '#src/app-config/app-config.js';
+import {
+  DemoCaptionSource,
+  buildDemoSchedule,
+  buildFragment,
+} from '#src/server/features/demo-room/demo-caption-source.js';
+import { SessionStatusChannel } from '#src/server/features/transcription-stream/events/session-status.events.js';
+import {
+  TranscriptChannel,
+  type TranscriptMessage,
+} from '#src/server/features/transcription-stream/events/transcript.events.js';
+import { EventBusService } from '#src/server/shared/services/event-bus.service.js';
+import { createMockLogger } from '#tests/utils/mock-logger.js';
+
+const SESSION_UID = 'demo-session-under-test';
+
+describe('buildFragment', (it) => {
+  it('splits into space-prefixed word tokens that rejoin to the source text', () => {
+    // Act
+    const fragment = buildFragment('who are you', 'alice', false, 0, 3);
+
+    // Assert
+    expect(fragment.text).toStrictEqual(['who', ' are', ' you']);
+    expect(fragment.text.join('')).toBe('who are you');
+  });
+
+  it('folds a capitalized speaker label into the first token on a turn start', () => {
+    // Act
+    const fragment = buildFragment('who are', 'caterpillar', true, 0, 2);
+
+    // Assert - the label rides on the leading token; the wire schema has no
+    // speaker field.
+    expect(fragment.text[0]).toBe('Caterpillar:');
+    expect(fragment.text.join('')).toBe('Caterpillar: who are');
+  });
+
+  it('does not prefix a speaker label when the utterance continues a turn', () => {
+    // Act
+    const fragment = buildFragment('and again', 'caterpillar', false, 0, 2);
+
+    // Assert
+    expect(fragment.text[0]).toBe('and');
+  });
+
+  it('emits per-token timings within the utterance window, aligned to text', () => {
+    // Act
+    const fragment = buildFragment('one two', 'alice', false, 4, 6);
+
+    // Assert
+    expect(fragment.starts).toStrictEqual([4, 5]);
+    expect(fragment.ends).toStrictEqual([5, 6]);
+    expect(fragment.starts).toHaveLength(fragment.text.length);
+    expect(fragment.ends).toHaveLength(fragment.text.length);
+  });
+});
+
+describe('buildDemoSchedule', (it) => {
+  it('emits interim at the midpoint then final at the end, per utterance', () => {
+    // Arrange
+    const utterances = [
+      {
+        start: 0,
+        end: 2,
+        speaker: 'alice',
+        spoken: 'hello there',
+        progresstxt: 'hello',
+      },
+    ];
+
+    // Act
+    const { events } = buildDemoSchedule(utterances);
+
+    // Assert
+    expect(events).toHaveLength(2);
+    expect(events[0]?.atMs).toBe(1000); // midpoint of [0, 2]
+    expect(events[0]?.message.inProgress?.text.join('')).toBe('Alice: hello');
+    expect(events[0]?.message.final).toBeNull();
+    expect(events[1]?.atMs).toBe(2000); // end
+    expect(events[1]?.message.final?.text.join('')).toBe('Alice: hello there');
+    expect(events[1]?.message.inProgress).toBeNull();
+  });
+
+  it('skips the interim caption when progresstxt is empty', () => {
+    // Arrange - short utterances (e.g. "No.") carry no interim.
+    const utterances = [
+      { start: 0, end: 1, speaker: 'alice', spoken: 'No.', progresstxt: '' },
+    ];
+
+    // Act
+    const { events } = buildDemoSchedule(utterances);
+
+    // Assert - only the final event exists
+    expect(events).toHaveLength(1);
+    expect(events[0]?.message.final?.text.join('')).toBe('Alice: No.');
+  });
+
+  it('prefixes the speaker label only at a change of speaker', () => {
+    // Arrange
+    const utterances = [
+      { start: 0, end: 1, speaker: 'alice', spoken: 'a', progresstxt: '' },
+      { start: 1, end: 2, speaker: 'alice', spoken: 'b', progresstxt: '' },
+      { start: 2, end: 3, speaker: 'pigeon', spoken: 'c', progresstxt: '' },
+    ];
+
+    // Act
+    const finals = buildDemoSchedule(utterances).events.map((e) =>
+      e.message.final?.text.join(''),
+    );
+
+    // Assert
+    expect(finals).toStrictEqual(['Alice: a', 'b', 'Pigeon: c']);
+  });
+
+  it('orders events by time and derives loop length from the last event', () => {
+    // Arrange
+    const utterances = [
+      { start: 0, end: 2, speaker: 'alice', spoken: 'x', progresstxt: 'x' },
+      { start: 3, end: 5, speaker: 'alice', spoken: 'y', progresstxt: 'y' },
+    ];
+
+    // Act
+    const { events, loopMs } = buildDemoSchedule(utterances);
+
+    // Assert - monotonic non-decreasing atMs; loopMs is last end + tail gap
+    const times = events.map((e) => e.atMs);
+    expect(times).toStrictEqual([...times].sort((a, b) => a - b));
+    expect(loopMs).toBe(5000 + 2000);
+  });
+});
+
+describe('DemoCaptionSource', () => {
+  let bus: EventBusService;
+  let orchestrator: { registerSyntheticSession: ReturnType<typeof vi.fn> };
+  let transcripts: TranscriptMessage[];
+  let statuses: unknown[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    bus = new EventBusService(createMockLogger() as never);
+    orchestrator = { registerSyntheticSession: vi.fn() };
+    transcripts = [];
+    statuses = [];
+    bus.subscribe(TranscriptChannel, (m) => transcripts.push(m), SESSION_UID);
+    bus.subscribe(SessionStatusChannel, (m) => statuses.push(m), SESSION_UID);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makeSource(enabled: boolean): DemoCaptionSource {
+    const config: DemoRoomConfig = { enabled, sessionUid: SESSION_UID };
+    return new DemoCaptionSource(
+      createMockLogger() as never,
+      bus,
+      orchestrator as never,
+      config,
+    );
+  }
+
+  describe('when disabled', (it) => {
+    it('does nothing: no timer, no status, no captions', () => {
+      // Act
+      makeSource(false).start();
+
+      // Assert
+      expect(vi.getTimerCount()).toBe(0);
+      expect(orchestrator.registerSyntheticSession).not.toHaveBeenCalled();
+      expect(transcripts).toHaveLength(0);
+      expect(statuses).toHaveLength(0);
+    });
+  });
+
+  describe('when enabled', (it) => {
+    it('registers a healthy synthetic status and publishes it once', () => {
+      // Act
+      makeSource(true).start();
+
+      // Assert
+      expect(orchestrator.registerSyntheticSession).toHaveBeenCalledWith(
+        SESSION_UID,
+        { transcriptionServiceConnected: true, sourceDeviceConnected: true },
+      );
+      expect(statuses).toStrictEqual([
+        { transcriptionServiceConnected: true, sourceDeviceConnected: true },
+      ]);
+    });
+
+    it('publishes the first caption as an interim with the speaker prefix', () => {
+      // Arrange
+      makeSource(true).start();
+
+      // Act - the first fixture utterance (Caterpillar "Who are you?") has its
+      // interim at its midpoint, 500ms in.
+      vi.advanceTimersByTime(600);
+
+      // Assert
+      expect(transcripts).toHaveLength(1);
+      expect(transcripts[0]?.final).toBeNull();
+      expect(transcripts[0]?.inProgress?.text[0]).toBe('Caterpillar:');
+    });
+
+    it('loops forever: the stream keeps producing captions past one pass', () => {
+      // Arrange
+      const source = makeSource(true);
+      source.start();
+
+      // Act - advance well past a single loop.
+      vi.advanceTimersByTime(1_000_000);
+      const afterOne = transcripts.length;
+      vi.advanceTimersByTime(1_000_000);
+
+      // Assert - still emitting, and a timer is always armed for the next event.
+      expect(afterOne).toBeGreaterThan(0);
+      expect(transcripts.length).toBeGreaterThan(afterOne);
+      expect(vi.getTimerCount()).toBe(1);
+
+      source.stop();
+    });
+
+    it('stops emitting after stop()', () => {
+      // Arrange
+      const source = makeSource(true);
+      source.start();
+      vi.advanceTimersByTime(600);
+      const count = transcripts.length;
+
+      // Act
+      source.stop();
+      vi.advanceTimersByTime(1_000_000);
+
+      // Assert
+      expect(transcripts).toHaveLength(count);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+  });
+});

--- a/apps/node-server/tests/unit/features/demo-room/demo-fixture.test.ts
+++ b/apps/node-server/tests/unit/features/demo-room/demo-fixture.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect } from 'vitest';
+
+import demoFixture from '#src/server/features/demo-room/fixtures/alice-chapter-v.utterances.json' with { type: 'json' };
+
+/**
+ * Guards the checked-in fixture so it cannot rot: the emitter trusts these
+ * invariants (non-overlapping, ordered, known speakers, non-empty spoken text)
+ * rather than re-validating at runtime.
+ */
+const ALLOWED_SPEAKERS = new Set(['caterpillar', 'alice', 'pigeon']);
+
+describe('alice-chapter-v.utterances fixture', (it) => {
+  it('has the advertised speakers, count, and Gutenberg attribution', () => {
+    expect(demoFixture.speakers).toStrictEqual([
+      'caterpillar',
+      'alice',
+      'pigeon',
+    ]);
+    expect(demoFixture.utterances).toHaveLength(demoFixture.utteranceCount);
+    expect(demoFixture.utterances.length).toBeGreaterThan(0);
+    expect(demoFixture.source.attribution).toMatch(/Project Gutenberg/i);
+    expect(demoFixture.loop).toBe(true);
+  });
+
+  it('has a valid, forward window for every utterance', () => {
+    for (const u of demoFixture.utterances) {
+      expect(u.start).toBeGreaterThanOrEqual(0);
+      expect(u.end).toBeGreaterThan(u.start);
+      expect(u.spoken.trim().length).toBeGreaterThan(0);
+      expect(typeof u.progresstxt).toBe('string');
+      expect(ALLOWED_SPEAKERS.has(u.speaker)).toBe(true);
+    }
+  });
+
+  it('is ordered and non-overlapping', () => {
+    for (let i = 1; i < demoFixture.utterances.length; i++) {
+      const prev = demoFixture.utterances[i - 1];
+      const curr = demoFixture.utterances[i];
+      expect(curr?.start).toBeGreaterThanOrEqual(prev?.end ?? 0);
+    }
+  });
+});

--- a/apps/node-server/tests/unit/features/telemetry/redis-telemetry-publisher.service.test.ts
+++ b/apps/node-server/tests/unit/features/telemetry/redis-telemetry-publisher.service.test.ts
@@ -41,8 +41,8 @@ class FakeRedis {
   execError: Error | null = null;
   /** Resolves the in-flight `exec` when set, so overlap can be exercised. */
   releaseExec: (() => void) | null = null;
-  quit = vi.fn(async () => 'OK');
-  publish = vi.fn(async () => 0);
+  quit = vi.fn(() => Promise.resolve('OK'));
+  publish = vi.fn(() => Promise.resolve(0));
 
   private _handlers = new Map<string, (arg?: unknown) => void>();
   on = vi.fn((event: string, handler: (arg?: unknown) => void) => {
@@ -344,8 +344,9 @@ describe('RedisTelemetryPublisher failure handling', (it) => {
     // Assert
     expect(h.redis.commands.length).toBe(commandsAfterFirst);
 
-    // Cleanup - let the first beat finish.
-    h.redis.releaseExec?.();
+    // Cleanup - let the first beat finish. `exec` always reassigns
+    // `releaseExec` to the in-flight resolver, so it is non-null here.
+    h.redis.releaseExec();
     await first;
   });
 });

--- a/apps/node-server/tests/utils/use-server.ts
+++ b/apps/node-server/tests/utils/use-server.ts
@@ -5,11 +5,13 @@ import { LogLevel } from '@scribear/base-fastify-server';
 import type {
   AppConfig,
   BaseConfig,
+  DemoRoomConfig,
   SessionManagerClientConfig,
   TelemetryPublisherConfig,
   TranscriptionServiceClientConfig,
 } from '#src/app-config/app-config.js';
 import createServer from '#src/server/create-server.js';
+import { DEFAULT_DEMO_SESSION_UID } from '#src/server/features/demo-room/demo-room.constants.js';
 import type { ServiceAuthConfig } from '#src/server/shared/services/service-auth.service.js';
 import type { SessionTokenConfig } from '#src/server/shared/services/session-token.service.js';
 
@@ -35,6 +37,7 @@ export interface TestAppConfigOverrides {
   sessionManagerClientConfig?: Partial<SessionManagerClientConfig>;
   transcriptionServiceClientConfig?: Partial<TranscriptionServiceClientConfig>;
   telemetryPublisherConfig?: Partial<TelemetryPublisherConfig>;
+  demoRoomConfig?: Partial<DemoRoomConfig>;
 }
 
 /**
@@ -89,6 +92,13 @@ export function buildTestAppConfig(
       redisUrl: '',
       nodeInstanceId: 'test-node-instance',
       ...overrides.telemetryPublisherConfig,
+    },
+    // Off by default so the demo caption source is neither constructed nor
+    // started for suites that don't opt in.
+    demoRoomConfig: {
+      enabled: false,
+      sessionUid: DEFAULT_DEMO_SESSION_UID,
+      ...overrides.demoRoomConfig,
     },
   } as unknown as AppConfig;
 }

--- a/apps/node-server/tsconfig.json
+++ b/apps/node-server/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": ".",
+    "resolveJsonModule": true,
     "paths": {
       "#src/*": [
         "./src/*"
@@ -14,7 +15,8 @@
   },
   "include": [
     "src",
-    "tests"
+    "tests",
+    "src/server/features/demo-room/fixtures/*.json"
   ],
   "references": [
     {

--- a/apps/node-server/vitest.config.ts
+++ b/apps/node-server/vitest.config.ts
@@ -13,8 +13,9 @@ export default mergeConfig(
         //
         // The demo-room fixture generator is a standalone Python dev tool that
         // lives beside the fixture it produces; it is not application source
-        // and must not be fed to the JS coverage instrumenter.
-        exclude: ['src/index.ts', '**/*.py'],
+        // and must not be fed to the JS coverage instrumenter. The same goes
+        // for the JSON fixtures it emits — data, not code.
+        exclude: ['src/index.ts', '**/*.py', '**/*.json'],
       },
       projects: [
         {

--- a/apps/node-server/vitest.config.ts
+++ b/apps/node-server/vitest.config.ts
@@ -10,7 +10,11 @@ export default mergeConfig(
         // Process entrypoint: bootstraps and starts the server. It has no unit-
         // testable logic and is exercised by the integration suite, so exclude
         // it rather than report it as uncovered.
-        exclude: ['src/index.ts'],
+        //
+        // The demo-room fixture generator is a standalone Python dev tool that
+        // lives beside the fixture it produces; it is not application source
+        // and must not be fed to the JS coverage instrumenter.
+        exclude: ['src/index.ts', '**/*.py'],
       },
       projects: [
         {

--- a/apps/session-manager/.env.example
+++ b/apps/session-manager/.env.example
@@ -29,3 +29,15 @@ DB_PORT=5432
 DB_NAME=scribear-db-dev
 DB_USER=scribear
 DB_PASSWORD=CHANGEME
+
+#### Demo caption room (dev/staging only). When enabled, the Session Manager
+#### seeds a joinable demo session ("Demo - Alice in Wonderland") with a
+#### stable join code, whose uid the Node Server publishes a looping fixture
+#### caption stream into (see apps/node-server/.env.example). OFF by default.
+#### Must stay "false" in production.
+DEMO_ROOM_ENABLED=false
+
+#### Fixed UUID for the seeded demo session above. Must be identical to the
+#### Node Server's DEMO_SESSION_UID - session tokens are verified against the
+#### URL's sessionUid, so the two services must agree on this value.
+DEMO_SESSION_UID=deadbeef-0000-4000-8000-000000000001

--- a/apps/session-manager/src/app-config/app-config.ts
+++ b/apps/session-manager/src/app-config/app-config.ts
@@ -5,6 +5,7 @@ import type { Static } from 'typebox';
 import { LogLevel } from '@scribear/base-fastify-server';
 
 import type { DBClientConfig } from '#src/db/db-client.js';
+import { DEFAULT_DEMO_SESSION_UID } from '#src/server/features/demo-room/demo-room.constants.js';
 import {
   DEFAULT_MATERIALIZATION_WORKER_CONFIG,
   type MaterializationWorkerConfig,
@@ -35,6 +36,17 @@ const CONFIG_SCHEMA = Type.Object({
     default: 60,
   }),
   DEVICE_ONLINE_TTL_SEC: Type.Integer({ minimum: 1, default: 180 }),
+
+  // Dev/staging-only demo caption room (see
+  // apps/node-server/PLAN-Demo-CAPTION_ROOM.md). Off by default so a
+  // production instance never seeds a real, joinable session; enabled
+  // explicitly in the dev and staging deployments. env-schema coerces the
+  // strings "true"/"false" only - "1"/"0"/"" are rejected at boot.
+  DEMO_ROOM_ENABLED: Type.Boolean({ default: false }),
+  // Session UID the demo session is seeded with. Must match the Node
+  // Server's DEMO_SESSION_UID, so both services default to (and are
+  // configured with) the same value.
+  DEMO_SESSION_UID: Type.String({ default: DEFAULT_DEMO_SESSION_UID }),
 });
 
 export interface BaseConfig {
@@ -42,6 +54,13 @@ export interface BaseConfig {
   logLevel: LogLevel;
   port: number;
   host: string;
+}
+
+export interface DemoRoomConfig {
+  /** When false, the demo room seeder is never constructed or run. */
+  enabled: boolean;
+  /** Session UID the seeded demo session is created with. */
+  sessionUid: string;
 }
 
 export class AppConfig {
@@ -94,6 +113,13 @@ export class AppConfig {
 
   get materializationWorkerConfig(): MaterializationWorkerConfig {
     return DEFAULT_MATERIALIZATION_WORKER_CONFIG;
+  }
+
+  get demoRoomConfig(): DemoRoomConfig {
+    return {
+      enabled: this._env.DEMO_ROOM_ENABLED,
+      sessionUid: this._env.DEMO_SESSION_UID,
+    };
   }
 
   constructor(path?: string) {

--- a/apps/session-manager/src/server/create-server.ts
+++ b/apps/session-manager/src/server/create-server.ts
@@ -59,6 +59,26 @@ async function createServer(config: AppConfig) {
     await materializationWorker.stop();
   });
 
+  // Demo caption room (dev/staging only). Resolved solely when enabled so a
+  // production instance never seeds a real, joinable session. Idempotently
+  // ensures a demo room/device/session exist and logs a current join code;
+  // see `apps/node-server/PLAN-Demo-CAPTION_ROOM.md`.
+  if (config.demoRoomConfig.enabled) {
+    const demoRoomSeeder =
+      dependencyContainer.resolve<AppDependencies['demoRoomSeeder']>(
+        'demoRoomSeeder',
+      );
+    fastify.addHook('onReady', async () => {
+      // A seeding failure (e.g. a transient DB error) must not take down an
+      // otherwise-healthy dev/staging instance over a demo feature.
+      try {
+        await demoRoomSeeder.seed();
+      } catch (err) {
+        logger.error({ err }, 'demo caption room: seeding failed');
+      }
+    });
+  }
+
   // Drain the pg pool on shutdown. Without this, in-flight idle clients
   // surface a fatal admin-shutdown error (Postgres 57P01) when the database
   // shuts down before us, and pg-pool re-emits that as an unhandled `error`

--- a/apps/session-manager/src/server/dependency-injection/app-dependencies.ts
+++ b/apps/session-manager/src/server/dependency-injection/app-dependencies.ts
@@ -3,8 +3,13 @@ import '@fastify/awilix';
 
 import type { BaseDependencies } from '@scribear/base-fastify-server';
 
-import type { AppConfig, BaseConfig } from '#src/app-config/app-config.js';
+import type {
+  AppConfig,
+  BaseConfig,
+  DemoRoomConfig,
+} from '#src/app-config/app-config.js';
 import type { DBClient, DBClientConfig } from '#src/db/db-client.js';
+import type { DemoRoomSeeder } from '#src/server/features/demo-room/demo-room-seeder.js';
 import type { DeviceManagementController } from '#src/server/features/device-management/device-management.controller.js';
 import type { DeviceManagementRepository } from '#src/server/features/device-management/device-management.repository.js';
 import type { DeviceManagementService } from '#src/server/features/device-management/device-management.service.js';
@@ -53,6 +58,7 @@ interface AppDependencies extends BaseDependencies {
   sessionTokenConfig: SessionTokenConfig;
   dbClientConfig: DBClientConfig;
   materializationWorkerConfig: MaterializationWorkerConfig;
+  demoRoomConfig: DemoRoomConfig;
 
   // Database
   dbClient: DBClient;
@@ -94,6 +100,9 @@ interface AppDependencies extends BaseDependencies {
   sessionAuthController: SessionAuthController;
   sessionAuthService: SessionAuthService;
   sessionAuthRepository: SessionAuthRepository;
+
+  // Demo caption room (dev/staging only)
+  demoRoomSeeder: DemoRoomSeeder;
 }
 
 /**

--- a/apps/session-manager/src/server/dependency-injection/register-dependencies.ts
+++ b/apps/session-manager/src/server/dependency-injection/register-dependencies.ts
@@ -7,6 +7,7 @@ import {
 } from 'awilix';
 
 import { DBClient } from '#src/db/db-client.js';
+import { DemoRoomSeeder } from '#src/server/features/demo-room/demo-room-seeder.js';
 import { DeviceManagementController } from '#src/server/features/device-management/device-management.controller.js';
 import { DeviceManagementRepository } from '#src/server/features/device-management/device-management.repository.js';
 import { DeviceManagementService } from '#src/server/features/device-management/device-management.service.js';
@@ -51,6 +52,7 @@ function registerDependencies(
     sessionTokenConfig: asValue(config.sessionTokenConfig),
     dbClientConfig: asValue(config.dbClientConfig),
     materializationWorkerConfig: asValue(config.materializationWorkerConfig),
+    demoRoomConfig: asValue(config.demoRoomConfig),
 
     // Database
     dbClient: asClass(DBClient, { lifetime: Lifetime.SINGLETON }),
@@ -142,6 +144,17 @@ function registerDependencies(
     }),
     sessionAuthRepository: asClass(SessionAuthRepository, {
       lifetime: Lifetime.SINGLETON,
+    }),
+
+    // Demo caption room (dev/staging only). Constructed regardless, but a
+    // no-op unless `demoRoomConfig.enabled`; `create-server.ts` only resolves
+    // and runs it when the flag is set. SCOPED (not SINGLETON) because it
+    // depends on scoped services; resolving it once from the root container
+    // at startup produces a single instance for the process, with its scoped
+    // dependencies cached on that same root scope (same pattern as
+    // `materializationWorker` above).
+    demoRoomSeeder: asClass(DemoRoomSeeder, {
+      lifetime: Lifetime.SCOPED,
     }),
   } as NameAndRegistrationPair<AppDependencies>);
 }

--- a/apps/session-manager/src/server/features/demo-room/demo-room-seeder.ts
+++ b/apps/session-manager/src/server/features/demo-room/demo-room-seeder.ts
@@ -1,0 +1,132 @@
+import type { DemoRoomConfig } from '#src/app-config/app-config.js';
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+import type { Session } from '#src/server/features/schedule-management/schedule-management.repository.js';
+
+import {
+  DEMO_ROOM_NAME,
+  DEMO_SESSION_NAME,
+  DEMO_SOURCE_DEVICE_NAME,
+  DEMO_TRANSCRIPTION_PROVIDER_ID,
+  DEMO_TRANSCRIPTION_STREAM_CONFIG,
+} from './demo-room.constants.js';
+
+/**
+ * Dev/staging-only boot-time seeder for a joinable "demo caption room".
+ *
+ * This is the Session Manager half of the demo caption room; the Node Server
+ * half (`DemoCaptionSource`) publishes a looping fixture caption stream for a
+ * fixed `sessionUid` (see `apps/node-server/PLAN-Demo-CAPTION_ROOM.md`). A
+ * browser can only join that stream through the normal join-code -> session
+ * -token exchange, which requires a *real, currently-active* Session Manager
+ * session whose `uid` is exactly that fixed value. This seeder ensures one
+ * exists.
+ *
+ * At boot, when `demoRoomConfig.enabled`, `seed()`:
+ *   1. Looks up a session by `demoRoomConfig.sessionUid`. If found, nothing is
+ *      created - idempotent across restarts.
+ *   2. Otherwise creates a placeholder source device, a dedicated room
+ *      (`autoSessionEnabled: false`, so the auto-session reconciler never
+ *      touches it), and an open-ended (`scheduledEndTime: null`) `ON_DEMAND`
+ *      session inserted with that exact fixed `uid`.
+ *   3. Either way, ensures a currently-valid join code exists and logs it -
+ *      join codes rotate and there is no fixed one, so this is the only way
+ *      for a developer to obtain a code to hand to a client/kiosk/standalone
+ *      webapp.
+ *
+ * Never constructed when the feature is off; a production instance never
+ * seeds a real, joinable session (see `create-server.ts`).
+ */
+export class DemoRoomSeeder {
+  private readonly _logger: AppDependencies['logger'];
+  private readonly _config: DemoRoomConfig;
+  private readonly _roomManagementService: AppDependencies['roomManagementService'];
+  private readonly _deviceManagementService: AppDependencies['deviceManagementService'];
+  private readonly _scheduleManagementRepository: AppDependencies['scheduleManagementRepository'];
+  private readonly _sessionAuthService: AppDependencies['sessionAuthService'];
+
+  constructor(
+    logger: AppDependencies['logger'],
+    demoRoomConfig: AppDependencies['demoRoomConfig'],
+    roomManagementService: AppDependencies['roomManagementService'],
+    deviceManagementService: AppDependencies['deviceManagementService'],
+    scheduleManagementRepository: AppDependencies['scheduleManagementRepository'],
+    sessionAuthService: AppDependencies['sessionAuthService'],
+  ) {
+    this._logger = logger;
+    this._config = demoRoomConfig;
+    this._roomManagementService = roomManagementService;
+    this._deviceManagementService = deviceManagementService;
+    this._scheduleManagementRepository = scheduleManagementRepository;
+    this._sessionAuthService = sessionAuthService;
+  }
+
+  /**
+   * Ensures the demo room/device/session exist and a join code is minted,
+   * then logs the join code. No-op when the feature is disabled. Safe to call
+   * once at boot; safe to call again on every restart (idempotent).
+   * @param now Reference instant; defaults to the current time.
+   */
+  async seed(now: Date = new Date()): Promise<void> {
+    if (!this._config.enabled) return;
+
+    const db = this._scheduleManagementRepository.db;
+    const existing = await this._scheduleManagementRepository.findSessionByUid(
+      db,
+      this._config.sessionUid,
+    );
+    const session = existing ?? (await this._createDemoSession(now));
+
+    const joinCode = await this._sessionAuthService.ensureCurrentJoinCode(
+      session.uid,
+      now,
+    );
+    if (joinCode === null) {
+      // Defensive: we just resolved this session (found or created), so a
+      // missing join code here would only mean it was deleted concurrently.
+      this._logger.error(
+        { sessionUid: session.uid },
+        'demo caption room: session vanished before a join code could be minted',
+      );
+      return;
+    }
+
+    this._logger.info(
+      { joinCode, sessionUid: session.uid },
+      'demo caption room seeded; join with this code',
+    );
+  }
+
+  /**
+   * Creates the placeholder source device, the dedicated demo room, and the
+   * open-ended `ON_DEMAND` session with the fixed demo `uid`.
+   */
+  private async _createDemoSession(now: Date): Promise<Session> {
+    const device = await this._deviceManagementService.registerDevice(
+      DEMO_SOURCE_DEVICE_NAME,
+    );
+
+    const room = await this._roomManagementService.createRoom({
+      name: DEMO_ROOM_NAME,
+      timezone: 'UTC',
+      autoSessionEnabled: false,
+      sourceDeviceUids: [device.deviceUid],
+    });
+    if (typeof room === 'string') {
+      throw new Error(`demo caption room: createRoom failed: ${room}`);
+    }
+
+    const db = this._scheduleManagementRepository.db;
+    return this._scheduleManagementRepository.insertSessionWithUid(db, {
+      uid: this._config.sessionUid,
+      roomUid: room.uid,
+      name: DEMO_SESSION_NAME,
+      type: 'ON_DEMAND',
+      scheduledSessionUid: null,
+      scheduledStartTime: now,
+      scheduledEndTime: null,
+      joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS', 'SEND_AUDIO'],
+      transcriptionProviderId: DEMO_TRANSCRIPTION_PROVIDER_ID,
+      transcriptionStreamConfig: DEMO_TRANSCRIPTION_STREAM_CONFIG,
+    });
+  }
+}

--- a/apps/session-manager/src/server/features/demo-room/demo-room.constants.ts
+++ b/apps/session-manager/src/server/features/demo-room/demo-room.constants.ts
@@ -1,0 +1,44 @@
+/**
+ * Fixed identity of the demo caption session.
+ *
+ * The Session Manager seeds a real, currently-active `ON_DEMAND` session whose
+ * `uid` is exactly this value, so a browser can obtain a session token for it
+ * through the normal join-code exchange. The Node Server's `DemoCaptionSource`
+ * publishes captions on the matching `transcript:${sessionUid}` bus channel
+ * (see `apps/node-server/PLAN-Demo-CAPTION_ROOM.md`). The two services are kept
+ * in sync by the `DEMO_SESSION_UID` env var, which defaults to this literal on
+ * both.
+ *
+ * `deadbeef` is a memorable, valid hex UUID node; the `4` and `8` nibbles keep
+ * it a well-formed v4 UUID.
+ */
+export const DEFAULT_DEMO_SESSION_UID = 'deadbeef-0000-4000-8000-000000000001';
+
+/** Display name of the room the demo session lives in. */
+export const DEMO_ROOM_NAME = 'Demo — Alice in Wonderland';
+
+/** Name of the placeholder source device created to own the demo room. */
+export const DEMO_SOURCE_DEVICE_NAME = 'demo-caption-room-source';
+
+/** Name recorded on the seeded session row. */
+export const DEMO_SESSION_NAME = 'Demo — Alice in Wonderland';
+
+/**
+ * Transcription provider id recorded on the seeded session. The demo session
+ * never dials a real provider - the Node Server's `DemoCaptionSource` publishes
+ * captions directly onto the event bus and never opens an upstream connection
+ * for this session - so this only needs to be a value the schema accepts.
+ * `debug` mirrors the provider id used by the Node Server integration test
+ * seeder (`apps/node-server/tests/utils/seed-session.ts`).
+ */
+export const DEMO_TRANSCRIPTION_PROVIDER_ID = 'debug';
+
+/**
+ * Minimal stream config recorded alongside the provider id above; shape
+ * mirrors the `debug` provider config used elsewhere in the monorepo's test
+ * seeders. Not read by anything at runtime for the demo session.
+ */
+export const DEMO_TRANSCRIPTION_STREAM_CONFIG = {
+  sample_rate: 48_000,
+  num_channels: 1,
+};

--- a/apps/session-manager/src/server/features/schedule-management/schedule-management.repository.ts
+++ b/apps/session-manager/src/server/features/schedule-management/schedule-management.repository.ts
@@ -1020,6 +1020,55 @@ export class ScheduleManagementRepository {
   }
 
   /**
+   * Inserts a single `sessions` row with an explicit `uid`, bypassing the
+   * `gen_random_uuid()` default every other insert path relies on. Used only
+   * by the boot-time demo-room seeder, which needs a session whose `uid`
+   * matches a fixed constant shared with the Node Server so a browser's
+   * join-code exchange yields a session token the Node Server's `sessionUid`
+   * check accepts (see `apps/node-server/PLAN-Demo-CAPTION_ROOM.md`). No
+   * request-driven path creates a session this way - `insertSessions` remains
+   * the only insert path for schedule materialization and `createOnDemandSession`.
+   *
+   * Idempotent under a race with another instance seeding the same uid: on a
+   * primary-key conflict the insert is a no-op and the already-persisted row
+   * is returned instead.
+   * @param db Kysely client or transaction.
+   * @param row Fields to insert, plus the fixed `uid`.
+   * @returns The persisted session (either just-inserted or pre-existing).
+   */
+  async insertSessionWithUid(
+    db: DBOrTrx,
+    row: SessionInsert & { uid: string },
+  ): Promise<Session> {
+    await db
+      .insertInto('sessions')
+      .values({
+        uid: row.uid,
+        room_uid: row.roomUid,
+        name: row.name,
+        type: row.type,
+        scheduled_session_uid: row.scheduledSessionUid,
+        scheduled_start_time: row.scheduledStartTime,
+        scheduled_end_time: row.scheduledEndTime,
+        join_code_scopes: row.joinCodeScopes,
+        transcription_provider_id: row.transcriptionProviderId,
+        transcription_stream_config: row.transcriptionStreamConfig,
+      })
+      .onConflict((oc) => oc.column('uid').doNothing())
+      .execute();
+
+    const persisted = await this.findSessionByUid(db, row.uid);
+    if (!persisted) {
+      // Defensive: the insert either created the row or a conflict means
+      // another writer already did - one of the two must be visible here.
+      throw new Error(
+        `insertSessionWithUid: no session found for uid ${row.uid} after insert`,
+      );
+    }
+    return persisted;
+  }
+
+  /**
    * Updates `scheduled_end_time` and bumps `session_config_version`.
    * @returns The new `session_config_version`.
    */

--- a/apps/session-manager/src/server/features/session-auth/session-auth.service.ts
+++ b/apps/session-manager/src/server/features/session-auth/session-auth.service.ts
@@ -133,6 +133,43 @@ export class SessionAuthService {
   }
 
   /**
+   * Ensures a currently-valid join code exists for a session, minting one if
+   * none is active. Unlike `fetchJoinCodes`, this skips the device-membership
+   * check and next-code precomputation - there is no device request context
+   * at boot - so it is only appropriate for boot-time seeding (the demo-room
+   * seeder), not for the device-facing join-code endpoint.
+   *
+   * @param sessionUid The session to ensure a join code for.
+   * @param now Reference instant for expiry calculations.
+   * @returns The current join code, or `null` if the session does not exist.
+   */
+  async ensureCurrentJoinCode(
+    sessionUid: string,
+    now: Date,
+  ): Promise<string | null> {
+    return this._repo.db.transaction().execute(async (trx) => {
+      const locked = await this._repo.lockSession(trx, sessionUid);
+      if (!locked) return null;
+
+      const codes = await this._repo.findActiveJoinCodes(trx, sessionUid, now);
+      const current = codes.find(
+        (c) =>
+          c.validStart.getTime() <= now.getTime() &&
+          c.validEnd.getTime() > now.getTime(),
+      );
+      if (current) return current.joinCode;
+
+      const inserted = await this._repo.insertJoinCode(trx, {
+        joinCode: this._generateJoinCode(),
+        sessionUid,
+        validStart: now,
+        validEnd: new Date(now.getTime() + JOIN_CODE_DURATION_MS),
+      });
+      return inserted.joinCode;
+    });
+  }
+
+  /**
    * Mints a short-lived session token for a device that already authenticates
    * via a long-lived `DEVICE_TOKEN` cookie. No refresh token is issued: the
    * device re-calls this endpoint with its cookie when the session token

--- a/apps/session-manager/tests/integration/features/probes/probes.routes.test.ts
+++ b/apps/session-manager/tests/integration/features/probes/probes.routes.test.ts
@@ -59,6 +59,10 @@ describe('Probes Routes', () => {
           staleAfterMs: 24 * 60 * 60 * 1000,
           maxRoomsPerTick: 1000,
         },
+        demoRoomConfig: {
+          enabled: false,
+          sessionUid: 'deadbeef-0000-4000-8000-000000000001',
+        },
       } as unknown as AppConfig;
       const { fastify } = await createServer(brokenConfig);
       await fastify.ready();

--- a/apps/session-manager/tests/unit/app-config/app-config.test.ts
+++ b/apps/session-manager/tests/unit/app-config/app-config.test.ts
@@ -21,7 +21,13 @@ const VALID_ENV: Record<string, string> = {
   DB_USER: 'dbuser',
   DB_PASSWORD: 'dbpass',
 };
-const ENV_KEYS = Object.keys(VALID_ENV);
+/**
+ * Optional variables, absent from {@link VALID_ENV} on purpose: they are
+ * cleared before each test so the defaults are what is exercised, and restored
+ * afterwards like the rest.
+ */
+const OPTIONAL_ENV_KEYS = ['DEMO_ROOM_ENABLED', 'DEMO_SESSION_UID'];
+const ENV_KEYS = [...Object.keys(VALID_ENV), ...OPTIONAL_ENV_KEYS];
 
 // A path that does not exist, used to disable dotenv file loading so validation
 // failures depend only on `process.env` (env-schema silently ignores ENOENT).
@@ -36,7 +42,12 @@ describe('AppConfig', () => {
     savedEnv = {};
     for (const key of ENV_KEYS) {
       savedEnv[key] = process.env[key];
-      process.env[key] = VALID_ENV[key];
+      const value = VALID_ENV[key];
+      if (value === undefined) {
+        Reflect.deleteProperty(process.env, key);
+      } else {
+        process.env[key] = value;
+      }
     }
     // Deterministic, non-dev argv unless a test opts in.
     process.argv = ['node', 'app-config.test.ts'];
@@ -126,6 +137,42 @@ describe('AppConfig', () => {
 
       // Assert
       expect(config.baseConfig.isDevelopment).toBe(false);
+    });
+  });
+
+  describe('demo room configuration', (it) => {
+    it('is disabled with the default session uid when unset', () => {
+      // Act - both vars are absent, the production default.
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert
+      expect(config.demoRoomConfig).toStrictEqual({
+        enabled: false,
+        sessionUid: 'deadbeef-0000-4000-8000-000000000001',
+      });
+    });
+
+    it('maps an explicit enable flag and session uid', () => {
+      // Arrange
+      process.env['DEMO_ROOM_ENABLED'] = 'true';
+      process.env['DEMO_SESSION_UID'] = 'aaaaaaaa-0000-4000-8000-000000000002';
+
+      // Act
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert
+      expect(config.demoRoomConfig).toStrictEqual({
+        enabled: true,
+        sessionUid: 'aaaaaaaa-0000-4000-8000-000000000002',
+      });
+    });
+
+    it('rejects a non-boolean enable flag (only true/false are accepted)', () => {
+      // Arrange - env-schema coerces "true"/"false" but not "1".
+      process.env['DEMO_ROOM_ENABLED'] = '1';
+
+      // Act / Assert
+      expect(() => new AppConfig(NO_DOTENV_FILE)).toThrow();
     });
   });
 

--- a/apps/session-manager/tests/unit/features/schedule-management/utils/window-materializer.test.ts
+++ b/apps/session-manager/tests/unit/features/schedule-management/utils/window-materializer.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import { materializeWindow } from '#src/server/features/schedule-management/utils/window-materializer.js';
+import type { AutoSessionWindow } from '#src/server/features/schedule-management/schedule-management.repository.js';
+
+const TZ_UTC = 'UTC';
+
+function makeWindow(overrides: Partial<AutoSessionWindow>): AutoSessionWindow {
+  const activeStart = overrides.activeStart ?? new Date('2024-01-01T00:00:00Z');
+  return {
+    uid: 'window-1',
+    roomUid: 'room-1',
+    localStartTime: '09:00:00',
+    localEndTime: '10:00:00',
+    daysOfWeek: ['MON'],
+    joinCodeScopes: ['SEND_AUDIO'],
+    transcriptionProviderId: 'provider-1',
+    transcriptionStreamConfig: null,
+    activeStart,
+    activeEnd: null,
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('materializeWindow', () => {
+  describe('days mapping', () => {
+    it('passes daysOfWeek through to the synthetic WEEKLY schedule', () => {
+      // Arrange - fires TUE/THU, 14:00-14:30 UTC
+      const window = makeWindow({
+        localStartTime: '14:00:00',
+        localEndTime: '14:30:00',
+        daysOfWeek: ['TUE', 'THU'],
+      });
+
+      // Act
+      const result = materializeWindow(
+        window,
+        TZ_UTC,
+        new Date('2024-06-03T00:00:00Z'), // Mon
+        new Date('2024-06-10T00:00:00Z'), // Next Mon (exclusive)
+      );
+
+      // Assert - only Tue and Thu occurrences, tagged with the window's uid
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        windowUid: 'window-1',
+        startUtc: new Date('2024-06-04T14:00:00Z'), // Tue
+        endUtc: new Date('2024-06-04T14:30:00Z'),
+      });
+      expect(result[1]).toEqual({
+        windowUid: 'window-1',
+        startUtc: new Date('2024-06-06T14:00:00Z'), // Thu
+        endUtc: new Date('2024-06-06T14:30:00Z'),
+      });
+    });
+  });
+
+  describe('activeStart clipping', () => {
+    it('drops an occurrence whose computed start falls before activeStart', () => {
+      // Arrange - activeStart lands mid-day, after the occurrence's local start
+      // time on that same day, so the occurrence must not be included.
+      const window = makeWindow({
+        activeStart: new Date('2024-06-03T14:00:00Z'), // Mon 14:00 UTC
+        localStartTime: '09:00:00', // Mon 09:00 UTC - before activeStart
+        localEndTime: '10:00:00',
+        daysOfWeek: ['MON'],
+      });
+
+      // Act
+      const result = materializeWindow(
+        window,
+        TZ_UTC,
+        new Date('2024-06-01T00:00:00Z'),
+        new Date('2024-06-30T00:00:00Z'),
+      );
+
+      // Assert - the Mon Jun 3 occurrence is clipped away entirely (its
+      // computed start is before activeStart); the later qualifying Mondays
+      // within the window (Jun 10, 17, 24) are unaffected by activeStart.
+      expect(result).toHaveLength(3);
+      expect(result[0]!.startUtc).toEqual(new Date('2024-06-10T09:00:00Z'));
+      expect(result[1]!.startUtc).toEqual(new Date('2024-06-17T09:00:00Z'));
+      expect(result[2]!.startUtc).toEqual(new Date('2024-06-24T09:00:00Z'));
+    });
+  });
+
+  describe('midnight-wrap', () => {
+    it('produces a cross-midnight occurrence when localEndTime < localStartTime', () => {
+      // Arrange - 23:00-01:00 means the window runs from Mon 23:00 to Tue 01:00
+      const window = makeWindow({
+        localStartTime: '23:00:00',
+        localEndTime: '01:00:00',
+        daysOfWeek: ['MON'],
+      });
+
+      // Act
+      const result = materializeWindow(
+        window,
+        TZ_UTC,
+        new Date('2024-06-03T00:00:00Z'),
+        new Date('2024-06-10T00:00:00Z'),
+      );
+
+      // Assert
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        windowUid: 'window-1',
+        startUtc: new Date('2024-06-03T23:00:00Z'),
+        endUtc: new Date('2024-06-04T01:00:00Z'),
+      });
+    });
+  });
+});

--- a/apps/session-manager/tests/utils/use-server.ts
+++ b/apps/session-manager/tests/utils/use-server.ts
@@ -2,7 +2,11 @@ import { afterAll, beforeAll, inject } from 'vitest';
 
 import { LogLevel } from '@scribear/base-fastify-server';
 
-import type { AppConfig, BaseConfig } from '#src/app-config/app-config.js';
+import type {
+  AppConfig,
+  BaseConfig,
+  DemoRoomConfig,
+} from '#src/app-config/app-config.js';
 import type { DBClientConfig } from '#src/db/db-client.js';
 import createServer from '#src/server/create-server.js';
 import type { MaterializationWorkerConfig } from '#src/server/features/schedule-management/materialization.worker.js';
@@ -34,6 +38,7 @@ export interface TestAppConfigOverrides {
   dbClientConfig?: Partial<DBClientConfig>;
   devicePresenceConfig?: Partial<DevicePresenceConfig>;
   materializationWorkerConfig?: Partial<MaterializationWorkerConfig>;
+  demoRoomConfig?: Partial<DemoRoomConfig>;
 }
 
 /**
@@ -88,6 +93,13 @@ export function buildTestAppConfig(
       staleAfterMs: 24 * 60 * 60 * 1000,
       maxRoomsPerTick: 1000,
       ...overrides.materializationWorkerConfig,
+    },
+    // Off by default so ordinary suites never seed a demo room; suites
+    // exercising the seeder itself pass `{ demoRoomConfig: { enabled: true } }`.
+    demoRoomConfig: {
+      enabled: false,
+      sessionUid: 'deadbeef-0000-4000-8000-000000000001',
+      ...overrides.demoRoomConfig,
     },
   } as unknown as AppConfig;
 }

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -80,6 +80,21 @@ JWT_SECRET=CHANGEME-JWT-must-be-at-least-32-characters-long
 #   NODE_SERVER_REDIS_URL=redis://:CHANGEME@redis:6379
 NODE_SERVER_REDIS_URL=
 
+# -- Demo Caption Room ------
+# Dev/staging only. When enabled, the Node Server auto-emits a never-ending,
+# looping caption stream (Alice's Adventures in Wonderland, Chapter V) and the
+# Session Manager seeds a matching joinable session, so the client/kiosk/
+# standalone webapps can be exercised end-to-end with no microphone, source
+# device, or Python transcription service running. Both services read these
+# same two values - see apps/node-server/.env.example and
+# apps/session-manager/.env.example for detail.
+#
+# Defaulted OFF. Set DEMO_ROOM_ENABLED=true ONLY for a dev or staging
+# deployment; a production deployment must leave this "false" (or unset).
+DEMO_ROOM_ENABLED=false
+# Fixed UUID shared by both services when the demo room is enabled above.
+DEMO_SESSION_UID=deadbeef-0000-4000-8000-000000000001
+
 # -- Admin Website -----
 # ADMIN_API_KEY reuses SESSION_MANAGER_API_KEY (see Session Manager section above).
 ADMIN_LOG_LEVEL=info

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -84,6 +84,13 @@ services:
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
+      # Demo caption room (dev/staging only). Seeds a joinable demo session
+      # whose uid the Node Server publishes a looping fixture caption stream
+      # into - see apps/session-manager/.env.example and
+      # apps/node-server/.env.example. Defaulted "false"; set true only in a
+      # dev or staging .env, never in production.
+      DEMO_ROOM_ENABLED: ${DEMO_ROOM_ENABLED:-false}
+      DEMO_SESSION_UID: ${DEMO_SESSION_UID:-}
     depends_on:
       scribear-db:
         condition: service_healthy
@@ -159,6 +166,13 @@ services:
       # sets to the container name, so scaling this service gives each replica
       # a distinct identity with no further configuration.
       REDIS_URL: ${NODE_SERVER_REDIS_URL:-}
+      # Demo caption room (dev/staging only). When true, this Node Server
+      # auto-emits a looping fixture caption stream for DEMO_SESSION_UID - see
+      # apps/node-server/.env.example. Defaulted "false"; set true only in a
+      # dev or staging .env, never in production. DEMO_SESSION_UID must match
+      # the value given to the session-manager service above.
+      DEMO_ROOM_ENABLED: ${DEMO_ROOM_ENABLED:-false}
+      DEMO_SESSION_UID: ${DEMO_SESSION_UID:-}
     depends_on:
       transcription-service:
         condition: service_healthy

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -211,7 +211,7 @@ export default defineConfig([
     // Disable strict type checking rules for test files
     // There's no real point in making sure JSON outputs are a certain type
     // When the test file is about to check it.
-    files: ['**/*.test.ts'],
+    files: ['**/*.test.{ts,tsx}'],
     rules: {
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "@eslint-react/eslint-plugin": "2.13.0",
         "@testing-library/jest-dom": "7.0.0",
         "@testing-library/react": "16.3.2",
+        "@testing-library/user-event": "14.6.1",
         "eslint-plugin-react-hooks": "7.0.1",
         "eslint-plugin-react-refresh": "0.5.2",
         "jsdom": "29.1.1"
@@ -4182,6 +4183,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@trivago/prettier-plugin-sort-imports": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1923,9 +1923,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2010,9 +2010,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5550,9 +5550,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6962,9 +6962,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7322,9 +7322,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -7427,9 +7427,9 @@
       }
     },
     "node_modules/fastify/node_modules/fast-json-stringify/node_modules/fast-uri": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.0.tgz",
-      "integrity": "sha512-ZodJ2cRiLVWGi9IgPb3mbgSqM4CD3LexCHkuv0FfBXHJI1ADfucTD06m6clO2Cy5RZYsw/SiCVl/dyrFI/SYWA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
+      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
       "funding": [
         {
           "type": "github",
@@ -10243,9 +10243,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,8 +82,11 @@
       },
       "devDependencies": {
         "@eslint-react/eslint-plugin": "2.13.0",
+        "@testing-library/jest-dom": "7.0.0",
+        "@testing-library/react": "16.3.2",
         "eslint-plugin-react-hooks": "7.0.1",
-        "eslint-plugin-react-refresh": "0.5.2"
+        "eslint-plugin-react-refresh": "0.5.2",
+        "jsdom": "29.1.1"
       }
     },
     "apps/client-webapp": {
@@ -500,6 +503,64 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -861,6 +922,19 @@
         }
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@changesets/apply-release-plan": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.0.tgz",
@@ -1133,6 +1207,146 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -2094,6 +2308,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fastify/accept-negotiator": {
@@ -3873,6 +4105,85 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@trivago/prettier-plugin-sort-imports": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-6.0.2.tgz",
@@ -3913,6 +4224,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5189,6 +5508,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -5488,6 +5817,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/birecord": {
@@ -5961,6 +6300,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concurrently/node_modules/shell-quote": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/concurrently/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -6172,11 +6524,46 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/dateformat": {
       "version": "4.6.3",
@@ -6204,6 +6591,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -6379,6 +6773,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -6499,6 +6901,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -7815,6 +8230,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -7945,6 +8373,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -8060,6 +8498,13 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -8232,6 +8677,67 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/jsesc": {
@@ -8647,6 +9153,17 @@
         "node": ">=12"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -8684,6 +9201,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -8751,6 +9275,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -9128,6 +9662,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -9489,6 +10036,44 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -9899,6 +10484,20 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -10173,6 +10772,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -10240,19 +10852,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
-      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -10572,6 +11171,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -10615,6 +11227,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tabbable": {
       "version": "6.4.0",
@@ -10794,6 +11413,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
@@ -10842,6 +11481,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -11554,6 +12219,54 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11724,6 +12437,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
         "@testing-library/user-event": "14.6.1",
         "eslint-plugin-react-hooks": "7.0.1",
         "eslint-plugin-react-refresh": "0.5.2",
+        "jest-axe": "10.0.0",
         "jsdom": "29.1.1"
       }
     },
@@ -3051,6 +3052,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -4093,6 +4107,13 @@
     "node_modules/@scribear/visualizer-ui": {
       "resolved": "libs/ui/visualizer-ui",
       "link": true
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -5629,6 +5650,16 @@
         "awilix": ">=9.0.0"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
+      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/b4a": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
@@ -6666,6 +6697,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -8652,6 +8693,134 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
       "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-axe": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-10.0.0.tgz",
+      "integrity": "sha512-9QR0M7//o5UVRnEUUm68IsGapHrcKGakYy9dKWWMX79LmeUKguDI6DREyljC5I13j78OUmtKLF5My6ccffLFBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axe-core": "4.10.2",
+        "chalk": "4.1.2",
+        "jest-matcher-utils": "29.2.2",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.2.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.2.tgz",
+      "integrity": "sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
## Summary

Brings the `admin-tests` work + the `demo-caption-room` feature onto current `staging` (which now includes the dependency bumps and the `useAsyncData` admin refactor from #145). Three strands:

1. **Admin test coverage** — unit tests for admin-webapp pages/lib, admin-server routes, and session-manager (window-materializer), plus a vitest + testing-library harness. ~22 commits from the `admin-tests` branch.
2. **Demo caption room** — a dev/staging-only looping demo caption stream (node-server + session-manager + deployment; fixtures derived from Alice in Wonderland Ch. V, public domain).
3. **Test linting** — `admin-webapp` and `node-server` previously linted only `./src`, so their test files were never checked; enabled `./tests` linting in both and fixed the four errors that surfaced.

## Integration notes

- Merged `staging` in and resolved conflicts: `admin-webapp/package.json` (union of staging's eslint deps + admin-tests's testing-library/jest-axe/jsdom) and `package-lock.json` (regenerated). Page source files auto-merged — the `useAsyncData` refactor and the admin-tests dialog-diff/WCAG changes landed in different regions.
- The tests, written against the pre-refactor components, pass unchanged against the refactored ones.
- Fixed the demo's `.json` fixtures crashing vitest coverage instrumentation (extended node-server's coverage exclude, alongside the existing `.py` exclude).

## Verification

- **767 unit tests pass:** admin-webapp 153, admin-server 86, session-manager 381, node-server 147.
- Full monorepo lint green (all 30 workspaces); `tsc -b` clean; `package-lock.json` `npm ci`-clean.
- **Not run:** the `test:integration` suites (node-server/session-manager demo-room + telemetry) need Docker/testcontainers.

## Pre-existing, out of scope

`node-server`'s telemetry test lint errors were latent because its gate was `eslint ./src`; enabling test linting surfaced and fixed them here. No other latent test-lint issues remained across the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
