### PR TITLE
feat(demo-room): admin console link, on-by-default, /client routing

### DIFF
--- a/.changeset/admin-demo-room-link.md
+++ b/.changeset/admin-demo-room-link.md
@@ -1,0 +1,38 @@
+---
+'@scribear/session-manager-schema': minor
+'@scribear/session-manager-client': minor
+'@scribear/session-manager': minor
+'@scribear/node-server': minor
+'@scribear/admin-server': minor
+'@scribear/admin-webapp': minor
+'@scribear/kiosk-webapp': patch
+'@scribear/scribear-nginx': patch
+---
+
+Demo caption room: on by default everywhere, surfaced in the admin console with
+a one-click "open live captions" link, with a bare-`/client` routing fix.
+
+- **On by default.** `DEMO_ROOM_ENABLED` now defaults to `true` in both the Node
+  Server and Session Manager (every environment, including production); set
+  `DEMO_ROOM_ENABLED=false` to turn it off. `DEMO_SESSION_UID` is no longer
+  plumbed through `deployment/compose.yml` — both services share the same
+  built-in default, so neither var needs setting for a working demo room.
+- **Admin dashboard — Demo caption room card.** Shows whether the demo room is
+  enabled and whether its seeded session is currently joinable, and — when it is
+  — an **Open live captions** button that opens the client webapp straight into
+  the looping demo captions with no manual join-code entry. A forcing function
+  for exercising the client frontend end-to-end without a mic, source device, or
+  transcription service.
+- **Session Manager — `GET /demo-room/status` (admin-key).** Reports
+  `{ enabled, sessionUid, active, roomName, joinCode }`, minting/returning a
+  currently-valid join code (via the same idempotent `ensureCurrentJoinCode` the
+  seeder uses) only when the session is active. Plumbed through the
+  session-manager schema + client and proxied by the admin server's gateway with
+  the admin API key it already holds; the console builds the same-origin
+  `/client/#config=<base64>` deep link the kiosk QR uses.
+- **nginx — route bare `/client`.** A request to `/client` (no trailing slash)
+  now 308-redirects to `/client/` (the browser preserves the `#config=...`
+  fragment), so deep links resolve regardless of the trailing slash.
+- **Kiosk — fix QR 404.** The QR code defaulted to `${origin}/client` (no
+  trailing slash); the reverse proxy only serves `/client/`, so scanned codes
+  404'd. Now defaults to `${origin}/client/`.

--- a/apps/admin-server/src/server/create-server.ts
+++ b/apps/admin-server/src/server/create-server.ts
@@ -12,6 +12,7 @@ import registerDependencies from './dependency-injection/register-dependencies.j
 import { auditRouter } from './features/audit/audit.router.js';
 import { authRouter } from './features/auth/auth.router.js';
 import { configCheckRouter } from './features/config-check/config-check.router.js';
+import { demoRoomRouter } from './features/demo-room/demo-room.router.js';
 import { devicesRouter } from './features/devices/devices.router.js';
 import { fleetRouter } from './features/fleet/fleet.router.js';
 import { healthRouter } from './features/health/health.router.js';
@@ -56,6 +57,7 @@ async function createServer(config: AppConfig) {
   fastify.register(roomsRouter);
   fastify.register(devicesRouter);
   fastify.register(schedulingRouter);
+  fastify.register(demoRoomRouter);
   fastify.register(auditRouter);
   fastify.register(fleetRouter);
 

--- a/apps/admin-server/src/server/dependency-injection/app-dependencies.ts
+++ b/apps/admin-server/src/server/dependency-injection/app-dependencies.ts
@@ -15,6 +15,7 @@ import type {
   ConfigCheckConfig,
   ConfigCheckService,
 } from '#src/server/features/config-check/config-check.service.js';
+import type { DemoRoomController } from '#src/server/features/demo-room/demo-room.controller.js';
 import type { DevicesController } from '#src/server/features/devices/devices.controller.js';
 import type { FleetController } from '#src/server/features/fleet/fleet.controller.js';
 import type { HealthController } from '#src/server/features/health/health.controller.js';
@@ -102,6 +103,9 @@ interface AppDependencies extends BaseDependencies {
 
   // Scheduling
   schedulingController: SchedulingController;
+
+  // Demo caption room
+  demoRoomController: DemoRoomController;
 
   // Audit
   auditController: AuditController;

--- a/apps/admin-server/src/server/dependency-injection/register-dependencies.ts
+++ b/apps/admin-server/src/server/dependency-injection/register-dependencies.ts
@@ -18,6 +18,7 @@ import { AuditController } from '#src/server/features/audit/audit.controller.js'
 import { AuthController } from '#src/server/features/auth/auth.controller.js';
 import { ConfigCheckController } from '#src/server/features/config-check/config-check.controller.js';
 import { ConfigCheckService } from '#src/server/features/config-check/config-check.service.js';
+import { DemoRoomController } from '#src/server/features/demo-room/demo-room.controller.js';
 import { DevicesController } from '#src/server/features/devices/devices.controller.js';
 import { FleetController } from '#src/server/features/fleet/fleet.controller.js';
 import { HealthController } from '#src/server/features/health/health.controller.js';
@@ -120,6 +121,10 @@ function registerDependencies(
 
     // Scheduling
     schedulingController: asClass(SchedulingController, {
+      lifetime: Lifetime.SCOPED,
+    }),
+
+    demoRoomController: asClass(DemoRoomController, {
       lifetime: Lifetime.SCOPED,
     }),
 

--- a/apps/admin-server/src/server/features/demo-room/demo-room.controller.ts
+++ b/apps/admin-server/src/server/features/demo-room/demo-room.controller.ts
@@ -1,0 +1,28 @@
+import type {
+  BaseFastifyReply,
+  BaseFastifyRequest,
+} from '@scribear/base-fastify-server';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+
+/**
+ * Surfaces the demo caption room to the admin console: whether
+ * it is enabled, whether its seeded session is currently joinable, and a
+ * currently-valid join code when it is. A thin pass-through of the Session
+ * Manager's `demo-room/status` (reached with the admin API key via the
+ * gateway); the console turns the join code into a `/client/#config=...`
+ * deep-link itself, since that link is same-origin behind the reverse proxy.
+ */
+export class DemoRoomController {
+  private _gateway: AppDependencies['sessionManagerGatewayService'];
+
+  constructor(
+    sessionManagerGatewayService: AppDependencies['sessionManagerGatewayService'],
+  ) {
+    this._gateway = sessionManagerGatewayService;
+  }
+
+  async status(req: BaseFastifyRequest, res: BaseFastifyReply) {
+    this._gateway.respond(req, res, await this._gateway.getDemoRoomStatus());
+  }
+}

--- a/apps/admin-server/src/server/features/demo-room/demo-room.router.ts
+++ b/apps/admin-server/src/server/features/demo-room/demo-room.router.ts
@@ -1,0 +1,14 @@
+import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
+
+import resolveHandler from '#src/server/dependency-injection/resolve-handler.js';
+import { requireSessionHook } from '#src/server/shared/hooks/require-session.hook.js';
+
+import { DEMO_ROOM_STATUS_ROUTE } from './demo-room.schema.js';
+
+export function demoRoomRouter(fastify: BaseFastifyInstance) {
+  fastify.route({
+    ...DEMO_ROOM_STATUS_ROUTE,
+    preHandler: [requireSessionHook],
+    handler: resolveHandler('demoRoomController', 'status'),
+  });
+}

--- a/apps/admin-server/src/server/features/demo-room/demo-room.schema.ts
+++ b/apps/admin-server/src/server/features/demo-room/demo-room.schema.ts
@@ -1,0 +1,6 @@
+import { ADMIN_BASE_PATH } from '#src/server/base-path.js';
+
+export const DEMO_ROOM_STATUS_ROUTE = {
+  method: 'GET' as const,
+  url: `${ADMIN_BASE_PATH}/demo-room/status`,
+};

--- a/apps/admin-server/src/server/shared/services/session-manager-gateway.service.ts
+++ b/apps/admin-server/src/server/shared/services/session-manager-gateway.service.ts
@@ -305,6 +305,12 @@ export class SessionManagerGatewayService {
     });
   }
 
+  // ---- Demo room ----
+
+  getDemoRoomStatus() {
+    return this._client.demoRoom.status({ headers: this._authHeaders() });
+  }
+
   // ---- Probes (unauthenticated upstream) ----
 
   readiness() {

--- a/apps/admin-server/tests/integration/demo-room.routes.test.ts
+++ b/apps/admin-server/tests/integration/demo-room.routes.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect } from 'vitest';
+
+import { SessionManagerMock } from '#tests/utils/mock-session-manager.js';
+import { useDb } from '#tests/utils/use-db.js';
+import { TEST_ADMIN_KEY, login, useServer } from '#tests/utils/use-server.js';
+
+const URL = '/api/admin/v1/demo-room/status';
+const DEMO_UID = 'deadbeef-0000-4000-8000-000000000001';
+
+describe('Demo room routes', () => {
+  const server = useServer();
+  useDb();
+  let sm: SessionManagerMock;
+  beforeEach(() => {
+    sm = new SessionManagerMock();
+  });
+  afterEach(() => {
+    sm.restore();
+  });
+
+  describe('auth guard', (it) => {
+    it('rejects an unauthenticated request with 401 and makes NO upstream call', async () => {
+      // Act
+      const res = await server.fastify.inject({ method: 'GET', url: URL });
+
+      // Assert
+      expect(res.statusCode).toBe(401);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'UNAUTHENTICATED',
+      );
+      expect(sm.requests.length).toBe(0);
+    });
+  });
+
+  describe('status passthrough', (it) => {
+    it('returns the running status and injects the admin key upstream', async () => {
+      // Arrange
+      const upstreamBody = {
+        enabled: true,
+        sessionUid: DEMO_UID,
+        active: true,
+        roomName: 'Demo — Alice in Wonderland',
+        joinCode: 'ABCD1234',
+      };
+      sm.respondWith({ status: 200, body: upstreamBody });
+      const { cookie } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: URL,
+        headers: { cookie },
+      });
+
+      // Assert — envelope passthrough
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ ok: true, data: upstreamBody });
+      // Assert — the admin key is injected server-side, never from the browser
+      const upstream = sm.requests.find((r) =>
+        r.url.includes('/demo-room/status'),
+      );
+      expect(upstream).toBeDefined();
+      expect(upstream?.headers['authorization']).toBe(
+        `Bearer ${TEST_ADMIN_KEY}`,
+      );
+    });
+
+    it('passes a disabled upstream status through unchanged', async () => {
+      // Arrange
+      const upstreamBody = {
+        enabled: false,
+        sessionUid: DEMO_UID,
+        active: false,
+        roomName: null,
+        joinCode: null,
+      };
+      sm.respondWith({ status: 200, body: upstreamBody });
+      const { cookie } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: URL,
+        headers: { cookie },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ ok: true, data: upstreamBody });
+    });
+  });
+});

--- a/apps/admin-webapp/src/features/dashboard/dashboard-page.tsx
+++ b/apps/admin-webapp/src/features/dashboard/dashboard-page.tsx
@@ -22,6 +22,7 @@ import { ApiError, isApiErrorCode } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 
+import { DemoRoomCard } from './demo-room-card';
 import { FleetPanel } from './fleet-panel';
 
 type HealthColor = 'success' | 'warning' | 'error' | 'default';
@@ -169,6 +170,8 @@ export const DashboardPage = () => {
           Health status unavailable.
         </Typography>
       )}
+
+      <DemoRoomCard />
 
       <FleetPanel />
 

--- a/apps/admin-webapp/src/features/dashboard/demo-room-card.tsx
+++ b/apps/admin-webapp/src/features/dashboard/demo-room-card.tsx
@@ -1,0 +1,148 @@
+import { useEffect } from 'react';
+
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import type { DemoRoomStatus } from '#src/lib/admin-api';
+import { adminApi } from '#src/lib/admin-api';
+import { useAsyncData } from '#src/lib/use-async-data';
+
+// Join codes rotate on a ~5 minute window server-side; re-poll well inside that
+// so the "Open live captions" link stays exchangeable without a manual refresh.
+const POLL_MS = 120_000;
+
+/**
+ * Builds a client-webapp deep link that auto-joins the demo session. The client
+ * webapp reads a base64 `#config=` fragment and pre-fills/exchanges the join
+ * code — the same format the kiosk QR uses. The link is same-origin: the admin
+ * console and the client webapp are both served behind the one reverse proxy,
+ * so a root-relative origin is correct in every environment.
+ *
+ * The trailing slash matters: nginx serves the client webapp at `/client/`, and
+ * `/client` (no slash) 404s.
+ */
+function buildJoinUrl(joinCode: string): string {
+  const config = { clientSessionConfig: { joinCode } };
+  const encoded = btoa(JSON.stringify(config));
+  return `${window.location.origin}/client/#config=${encoded}`;
+}
+
+type ChipColor = 'success' | 'warning' | 'default';
+
+function statusChip(status: DemoRoomStatus): {
+  label: string;
+  color: ChipColor;
+} {
+  if (!status.enabled) return { label: 'Disabled', color: 'default' };
+  if (!status.active) return { label: 'Not running', color: 'warning' };
+  return { label: 'Running', color: 'success' };
+}
+
+/**
+ * Dashboard card for the demo caption room. Shows whether the feature is
+ * enabled and its seeded session is currently joinable, and — when it is — a
+ * one-click link that opens the client webapp straight into the live captions
+ * (no manual join-code entry). Also a forcing function for exercising the
+ * client frontend end-to-end without a mic or source device.
+ */
+export const DemoRoomCard = () => {
+  const { data, loading, reload } = useAsyncData<DemoRoomStatus>(
+    () => adminApi.demoRoom(),
+    [],
+  );
+
+  useEffect(() => {
+    const id = window.setInterval(reload, POLL_MS);
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [reload]);
+
+  const chip = data ? statusChip(data) : null;
+  const joinUrl =
+    data?.active && data.joinCode !== null ? buildJoinUrl(data.joinCode) : null;
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        sx={{ mb: 1 }}
+      >
+        <Typography variant="h6" component="h2">
+          Demo caption room
+        </Typography>
+        {chip && <Chip size="small" label={chip.label} color={chip.color} />}
+      </Stack>
+
+      <Card sx={{ maxWidth: 480 }}>
+        <CardContent>
+          {loading && data === null ? (
+            <CircularProgress size={24} />
+          ) : data === null ? (
+            <Typography variant="body2" color="text.secondary">
+              Demo room status unavailable.
+            </Typography>
+          ) : !data.enabled ? (
+            <Typography variant="body2" color="text.secondary">
+              Off — <code>DEMO_ROOM_ENABLED=false</code> is set on the Session
+              Manager and Node Server. It runs by default; clear that flag to
+              bring back the looping demo caption stream, which needs no
+              microphone or source device.
+            </Typography>
+          ) : !data.active ? (
+            <Typography variant="body2" color="text.secondary">
+              Enabled, but no joinable demo session was found yet — the seeder
+              may still be starting, or seeding failed. Check the Session
+              Manager logs.
+            </Typography>
+          ) : (
+            <Stack spacing={1.5}>
+              <Typography variant="body2" color="text.secondary">
+                {data.roomName ?? 'Demo room'} is live. Open it to watch the
+                looping captions in the client webapp — no join code entry
+                needed.
+              </Typography>
+              <Box>
+                {joinUrl !== null ? (
+                  <Button
+                    variant="contained"
+                    startIcon={<OpenInNewIcon />}
+                    component="a"
+                    href={joinUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Open live captions
+                  </Button>
+                ) : (
+                  <Button
+                    variant="contained"
+                    startIcon={<OpenInNewIcon />}
+                    disabled
+                  >
+                    Open live captions
+                  </Button>
+                )}
+              </Box>
+              {data.joinCode !== null && (
+                <Typography variant="caption" color="text.secondary">
+                  Join code <strong>{data.joinCode}</strong> · rotates every few
+                  minutes
+                </Typography>
+              )}
+            </Stack>
+          )}
+        </CardContent>
+      </Card>
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -109,6 +109,20 @@ export interface HealthComponent {
   detail?: string;
 }
 
+/**
+ * Status of the demo caption room. `enabled` reflects the
+ * server flag; `active` means the seeded session is currently joinable; a
+ * non-null `joinCode` is a currently-valid code (it rotates ~every 5 min, so
+ * the dashboard re-polls to keep it fresh).
+ */
+export interface DemoRoomStatus {
+  enabled: boolean;
+  sessionUid: string;
+  active: boolean;
+  roomName: string | null;
+  joinCode: string | null;
+}
+
 export interface HealthReport {
   bff: string;
   /** Every checked dependency. A list rather than named fields so the
@@ -468,6 +482,11 @@ export class AdminApiClient {
   // ---- Config check ----
   configCheck(): Promise<ConfigCheckReport> {
     return this._request('GET', '/config-check');
+  }
+
+  // ---- Demo caption room ----
+  demoRoom(): Promise<DemoRoomStatus> {
+    return this._request('GET', '/demo-room/status');
   }
 
   // ---- Fleet telemetry ----

--- a/apps/kiosk-webapp/src/features/kiosk-provider/components/join-code-qr-code.tsx
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/components/join-code-qr-code.tsx
@@ -2,8 +2,11 @@ import Box from '@mui/material/Box';
 
 import { QRCodeSVG } from 'qrcode.react';
 
+// Trailing slash is required: the reverse proxy serves the client webapp at
+// `/client/`, and a request to `/client` (no slash) 404s. A scanned QR encodes
+// this verbatim, so the slash is what makes the scanned link resolve.
 const CLIENT_WEBAPP_URL =
-  import.meta.env.VITE_CLIENT_WEBAPP_URL ?? `${window.location.origin}/client`;
+  import.meta.env.VITE_CLIENT_WEBAPP_URL ?? `${window.location.origin}/client/`;
 
 /**
  * Builds a client webapp URL with the join code embedded as a URL config

--- a/apps/node-server/.env.example
+++ b/apps/node-server/.env.example
@@ -24,17 +24,17 @@ SESSION_MANAGER_SERVICE_API_KEY=CHANGEME
 TRANSCRIPTION_SERVICE_BASE_URL=http://localhost:8000
 TRANSCRIPTION_SERVICE_API_KEY=CHANGEME
 
-#### Demo caption room (dev/staging only). When enabled, this Node Server
-#### auto-emits a never-ending, looping caption stream - the dialogue of
-#### Alice's Adventures in Wonderland, Chapter V - to DEMO_SESSION_UID below,
-#### so the client, kiosk, and standalone webapps can be exercised end-to-end
-#### with no microphone, source device, or Python transcription service
-#### running. OFF by default. Must stay "false" in production: this publishes
-#### fixture captions into a real, joinable session.
-DEMO_ROOM_ENABLED=false
+#### Demo caption room. When enabled, this Node Server auto-emits a
+#### never-ending, looping caption stream - the dialogue of Alice's Adventures
+#### in Wonderland, Chapter V - for the demo session, so the client, kiosk, and
+#### standalone webapps can be exercised end-to-end with no microphone, source
+#### device, or Python transcription service running. ON by default; uncomment
+#### the line below to turn it off.
+# DEMO_ROOM_ENABLED=false
 
-#### Fixed UUID identifying the demo session above. Must be identical to the
-#### Session Manager's DEMO_SESSION_UID (apps/session-manager/.env.example),
-#### which seeds the joinable session with this same uid - the two only work
-#### together.
-DEMO_SESSION_UID=deadbeef-0000-4000-8000-000000000001
+#### Fixed UUID identifying the demo session. Both services ship the same
+#### built-in default, so this normally needs no setting; override it only if
+#### you set the identical value on the Session Manager too
+#### (apps/session-manager/.env.example) - session tokens are verified against
+#### the URL's sessionUid, so the two services must agree.
+# DEMO_SESSION_UID=deadbeef-0000-4000-8000-000000000001

--- a/apps/node-server/PLAN-Demo-CAPTION_ROOM.md
+++ b/apps/node-server/PLAN-Demo-CAPTION_ROOM.md
@@ -1,5 +1,14 @@
 # PLAN: Demo caption room
 
+> **Update (post-implementation).** The demo room is now **enabled by default**
+> in every environment — set `DEMO_ROOM_ENABLED=false` to disable — and
+> `DEMO_SESSION_UID` is no longer passed through `deployment/compose.yml` (both
+> services use the same built-in default). The "off by default / dev-staging
+> only / prod safety" statements below describe the original design and are
+> superseded on those points. The admin console also surfaces the room's status
+> and a one-click join link. See the **Demo Caption Room** wiki page for current
+> usage.
+
 Status: **node-server side implemented and tested; Session Manager seeding is
 the remaining half.**
 

--- a/apps/node-server/src/app-config/app-config.ts
+++ b/apps/node-server/src/app-config/app-config.ts
@@ -24,14 +24,16 @@ const CONFIG_SCHEMA = Type.Object({
   // is what keeps a deployment that predates B1.7 booting unchanged.
   REDIS_URL: Type.String({ default: '' }),
   NODE_INSTANCE_ID: Type.String({ default: '' }),
-  // Dev/staging-only demo caption room (see PLAN-Demo-CAPTION_ROOM.md). Off by
-  // default so a production instance never emits synthetic captions; enabled
-  // explicitly in the dev and staging deployments. env-schema coerces the
-  // strings "true"/"false" only - "1"/"0"/"" are rejected at boot.
-  DEMO_ROOM_ENABLED: Type.Boolean({ default: false }),
+  // Demo caption room (see PLAN-Demo-CAPTION_ROOM.md): emits a looping,
+  // synthetic caption stream that needs no microphone, source device, or
+  // transcription-service. On by default in every environment (including
+  // production) so the webapps always have something to show; set
+  // DEMO_ROOM_ENABLED=false to turn it off. env-schema coerces the strings
+  // "true"/"false" only - "1"/"0"/"" are rejected at boot.
+  DEMO_ROOM_ENABLED: Type.Boolean({ default: true }),
   // Session UID the demo captions are published for. Must match the session the
-  // Session Manager seeds, so both services default to (and are configured
-  // with) the same value.
+  // Session Manager seeds; both services share the same built-in default, so
+  // neither normally needs this set - override only if you change both.
   DEMO_SESSION_UID: Type.String({ default: DEFAULT_DEMO_SESSION_UID }),
 });
 

--- a/apps/node-server/src/server/create-server.ts
+++ b/apps/node-server/src/server/create-server.ts
@@ -53,9 +53,10 @@ async function createServer(config: AppConfig) {
     );
   }
 
-  // Demo caption room (dev/staging only). Resolved solely when enabled so a
-  // production instance never constructs it. It publishes a looping synthetic
-  // caption stream for the demo session; see PLAN-Demo-CAPTION_ROOM.md.
+  // Demo caption room. Resolved and started only when enabled - which is the
+  // default in every environment; set DEMO_ROOM_ENABLED=false to skip it. It
+  // publishes a looping synthetic caption stream for the demo session; see
+  // PLAN-Demo-CAPTION_ROOM.md.
   if (config.demoRoomConfig.enabled) {
     const demoCaptionSource =
       dependencyContainer.resolve<AppDependencies['demoCaptionSource']>(

--- a/apps/node-server/src/server/dependency-injection/app-dependencies.ts
+++ b/apps/node-server/src/server/dependency-injection/app-dependencies.ts
@@ -76,7 +76,7 @@ interface AppDependencies extends BaseDependencies {
   transcriptionOrchestratorService: TranscriptionOrchestratorService;
   transcriptionStreamController: TranscriptionStreamController;
 
-  // Demo caption room (dev/staging only)
+  // Demo caption room
   demoCaptionSource: DemoCaptionSource;
 }
 

--- a/apps/node-server/src/server/dependency-injection/register-dependencies.ts
+++ b/apps/node-server/src/server/dependency-injection/register-dependencies.ts
@@ -155,9 +155,9 @@ function registerDependencies(
       lifetime: Lifetime.SCOPED,
     }),
 
-    // Demo caption room (dev/staging only). Constructed regardless, but a no-op
-    // unless `demoRoomConfig.enabled`; `createServer` only resolves and starts
-    // it when the flag is set.
+    // Demo caption room. Constructed regardless, but a no-op unless
+    // `demoRoomConfig.enabled` (the default); `createServer` only resolves and
+    // starts it when enabled.
     demoCaptionSource: asClass(DemoCaptionSource, {
       lifetime: Lifetime.SINGLETON,
     }),

--- a/apps/node-server/src/server/features/demo-room/demo-caption-source.ts
+++ b/apps/node-server/src/server/features/demo-room/demo-caption-source.ts
@@ -141,7 +141,7 @@ export function buildDemoSchedule(utterances: readonly DemoUtterance[]): {
 }
 
 /**
- * Dev/staging-only source of a self-contained, looping caption stream.
+ * Source of a self-contained, looping caption stream.
  *
  * When enabled, it publishes the compiled fixture to `TranscriptChannel` for
  * the demo session on a self-correcting virtual clock - exactly the channel the

--- a/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
@@ -143,7 +143,7 @@ export class TranscriptionOrchestratorService {
   private _sessions = new Map<string, SessionState>();
   /**
    * Status overrides for sessions that have no real upstream - only the
-   * dev/staging demo caption room (see `demo-room/`). Kept separate from
+   * demo caption room (see `demo-room/`). Kept separate from
    * `_sessions` so nothing that iterates real session state (e.g.
    * `sessionSnapshots`, which dereferences `state.upstream`) ever sees a
    * session without an upstream connection.
@@ -195,7 +195,7 @@ export class TranscriptionOrchestratorService {
 
   /**
    * Register a status override for a session with no real upstream. Used only
-   * by the dev/staging demo caption room, which publishes transcripts to
+   * by the demo caption room, which publishes transcripts to
    * {@link TranscriptChannel} directly and needs joining clients to see the
    * session as connected rather than "waiting for source". Ignored for any
    * session that also has real source connections (`_sessions` wins in

--- a/apps/node-server/tests/unit/app-config/app-config.test.ts
+++ b/apps/node-server/tests/unit/app-config/app-config.test.ts
@@ -185,8 +185,22 @@ describe('AppConfig', () => {
   });
 
   describe('demo room configuration', (it) => {
-    it('is disabled with the default session uid when unset', () => {
-      // Act - both vars are absent, the production default.
+    it('is enabled with the default session uid when unset', () => {
+      // Act - both vars are absent; the demo room is on by default.
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert
+      expect(config.demoRoomConfig).toStrictEqual({
+        enabled: true,
+        sessionUid: 'deadbeef-0000-4000-8000-000000000001',
+      });
+    });
+
+    it('can be turned off with DEMO_ROOM_ENABLED=false', () => {
+      // Arrange
+      process.env['DEMO_ROOM_ENABLED'] = 'false';
+
+      // Act
       const config = new AppConfig(NO_DOTENV_FILE);
 
       // Assert

--- a/apps/session-manager/.env.example
+++ b/apps/session-manager/.env.example
@@ -30,14 +30,15 @@ DB_NAME=scribear-db-dev
 DB_USER=scribear
 DB_PASSWORD=CHANGEME
 
-#### Demo caption room (dev/staging only). When enabled, the Session Manager
-#### seeds a joinable demo session ("Demo - Alice in Wonderland") with a
-#### stable join code, whose uid the Node Server publishes a looping fixture
-#### caption stream into (see apps/node-server/.env.example). OFF by default.
-#### Must stay "false" in production.
-DEMO_ROOM_ENABLED=false
+#### Demo caption room. When enabled, the Session Manager seeds a joinable demo
+#### session ("Demo - Alice in Wonderland") with a rotating join code, whose uid
+#### the Node Server publishes a looping fixture caption stream into (see
+#### apps/node-server/.env.example). ON by default; uncomment the line below to
+#### turn it off.
+# DEMO_ROOM_ENABLED=false
 
-#### Fixed UUID for the seeded demo session above. Must be identical to the
-#### Node Server's DEMO_SESSION_UID - session tokens are verified against the
-#### URL's sessionUid, so the two services must agree on this value.
-DEMO_SESSION_UID=deadbeef-0000-4000-8000-000000000001
+#### Fixed UUID for the seeded demo session. Both services ship the same
+#### built-in default, so this normally needs no setting; override it only if
+#### you set the identical value on the Node Server too - session tokens are
+#### verified against the URL's sessionUid, so the two services must agree.
+# DEMO_SESSION_UID=deadbeef-0000-4000-8000-000000000001

--- a/apps/session-manager/src/app-config/app-config.ts
+++ b/apps/session-manager/src/app-config/app-config.ts
@@ -37,15 +37,15 @@ const CONFIG_SCHEMA = Type.Object({
   }),
   DEVICE_ONLINE_TTL_SEC: Type.Integer({ minimum: 1, default: 180 }),
 
-  // Dev/staging-only demo caption room (see
-  // apps/node-server/PLAN-Demo-CAPTION_ROOM.md). Off by default so a
-  // production instance never seeds a real, joinable session; enabled
-  // explicitly in the dev and staging deployments. env-schema coerces the
-  // strings "true"/"false" only - "1"/"0"/"" are rejected at boot.
-  DEMO_ROOM_ENABLED: Type.Boolean({ default: false }),
-  // Session UID the demo session is seeded with. Must match the Node
-  // Server's DEMO_SESSION_UID, so both services default to (and are
-  // configured with) the same value.
+  // Demo caption room (see apps/node-server/PLAN-Demo-CAPTION_ROOM.md): seeds a
+  // joinable, open-ended session so the webapps can be exercised end-to-end. On
+  // by default in every environment (including production); set
+  // DEMO_ROOM_ENABLED=false to turn it off. env-schema coerces the strings
+  // "true"/"false" only - "1"/"0"/"" are rejected at boot.
+  DEMO_ROOM_ENABLED: Type.Boolean({ default: true }),
+  // Session UID the demo session is seeded with. Must match the Node Server's
+  // DEMO_SESSION_UID; both services share the same built-in default, so neither
+  // normally needs this set - override only if you change both.
   DEMO_SESSION_UID: Type.String({ default: DEFAULT_DEMO_SESSION_UID }),
 });
 

--- a/apps/session-manager/src/server/create-server.ts
+++ b/apps/session-manager/src/server/create-server.ts
@@ -7,6 +7,7 @@ import type { AppConfig } from '#src/app-config/app-config.js';
 
 import type { AppDependencies } from './dependency-injection/app-dependencies.js';
 import registerDependencies from './dependency-injection/register-dependencies.js';
+import { demoRoomRouter } from './features/demo-room/demo-room.router.js';
 import { deviceManagementRouter } from './features/device-management/device-management.router.js';
 import { probesRouter } from './features/probes/probes.router.js';
 import { roomManagementRouter } from './features/room-management/room-management.router.js';
@@ -48,6 +49,7 @@ async function createServer(config: AppConfig) {
   fastify.register(roomManagementRouter);
   fastify.register(scheduleManagementRouter);
   fastify.register(sessionAuthRouter);
+  fastify.register(demoRoomRouter);
 
   const materializationWorker = dependencyContainer.resolve<
     AppDependencies['materializationWorker']
@@ -59,10 +61,10 @@ async function createServer(config: AppConfig) {
     await materializationWorker.stop();
   });
 
-  // Demo caption room (dev/staging only). Resolved solely when enabled so a
-  // production instance never seeds a real, joinable session. Idempotently
-  // ensures a demo room/device/session exist and logs a current join code;
-  // see `apps/node-server/PLAN-Demo-CAPTION_ROOM.md`.
+  // Demo caption room. Resolved and run only when enabled - which is the
+  // default in every environment; set DEMO_ROOM_ENABLED=false to skip it.
+  // Idempotently ensures a demo room/device/session exist and logs a current
+  // join code; see `apps/node-server/PLAN-Demo-CAPTION_ROOM.md`.
   if (config.demoRoomConfig.enabled) {
     const demoRoomSeeder =
       dependencyContainer.resolve<AppDependencies['demoRoomSeeder']>(
@@ -70,7 +72,7 @@ async function createServer(config: AppConfig) {
       );
     fastify.addHook('onReady', async () => {
       // A seeding failure (e.g. a transient DB error) must not take down an
-      // otherwise-healthy dev/staging instance over a demo feature.
+      // otherwise-healthy instance over a demo feature.
       try {
         await demoRoomSeeder.seed();
       } catch (err) {

--- a/apps/session-manager/src/server/dependency-injection/app-dependencies.ts
+++ b/apps/session-manager/src/server/dependency-injection/app-dependencies.ts
@@ -10,6 +10,7 @@ import type {
 } from '#src/app-config/app-config.js';
 import type { DBClient, DBClientConfig } from '#src/db/db-client.js';
 import type { DemoRoomSeeder } from '#src/server/features/demo-room/demo-room-seeder.js';
+import type { DemoRoomController } from '#src/server/features/demo-room/demo-room.controller.js';
 import type { DeviceManagementController } from '#src/server/features/device-management/device-management.controller.js';
 import type { DeviceManagementRepository } from '#src/server/features/device-management/device-management.repository.js';
 import type { DeviceManagementService } from '#src/server/features/device-management/device-management.service.js';
@@ -101,8 +102,9 @@ interface AppDependencies extends BaseDependencies {
   sessionAuthService: SessionAuthService;
   sessionAuthRepository: SessionAuthRepository;
 
-  // Demo caption room (dev/staging only)
+  // Demo caption room
   demoRoomSeeder: DemoRoomSeeder;
+  demoRoomController: DemoRoomController;
 }
 
 /**

--- a/apps/session-manager/src/server/dependency-injection/register-dependencies.ts
+++ b/apps/session-manager/src/server/dependency-injection/register-dependencies.ts
@@ -8,6 +8,7 @@ import {
 
 import { DBClient } from '#src/db/db-client.js';
 import { DemoRoomSeeder } from '#src/server/features/demo-room/demo-room-seeder.js';
+import { DemoRoomController } from '#src/server/features/demo-room/demo-room.controller.js';
 import { DeviceManagementController } from '#src/server/features/device-management/device-management.controller.js';
 import { DeviceManagementRepository } from '#src/server/features/device-management/device-management.repository.js';
 import { DeviceManagementService } from '#src/server/features/device-management/device-management.service.js';
@@ -146,14 +147,20 @@ function registerDependencies(
       lifetime: Lifetime.SINGLETON,
     }),
 
-    // Demo caption room (dev/staging only). Constructed regardless, but a
-    // no-op unless `demoRoomConfig.enabled`; `create-server.ts` only resolves
-    // and runs it when the flag is set. SCOPED (not SINGLETON) because it
+    // Demo caption room. Constructed regardless, but a
+    // no-op unless `demoRoomConfig.enabled` (the default); `create-server.ts`
+    // only resolves and runs it when enabled. SCOPED (not SINGLETON) because it
     // depends on scoped services; resolving it once from the root container
     // at startup produces a single instance for the process, with its scoped
     // dependencies cached on that same root scope (same pattern as
     // `materializationWorker` above).
     demoRoomSeeder: asClass(DemoRoomSeeder, {
+      lifetime: Lifetime.SCOPED,
+    }),
+    // Read-only status endpoint for the admin console. Always registered (the
+    // route reports `enabled: false` when the feature is off), so unlike the
+    // seeder it is not gated behind the flag at wiring time.
+    demoRoomController: asClass(DemoRoomController, {
       lifetime: Lifetime.SCOPED,
     }),
   } as NameAndRegistrationPair<AppDependencies>);

--- a/apps/session-manager/src/server/features/demo-room/demo-room-seeder.ts
+++ b/apps/session-manager/src/server/features/demo-room/demo-room-seeder.ts
@@ -11,7 +11,7 @@ import {
 } from './demo-room.constants.js';
 
 /**
- * Dev/staging-only boot-time seeder for a joinable "demo caption room".
+ * Boot-time seeder for a joinable "demo caption room".
  *
  * This is the Session Manager half of the demo caption room; the Node Server
  * half (`DemoCaptionSource`) publishes a looping fixture caption stream for a
@@ -33,8 +33,8 @@ import {
  *      for a developer to obtain a code to hand to a client/kiosk/standalone
  *      webapp.
  *
- * Never constructed when the feature is off; a production instance never
- * seeds a real, joinable session (see `create-server.ts`).
+ * Enabled by default; when `DEMO_ROOM_ENABLED=false` it is never resolved and
+ * no session is seeded (see `create-server.ts`).
  */
 export class DemoRoomSeeder {
   private readonly _logger: AppDependencies['logger'];

--- a/apps/session-manager/src/server/features/demo-room/demo-room.controller.ts
+++ b/apps/session-manager/src/server/features/demo-room/demo-room.controller.ts
@@ -1,0 +1,109 @@
+import type {
+  BaseFastifyReply,
+  BaseFastifyRequest,
+} from '@scribear/base-fastify-server';
+import { DEMO_ROOM_STATUS_SCHEMA } from '@scribear/session-manager-schema';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+import type { Session } from '#src/server/features/schedule-management/schedule-management.repository.js';
+
+/**
+ * Admin-facing status for the demo caption room.
+ *
+ * The seeder (`DemoRoomSeeder`) creates a joinable session at boot when the
+ * feature is enabled but only *logs* the rotating join code; there is no other
+ * way to obtain it. This controller closes that gap for the admin console: it
+ * reports whether the feature is on and the seeded session is currently
+ * joinable, and — when it is — mints/returns a currently-valid join code (via
+ * the same idempotent `ensureCurrentJoinCode` the seeder uses) so the console
+ * can build a one-click "open live captions" link.
+ *
+ * The join code is only ever returned to an authenticated admin operator (this
+ * route is admin-key protected). When `DEMO_ROOM_ENABLED=false` the feature is
+ * off and this route reports `enabled: false` with a `null` join code.
+ */
+export class DemoRoomController {
+  private readonly _config: AppDependencies['demoRoomConfig'];
+  private readonly _scheduleManagementRepository: AppDependencies['scheduleManagementRepository'];
+  private readonly _sessionAuthService: AppDependencies['sessionAuthService'];
+
+  constructor(
+    demoRoomConfig: AppDependencies['demoRoomConfig'],
+    scheduleManagementRepository: AppDependencies['scheduleManagementRepository'],
+    sessionAuthService: AppDependencies['sessionAuthService'],
+  ) {
+    this._config = demoRoomConfig;
+    this._scheduleManagementRepository = scheduleManagementRepository;
+    this._sessionAuthService = sessionAuthService;
+  }
+
+  async status(
+    _req: BaseFastifyRequest<typeof DEMO_ROOM_STATUS_SCHEMA>,
+    res: BaseFastifyReply<typeof DEMO_ROOM_STATUS_SCHEMA>,
+  ) {
+    const { enabled, sessionUid } = this._config;
+
+    if (!enabled) {
+      res.code(200).send({
+        enabled: false,
+        sessionUid,
+        active: false,
+        roomName: null,
+        joinCode: null,
+      });
+      return;
+    }
+
+    const now = new Date();
+    const db = this._scheduleManagementRepository.db;
+    const session = await this._scheduleManagementRepository.findSessionByUid(
+      db,
+      sessionUid,
+    );
+
+    if (!session) {
+      // Enabled, but the seeder has not created the session (not booted yet, or
+      // seeding failed). Configured but not joinable.
+      res.code(200).send({
+        enabled: true,
+        sessionUid,
+        active: false,
+        roomName: null,
+        joinCode: null,
+      });
+      return;
+    }
+
+    const active = isSessionCurrentlyActive(session, now);
+    // Only mint a code when it would actually exchange — a code for an inactive
+    // session would 409 on exchange and mislead the console.
+    const joinCode = active
+      ? await this._sessionAuthService.ensureCurrentJoinCode(sessionUid, now)
+      : null;
+
+    res.code(200).send({
+      enabled: true,
+      sessionUid,
+      active,
+      roomName: session.name,
+      joinCode,
+    });
+  }
+}
+
+/**
+ * Mirrors the active-window check the session-auth service applies before an
+ * exchange: started, and not yet ended (open-ended sessions have a null
+ * `effectiveEnd` and are always current once started). The seeded demo session
+ * is open-ended, so this is effectively "has the seed run and its start passed".
+ */
+function isSessionCurrentlyActive(session: Session, now: Date): boolean {
+  if (session.effectiveStart.getTime() > now.getTime()) return false;
+  if (
+    session.effectiveEnd !== null &&
+    session.effectiveEnd.getTime() <= now.getTime()
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/apps/session-manager/src/server/features/demo-room/demo-room.router.ts
+++ b/apps/session-manager/src/server/features/demo-room/demo-room.router.ts
@@ -1,0 +1,22 @@
+import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
+import {
+  DEMO_ROOM_STATUS_ROUTE,
+  DEMO_ROOM_STATUS_SCHEMA,
+} from '@scribear/session-manager-schema';
+
+import resolveHandler from '#src/server/dependency-injection/resolve-handler.js';
+import { adminApiKeyHook } from '#src/server/hooks/admin-api-key.hook.js';
+
+/**
+ * Demo caption room status, for the admin console. Admin-key protected like the
+ * other management routes; always registered (returns `enabled: false` when the
+ * feature is off) so the console has a stable endpoint to poll.
+ */
+export function demoRoomRouter(fastify: BaseFastifyInstance) {
+  fastify.route({
+    ...DEMO_ROOM_STATUS_ROUTE,
+    schema: DEMO_ROOM_STATUS_SCHEMA,
+    preHandler: adminApiKeyHook,
+    handler: resolveHandler('demoRoomController', 'status'),
+  });
+}

--- a/apps/session-manager/tests/unit/app-config/app-config.test.ts
+++ b/apps/session-manager/tests/unit/app-config/app-config.test.ts
@@ -141,8 +141,22 @@ describe('AppConfig', () => {
   });
 
   describe('demo room configuration', (it) => {
-    it('is disabled with the default session uid when unset', () => {
-      // Act - both vars are absent, the production default.
+    it('is enabled with the default session uid when unset', () => {
+      // Act - both vars are absent; the demo room is on by default.
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert
+      expect(config.demoRoomConfig).toStrictEqual({
+        enabled: true,
+        sessionUid: 'deadbeef-0000-4000-8000-000000000001',
+      });
+    });
+
+    it('can be turned off with DEMO_ROOM_ENABLED=false', () => {
+      // Arrange
+      process.env['DEMO_ROOM_ENABLED'] = 'false';
+
+      // Act
       const config = new AppConfig(NO_DOTENV_FILE);
 
       // Assert

--- a/apps/session-manager/tests/unit/features/demo-room/demo-room.controller.test.ts
+++ b/apps/session-manager/tests/unit/features/demo-room/demo-room.controller.test.ts
@@ -1,0 +1,123 @@
+import { type Mock, beforeEach, describe, expect, vi } from 'vitest';
+
+import { DemoRoomController } from '#src/server/features/demo-room/demo-room.controller.js';
+
+const DEMO_UID = 'deadbeef-0000-4000-8000-000000000001';
+const PAST = new Date('2020-01-01T00:00:00.000Z');
+const FUTURE = new Date('2999-01-01T00:00:00.000Z');
+
+function activeSession() {
+  return {
+    uid: DEMO_UID,
+    name: 'Demo — Alice in Wonderland',
+    // Started long ago, open-ended: always "currently active".
+    effectiveStart: PAST,
+    effectiveEnd: null,
+  };
+}
+
+describe('DemoRoomController', (it) => {
+  let mockRepo: { db: object; findSessionByUid: Mock };
+  let mockAuth: { ensureCurrentJoinCode: Mock };
+  let mockSend: Mock;
+  let mockCode: Mock;
+  let mockRes: { code: Mock };
+
+  function build(enabled: boolean) {
+    return new DemoRoomController(
+      { enabled, sessionUid: DEMO_UID },
+      mockRepo as never,
+      mockAuth as never,
+    );
+  }
+
+  beforeEach(() => {
+    mockRepo = { db: {}, findSessionByUid: vi.fn() };
+    mockAuth = { ensureCurrentJoinCode: vi.fn() };
+    mockSend = vi.fn();
+    mockCode = vi.fn().mockReturnValue({ send: mockSend });
+    mockRes = { code: mockCode };
+  });
+
+  it('reports disabled without touching the DB or minting a code', async () => {
+    await build(false).status({} as never, mockRes as never);
+
+    expect(mockRepo.findSessionByUid).not.toHaveBeenCalled();
+    expect(mockAuth.ensureCurrentJoinCode).not.toHaveBeenCalled();
+    expect(mockCode).toHaveBeenCalledWith(200);
+    expect(mockSend).toHaveBeenCalledWith({
+      enabled: false,
+      sessionUid: DEMO_UID,
+      active: false,
+      roomName: null,
+      joinCode: null,
+    });
+  });
+
+  it('reports enabled-but-not-running when the session has not been seeded', async () => {
+    mockRepo.findSessionByUid.mockResolvedValue(undefined);
+
+    await build(true).status({} as never, mockRes as never);
+
+    expect(mockAuth.ensureCurrentJoinCode).not.toHaveBeenCalled();
+    expect(mockSend).toHaveBeenCalledWith({
+      enabled: true,
+      sessionUid: DEMO_UID,
+      active: false,
+      roomName: null,
+      joinCode: null,
+    });
+  });
+
+  it('mints and returns a join code for an active seeded session', async () => {
+    mockRepo.findSessionByUid.mockResolvedValue(activeSession());
+    mockAuth.ensureCurrentJoinCode.mockResolvedValue('ABCD1234');
+
+    await build(true).status({} as never, mockRes as never);
+
+    expect(mockAuth.ensureCurrentJoinCode).toHaveBeenCalledWith(
+      DEMO_UID,
+      expect.any(Date),
+    );
+    expect(mockSend).toHaveBeenCalledWith({
+      enabled: true,
+      sessionUid: DEMO_UID,
+      active: true,
+      roomName: 'Demo — Alice in Wonderland',
+      joinCode: 'ABCD1234',
+    });
+  });
+
+  it('does not mint a code for a session whose window has ended', async () => {
+    mockRepo.findSessionByUid.mockResolvedValue({
+      ...activeSession(),
+      effectiveEnd: PAST,
+    });
+
+    await build(true).status({} as never, mockRes as never);
+
+    expect(mockAuth.ensureCurrentJoinCode).not.toHaveBeenCalled();
+    expect(mockSend).toHaveBeenCalledWith({
+      enabled: true,
+      sessionUid: DEMO_UID,
+      active: false,
+      roomName: 'Demo — Alice in Wonderland',
+      joinCode: null,
+    });
+  });
+
+  it('treats a not-yet-started session as not active', async () => {
+    mockRepo.findSessionByUid.mockResolvedValue({
+      ...activeSession(),
+      effectiveStart: FUTURE,
+      effectiveEnd: null,
+    });
+
+    await build(true).status({} as never, mockRes as never);
+
+    expect(mockAuth.ensureCurrentJoinCode).not.toHaveBeenCalled();
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({ active: false, joinCode: null }),
+    );
+  });
+});

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -81,19 +81,17 @@ JWT_SECRET=CHANGEME-JWT-must-be-at-least-32-characters-long
 NODE_SERVER_REDIS_URL=
 
 # -- Demo Caption Room ------
-# Dev/staging only. When enabled, the Node Server auto-emits a never-ending,
-# looping caption stream (Alice's Adventures in Wonderland, Chapter V) and the
-# Session Manager seeds a matching joinable session, so the client/kiosk/
-# standalone webapps can be exercised end-to-end with no microphone, source
-# device, or Python transcription service running. Both services read these
-# same two values - see apps/node-server/.env.example and
+# When enabled, the Node Server auto-emits a never-ending, looping caption
+# stream (Alice's Adventures in Wonderland, Chapter V) and the Session Manager
+# seeds a matching joinable session, so the client/kiosk/standalone webapps can
+# be exercised end-to-end with no microphone, source device, or Python
+# transcription service running. See apps/node-server/.env.example and
 # apps/session-manager/.env.example for detail.
 #
-# Defaulted OFF. Set DEMO_ROOM_ENABLED=true ONLY for a dev or staging
-# deployment; a production deployment must leave this "false" (or unset).
-DEMO_ROOM_ENABLED=false
-# Fixed UUID shared by both services when the demo room is enabled above.
-DEMO_SESSION_UID=deadbeef-0000-4000-8000-000000000001
+# ON by default in every environment (including production). Uncomment the line
+# below to turn it off. The demo session uid uses a built-in default shared by
+# both services, so it needs no setting here.
+# DEMO_ROOM_ENABLED=false
 
 # -- Admin Website -----
 # ADMIN_API_KEY reuses SESSION_MANAGER_API_KEY (see Session Manager section above).

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -84,13 +84,13 @@ services:
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
-      # Demo caption room (dev/staging only). Seeds a joinable demo session
-      # whose uid the Node Server publishes a looping fixture caption stream
-      # into - see apps/session-manager/.env.example and
-      # apps/node-server/.env.example. Defaulted "false"; set true only in a
-      # dev or staging .env, never in production.
-      DEMO_ROOM_ENABLED: ${DEMO_ROOM_ENABLED:-false}
-      DEMO_SESSION_UID: ${DEMO_SESSION_UID:-}
+      # Demo caption room. Seeds a joinable demo session whose uid the Node
+      # Server publishes a looping fixture caption stream into - see
+      # apps/session-manager/.env.example. On by default; set
+      # DEMO_ROOM_ENABLED=false in the deployment .env to turn it off. The
+      # session uid uses a built-in default shared with the Node Server, so it
+      # does not need to be passed here.
+      DEMO_ROOM_ENABLED: ${DEMO_ROOM_ENABLED:-true}
     depends_on:
       scribear-db:
         condition: service_healthy
@@ -166,13 +166,13 @@ services:
       # sets to the container name, so scaling this service gives each replica
       # a distinct identity with no further configuration.
       REDIS_URL: ${NODE_SERVER_REDIS_URL:-}
-      # Demo caption room (dev/staging only). When true, this Node Server
-      # auto-emits a looping fixture caption stream for DEMO_SESSION_UID - see
-      # apps/node-server/.env.example. Defaulted "false"; set true only in a
-      # dev or staging .env, never in production. DEMO_SESSION_UID must match
-      # the value given to the session-manager service above.
-      DEMO_ROOM_ENABLED: ${DEMO_ROOM_ENABLED:-false}
-      DEMO_SESSION_UID: ${DEMO_SESSION_UID:-}
+      # Demo caption room. When enabled, this Node Server auto-emits a looping
+      # fixture caption stream for the demo session - see
+      # apps/node-server/.env.example. On by default; set DEMO_ROOM_ENABLED=false
+      # in the deployment .env to turn it off. The session uid uses a built-in
+      # default shared with the session-manager service above, so it does not
+      # need to be passed here.
+      DEMO_ROOM_ENABLED: ${DEMO_ROOM_ENABLED:-true}
     depends_on:
       transcription-service:
         condition: service_healthy

--- a/infra/scribear-nginx/nginx.conf
+++ b/infra/scribear-nginx/nginx.conf
@@ -94,6 +94,15 @@ http {
 
         # -- Frontend Webapps --
 
+        # The client webapp is served under /client/ (trailing slash). A bare
+        # /client would otherwise 404, since there is no server-level root. The
+        # browser preserves the URL fragment across this redirect, so a deep
+        # link like /client#config=<...> still arrives as /client/#config=<...>
+        # (used by the kiosk QR and the admin "open live captions" link).
+        location = /client {
+            return 308 /client/;
+        }
+
         location /client/ {
             proxy_pass http://client-webapp/;
             proxy_set_header Host              $host;

--- a/libs/clients/session-manager-client/src/create-session-manager-client.ts
+++ b/libs/clients/session-manager-client/src/create-session-manager-client.ts
@@ -1,3 +1,4 @@
+import { createDemoRoomClient } from './demo-room-client.js';
 import { createDeviceManagementClient } from './device-management-client.js';
 import { createProbesClient } from './probes-client.js';
 import { createRoomManagementClient } from './room-management-client.js';
@@ -19,6 +20,7 @@ function createSessionManagerClient(baseUrl: string) {
     deviceManagement: createDeviceManagementClient(baseUrl),
     scheduleManagement: createScheduleManagementClient(baseUrl),
     sessionAuth: createSessionAuthClient(baseUrl),
+    demoRoom: createDemoRoomClient(baseUrl),
   };
 }
 

--- a/libs/clients/session-manager-client/src/demo-room-client.ts
+++ b/libs/clients/session-manager-client/src/demo-room-client.ts
@@ -1,0 +1,17 @@
+import { createEndpointClient } from '@scribear/base-api-client';
+import {
+  DEMO_ROOM_STATUS_ROUTE,
+  DEMO_ROOM_STATUS_SCHEMA,
+} from '@scribear/session-manager-schema';
+
+function createDemoRoomClient(baseUrl: string) {
+  return {
+    status: createEndpointClient(
+      DEMO_ROOM_STATUS_SCHEMA,
+      DEMO_ROOM_STATUS_ROUTE,
+      baseUrl,
+    ),
+  };
+}
+
+export { createDemoRoomClient };

--- a/libs/clients/session-manager-client/src/index.ts
+++ b/libs/clients/session-manager-client/src/index.ts
@@ -7,3 +7,4 @@ export { createRoomManagementClient } from './room-management-client.js';
 export { createDeviceManagementClient } from './device-management-client.js';
 export { createScheduleManagementClient } from './schedule-management-client.js';
 export { createSessionAuthClient } from './session-auth-client.js';
+export { createDemoRoomClient } from './demo-room-client.js';

--- a/libs/schemas/session-manager-schema/src/demo-room/routes/demo-room-status.schema.ts
+++ b/libs/schemas/session-manager-schema/src/demo-room/routes/demo-room-status.schema.ts
@@ -1,0 +1,75 @@
+import { Type } from 'typebox';
+
+import {
+  type BaseRouteDefinition,
+  type BaseRouteSchema,
+  STANDARD_ERROR_REPLIES,
+} from '@scribear/base-schema';
+
+import { SESSION_MANAGER_BASE_PATH } from '#src/base-path.js';
+import {
+  ADMIN_API_KEY_AUTH_HEADER_SCHEMA,
+  ADMIN_API_KEY_SECURITY,
+  INVALID_ADMIN_KEY_REPLY_SCHEMA,
+} from '#src/shared/security/admin-api-key.js';
+import { DEMO_ROOM_TAG } from '#src/tags.js';
+
+/**
+ * Operational status of the demo caption room, for the admin console. Reports
+ * whether the feature is switched on, whether the seeded session is currently
+ * joinable, and — when it is — a currently-valid join code so the console can
+ * build a one-click "open live captions" link.
+ *
+ * `joinCode` is intentionally exposed here (unlike the device-facing
+ * `fetch-join-code` route, which requires a device token) because this route is
+ * admin-key protected — only an authenticated operator ever sees it. When
+ * `DEMO_ROOM_ENABLED=false` the feature is off and this route returns
+ * `enabled: false` with a `null` code.
+ */
+export const DEMO_ROOM_STATUS_RESPONSE_SCHEMA = Type.Object(
+  {
+    enabled: Type.Boolean({
+      description: 'Whether `DEMO_ROOM_ENABLED` is set on the Session Manager.',
+    }),
+    sessionUid: Type.String({
+      format: 'uuid',
+      description: 'The configured `DEMO_SESSION_UID` the demo captions use.',
+    }),
+    active: Type.Boolean({
+      description:
+        'Whether the seeded demo session exists and is currently within its ' +
+        'effective window — i.e. a join code will exchange successfully.',
+    }),
+    roomName: Type.Union([Type.String(), Type.Null()], {
+      description: 'Display name of the demo room, or null when not seeded.',
+    }),
+    joinCode: Type.Union([Type.String(), Type.Null()], {
+      description:
+        'A currently-valid join code for the demo session, or null when the ' +
+        'feature is off or the session is not active. Rotates on a ~5 minute ' +
+        'window; minted on demand.',
+    }),
+  },
+  { $id: 'DemoRoomStatus' },
+);
+
+export const DEMO_ROOM_STATUS_SCHEMA = {
+  description:
+    'Report whether the demo caption room is enabled and joinable, with a ' +
+    'currently-valid join code when it is.',
+  tags: [DEMO_ROOM_TAG],
+  security: ADMIN_API_KEY_SECURITY,
+  headers: Type.Object({
+    authorization: ADMIN_API_KEY_AUTH_HEADER_SCHEMA,
+  }),
+  response: {
+    200: DEMO_ROOM_STATUS_RESPONSE_SCHEMA,
+    ...STANDARD_ERROR_REPLIES,
+    ...INVALID_ADMIN_KEY_REPLY_SCHEMA,
+  },
+} satisfies BaseRouteSchema;
+
+export const DEMO_ROOM_STATUS_ROUTE: BaseRouteDefinition = {
+  method: 'GET',
+  url: `${SESSION_MANAGER_BASE_PATH}/demo-room/status`,
+};

--- a/libs/schemas/session-manager-schema/src/index.ts
+++ b/libs/schemas/session-manager-schema/src/index.ts
@@ -60,3 +60,5 @@ export * from './session-auth/routes/fetch-join-code.schema.js';
 export * from './session-auth/routes/exchange-device-token.schema.js';
 export * from './session-auth/routes/exchange-join-code.schema.js';
 export * from './session-auth/routes/refresh-session-token.schema.js';
+
+export * from './demo-room/routes/demo-room-status.schema.js';

--- a/libs/schemas/session-manager-schema/src/tags.ts
+++ b/libs/schemas/session-manager-schema/src/tags.ts
@@ -6,6 +6,7 @@ export const DEVICE_MANAGEMENT_TAG = 'Device Management';
 export const SCHEDULE_MANAGEMENT_TAG = 'Schedule Management';
 export const SESSION_MANAGEMENT_TAG = 'Session Management';
 export const SESSION_AUTH_TAG = 'Session Auth';
+export const DEMO_ROOM_TAG = 'Demo Room';
 
 export const OPENAPI_TAGS: BaseTagsDefinition = [
   { name: PROBES_TAG, description: 'Liveness and readiness probe endpoints.' },
@@ -26,5 +27,10 @@ export const OPENAPI_TAGS: BaseTagsDefinition = [
     name: SESSION_AUTH_TAG,
     description:
       'Join code issuance, join code exchange, source-device session auth, and session token refresh.',
+  },
+  {
+    name: DEMO_ROOM_TAG,
+    description:
+      'Demo caption room: status and join code for the admin console.',
   },
 ];


### PR DESCRIPTION
Surface the demo caption room in the admin console and make it available by default in every environment.

- admin dashboard "Demo caption room" card: status chip + one-click "Open live captions" deep link into the client webapp, no manual join-code entry
- session-manager: GET /demo-room/status (admin-key) reports {enabled,sessionUid,active,roomName,joinCode}, minting a current join code via the same idempotent ensureCurrentJoinCode the seeder uses; plumbed through the schema + client and proxied by the admin-server gateway
- DEMO_ROOM_ENABLED now defaults to true in both services (every environment); disable with DEMO_ROOM_ENABLED=false. DEMO_SESSION_UID dropped from compose.yml - both services share the same built-in default
- nginx: 308-redirect bare /client -> /client/ (browser preserves the #config fragment), so deep links resolve regardless of the trailing slash
- kiosk: fix the QR default that pointed at /client (no slash) and 404'd
- update .env.example (x3), comments, PLAN note, app-config tests, changeset