### PR TITLE
Fix session/provider races and hardening across client, kiosk, standalone webapps

### DIFF
--- a/apps/client-webapp/index.html
+++ b/apps/client-webapp/index.html
@@ -3,19 +3,19 @@
 
 <head>
   <meta charset="UTF-8" />
-  <link rel="icon" type="image/png" href="/favicon/favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg" />
-  <link rel="shortcut icon" href="/favicon/favicon.ico" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" href="./favicon/favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="./favicon/favicon.svg" />
+  <link rel="shortcut icon" href="./favicon/favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="./favicon/apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="ScribeAR - Live Captions" />
-  <link rel="manifest" href="/favicon/site.webmanifest" />
+  <link rel="manifest" href="./favicon/site.webmanifest" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ScribeAR Client</title>
 </head>
 
 <body>
   <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
+  <script type="module" src="./src/main.tsx"></script>
 </body>
 
 </html>

--- a/apps/client-webapp/src/components/rehydrate-gate.tsx
+++ b/apps/client-webapp/src/components/rehydrate-gate.tsx
@@ -1,7 +1,7 @@
 import { PageLoadSpinner } from '@scribear/core-ui';
 import { selectIsRehydrated } from '@scribear/redux-remember-store';
 
-import { useAppSelector } from '#src/store/use-redux.js';
+import { useAppSelector } from '#src/store/use-redux';
 
 /**
  * Shows a loading spinner until `isRehydrated` is true, then renders children.

--- a/apps/client-webapp/src/features/session-provider/components/join-session-modal.tsx
+++ b/apps/client-webapp/src/features/session-provider/components/join-session-modal.tsx
@@ -65,8 +65,13 @@ export const JoinSessionModal = () => {
               setJoinCode(e.target.value.toUpperCase());
             }}
             error={joinError !== null}
-            slotProps={{ htmlInput: { maxLength: 16 } }}
-            sx={{ mb: 2, fontFamily: 'monospace' }}
+            slotProps={{
+              htmlInput: {
+                maxLength: 16,
+                style: { fontFamily: 'monospace' },
+              },
+            }}
+            sx={{ mb: 2 }}
           />
           {joinError !== null && (
             <Alert severity="error" sx={{ mb: 2 }}>

--- a/apps/client-webapp/src/features/session-provider/services/client-session-service.ts
+++ b/apps/client-webapp/src/features/session-provider/services/client-session-service.ts
@@ -86,6 +86,15 @@ function jitter(baseMs: number, fraction: number): number {
 }
 
 /**
+ * Decode a base64url string (the encoding used by JWT segments) to its raw
+ * text. `atob` only accepts standard base64, so map the URL-safe alphabet
+ * back first; `atob` itself tolerates the missing `=` padding.
+ */
+function base64UrlDecode(value: string): string {
+  return atob(value.replaceAll('-', '+').replaceAll('_', '/'));
+}
+
+/**
  * Decode the `exp` claim of a JWT. Returns `null` if the token can't be
  * parsed (malformed or unsigned).
  */
@@ -93,7 +102,9 @@ function decodeJwtExpiryMs(token: string): number | null {
   const parts = token.split('.');
   if (parts.length < 2) return null;
   try {
-    const payload = JSON.parse(atob(parts[1] ?? '')) as { exp?: number };
+    const payload = JSON.parse(base64UrlDecode(parts[1] ?? '')) as {
+      exp?: number;
+    };
     if (typeof payload.exp !== 'number') return null;
     return payload.exp * 1000;
   } catch {
@@ -182,14 +193,21 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
    */
   async joinSession(joinCode: string): Promise<void> {
     this._teardownActiveSession();
+    // _teardownActiveSession bumped _epoch; capture it so that a later teardown
+    // (a second joinSession, or a leaveSession) invalidates this in-flight
+    // exchange - otherwise a stale response would open a leaked socket and
+    // clobber the newer session.
+    const epoch = this._epoch;
     this._identity = null;
     this.emit('sessionIdentity', null);
     this.emit('joinError', null);
 
     const [response, error] =
       await this._sessionManagerClient.sessionAuth.exchangeJoinCode({
-        body: { joinCode },
+        body: { joinCode: joinCode.trim().toUpperCase() },
       });
+
+    if (epoch !== this._epoch) return;
 
     if (error instanceof NetworkError) {
       this.emit('joinError', JoinError.NETWORK_ERROR);

--- a/apps/client-webapp/src/features/session-provider/stores/client-session-service-middleware.ts
+++ b/apps/client-webapp/src/features/session-provider/stores/client-session-service-middleware.ts
@@ -109,7 +109,8 @@ export const createClientSessionServiceMiddleware =
       const joinCode = selectJoinCode(state);
       if (joinCode === null) return;
       store.dispatch(setJoinCode(null));
-      void service.joinSession(joinCode.trim().toUpperCase());
+      // joinSession normalizes (trim + upper-case) internally.
+      void service.joinSession(joinCode);
     };
 
     return (next) => (action) => {

--- a/apps/client-webapp/src/features/url-config/schemas/url-config-schemas.ts
+++ b/apps/client-webapp/src/features/url-config/schemas/url-config-schemas.ts
@@ -5,10 +5,12 @@ import { appLayoutPreferencesSchema } from '@scribear/app-layout-store';
 import { themePreferencesSchema } from '@scribear/theme-customization-store';
 import { transcriptionDisplayPreferencesSchema } from '@scribear/transcription-display-store';
 
+// Only `joinCode` is a valid inbound channel from URL config - it's the
+// one-shot value the middleware consumes on load. The session identity
+// (sessionUid / sessionRefreshToken / clientId) is issued by the server and
+// must never be settable from a URL, or a crafted link could pre-seed a
+// foreign or stale session into localStorage.
 const clientSessionConfigSchema = Type.Object({
-  sessionUid: Type.Union([Type.String(), Type.Null()]),
-  sessionRefreshToken: Type.Union([Type.String(), Type.Null()]),
-  clientId: Type.Union([Type.String(), Type.Null()]),
   joinCode: Type.Union([Type.String(), Type.Null()]),
 });
 

--- a/apps/kiosk-webapp/index.html
+++ b/apps/kiosk-webapp/index.html
@@ -3,19 +3,19 @@
 
 <head>
   <meta charset="UTF-8" />
-  <link rel="icon" type="image/png" href="/favicon/favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg" />
-  <link rel="shortcut icon" href="/favicon/favicon.ico" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" href="./favicon/favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="./favicon/favicon.svg" />
+  <link rel="shortcut icon" href="./favicon/favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="./favicon/apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="ScribeAR - Live Captions" />
-  <link rel="manifest" href="/favicon/site.webmanifest" />
+  <link rel="manifest" href="./favicon/site.webmanifest" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ScribeAR Kiosk</title>
 </head>
 
 <body>
   <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
+  <script type="module" src="./src/main.tsx"></script>
 </body>
 
 </html>

--- a/apps/kiosk-webapp/src/components/rehydrate-gate.tsx
+++ b/apps/kiosk-webapp/src/components/rehydrate-gate.tsx
@@ -1,7 +1,7 @@
 import { PageLoadSpinner } from '@scribear/core-ui';
 import { selectIsRehydrated } from '@scribear/redux-remember-store';
 
-import { useAppSelector } from '#src/store/use-redux.js';
+import { useAppSelector } from '#src/store/use-redux';
 
 /**
  * Props for {@link RehydrateGate}.

--- a/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
@@ -156,6 +156,15 @@ function jitter(baseMs: number, fraction: number): number {
 }
 
 /**
+ * Decode a base64url string (the encoding used by JWT segments) to its raw
+ * text. `atob` only accepts standard base64, so map the URL-safe alphabet
+ * back first; `atob` itself tolerates the missing `=` padding.
+ */
+function base64UrlDecode(value: string): string {
+  return atob(value.replaceAll('-', '+').replaceAll('_', '/'));
+}
+
+/**
  * Decode the `exp` claim of a JWT. Returns `null` if the token can't be
  * parsed (malformed or unsigned).
  */
@@ -163,7 +172,9 @@ function decodeJwtExpiryMs(token: string): number | null {
   const parts = token.split('.');
   if (parts.length < 2) return null;
   try {
-    const payload = JSON.parse(atob(parts[1] ?? '')) as { exp?: number };
+    const payload = JSON.parse(base64UrlDecode(parts[1] ?? '')) as {
+      exp?: number;
+    };
     if (typeof payload.exp !== 'number') return null;
     return payload.exp * 1000;
   } catch {
@@ -632,6 +643,10 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
     this.emit('connectionStatus', SessionConnectionStatus.CONNECTING);
 
     const token = await this._fetchSessionToken(session.uid);
+    // A newer _enterActive / _enterIdle may have superseded this session while
+    // the token request was in flight. If so, that flow now owns the socket
+    // and token state - bail before clobbering it (and leaking a socket).
+    if (this._activeSession !== session) return;
     if (token === null) {
       this.emit('connectionStatus', SessionConnectionStatus.DISCONNECTED);
       // Fall back to IDLE; the schedule poll will re-trigger if the session
@@ -834,17 +849,22 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
    * token for device-authenticated sessions in the current schema.
    */
   private async _refreshSessionToken(sessionUid: string): Promise<void> {
-    if (this._socket === null) return;
+    const socket = this._socket;
+    if (socket === null) return;
     if (this._activeSession?.uid !== sessionUid) return;
 
     const token = await this._fetchSessionToken(sessionUid);
+    // Re-check after the await: teardown or a session switch may have swapped
+    // or dropped the socket while the token request was in flight. Comparing
+    // against the captured handle catches both (null, or a different socket).
+    if (this._socket !== socket) return;
     if (token === null) {
       // Refresh failed - drop the connection and let schedule sync recover.
       void this._enterIdle();
       return;
     }
     this._sessionToken = token;
-    this._socket.send({
+    socket.send({
       type: TranscriptionStreamClientMessageType.AUTH,
       sessionToken: token,
     });

--- a/apps/kiosk-webapp/src/features/url-config/schemas/url-config-schemas.ts
+++ b/apps/kiosk-webapp/src/features/url-config/schemas/url-config-schemas.ts
@@ -6,13 +6,6 @@ import { microphonePreferencesSchema } from '@scribear/microphone-store';
 import { themePreferencesSchema } from '@scribear/theme-customization-store';
 import { transcriptionDisplayPreferencesSchema } from '@scribear/transcription-display-store';
 
-const kioskConfigSchema = Type.Object({
-  deviceName: Type.Union([Type.String(), Type.Null()]),
-  activeSessionId: Type.Union([Type.String(), Type.Null()]),
-  prevEventId: Type.Number(),
-  sessionRefreshToken: Type.Union([Type.String(), Type.Null()]),
-});
-
 const splitScreenPreferencesSchema = Type.Object({
   targetRightPanelWidthPercent: Type.Number(),
   isRightPanelOpen: Type.Boolean(),
@@ -25,6 +18,5 @@ export const urlConfigSchemas: Record<string, TSchema> = {
   transcriptionDisplayPreferences: Type.Partial(
     transcriptionDisplayPreferencesSchema,
   ),
-  kioskConfig: Type.Partial(kioskConfigSchema),
   splitScreenPreferences: Type.Partial(splitScreenPreferencesSchema),
 };

--- a/apps/standalone-webapp/index.html
+++ b/apps/standalone-webapp/index.html
@@ -3,19 +3,19 @@
 
 <head>
   <meta charset="UTF-8" />
-  <link rel="icon" type="image/png" href="/favicon/favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg" />
-  <link rel="shortcut icon" href="/favicon/favicon.ico" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" href="./favicon/favicon-96x96.png" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="./favicon/favicon.svg" />
+  <link rel="shortcut icon" href="./favicon/favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="./favicon/apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="ScribeAR - Live Captions" />
-  <link rel="manifest" href="/favicon/site.webmanifest" />
+  <link rel="manifest" href="./favicon/site.webmanifest" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ScribeAR - Live Captions</title>
 </head>
 
 <body>
   <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
+  <script type="module" src="./src/main.tsx"></script>
 </body>
 
 </html>

--- a/apps/standalone-webapp/src/components/rehydrate-gate.tsx
+++ b/apps/standalone-webapp/src/components/rehydrate-gate.tsx
@@ -1,7 +1,7 @@
 import { PageLoadSpinner } from '@scribear/core-ui';
 import { selectIsRehydrated } from '@scribear/redux-remember-store';
 
-import { useAppSelector } from '#src/store/use-redux.js';
+import { useAppSelector } from '#src/store/use-redux';
 
 /**
  * Props for {@link RehydrateGate}.

--- a/apps/standalone-webapp/src/features/transcription-providers/services/provider-service.ts
+++ b/apps/standalone-webapp/src/features/transcription-providers/services/provider-service.ts
@@ -114,6 +114,15 @@ export class ProviderService extends EventEmitter<ProviderServiceEvents> {
     });
 
     await provider.activateProvider(config);
+
+    // Guard the post-await boundary the same way as the load step above. Today
+    // both providers activate synchronously so this can't be superseded, but if
+    // a provider ever makes `activateProvider` async, a newer activation could
+    // have started meanwhile - bail so no stale follow-up work runs. (We do not
+    // call `deactivateProvider()` here: providers are cached singletons, so a
+    // superseding activation of the *same* id reuses this instance and tearing
+    // it down would kill the newer activation.)
+    if (this._activationToken !== token) return;
   }
 
   /**


### PR DESCRIPTION
## Summary

Session/provider race and hardening fixes across the client, kiosk, and standalone webapps, reconciled onto `staging` against the CI toolchain (`@eslint-react` 5.18.0).

### Client webapp
- **Guard the `joinSession` exchange across its await (epoch)** so a stale or duplicate response can't open a leaked socket or clobber a newer session; normalize the join code (trim/upper-case) in the service.
- Decode the JWT `exp` claim as **base64url** instead of passing base64url straight to `atob`.
- **Restrict the URL-config schema to `joinCode` only** so a crafted link can't seed `sessionUid`/`sessionRefreshToken`/`clientId` into `localStorage` (security).
- Apply monospace to the join-code input element (not the field root), drop a stray `.js` import suffix, and make `index.html` asset paths relative to match `base: './'`.

### Kiosk webapp
- **Add post-await guards to `_enterActive` and `_refreshSessionToken`** so an auto-driven schedule update can't leave a socket bound to a stale session, clobber token/socket state, or send on a torn-down socket.
- Decode the JWT `exp` claim as base64url.
- Remove the orphaned `kioskConfig` URL-config schema (no matching reducer; device auth is the `DEVICE_TOKEN` cookie).
- Drop a stray `.js` import suffix and make `index.html` asset paths relative.

### Standalone webapp
- Guard the post-await boundary in `_activateProvider` defensively for future async providers (no-op today; both providers activate synchronously).
- Drop a stray `.js` import suffix and make `index.html` asset paths relative.

## Reconciliation note

Two `eslint-disable` directives from the source change were adjusted to their correct **5.18.0** rule names (the original was authored against a stale plugin version):
- `set-state-in-effect` → `@eslint-react/set-state-in-effect, react-hooks/set-state-in-effect`
- `static-components` → `react-hooks/static-components, @eslint-react/static-components`

## Verification

Per changed workspace (`client-webapp`, `kiosk-webapp`, `standalone-webapp`), after `npm ci`:
- `lint` — clean
- `build` (`tsc -b && vite build`, covers typecheck) — passes (only the pre-existing >500 kB chunk-size warning)
- `format` (`prettier --check`) — clean

These webapp workspaces have no `test:unit`/`test:integration` scripts.
