### PR TITLE
feat(a11y): WCAG 2.1 AA frontend fixes + mock server for authed axe scans

### DIFF
--- a/apps/client-webapp/src/features/session-provider/components/join-session-modal.tsx
+++ b/apps/client-webapp/src/features/session-provider/components/join-session-modal.tsx
@@ -1,4 +1,4 @@
-import { type SyntheticEvent, useState } from 'react';
+import { type SyntheticEvent, useId, useState } from 'react';
 
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -41,6 +41,8 @@ export const JoinSessionModal = () => {
   const lifecycle = useAppSelector(selectLifecycle);
   const joinError = useAppSelector(selectJoinError);
   const [joinCode, setJoinCode] = useState('');
+  const titleId = useId();
+  const errorId = useId();
 
   const isOpen = lifecycle === ClientLifecycle.IDLE;
 
@@ -52,8 +54,8 @@ export const JoinSessionModal = () => {
   };
 
   return (
-    <Dialog open={isOpen} disableEscapeKeyDown>
-      <DialogTitle>Join Session</DialogTitle>
+    <Dialog open={isOpen} disableEscapeKeyDown aria-labelledby={titleId}>
+      <DialogTitle id={titleId}>Join Session</DialogTitle>
       <DialogContent>
         <Box component="form" onSubmit={handleSubmit} sx={{ pt: 1 }}>
           <TextField
@@ -69,12 +71,15 @@ export const JoinSessionModal = () => {
               htmlInput: {
                 maxLength: 16,
                 style: { fontFamily: 'monospace' },
+                'aria-describedby': joinError !== null ? errorId : undefined,
               },
             }}
             sx={{ mb: 2 }}
           />
           {joinError !== null && (
-            <Alert severity="error" sx={{ mb: 2 }}>
+            // role="alert" (MUI Alert default) announces it; the id ties it to
+            // the field for follow-up navigation. SC 4.1.3, 3.3.1
+            <Alert id={errorId} severity="error" sx={{ mb: 2 }}>
               {JOIN_ERROR_MESSAGES[joinError]}
             </Alert>
           )}

--- a/apps/client-webapp/src/features/session-provider/components/latency-badge.tsx
+++ b/apps/client-webapp/src/features/session-provider/components/latency-badge.tsx
@@ -51,7 +51,6 @@ export const LatencyBadge = () => {
         zIndex: (theme) => theme.zIndex.tooltip,
         fontVariantNumeric: 'tabular-nums',
       }}
-      aria-label="Transcription latency (final / interim)"
     >
       <Typography variant="caption" component="div">
         Pipeline: {formatLatency(pipelineFinal)} /{' '}

--- a/apps/kiosk-webapp/src/features/kiosk-provider/components/join-code-qr-code.tsx
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/components/join-code-qr-code.tsx
@@ -29,7 +29,15 @@ export const JoinCodeQrCode = ({ joinCode }: JoinCodeQrCodeProps) => {
 
   return (
     <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
-      <QRCodeSVG value={joinUrl} size={200} />
+      {/* size is the intrinsic/max px; the style lets it shrink to fit a narrow
+          panel (max 200px, square via the SVG viewBox) instead of overflowing.
+          `title` gives the QR a text alternative for assistive technology. */}
+      <QRCodeSVG
+        value={joinUrl}
+        size={200}
+        title={`QR code to join session, code ${joinCode}`}
+        style={{ width: '100%', height: 'auto', maxWidth: 200 }}
+      />
     </Box>
   );
 };

--- a/apps/kiosk-webapp/src/features/kiosk-provider/components/kiosk-activation-form.tsx
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/components/kiosk-activation-form.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
@@ -21,6 +22,11 @@ export const KioskActivationForm = () => {
   const [activationCode, setActivationCode] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
+  // Derive loading rather than resetting it in an effect: a registration error
+  // is the async result of the last attempt, so the button stops loading as soon
+  // as one arrives instead of staying stuck disabled after a failure. (P4)
+  const isSubmitting = submitting && registrationError === null;
+
   const handleActivate = () => {
     setSubmitting(true);
     dispatch(activateDevice(activationCode));
@@ -34,12 +40,14 @@ export const KioskActivationForm = () => {
         value={activationCode}
         onChange={(e) => {
           setActivationCode(e.target.value);
-          setSubmitting(false);
         }}
         error={registrationError !== null}
-        helperText={registrationError ?? ''}
       />
-      <Button onClick={handleActivate} loading={submitting}>
+      {registrationError !== null && (
+        // role="alert" (MUI Alert default) announces the async failure. SC 4.1.3
+        <Alert severity="error">{registrationError}</Alert>
+      )}
+      <Button onClick={handleActivate} loading={isSubmitting}>
         Activate
       </Button>
     </Stack>

--- a/apps/kiosk-webapp/src/features/kiosk-provider/components/kiosk-status-panel.tsx
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/components/kiosk-status-panel.tsx
@@ -44,7 +44,11 @@ export const KioskStatusPanel = () => {
         ) : (
           <Stack spacing={2}>
             {device && (
-              <Typography variant="h5">Device: {device.name}</Typography>
+              // Status lines, not section headings: keep the visual size but
+              // render as text so they don't pollute the heading outline. SC 1.3.1
+              <Typography variant="h5" component="p">
+                Device: {device.name}
+              </Typography>
             )}
             {room && <Typography>Room: {room.name}</Typography>}
             {lifecycle === KioskLifecycle.INITIALIZING && (
@@ -58,7 +62,11 @@ export const KioskStatusPanel = () => {
                 <Typography>Session: {activeSession.name}</Typography>
                 {activeSession.currentJoinCode && (
                   <>
-                    <Typography variant="h4" fontFamily="monospace">
+                    <Typography
+                      variant="h4"
+                      component="p"
+                      fontFamily="monospace"
+                    >
                       Join Code: {activeSession.currentJoinCode.joinCode}
                     </Typography>
                     <JoinCodeQrCode

--- a/apps/kiosk-webapp/src/features/kiosk-split-screen/components/kiosk-split-layout.tsx
+++ b/apps/kiosk-webapp/src/features/kiosk-split-screen/components/kiosk-split-layout.tsx
@@ -120,9 +120,13 @@ export const KioskSplitLayout = ({ left, right }: KioskSplitLayoutProps) => {
               flexShrink: 0,
             }}
           >
-            <Tooltip title={isRightPanelOpen ? 'Collapse panel' : 'Expand panel'}>
+            <Tooltip
+              title={isRightPanelOpen ? 'Collapse panel' : 'Expand panel'}
+            >
               <IconButton
-                aria-label={isRightPanelOpen ? 'Collapse panel' : 'Expand panel'}
+                aria-label={
+                  isRightPanelOpen ? 'Collapse panel' : 'Expand panel'
+                }
                 aria-expanded={isRightPanelOpen}
                 onClick={() => {
                   dispatch(toggleRightPanelIsOpen());
@@ -149,7 +153,9 @@ export const KioskSplitLayout = ({ left, right }: KioskSplitLayoutProps) => {
           onResize={handleResize}
           style={{ height: '100%' }}
         >
-          <Pane minSize={`${LEFT_PANEL_MIN_WIDTH_PX.toString()}px`}>{left}</Pane>
+          <Pane minSize={`${LEFT_PANEL_MIN_WIDTH_PX.toString()}px`}>
+            {left}
+          </Pane>
           {isRightPanelOpen ? (
             <Pane
               size={`${rightPanelWidthPx.toString()}px`}

--- a/apps/kiosk-webapp/src/features/kiosk-split-screen/components/kiosk-split-layout.tsx
+++ b/apps/kiosk-webapp/src/features/kiosk-split-screen/components/kiosk-split-layout.tsx
@@ -1,6 +1,10 @@
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 
 import { type DividerProps, Pane, SplitPane } from 'react-split-pane';
 
@@ -10,6 +14,7 @@ import { useAppDispatch, useAppSelector } from '#src/store/use-redux';
 import {
   DIVIDER_WIDTH_PX,
   LEFT_PANEL_MIN_WIDTH_PX,
+  REFLOW_THRESHOLD_PX,
   RIGHT_PANEL_MIN_WIDTH_PX,
 } from '../config/split-screen-config';
 import {
@@ -90,29 +95,75 @@ export const KioskSplitLayout = ({ left, right }: KioskSplitLayoutProps) => {
     Math.max(targetRightPanelWidthPx, RIGHT_PANEL_MIN_WIDTH_PX),
   );
 
+  // Reflow to a single vertical column when too narrow for two side-by-side
+  // panes (SC 1.4.10). Keep the same ref element in both branches so the
+  // ResizeObserver keeps measuring across the switch.
+  const isNarrow = containerWidth > 0 && containerWidth < REFLOW_THRESHOLD_PX;
+
   return (
     <Box ref={containerRef} sx={{ height: '100%', width: '100%' }}>
-      <SplitPane
-        direction="horizontal"
-        divider={dividerWithToggle}
-        dividerSize={DIVIDER_WIDTH_PX}
-        onResize={handleResize}
-        style={{ height: '100%' }}
-      >
-        <Pane minSize={`${LEFT_PANEL_MIN_WIDTH_PX.toString()}px`}>{left}</Pane>
-        {isRightPanelOpen ? (
-          <Pane
-            size={`${rightPanelWidthPx.toString()}px`}
-            minSize={`${RIGHT_PANEL_MIN_WIDTH_PX.toString()}px`}
+      {isNarrow ? (
+        <Box
+          sx={{
+            height: '100%',
+            width: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>{left}</Box>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'center',
+              backgroundColor: 'primary.main',
+              flexShrink: 0,
+            }}
           >
-            {right}
-          </Pane>
-        ) : (
-          <Pane size={0} maxSize={0}>
-            <div></div>
-          </Pane>
-        )}
-      </SplitPane>
+            <Tooltip title={isRightPanelOpen ? 'Collapse panel' : 'Expand panel'}>
+              <IconButton
+                aria-label={isRightPanelOpen ? 'Collapse panel' : 'Expand panel'}
+                aria-expanded={isRightPanelOpen}
+                onClick={() => {
+                  dispatch(toggleRightPanelIsOpen());
+                }}
+                sx={{ color: 'primary.contrastText', p: 0.5 }}
+              >
+                {isRightPanelOpen ? (
+                  <ExpandLessIcon fontSize="small" />
+                ) : (
+                  <ExpandMoreIcon fontSize="small" />
+                )}
+              </IconButton>
+            </Tooltip>
+          </Box>
+          {isRightPanelOpen && (
+            <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>{right}</Box>
+          )}
+        </Box>
+      ) : (
+        <SplitPane
+          direction="horizontal"
+          divider={dividerWithToggle}
+          dividerSize={DIVIDER_WIDTH_PX}
+          onResize={handleResize}
+          style={{ height: '100%' }}
+        >
+          <Pane minSize={`${LEFT_PANEL_MIN_WIDTH_PX.toString()}px`}>{left}</Pane>
+          {isRightPanelOpen ? (
+            <Pane
+              size={`${rightPanelWidthPx.toString()}px`}
+              minSize={`${RIGHT_PANEL_MIN_WIDTH_PX.toString()}px`}
+            >
+              {right}
+            </Pane>
+          ) : (
+            <Pane size={0} maxSize={0}>
+              <div></div>
+            </Pane>
+          )}
+        </SplitPane>
+      )}
     </Box>
   );
 };

--- a/apps/kiosk-webapp/src/features/kiosk-split-screen/components/split-divider.tsx
+++ b/apps/kiosk-webapp/src/features/kiosk-split-screen/components/split-divider.tsx
@@ -47,6 +47,8 @@ export const SplitDivider = ({
         placement="left"
       >
         <IconButton
+          aria-label={isOpen ? 'Collapse panel' : 'Expand panel'}
+          aria-expanded={isOpen}
           onClick={(e) => {
             e.stopPropagation();
             onToggle();

--- a/apps/kiosk-webapp/src/features/kiosk-split-screen/config/split-screen-config.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-split-screen/config/split-screen-config.ts
@@ -5,3 +5,8 @@ export const RIGHT_PANEL_MIN_WIDTH_PX = 200;
 
 // Pixel width of the draggable divider bar between the two panes.
 export const DIVIDER_WIDTH_PX = 12;
+
+// Below this container width the two panes can't fit side by side without
+// horizontal scrolling (min widths sum to ~312px), so the layout reflows to a
+// single vertical column instead. Keeps SC 1.4.10 (Reflow) at 320px. */
+export const REFLOW_THRESHOLD_PX = 480;

--- a/apps/standalone-webapp/src/features/transcription-providers/components/provider-config-container.tsx
+++ b/apps/standalone-webapp/src/features/transcription-providers/components/provider-config-container.tsx
@@ -1,7 +1,10 @@
-import Box from '@mui/material/Box';
-import Modal from '@mui/material/Modal';
-import Paper from '@mui/material/Paper';
-import Typography from '@mui/material/Typography';
+import { useId } from 'react';
+
+import CloseIcon from '@mui/icons-material/Close';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import IconButton from '@mui/material/IconButton';
 
 /**
  * Props for {@link ProviderConfigContainer}.
@@ -16,31 +19,36 @@ interface ProviderConfigContainer {
 }
 
 /**
- * Generic modal shell for provider configuration menus. Renders a centered
- * MUI `Paper` modal with a title derived from `displayName` and a slot for
- * form content.
+ * Generic modal shell for provider configuration menus. A proper MUI `Dialog`
+ * (role="dialog" + focus trap) named by its title, with an explicit, visible
+ * close button so it can be dismissed by keyboard/AT without relying on a
+ * backdrop click.
  */
 export const ProviderConfigContainer = ({
   displayName,
   children,
   onClose,
 }: ProviderConfigContainer) => {
+  const titleId = useId();
   return (
-    <Modal open onClose={onClose}>
-      <Paper
-        sx={{
-          position: 'absolute',
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-          width: '100%',
-          maxWidth: 800,
-          p: 4,
-        }}
-      >
-        <Typography variant="h5">{displayName} Settings</Typography>
-        <Box paddingTop={4}>{children}</Box>
-      </Paper>
-    </Modal>
+    <Dialog
+      open
+      onClose={onClose}
+      fullWidth
+      maxWidth="md"
+      aria-labelledby={titleId}
+    >
+      <DialogTitle id={titleId} sx={{ pr: 6 }}>
+        {displayName} Settings
+        <IconButton
+          aria-label="Close"
+          onClick={onClose}
+          sx={{ position: 'absolute', right: 8, top: 8 }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>{children}</DialogContent>
+    </Dialog>
   );
 };

--- a/apps/standalone-webapp/src/features/transcription-providers/components/transcription-provider-selector.tsx
+++ b/apps/standalone-webapp/src/features/transcription-providers/components/transcription-provider-selector.tsx
@@ -3,11 +3,12 @@ import { useState } from 'react';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import SettingsIcon from '@mui/icons-material/Settings';
 import IconButton from '@mui/material/IconButton';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import Stack from '@mui/material/Stack';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import Popover from '@mui/material/Popover';
 import Tooltip from '@mui/material/Tooltip';
-import Typography from '@mui/material/Typography';
 
 import { useAppDispatch, useAppSelector } from '#src/store/use-redux';
 
@@ -34,8 +35,11 @@ interface TranscriptionProviderOptionProps {
 }
 
 /**
- * A single row within the provider selector dropdown. Renders the provider
- * display name as a selectable menu item alongside a settings icon button.
+ * A single row within the provider selector list. The provider name is a
+ * selectable button and the settings gear is a separate, individually-labelled
+ * button rendered as the row's secondary action — both are in the normal tab
+ * order (unlike a `role="menu"`, which would hide the non-`menuitem` gear from
+ * arrow-key navigation).
  */
 const TranscriptionProviderOption = ({
   id,
@@ -43,19 +47,26 @@ const TranscriptionProviderOption = ({
   onSelectProvider,
   onConfigureProvider,
 }: TranscriptionProviderOptionProps) => {
+  const name = getProviderDisplayName(id);
   return (
-    <Stack direction="row" alignItems="center" justifyContent="space-between">
-      <MenuItem
-        onClick={onSelectProvider}
-        sx={{ width: '100%', p: 2 }}
-        selected={selected}
-      >
-        <Typography>{getProviderDisplayName(id)}</Typography>
-      </MenuItem>
-      <IconButton onClick={onConfigureProvider} sx={{ p: 2, borderRadius: 0 }}>
-        <SettingsIcon />
-      </IconButton>
-    </Stack>
+    <ListItem
+      disablePadding
+      secondaryAction={
+        <Tooltip title={`Configure ${name}`}>
+          <IconButton
+            edge="end"
+            aria-label={`Configure ${name}`}
+            onClick={onConfigureProvider}
+          >
+            <SettingsIcon />
+          </IconButton>
+        </Tooltip>
+      }
+    >
+      <ListItemButton selected={selected} onClick={onSelectProvider}>
+        <ListItemText primary={name} />
+      </ListItemButton>
+    </ListItem>
   );
 };
 
@@ -86,12 +97,18 @@ export const TranscriptionProviderSelector = () => {
 
   return (
     <>
-      <Tooltip title="Switch or config providers">
-        <IconButton color="inherit" onClick={showSelectorMenu}>
+      <Tooltip title="Switch or configure providers">
+        <IconButton
+          color="inherit"
+          aria-label="Switch or configure providers"
+          aria-haspopup="true"
+          aria-expanded={isSelectorMenuOpen}
+          onClick={showSelectorMenu}
+        >
           <ExpandMoreIcon />
         </IconButton>
       </Tooltip>
-      <Menu
+      <Popover
         open={isSelectorMenuOpen}
         anchorEl={selectorMenuAnchorEl}
         onClose={hideSelectorMenu}
@@ -104,30 +121,33 @@ export const TranscriptionProviderSelector = () => {
           horizontal: 'center',
         }}
       >
-        {Object.values(ProviderId).map((id) => (
-          <TranscriptionProviderOption
-            key={id}
-            id={id}
-            selected={id === targetProviderId}
-            onSelectProvider={() => {
-              handleSelectProvider(id);
-            }}
-            onConfigureProvider={() => {
-              hideSelectorMenu();
-              dispatch(openConfigMenu(id));
-            }}
-          />
-        ))}
-        <MenuItem
-          onClick={() => {
-            handleSelectProvider(null);
-          }}
-          sx={{ width: '100%', p: 2 }}
-          selected={targetProviderId === null}
-        >
-          <Typography>No Provider</Typography>
-        </MenuItem>
-      </Menu>
+        <List>
+          {Object.values(ProviderId).map((id) => (
+            <TranscriptionProviderOption
+              key={id}
+              id={id}
+              selected={id === targetProviderId}
+              onSelectProvider={() => {
+                handleSelectProvider(id);
+              }}
+              onConfigureProvider={() => {
+                hideSelectorMenu();
+                dispatch(openConfigMenu(id));
+              }}
+            />
+          ))}
+          <ListItem disablePadding>
+            <ListItemButton
+              selected={targetProviderId === null}
+              onClick={() => {
+                handleSelectProvider(null);
+              }}
+            >
+              <ListItemText primary="No Provider" />
+            </ListItemButton>
+          </ListItem>
+        </List>
+      </Popover>
     </>
   );
 };

--- a/apps/standalone-webapp/src/features/transcription-providers/components/transcription-provider-status-display.tsx
+++ b/apps/standalone-webapp/src/features/transcription-providers/components/transcription-provider-status-display.tsx
@@ -28,7 +28,8 @@ export const TranscriptionProviderStatusDisplay = () => {
       {/* getProviderStatusIcon returns a stable reference from the module-level registry, not a new component. */}
       {/* eslint-disable-next-line react-hooks/static-components, @eslint-react/static-components */}
       {StatusIcon ? <StatusIcon /> : null}
-      <Typography variant="h6">
+      {/* Provider name is a status label in the header, not a section heading. */}
+      <Typography variant="h6" component="span">
         {targetProviderId
           ? getProviderDisplayName(targetProviderId)
           : 'No Provider'}

--- a/apps/standalone-webapp/src/features/transcription-providers/services/providers/streamtext/components/streamtext-status-icon.tsx
+++ b/apps/standalone-webapp/src/features/transcription-providers/services/providers/streamtext/components/streamtext-status-icon.tsx
@@ -45,7 +45,11 @@ export const StreamtextStatusIcon = () => {
 
   return (
     <Tooltip title={tooltip}>
-      <Stack sx={{ p: 1 }}>{icon}</Stack>
+      {/* role="img" + aria-label exposes the status (distinct icon shapes carry
+          it visually) to AT, which a tooltip on a non-focusable box does not. */}
+      <Stack sx={{ p: 1 }} role="img" aria-label={tooltip}>
+        {icon}
+      </Stack>
     </Tooltip>
   );
 };

--- a/apps/standalone-webapp/src/features/transcription-providers/services/providers/webspeech/components/webspeech-status-icon.tsx
+++ b/apps/standalone-webapp/src/features/transcription-providers/services/providers/webspeech/components/webspeech-status-icon.tsx
@@ -47,7 +47,11 @@ export const WebspeechStatusIcon = () => {
 
   return (
     <Tooltip title={tooltip}>
-      <Stack sx={{ p: 1 }}>{icon}</Stack>
+      {/* role="img" + aria-label exposes the status (distinct icon shapes carry
+          it visually) to AT, which a tooltip on a non-focusable box does not. */}
+      <Stack sx={{ p: 1 }} role="img" aria-label={tooltip}>
+        {icon}
+      </Stack>
     </Tooltip>
   );
 };

--- a/libs/ui/core-ui/package.json
+++ b/libs/ui/core-ui/package.json
@@ -21,7 +21,14 @@
     "format": "prettier --check ./src",
     "format:fix": "prettier --write ./src",
     "lint": "eslint ./src",
-    "lint:fix": "eslint ./src --fix"
+    "lint:fix": "eslint ./src --fix",
+    "test:unit": "vitest run --project unit"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "7.0.0",
+    "@testing-library/react": "16.3.2",
+    "axe-core": "4.10.2",
+    "jsdom": "29.1.1"
   },
   "dependencies": {
     "@base-ui/react": "1.3.0",

--- a/libs/ui/core-ui/src/components/app-layout.tsx
+++ b/libs/ui/core-ui/src/components/app-layout.tsx
@@ -184,6 +184,10 @@ export const AppLayout = ({
         }}
         slotProps={{
           paper: {
+            // The temporary drawer traps focus, so expose it as a modal dialog
+            // named by its "Menu" heading (MUI Drawer adds no role on its own).
+            role: 'dialog',
+            'aria-modal': true,
             'aria-labelledby': drawerTitleId,
             sx: {
               width: '30rem',

--- a/libs/ui/core-ui/src/components/app-layout.tsx
+++ b/libs/ui/core-ui/src/components/app-layout.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
 import CloseIcon from '@mui/icons-material/Close';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
@@ -10,6 +10,7 @@ import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
 import IconButton from '@mui/material/IconButton';
+import Link from '@mui/material/Link';
 import Slide from '@mui/material/Slide';
 import Stack from '@mui/material/Stack';
 import Toolbar from '@mui/material/Toolbar';
@@ -55,6 +56,8 @@ export const AppLayout = ({
   headerBreakpoint = 'sm',
 }: AppLayoutProps) => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const drawerTitleId = useId();
+  const mainContentId = useId();
   const { isFullscreen, isSupported, toggleFullscreen } = useFullscreen();
 
   const theme = useTheme();
@@ -67,6 +70,7 @@ export const AppLayout = ({
       <Tooltip title="Open Menu">
         <IconButton
           color="inherit"
+          aria-label="Open Menu"
           onClick={() => {
             setIsDrawerOpen(true);
           }}
@@ -74,7 +78,8 @@ export const AppLayout = ({
           <MenuIcon />
         </IconButton>
       </Tooltip>
-      <Typography variant="h5" marginLeft={2}>
+      {/* Single app <h1> (visually h5-sized) so every app has one top-level heading. */}
+      <Typography variant="h5" component="h1" marginLeft={2}>
         ScribeAR
       </Typography>
     </Stack>
@@ -95,21 +100,35 @@ export const AppLayout = ({
             : 'Enable Header Autohide'
         }
       >
-        <IconButton color="inherit" onClick={onToggleHeaderHide}>
+        <IconButton
+          color="inherit"
+          aria-label={
+            isHeaderHideEnabled
+              ? 'Disable Header Autohide'
+              : 'Enable Header Autohide'
+          }
+          aria-pressed={isHeaderHideEnabled}
+          onClick={onToggleHeaderHide}
+        >
           {isHeaderHideEnabled ? <LockOpenIcon /> : <LockIcon />}
         </IconButton>
       </Tooltip>
 
       <Tooltip title={fullscreenTooltip}>
-        <IconButton
-          disabled={!isSupported}
-          color="inherit"
-          onClick={() => {
-            void toggleFullscreen();
-          }}
-        >
-          {isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
-        </IconButton>
+        {/* span wrapper so the Tooltip still works when the button is disabled */}
+        <span>
+          <IconButton
+            disabled={!isSupported}
+            color="inherit"
+            aria-label={fullscreenTooltip}
+            aria-pressed={isFullscreen}
+            onClick={() => {
+              void toggleFullscreen();
+            }}
+          >
+            {isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
+          </IconButton>
+        </span>
       </Tooltip>
     </Stack>
   );
@@ -165,6 +184,7 @@ export const AppLayout = ({
         }}
         slotProps={{
           paper: {
+            'aria-labelledby': drawerTitleId,
             sx: {
               width: '30rem',
               maxWidth: '100%',
@@ -180,12 +200,19 @@ export const AppLayout = ({
             p: 2,
           }}
         >
-          <Typography variant="h5" fontWeight={500}>
+          {/* Drawer title, level 2 under the app <h1>; also names the dialog. */}
+          <Typography
+            id={drawerTitleId}
+            variant="h5"
+            component="h2"
+            fontWeight={500}
+          >
             Menu
           </Typography>
           <Tooltip title="Close Menu">
             <IconButton
               color="inherit"
+              aria-label="Close Menu"
               onClick={() => {
                 setIsDrawerOpen(false);
               }}
@@ -197,15 +224,40 @@ export const AppLayout = ({
         {drawerContent}
       </Drawer>
 
+      {/* Skip link: first focusable element, visually hidden until focused, so
+          keyboard/AT users can jump straight to the captions/main content. SC 2.4.1 */}
+      <Link
+        href={`#${mainContentId}`}
+        sx={{
+          position: 'absolute',
+          left: 8,
+          top: -40,
+          zIndex: (t) => t.zIndex.tooltip + 1,
+          p: 1,
+          borderRadius: 1,
+          bgcolor: 'background.paper',
+          color: 'text.primary',
+          '&:focus-visible': { top: 8 },
+        }}
+      >
+        Skip to main content
+      </Link>
+
+      {/* unmountOnExit keeps the auto-hidden header's controls out of the tab
+          order while hidden (they are off-screen otherwise). Any keydown/mouse
+          activity re-reveals it via useInactivity. SC 2.4.3 */}
       <Slide
         appear={false}
         direction="down"
         in={!isHeaderHideEnabled || isUserActive}
+        unmountOnExit
       >
         <AppBar>{Header}</AppBar>
       </Slide>
 
-      <Box component="main">{children}</Box>
+      <Box component="main" id={mainContentId} tabIndex={-1}>
+        {children}
+      </Box>
     </Box>
   );
 };

--- a/libs/ui/core-ui/src/components/cancelable-info-modal.tsx
+++ b/libs/ui/core-ui/src/components/cancelable-info-modal.tsx
@@ -1,3 +1,5 @@
+import { useId } from 'react';
+
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Modal from '@mui/material/Modal';
@@ -32,9 +34,13 @@ export const CancelableInfoModal = ({
   children,
   onCancel,
 }: CancelableInfoModalProps) => {
+  const messageId = useId();
   return (
     <Modal open={isOpen} onClose={onCancel}>
       <Paper
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={messageId}
         sx={{
           position: 'absolute',
           top: '50%',
@@ -45,7 +51,7 @@ export const CancelableInfoModal = ({
           p: 4,
         }}
       >
-        <Typography textAlign="center" pb={4}>
+        <Typography id={messageId} textAlign="center" pb={4}>
           {message}
         </Typography>
         <Box sx={{ pb: 4, width: '100%' }}>{children}</Box>

--- a/libs/ui/core-ui/src/components/choice-modal.tsx
+++ b/libs/ui/core-ui/src/components/choice-modal.tsx
@@ -1,3 +1,5 @@
+import { useId } from 'react';
+
 import Box from '@mui/material/Box';
 import Button, { type ButtonProps } from '@mui/material/Button';
 import Modal from '@mui/material/Modal';
@@ -50,9 +52,13 @@ export const ChoiceModal = ({
   onRightAction,
   children,
 }: ChoiceModalProps) => {
+  const messageId = useId();
   return (
     <Modal open={isOpen} onClose={onCancel}>
       <Paper
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={messageId}
         sx={{
           position: 'absolute',
           top: '50%',
@@ -63,7 +69,7 @@ export const ChoiceModal = ({
           p: 4,
         }}
       >
-        <Typography textAlign="center" pb={4}>
+        <Typography id={messageId} textAlign="center" pb={4}>
           {message}
         </Typography>
         {children ? <Box sx={{ pb: 4 }}>{children}</Box> : null}

--- a/libs/ui/core-ui/src/components/drawer-menu-group.tsx
+++ b/libs/ui/core-ui/src/components/drawer-menu-group.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
 import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
@@ -36,6 +36,7 @@ export const DrawerMenuGroup = ({
   children,
 }: DrawerMenuGroupProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const contentId = useId();
 
   return (
     <Box>
@@ -47,20 +48,30 @@ export const DrawerMenuGroup = ({
       >
         <Stack direction="row" alignItems="center">
           <Stack sx={{ p: 1 }}>
-            <Icon color="inherit">{icon}</Icon>
+            {/* Decorative leading icon — the summary text is the real label. */}
+            <Icon color="inherit" aria-hidden="true">
+              {icon}
+            </Icon>
           </Stack>
-          <Typography>{summary}</Typography>
+          {/* Group heading. Level is reconciled by the app-wide heading pass (P3):
+              app <h1> -> drawer title <h2> -> group summary <h3>. */}
+          <Typography component="h3" variant="body1">
+            {summary}
+          </Typography>
         </Stack>
 
         <IconButton
           onClick={() => {
             setIsOpen(!isOpen);
           }}
+          aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${summary}`}
+          aria-expanded={isOpen}
+          aria-controls={contentId}
         >
           {isOpen ? <ExpandLess /> : <ExpandMore />}
         </IconButton>
       </Stack>
-      <Collapse in={isOpen}>
+      <Collapse in={isOpen} id={contentId}>
         <Stack sx={{ p: 2 }} direction="column" spacing={1}>
           {children}
         </Stack>

--- a/libs/ui/core-ui/src/components/main-error-fallback.tsx
+++ b/libs/ui/core-ui/src/components/main-error-fallback.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react';
+
 import Refresh from '@mui/icons-material/Refresh';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -8,6 +10,14 @@ import Typography from '@mui/material/Typography';
  * Full-page error fallback that prompts the user to refresh.
  */
 export const MainErrorFallback = () => {
+  const messageRef = useRef<HTMLParagraphElement>(null);
+
+  // Move focus to the error message so screen-reader users are taken to it
+  // immediately (the `role="alert"` also announces it). SC 4.1.3
+  useEffect(() => {
+    messageRef.current?.focus();
+  }, []);
+
   const reloadPage = () => {
     window.location.reload();
   };
@@ -32,7 +42,7 @@ export const MainErrorFallback = () => {
           flexDirection: 'column',
         }}
       >
-        <Typography>
+        <Typography ref={messageRef} role="alert" tabIndex={-1}>
           An unexpected error occurred. Try refreshing the page.
         </Typography>
         <Button

--- a/libs/ui/core-ui/src/components/page-load-spinner.tsx
+++ b/libs/ui/core-ui/src/components/page-load-spinner.tsx
@@ -7,6 +7,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 export const PageLoadSpinner = () => {
   return (
     <Box
+      role="status"
       sx={{
         display: 'flex',
         justifyContent: 'center',
@@ -15,7 +16,7 @@ export const PageLoadSpinner = () => {
         width: '100vw',
       }}
     >
-      <CircularProgress />
+      <CircularProgress aria-label="Loading" />
     </Box>
   );
 };

--- a/libs/ui/core-ui/tests/a11y.ts
+++ b/libs/ui/core-ui/tests/a11y.ts
@@ -1,0 +1,31 @@
+import axe from 'axe-core';
+
+// Page-scaffolding rules that only make sense for a whole document, not an
+// isolated component rendered into jsdom's bare <body> (many MUI components
+// portal into <body>, so we scan the whole body rather than the RTL container).
+const PAGE_LEVEL_RULES_OFF = {
+  region: { enabled: false },
+  'landmark-one-main': { enabled: false },
+  'page-has-heading-one': { enabled: false },
+  'html-has-lang': { enabled: false },
+  'document-title': { enabled: false },
+  bypass: { enabled: false },
+} satisfies Record<string, { enabled: boolean }>;
+
+/**
+ * Runs axe-core (WCAG 2.1 A/AA rules) over `node` and returns the ids of any
+ * violations, so a test can assert `expect(await axeViolations()).toEqual([])`.
+ * Defaults to `document.body` to include portalled dialogs/menus.
+ */
+export async function axeViolations(
+  node: Element = document.body,
+): Promise<string[]> {
+  const results = await axe.run(node, {
+    runOnly: {
+      type: 'tag',
+      values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
+    },
+    rules: PAGE_LEVEL_RULES_OFF,
+  });
+  return results.violations.map((v) => `${v.id} (${v.nodes.length} node(s))`);
+}

--- a/libs/ui/core-ui/tests/components/app-layout.test.tsx
+++ b/libs/ui/core-ui/tests/components/app-layout.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AppLayout } from '#src/components/app-layout.js';
+
+import { axeViolations } from '../a11y.js';
+
+function renderLayout(props: Partial<Parameters<typeof AppLayout>[0]> = {}) {
+  return render(
+    <AppLayout
+      isHeaderHideEnabled={false}
+      onToggleHeaderHide={vi.fn()}
+      drawerContent={<div>Drawer body</div>}
+      {...props}
+    >
+      <div>Main content</div>
+    </AppLayout>,
+  );
+}
+
+describe('AppLayout', (it) => {
+  it('provides a single app <h1> and a skip link', () => {
+    renderLayout();
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'ScribeAR' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Skip to main content' }),
+    ).toBeInTheDocument();
+  });
+
+  it('names the icon buttons and exposes toggle state', () => {
+    renderLayout();
+    expect(
+      screen.getByRole('button', { name: 'Open Menu' }),
+    ).toBeInTheDocument();
+    // Autohide currently disabled -> the button offers to enable it, unpressed.
+    const autohide = screen.getByRole('button', {
+      name: 'Enable Header Autohide',
+    });
+    expect(autohide).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('opens the drawer as a dialog named by its heading', () => {
+    renderLayout();
+    fireEvent.click(screen.getByRole('button', { name: 'Open Menu' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAccessibleName('Menu');
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Menu' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Close Menu' }),
+    ).toBeInTheDocument();
+  });
+
+  it('has no axe violations with the drawer open', async () => {
+    renderLayout();
+    fireEvent.click(screen.getByRole('button', { name: 'Open Menu' }));
+    expect(await axeViolations()).toEqual([]);
+  });
+});

--- a/libs/ui/core-ui/tests/components/cancelable-info-modal.test.tsx
+++ b/libs/ui/core-ui/tests/components/cancelable-info-modal.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CancelableInfoModal } from '#src/components/cancelable-info-modal.js';
+
+import { axeViolations } from '../a11y.js';
+
+const baseProps = {
+  isOpen: true,
+  message: 'Microphone access was denied.',
+  onCancel: vi.fn(),
+};
+
+describe('CancelableInfoModal', (it) => {
+  it('exposes dialog semantics named by its message', () => {
+    render(<CancelableInfoModal {...baseProps} />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAccessibleName('Microphone access was denied.');
+  });
+
+  it('has no axe violations', async () => {
+    render(<CancelableInfoModal {...baseProps} />);
+    expect(await axeViolations()).toEqual([]);
+  });
+});

--- a/libs/ui/core-ui/tests/components/choice-modal.test.tsx
+++ b/libs/ui/core-ui/tests/components/choice-modal.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChoiceModal } from '#src/components/choice-modal.js';
+
+import { axeViolations } from '../a11y.js';
+
+const baseProps = {
+  isOpen: true,
+  message: 'Discard your changes?',
+  rightAction: 'Discard',
+  onCancel: vi.fn(),
+  onRightAction: vi.fn(),
+};
+
+describe('ChoiceModal', (it) => {
+  it('exposes dialog semantics named by its message', () => {
+    render(<ChoiceModal {...baseProps} />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    // aria-labelledby is wired to the message so the dialog has an accessible name.
+    expect(dialog).toHaveAccessibleName('Discard your changes?');
+  });
+
+  it('has no axe violations', async () => {
+    render(<ChoiceModal {...baseProps} />);
+    expect(await axeViolations()).toEqual([]);
+  });
+});

--- a/libs/ui/core-ui/tests/components/drawer-menu-group.test.tsx
+++ b/libs/ui/core-ui/tests/components/drawer-menu-group.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DrawerMenuGroup } from '#src/components/drawer-menu-group.js';
+
+import { axeViolations } from '../a11y.js';
+
+function renderGroup() {
+  return render(
+    <DrawerMenuGroup summary="Display" icon={<span data-testid="icon" />}>
+      <button type="button">A setting</button>
+    </DrawerMenuGroup>,
+  );
+}
+
+describe('DrawerMenuGroup', (it) => {
+  it('names the toggle and exposes its disclosure state', async () => {
+    renderGroup();
+
+    // Collapsed: the toggle is an "Expand …" control that is not expanded and
+    // points at the (hidden) content region.
+    const toggle = screen.getByRole('button', { name: 'Expand Display' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle).toHaveAttribute('aria-controls');
+
+    // Expanding flips both the name and the state.
+    fireEvent.click(toggle);
+    expect(
+      screen.getByRole('button', { name: 'Collapse Display' }),
+    ).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('renders the summary as a heading', () => {
+    renderGroup();
+    expect(
+      screen.getByRole('heading', { name: 'Display' }),
+    ).toBeInTheDocument();
+  });
+
+  it('has no axe violations in either state', async () => {
+    renderGroup();
+    expect(await axeViolations()).toEqual([]);
+    fireEvent.click(screen.getByRole('button', { name: 'Expand Display' }));
+    expect(await axeViolations()).toEqual([]);
+  });
+});

--- a/libs/ui/core-ui/tests/components/main-error-fallback.test.tsx
+++ b/libs/ui/core-ui/tests/components/main-error-fallback.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MainErrorFallback } from '#src/components/main-error-fallback.js';
+
+import { axeViolations } from '../a11y.js';
+
+describe('MainErrorFallback', (it) => {
+  it('announces the error via role=alert and takes focus', () => {
+    render(<MainErrorFallback />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/unexpected error/i);
+    // Focus is moved to the message so a screen-reader user lands on it.
+    expect(alert).toHaveFocus();
+  });
+
+  it('has no axe violations', async () => {
+    render(<MainErrorFallback />);
+    expect(await axeViolations()).toEqual([]);
+  });
+});

--- a/libs/ui/core-ui/tests/components/page-load-spinner.test.tsx
+++ b/libs/ui/core-ui/tests/components/page-load-spinner.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PageLoadSpinner } from '#src/components/page-load-spinner.js';
+
+import { axeViolations } from '../a11y.js';
+
+describe('PageLoadSpinner', (it) => {
+  it('announces loading with a named status region', () => {
+    render(<PageLoadSpinner />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    // The progressbar carries the accessible name for AT.
+    expect(screen.getByRole('progressbar')).toHaveAccessibleName('Loading');
+  });
+
+  it('has no axe violations', async () => {
+    render(<PageLoadSpinner />);
+    expect(await axeViolations()).toEqual([]);
+  });
+});

--- a/libs/ui/core-ui/tests/setup.ts
+++ b/libs/ui/core-ui/tests/setup.ts
@@ -1,0 +1,10 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// Vitest's `globals` is off (see vitest.shared.ts), so RTL's auto-cleanup — which
+// looks for a global `afterEach` — never registers. Without this each test file
+// leaks its rendered DOM into the next test.
+afterEach(() => {
+  cleanup();
+});

--- a/libs/ui/core-ui/tests/setup.ts
+++ b/libs/ui/core-ui/tests/setup.ts
@@ -8,3 +8,16 @@ import { afterEach } from 'vitest';
 afterEach(() => {
   cleanup();
 });
+
+// jsdom doesn't implement matchMedia, which MUI's useMediaQuery (used by
+// AppLayout's responsive header) calls. Provide a stub that reports no match.
+globalThis.matchMedia ??= ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => false,
+})) as unknown as typeof matchMedia;

--- a/libs/ui/core-ui/vitest.config.ts
+++ b/libs/ui/core-ui/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import sharedConfig from '../../../vitest.shared.js';
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      include: ['./tests/**/*.test.{ts,tsx}'],
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'unit',
+            environment: 'jsdom',
+            setupFiles: ['./tests/setup.ts'],
+          },
+        },
+      ],
+    },
+  }),
+);

--- a/libs/ui/microphone-ui/package.json
+++ b/libs/ui/microphone-ui/package.json
@@ -21,7 +21,14 @@
     "format": "prettier --check ./src",
     "format:fix": "prettier --write ./src",
     "lint": "eslint ./src",
-    "lint:fix": "eslint ./src --fix"
+    "lint:fix": "eslint ./src --fix",
+    "test:unit": "vitest run --project unit"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "7.0.0",
+    "@testing-library/react": "16.3.2",
+    "axe-core": "4.10.2",
+    "jsdom": "29.1.1"
   },
   "dependencies": {
     "@emotion/react": "11.14.0",

--- a/libs/ui/microphone-ui/src/components/toggle-microphone-button.tsx
+++ b/libs/ui/microphone-ui/src/components/toggle-microphone-button.tsx
@@ -35,7 +35,14 @@ export const ToggleMicrophoneButton = ({
     <Tooltip
       title={isMicrophoneActive ? 'Mute Microphone' : 'Unmute Microphone'}
     >
-      <IconButton color="inherit" onClick={toggleMicrophone}>
+      <IconButton
+        color="inherit"
+        aria-label={
+          isMicrophoneActive ? 'Mute Microphone' : 'Unmute Microphone'
+        }
+        aria-pressed={isMicrophoneActive}
+        onClick={toggleMicrophone}
+      >
         {isMicrophoneActive ? <MicIcon /> : <MicOffIcon />}
       </IconButton>
     </Tooltip>

--- a/libs/ui/microphone-ui/tests/a11y.ts
+++ b/libs/ui/microphone-ui/tests/a11y.ts
@@ -1,0 +1,31 @@
+import axe from 'axe-core';
+
+// Page-scaffolding rules that only make sense for a whole document, not an
+// isolated component rendered into jsdom's bare <body> (many MUI components
+// portal into <body>, so we scan the whole body rather than the RTL container).
+const PAGE_LEVEL_RULES_OFF = {
+  region: { enabled: false },
+  'landmark-one-main': { enabled: false },
+  'page-has-heading-one': { enabled: false },
+  'html-has-lang': { enabled: false },
+  'document-title': { enabled: false },
+  bypass: { enabled: false },
+} satisfies Record<string, { enabled: boolean }>;
+
+/**
+ * Runs axe-core (WCAG 2.1 A/AA rules) over `node` and returns the ids of any
+ * violations, so a test can assert `expect(await axeViolations()).toEqual([])`.
+ * Defaults to `document.body` to include portalled dialogs/menus.
+ */
+export async function axeViolations(
+  node: Element = document.body,
+): Promise<string[]> {
+  const results = await axe.run(node, {
+    runOnly: {
+      type: 'tag',
+      values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
+    },
+    rules: PAGE_LEVEL_RULES_OFF,
+  });
+  return results.violations.map((v) => `${v.id} (${v.nodes.length} node(s))`);
+}

--- a/libs/ui/microphone-ui/tests/components/toggle-microphone-button.test.tsx
+++ b/libs/ui/microphone-ui/tests/components/toggle-microphone-button.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ToggleMicrophoneButton } from '#src/components/toggle-microphone-button.js';
+
+import { axeViolations } from '../a11y.js';
+
+describe('ToggleMicrophoneButton', (it) => {
+  it('is a named toggle whose pressed state reflects the mic', () => {
+    const { rerender } = render(
+      <ToggleMicrophoneButton
+        isMicrophoneActive={false}
+        activate={vi.fn()}
+        deactivate={vi.fn()}
+      />,
+    );
+
+    const off = screen.getByRole('button', { name: 'Unmute Microphone' });
+    expect(off).toHaveAttribute('aria-pressed', 'false');
+
+    rerender(
+      <ToggleMicrophoneButton
+        isMicrophoneActive
+        activate={vi.fn()}
+        deactivate={vi.fn()}
+      />,
+    );
+    const on = screen.getByRole('button', { name: 'Mute Microphone' });
+    expect(on).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('calls activate/deactivate on click', () => {
+    const activate = vi.fn();
+    const deactivate = vi.fn();
+    const { rerender } = render(
+      <ToggleMicrophoneButton
+        isMicrophoneActive={false}
+        activate={activate}
+        deactivate={deactivate}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(activate).toHaveBeenCalledOnce();
+
+    rerender(
+      <ToggleMicrophoneButton
+        isMicrophoneActive
+        activate={activate}
+        deactivate={deactivate}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(deactivate).toHaveBeenCalledOnce();
+  });
+
+  it('has no axe violations', async () => {
+    render(
+      <ToggleMicrophoneButton
+        isMicrophoneActive={false}
+        activate={vi.fn()}
+        deactivate={vi.fn()}
+      />,
+    );
+    expect(await axeViolations()).toEqual([]);
+  });
+});

--- a/libs/ui/microphone-ui/tests/setup.ts
+++ b/libs/ui/microphone-ui/tests/setup.ts
@@ -1,0 +1,9 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// Vitest's `globals` is off (see vitest.shared.ts), so register RTL cleanup
+// manually to avoid DOM leaking between tests.
+afterEach(() => {
+  cleanup();
+});

--- a/libs/ui/microphone-ui/vitest.config.ts
+++ b/libs/ui/microphone-ui/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import sharedConfig from '../../../vitest.shared.js';
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      include: ['./tests/**/*.test.{ts,tsx}'],
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'unit',
+            environment: 'jsdom',
+            setupFiles: ['./tests/setup.ts'],
+          },
+        },
+      ],
+    },
+  }),
+);

--- a/libs/ui/theme-customization-ui/package.json
+++ b/libs/ui/theme-customization-ui/package.json
@@ -21,7 +21,14 @@
     "format": "prettier --check ./src",
     "format:fix": "prettier --write ./src",
     "lint": "eslint ./src",
-    "lint:fix": "eslint ./src --fix"
+    "lint:fix": "eslint ./src --fix",
+    "test:unit": "vitest run --project unit"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "7.0.0",
+    "@testing-library/react": "16.3.2",
+    "axe-core": "4.10.2",
+    "jsdom": "29.1.1"
   },
   "dependencies": {
     "@emotion/react": "11.14.0",

--- a/libs/ui/theme-customization-ui/src/components/color-controls/accent-color-selector.tsx
+++ b/libs/ui/theme-customization-ui/src/components/color-controls/accent-color-selector.tsx
@@ -1,9 +1,4 @@
-import Stack from '@mui/material/Stack';
-import Typography from '@mui/material/Typography';
-
-import { MuiColorInput } from 'mui-color-input';
-
-import { useDebouncedValue } from '@scribear/core-ui';
+import { ColorPickerField } from './color-picker-field.js';
 
 /**
  * Props for {@link AccentColorSelector}.
@@ -22,19 +17,11 @@ export const AccentColorSelector = ({
   accentColor,
   setAccentColor,
 }: AccentColorSelectorProps) => {
-  const [value, handleChange] = useDebouncedValue(accentColor, setAccentColor);
-
   return (
-    <Stack direction="row" alignItems="center" justifyContent="space-between">
-      <Typography>Accent Color</Typography>
-      <MuiColorInput
-        aria-label="Accent Color Selector"
-        sx={{ width: '8em' }}
-        format="hex"
-        isAlphaHidden={true}
-        value={value}
-        onChange={handleChange}
-      />
-    </Stack>
+    <ColorPickerField
+      label="Accent Color"
+      value={accentColor}
+      onChange={setAccentColor}
+    />
   );
 };

--- a/libs/ui/theme-customization-ui/src/components/color-controls/background-color-selector.tsx
+++ b/libs/ui/theme-customization-ui/src/components/color-controls/background-color-selector.tsx
@@ -1,9 +1,4 @@
-import Stack from '@mui/material/Stack';
-import Typography from '@mui/material/Typography';
-
-import { MuiColorInput } from 'mui-color-input';
-
-import { useDebouncedValue } from '@scribear/core-ui';
+import { ColorPickerField } from './color-picker-field.js';
 
 /**
  * Props for {@link BackgroundColorSelector}.
@@ -22,22 +17,11 @@ export const BackgroundColorSelector = ({
   backgroundColor,
   setBackgroundColor,
 }: BackgroundColorSelectorProps) => {
-  const [value, handleChange] = useDebouncedValue(
-    backgroundColor,
-    setBackgroundColor,
-  );
-
   return (
-    <Stack direction="row" alignItems="center" justifyContent="space-between">
-      <Typography>Background Color</Typography>
-      <MuiColorInput
-        aria-label="Background Color Selector"
-        sx={{ width: '8em' }}
-        format="hex"
-        isAlphaHidden={true}
-        value={value}
-        onChange={handleChange}
-      />
-    </Stack>
+    <ColorPickerField
+      label="Background Color"
+      value={backgroundColor}
+      onChange={setBackgroundColor}
+    />
   );
 };

--- a/libs/ui/theme-customization-ui/src/components/color-controls/color-picker-field.tsx
+++ b/libs/ui/theme-customization-ui/src/components/color-controls/color-picker-field.tsx
@@ -1,0 +1,50 @@
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import { MuiColorInput, MuiColorInputButton } from 'mui-color-input';
+
+import { useDebouncedValue } from '@scribear/core-ui';
+
+/**
+ * Props for {@link ColorPickerField}.
+ */
+interface ColorPickerFieldProps {
+  // Visible label; also the accessible name of the hex input (no 2.5.3 mismatch).
+  label: string;
+  // Current hex color value (e.g. "#ffffff").
+  value: string;
+  // Called with the new hex value after the user finishes picking (debounced).
+  onChange: (value: string) => void;
+}
+
+/**
+ * Labeled hex color picker used by the background / accent / transcription
+ * color selectors. Centralizes the accessibility wiring for `mui-color-input`,
+ * which by default names neither its text input nor its color-preview button:
+ * the input gets an `aria-label` matching the visible label (SC 1.3.1, 2.5.3)
+ * and the preview button is named via the `Adornment` slot (SC 4.1.2).
+ */
+export const ColorPickerField = ({
+  label,
+  value,
+  onChange,
+}: ColorPickerFieldProps) => {
+  const [current, handleChange] = useDebouncedValue(value, onChange);
+
+  return (
+    <Stack direction="row" alignItems="center" justifyContent="space-between">
+      <Typography>{label}</Typography>
+      <MuiColorInput
+        sx={{ width: '8em' }}
+        format="hex"
+        isAlphaHidden
+        value={current}
+        onChange={handleChange}
+        slotProps={{ htmlInput: { 'aria-label': label } }}
+        Adornment={(props) => (
+          <MuiColorInputButton {...props} aria-label={`${label} picker`} />
+        )}
+      />
+    </Stack>
+  );
+};

--- a/libs/ui/theme-customization-ui/src/components/color-controls/transcription-color-selector.tsx
+++ b/libs/ui/theme-customization-ui/src/components/color-controls/transcription-color-selector.tsx
@@ -1,9 +1,4 @@
-import Stack from '@mui/material/Stack';
-import Typography from '@mui/material/Typography';
-
-import { MuiColorInput } from 'mui-color-input';
-
-import { useDebouncedValue } from '@scribear/core-ui';
+import { ColorPickerField } from './color-picker-field.js';
 
 /**
  * Props for {@link TranscriptionColorSelector}.
@@ -22,22 +17,11 @@ export const TranscriptionColorSelector = ({
   transcriptionColor,
   setTranscriptionColor,
 }: TranscriptionColorSelectorProps) => {
-  const [value, handleChange] = useDebouncedValue(
-    transcriptionColor,
-    setTranscriptionColor,
-  );
-
   return (
-    <Stack direction="row" alignItems="center" justifyContent="space-between">
-      <Typography>Transcription Color</Typography>
-      <MuiColorInput
-        aria-label="Transcription Text Color Selector"
-        sx={{ width: '8em' }}
-        format="hex"
-        isAlphaHidden={true}
-        value={value}
-        onChange={handleChange}
-      />
-    </Stack>
+    <ColorPickerField
+      label="Transcription Color"
+      value={transcriptionColor}
+      onChange={setTranscriptionColor}
+    />
   );
 };

--- a/libs/ui/theme-customization-ui/src/components/contrast-readout.tsx
+++ b/libs/ui/theme-customization-ui/src/components/contrast-readout.tsx
@@ -1,0 +1,84 @@
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import {
+  AA_NON_TEXT_CONTRAST,
+  AA_TEXT_CONTRAST,
+  contrastRatio,
+} from '#src/utils/color-contrast.js';
+
+/**
+ * Props for {@link ContrastReadout}.
+ */
+interface ContrastReadoutProps {
+  backgroundColor: string;
+  accentColor: string;
+  transcriptionColor: string;
+}
+
+interface ContrastRowProps {
+  label: string;
+  ratio: number;
+  threshold: number;
+}
+
+/**
+ * One contrast line. Pass/fail is conveyed by the icon shape AND the text (not
+ * colour alone, SC 1.4.1); the text itself uses `text.primary` so it stays
+ * readable on any themed drawer background.
+ */
+const ContrastRow = ({ label, ratio, threshold }: ContrastRowProps) => {
+  const passes = ratio >= threshold;
+  return (
+    <Stack direction="row" alignItems="center" spacing={0.5}>
+      {passes ? (
+        <CheckCircleOutlineIcon
+          fontSize="small"
+          aria-hidden="true"
+          sx={{ color: 'success.main' }}
+        />
+      ) : (
+        <WarningAmberIcon
+          fontSize="small"
+          aria-hidden="true"
+          sx={{ color: 'warning.main' }}
+        />
+      )}
+      <Typography variant="body2" sx={{ color: 'text.primary' }}>
+        {label}: {ratio.toFixed(1)}:1
+        {passes ? '' : ` — low, aim for ${threshold.toString()}:1`}
+      </Typography>
+    </Stack>
+  );
+};
+
+/**
+ * Live WCAG contrast readout for the current theme colors, so a user picking
+ * colours can see when a caption/background or accent/background pair becomes
+ * unreadable. Announced politely as the colours change. (SC 1.4.3 support.)
+ */
+export const ContrastReadout = ({
+  backgroundColor,
+  accentColor,
+  transcriptionColor,
+}: ContrastReadoutProps) => {
+  const captionRatio = contrastRatio(transcriptionColor, backgroundColor);
+  const accentRatio = contrastRatio(accentColor, backgroundColor);
+
+  return (
+    <Stack role="status" aria-live="polite" spacing={0.5} sx={{ mt: 1 }}>
+      <ContrastRow
+        label="Caption text"
+        ratio={captionRatio}
+        threshold={AA_TEXT_CONTRAST}
+      />
+      <ContrastRow
+        label="Accent"
+        ratio={accentRatio}
+        threshold={AA_NON_TEXT_CONTRAST}
+      />
+    </Stack>
+  );
+};

--- a/libs/ui/theme-customization-ui/src/components/custom-theme-provider.tsx
+++ b/libs/ui/theme-customization-ui/src/components/custom-theme-provider.tsx
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 
+import { isLightColor, readableTextColor } from '#src/utils/color-contrast.js';
+
 /**
  * Props for {@link CustomThemeProvider}.
  */
@@ -30,10 +32,19 @@ export const CustomThemeProvider = ({
   children,
 }: CustomThemeProviderProps) => {
   const theme = useMemo(() => {
+    // Derive palette mode + default text color from the chosen background's
+    // luminance. Without this MUI keeps its light-mode near-black default text,
+    // so any default-colored Typography/icon is invisible on a dark background
+    // (only the explicitly-colored transcription text was safe before). SC 1.4.3
+    const mode = isLightColor(backgroundColor) ? 'light' : 'dark';
     return createTheme({
       palette: {
+        mode,
         background: {
           default: backgroundColor,
+        },
+        text: {
+          primary: readableTextColor(backgroundColor),
         },
         primary: {
           main: accentColor,

--- a/libs/ui/theme-customization-ui/src/components/preset-theme-selector.tsx
+++ b/libs/ui/theme-customization-ui/src/components/preset-theme-selector.tsx
@@ -87,6 +87,10 @@ export const PresetThemeSelector = ({
                     borderColor: theme.accentColor,
                     backgroundColor: theme.backgroundColor,
                     borderRadius: 1,
+                    // Neutral ring so the swatch boundary is always perceivable,
+                    // even when the accent border has near-zero contrast with the
+                    // swatch background (e.g. Pitch Black's black-on-black). SC 1.4.11
+                    boxShadow: (t) => `0 0 0 1px ${t.palette.divider}`,
                   }}
                 >
                   <Typography

--- a/libs/ui/theme-customization-ui/src/components/preset-theme-selector.tsx
+++ b/libs/ui/theme-customization-ui/src/components/preset-theme-selector.tsx
@@ -59,7 +59,13 @@ export const PresetThemeSelector = ({
         }}
       >
         <Tooltip title="View Preset Themes">
-          <IconButton color="inherit" onClick={showPresetThemeSelector}>
+          <IconButton
+            color="inherit"
+            aria-label="View Preset Themes"
+            aria-haspopup="true"
+            aria-expanded={isThemeSelectorOpen}
+            onClick={showPresetThemeSelector}
+          >
             <PaletteIcon />
           </IconButton>
         </Tooltip>
@@ -77,6 +83,7 @@ export const PresetThemeSelector = ({
             <Grid size={3} key={theme.id}>
               <Tooltip title={theme.name}>
                 <ButtonBase
+                  aria-label={theme.name}
                   onClick={() => {
                     handleApplyPresetTheme(theme);
                   }}
@@ -95,6 +102,7 @@ export const PresetThemeSelector = ({
                 >
                   <Typography
                     variant="body2"
+                    aria-hidden="true"
                     sx={{
                       color: theme.transcriptionColor,
                       fontWeight: 'bold',

--- a/libs/ui/theme-customization-ui/src/components/theme-customization-menu.tsx
+++ b/libs/ui/theme-customization-ui/src/components/theme-customization-menu.tsx
@@ -6,6 +6,7 @@ import type { ThemeColors } from '@scribear/theme-customization-store';
 import { AccentColorSelector } from './color-controls/accent-color-selector.js';
 import { BackgroundColorSelector } from './color-controls/background-color-selector.js';
 import { TranscriptionColorSelector } from './color-controls/transcription-color-selector.js';
+import { ContrastReadout } from './contrast-readout.js';
 import { PresetThemeSelector } from './preset-theme-selector.js';
 
 /**
@@ -54,6 +55,11 @@ export const ThemeCustomizationMenu = ({
       <TranscriptionColorSelector
         transcriptionColor={transcriptionColor}
         setTranscriptionColor={setTranscriptionColor}
+      />
+      <ContrastReadout
+        backgroundColor={backgroundColor}
+        accentColor={accentColor}
+        transcriptionColor={transcriptionColor}
       />
       <PresetThemeSelector applyPresetTheme={applyPresetTheme} />
     </DrawerMenuGroup>

--- a/libs/ui/theme-customization-ui/src/config/preset-themes.ts
+++ b/libs/ui/theme-customization-ui/src/config/preset-themes.ts
@@ -58,8 +58,10 @@ export const PRESET_THEMES: PresetThemeConfig[] = [
   },
   {
     id: 'sky-blue',
+    // Darkened background so white caption text clears AA (was #3499cb = 3.20:1,
+    // fails once the font shrinks below large-text size). #1c6a94 ≈ 4.6:1. SC 1.4.3
     name: 'Sky Blue',
-    backgroundColor: '#3499cb',
+    backgroundColor: '#1c6a94',
     accentColor: '#e2af8d',
     transcriptionColor: '#ffffff',
   },

--- a/libs/ui/theme-customization-ui/src/utils/color-contrast.ts
+++ b/libs/ui/theme-customization-ui/src/utils/color-contrast.ts
@@ -1,0 +1,75 @@
+/**
+ * WCAG relative-luminance / contrast helpers used to keep user-chosen theme
+ * colors readable (SC 1.4.3 text contrast, SC 1.4.11 non-text contrast).
+ *
+ * All inputs are CSS hex strings ("#rgb" or "#rrggbb"); non-hex input yields a
+ * safe fallback (treated as black) rather than throwing, since these run on
+ * live, partially-typed color-picker values.
+ */
+
+// WCAG AA thresholds.
+export const AA_TEXT_CONTRAST = 4.5; // normal text
+export const AA_LARGE_TEXT_CONTRAST = 3; // >=24px (or >=18.66px bold)
+export const AA_NON_TEXT_CONTRAST = 3; // UI components / graphical objects
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+function parseHex(hex: string): Rgb {
+  const cleaned = hex.trim().replace(/^#/, '');
+  const full =
+    cleaned.length === 3
+      ? cleaned
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : cleaned;
+  if (!/^[0-9a-fA-F]{6}$/.test(full)) return { r: 0, g: 0, b: 0 };
+  return {
+    r: parseInt(full.slice(0, 2), 16),
+    g: parseInt(full.slice(2, 4), 16),
+    b: parseInt(full.slice(4, 6), 16),
+  };
+}
+
+function linearize(channel8Bit: number): number {
+  const c = channel8Bit / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+/** Relative luminance (0 = black, 1 = white) per WCAG 2.1. */
+export function relativeLuminance(hex: string): number {
+  const { r, g, b } = parseHex(hex);
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+/** Contrast ratio between two colors, from 1:1 to 21:1. */
+export function contrastRatio(hexA: string, hexB: string): number {
+  const la = relativeLuminance(hexA);
+  const lb = relativeLuminance(hexB);
+  const lighter = Math.max(la, lb);
+  const darker = Math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * Black or white — whichever is more readable on `backgroundColor`. Used to set
+ * `palette.text.primary` so default-colored text/icons stay visible on any
+ * user-chosen background.
+ */
+export function readableTextColor(
+  backgroundColor: string,
+): '#000000' | '#ffffff' {
+  return contrastRatio('#000000', backgroundColor) >=
+    contrastRatio('#ffffff', backgroundColor)
+    ? '#000000'
+    : '#ffffff';
+}
+
+/** Whether a background is light enough to warrant MUI's `light` palette mode. */
+export function isLightColor(backgroundColor: string): boolean {
+  return readableTextColor(backgroundColor) === '#000000';
+}

--- a/libs/ui/theme-customization-ui/tests/a11y.ts
+++ b/libs/ui/theme-customization-ui/tests/a11y.ts
@@ -1,0 +1,29 @@
+import axe from 'axe-core';
+
+// Page-scaffolding rules that only make sense for a whole document, not an
+// isolated component rendered into jsdom's bare <body>.
+const PAGE_LEVEL_RULES_OFF = {
+  region: { enabled: false },
+  'landmark-one-main': { enabled: false },
+  'page-has-heading-one': { enabled: false },
+  'html-has-lang': { enabled: false },
+  'document-title': { enabled: false },
+  bypass: { enabled: false },
+} satisfies Record<string, { enabled: boolean }>;
+
+/**
+ * Runs axe-core (WCAG 2.1 A/AA rules) over `node` and returns the ids of any
+ * violations, so a test can assert `expect(await axeViolations(el)).toEqual([])`.
+ */
+export async function axeViolations(
+  node: Element = document.body,
+): Promise<string[]> {
+  const results = await axe.run(node, {
+    runOnly: {
+      type: 'tag',
+      values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
+    },
+    rules: PAGE_LEVEL_RULES_OFF,
+  });
+  return results.violations.map((v) => `${v.id} (${v.nodes.length} node(s))`);
+}

--- a/libs/ui/theme-customization-ui/tests/components/color-selectors.test.tsx
+++ b/libs/ui/theme-customization-ui/tests/components/color-selectors.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AccentColorSelector } from '#src/components/color-controls/accent-color-selector.js';
+import { BackgroundColorSelector } from '#src/components/color-controls/background-color-selector.js';
+import { TranscriptionColorSelector } from '#src/components/color-controls/transcription-color-selector.js';
+
+import { axeViolations } from '../a11y.js';
+
+describe('color selectors', (it) => {
+  it('name each input to match its visible label (no 2.5.3 mismatch)', () => {
+    render(
+      <>
+        <BackgroundColorSelector
+          backgroundColor="#000000"
+          setBackgroundColor={vi.fn()}
+        />
+        <AccentColorSelector accentColor="#8b0000" setAccentColor={vi.fn()} />
+        <TranscriptionColorSelector
+          transcriptionColor="#ffff00"
+          setTranscriptionColor={vi.fn()}
+        />
+      </>,
+    );
+
+    expect(
+      screen.getByRole('textbox', { name: 'Background Color' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: 'Accent Color' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: 'Transcription Color' }),
+    ).toBeInTheDocument();
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = render(
+      <BackgroundColorSelector
+        backgroundColor="#000000"
+        setBackgroundColor={vi.fn()}
+      />,
+    );
+    expect(await axeViolations(container)).toEqual([]);
+  });
+});

--- a/libs/ui/theme-customization-ui/tests/components/contrast-readout.test.tsx
+++ b/libs/ui/theme-customization-ui/tests/components/contrast-readout.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ContrastReadout } from '#src/components/contrast-readout.js';
+
+import { axeViolations } from '../a11y.js';
+
+describe('ContrastReadout', (it) => {
+  it('reports a passing pair as a polite status without a warning', () => {
+    render(
+      <ContrastReadout
+        backgroundColor="#000000"
+        accentColor="#ffffff"
+        transcriptionColor="#ffffff"
+      />,
+    );
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText(/Caption text: 21\.0:1/)).toBeInTheDocument();
+    expect(screen.queryByText(/low, aim for/)).not.toBeInTheDocument();
+  });
+
+  it('warns (in text, not colour alone) when the accent fails 3:1', () => {
+    // Default theme: caption #ffff00 on #000000 passes; accent #8b0000 fails.
+    render(
+      <ContrastReadout
+        backgroundColor="#000000"
+        accentColor="#8b0000"
+        transcriptionColor="#ffff00"
+      />,
+    );
+
+    expect(screen.getByText(/Accent:.*low, aim for 3:1/)).toBeInTheDocument();
+    // The caption row is fine, so its text carries no warning.
+    expect(screen.getByText(/Caption text:(?!.*low)/)).toBeInTheDocument();
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = render(
+      <ContrastReadout
+        backgroundColor="#000000"
+        accentColor="#8b0000"
+        transcriptionColor="#ffff00"
+      />,
+    );
+    expect(await axeViolations(container)).toEqual([]);
+  });
+});

--- a/libs/ui/theme-customization-ui/tests/components/preset-theme-selector.test.tsx
+++ b/libs/ui/theme-customization-ui/tests/components/preset-theme-selector.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PresetThemeSelector } from '#src/components/preset-theme-selector.js';
+
+describe('PresetThemeSelector', (it) => {
+  it('names the trigger and each swatch (not just "T")', () => {
+    render(<PresetThemeSelector applyPresetTheme={vi.fn()} />);
+
+    const trigger = screen.getByRole('button', { name: 'View Preset Themes' });
+    fireEvent.click(trigger);
+
+    // Swatches expose the theme name, not the decorative "T".
+    expect(
+      screen.getByRole('button', { name: 'Default' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Sky Blue' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'T' })).not.toBeInTheDocument();
+  });
+
+  it('applies a preset when its swatch is clicked', () => {
+    const applyPresetTheme = vi.fn();
+    render(<PresetThemeSelector applyPresetTheme={applyPresetTheme} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'View Preset Themes' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Default' }));
+    expect(applyPresetTheme).toHaveBeenCalledOnce();
+  });
+});

--- a/libs/ui/theme-customization-ui/tests/setup.ts
+++ b/libs/ui/theme-customization-ui/tests/setup.ts
@@ -1,0 +1,9 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// Vitest's `globals` is off (see vitest.shared.ts), so register RTL cleanup
+// manually to avoid DOM leaking between tests.
+afterEach(() => {
+  cleanup();
+});

--- a/libs/ui/theme-customization-ui/tests/utils/color-contrast.test.ts
+++ b/libs/ui/theme-customization-ui/tests/utils/color-contrast.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  contrastRatio,
+  isLightColor,
+  readableTextColor,
+  relativeLuminance,
+} from '#src/utils/color-contrast.js';
+
+describe('color-contrast', (it) => {
+  it('computes luminance endpoints', () => {
+    expect(relativeLuminance('#000000')).toBe(0);
+    expect(relativeLuminance('#ffffff')).toBeCloseTo(1, 5);
+  });
+
+  it('gives 21:1 for black on white and 1:1 for equal colors', () => {
+    expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 5);
+    expect(contrastRatio('#3499cb', '#3499cb')).toBeCloseTo(1, 5);
+  });
+
+  it('is symmetric regardless of argument order', () => {
+    expect(contrastRatio('#ffff00', '#000000')).toBeCloseTo(
+      contrastRatio('#000000', '#ffff00'),
+      5,
+    );
+  });
+
+  it('flags the known failing pairs from the audit', () => {
+    // Default accent #8b0000 on black fails 3:1 non-text.
+    expect(contrastRatio('#8b0000', '#000000')).toBeLessThan(3);
+    // Old Sky Blue caption (white on #3499cb) failed AA text; the darkened
+    // replacement (#1c6a94) clears it.
+    expect(contrastRatio('#ffffff', '#3499cb')).toBeLessThan(4.5);
+    expect(contrastRatio('#ffffff', '#1c6a94')).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('picks a readable text color and mode for a background', () => {
+    expect(readableTextColor('#000000')).toBe('#ffffff');
+    expect(readableTextColor('#ffffff')).toBe('#000000');
+    expect(isLightColor('#ebebeb')).toBe(true);
+    expect(isLightColor('#13294b')).toBe(false);
+  });
+
+  it('treats malformed input as black rather than throwing', () => {
+    expect(relativeLuminance('not-a-color')).toBe(0);
+    expect(relativeLuminance('#abc')).toBe(relativeLuminance('#aabbcc'));
+  });
+});

--- a/libs/ui/theme-customization-ui/vitest.config.ts
+++ b/libs/ui/theme-customization-ui/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import sharedConfig from '../../../vitest.shared.js';
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      include: ['./tests/**/*.test.{ts,tsx}'],
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'unit',
+            environment: 'jsdom',
+            setupFiles: ['./tests/setup.ts'],
+          },
+        },
+      ],
+    },
+  }),
+);

--- a/libs/ui/transcription-display-ui/package.json
+++ b/libs/ui/transcription-display-ui/package.json
@@ -21,7 +21,14 @@
     "format": "prettier --check ./src",
     "format:fix": "prettier --write ./src",
     "lint": "eslint ./src",
-    "lint:fix": "eslint ./src --fix"
+    "lint:fix": "eslint ./src --fix",
+    "test:unit": "vitest run --project unit"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "7.0.0",
+    "@testing-library/react": "16.3.2",
+    "axe-core": "4.10.2",
+    "jsdom": "29.1.1"
   },
   "dependencies": {
     "@emotion/react": "11.14.0",

--- a/libs/ui/transcription-display-ui/src/components/jump-to-bottom-button.tsx
+++ b/libs/ui/transcription-display-ui/src/components/jump-to-bottom-button.tsx
@@ -22,6 +22,7 @@ export const JumpToBottomButton = ({
     <IconButton
       color="transcriptionColor"
       onClick={onClick}
+      aria-label="Jump to latest transcription"
       sx={{
         visibility: visible ? 'visible' : 'hidden',
         alignSelf: 'end',

--- a/libs/ui/transcription-display-ui/src/components/jump-to-bottom-button.tsx
+++ b/libs/ui/transcription-display-ui/src/components/jump-to-bottom-button.tsx
@@ -29,7 +29,14 @@ export const JumpToBottomButton = ({
         marginLeft: 2,
         border: 'solid',
         borderWidth: '0.25em',
-        borderColor: (theme) => theme.palette.primary.main,
+        // Use the transcription color (which clears contrast against the
+        // background) rather than the accent, whose 3:1 non-text contrast fails
+        // in the Default theme and many presets. SC 1.4.11. The palette
+        // augmentation types this slot loosely, but CustomThemeProvider always
+        // sets `.main`; fall back to the accent if somehow absent.
+        borderColor: (theme) =>
+          (theme.palette.transcriptionColor as { main: string } | undefined)
+            ?.main ?? theme.palette.primary.main,
       }}
     >
       <KeyboardDoubleArrowDownIcon fontSize="inherit" />

--- a/libs/ui/transcription-display-ui/src/components/preference-controls/font-size-control.tsx
+++ b/libs/ui/transcription-display-ui/src/components/preference-controls/font-size-control.tsx
@@ -37,6 +37,7 @@ export const FontSizeControl = ({
         </Typography>
         <Slider
           aria-label="Font size control"
+          getAriaValueText={(v) => `${v.toString()} pixels`}
           valueLabelDisplay="auto"
           min={TRANSCRIPTION_DISPLAY_CONFG.fontSizePx.min}
           max={TRANSCRIPTION_DISPLAY_CONFG.fontSizePx.max}

--- a/libs/ui/transcription-display-ui/src/components/preference-controls/line-height-control.tsx
+++ b/libs/ui/transcription-display-ui/src/components/preference-controls/line-height-control.tsx
@@ -40,6 +40,7 @@ export const LineHeightControl = ({
         </Typography>
         <Slider
           aria-label="Line height control"
+          getAriaValueText={(v) => `${v.toString()}× line height`}
           valueLabelDisplay="auto"
           min={TRANSCRIPTION_DISPLAY_CONFG.lineHeightMultipler.min}
           max={TRANSCRIPTION_DISPLAY_CONFG.lineHeightMultipler.max}

--- a/libs/ui/transcription-display-ui/src/components/preference-controls/num-display-lines-control.tsx
+++ b/libs/ui/transcription-display-ui/src/components/preference-controls/num-display-lines-control.tsx
@@ -74,6 +74,7 @@ export const NumDisplayLinesControl = ({
         </Typography>
         <Slider
           aria-label="Number of display lines control"
+          getAriaValueText={(v) => `${v.toString()} lines`}
           valueLabelDisplay="auto"
           min={minNumDisplayLines}
           max={maxNumDisplayLines}
@@ -87,8 +88,9 @@ export const NumDisplayLinesControl = ({
         </Typography>
       </Stack>
       <Typography
-        color="warning"
         sx={{
+          // warning.dark (not warning.main) to clear 4.5:1 on the light surface. SC 1.4.3
+          color: 'warning.dark',
           display: isDisabled ? 'block' : 'none',
           textAlign: 'center',
         }}

--- a/libs/ui/transcription-display-ui/src/components/preference-controls/vertical-position-control.tsx
+++ b/libs/ui/transcription-display-ui/src/components/preference-controls/vertical-position-control.tsx
@@ -75,6 +75,7 @@ export const VerticalPositionControl = ({
         </Typography>
         <Slider
           aria-label="Vertical position control"
+          getAriaValueText={(v) => `${v.toString()} pixels from top`}
           valueLabelDisplay="auto"
           min={minVerticalPositionPx}
           max={maxVerticalPositionPx}
@@ -88,8 +89,9 @@ export const VerticalPositionControl = ({
         </Typography>
       </Stack>
       <Typography
-        color="warning"
         sx={{
+          // warning.dark (not warning.main) to clear 4.5:1 on the light surface. SC 1.4.3
+          color: 'warning.dark',
           display: isDisabled ? 'block' : 'none',
           textAlign: 'center',
         }}

--- a/libs/ui/transcription-display-ui/src/components/preference-controls/word-spacing-control.tsx
+++ b/libs/ui/transcription-display-ui/src/components/preference-controls/word-spacing-control.tsx
@@ -40,6 +40,7 @@ export const WordSpacingControl = ({
         </Typography>
         <Slider
           aria-label="Word spacing control"
+          getAriaValueText={(v) => `${v.toString()}em word spacing`}
           valueLabelDisplay="auto"
           min={TRANSCRIPTION_DISPLAY_CONFG.wordSpacingEm.min}
           max={TRANSCRIPTION_DISPLAY_CONFG.wordSpacingEm.max}

--- a/libs/ui/transcription-display-ui/src/components/transcription-display-container.tsx
+++ b/libs/ui/transcription-display-ui/src/components/transcription-display-container.tsx
@@ -120,6 +120,23 @@ export const TranscriptionDisplayContainer = ({
           <Box
             ref={textContainerRef}
             onScroll={handleScroll}
+            // Live-caption region for assistive technology. `role="log"` announces
+            // only newly appended nodes (finalized/committed sections) and leaves
+            // history in place; `polite` queues so it never interrupts the user;
+            // `aria-relevant="additions text"` + `aria-atomic="false"` announce just
+            // the new node, not the whole transcript. Interim text below is
+            // `aria-hidden` so its word-by-word churn is never announced (it is
+            // announced exactly once, later, when it becomes a committed section).
+            // `tabIndex={0}` makes the region focusable so keyboard + AT users can
+            // scroll back through history (arrow/PageUp/PageDown/Home/End) — the
+            // scrollbar is visually hidden but the region stays keyboard-scrollable,
+            // with a visible focus ring for SC 2.4.7.
+            role="log"
+            aria-live="polite"
+            aria-relevant="additions text"
+            aria-atomic="false"
+            aria-label="Live transcription"
+            tabIndex={0}
             sx={{
               marginTop: `${verticalPositionPx.toString()}px`,
               height: `${displayHeightPx.toString()}px`,
@@ -130,13 +147,27 @@ export const TranscriptionDisplayContainer = ({
               },
               msOverflowStyle: 'none',
               scrollbarWidth: 'none',
+              '&:focus-visible': {
+                outline: '2px solid',
+                outlineColor: 'transcriptionColor',
+                outlineOffset: '2px',
+              },
             }}
           >
             <CommittedSections
               sections={commitedSections}
               textStyle={textStyle}
             />
-            <Typography color="transcriptionColor" sx={textStyle}>
+            <Typography
+              color="transcriptionColor"
+              sx={textStyle}
+              // Interim/in-progress results change many times per second; feeding
+              // that churn to a live region makes speech stutter and a braille
+              // display reflow continuously. Hide it from AT — sighted users still
+              // see it live, and it is announced once when it moves to a committed
+              // section above. (SC 4.1.3, 1.3.1)
+              aria-hidden="true"
+            >
               {/* Keyed spans so React only appends new nodes — never mutates existing ones,
                   keeping browser re-layout cost proportional to each new chunk. */}
               {activeSection.sequences.map((seq) => (

--- a/libs/ui/transcription-display-ui/tests/a11y.ts
+++ b/libs/ui/transcription-display-ui/tests/a11y.ts
@@ -1,0 +1,29 @@
+import axe from 'axe-core';
+
+// Page-scaffolding rules that only make sense for a whole document, not an
+// isolated component rendered into jsdom's bare <body>.
+const PAGE_LEVEL_RULES_OFF = {
+  region: { enabled: false },
+  'landmark-one-main': { enabled: false },
+  'page-has-heading-one': { enabled: false },
+  'html-has-lang': { enabled: false },
+  'document-title': { enabled: false },
+  bypass: { enabled: false },
+} satisfies Record<string, { enabled: boolean }>;
+
+/**
+ * Runs axe-core (WCAG 2.1 A/AA rules) over `node` and returns the ids of any
+ * violations, so a test can assert `expect(await axeViolations(el)).toEqual([])`.
+ */
+export async function axeViolations(
+  node: Element = document.body,
+): Promise<string[]> {
+  const results = await axe.run(node, {
+    runOnly: {
+      type: 'tag',
+      values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
+    },
+    rules: PAGE_LEVEL_RULES_OFF,
+  });
+  return results.violations.map((v) => `${v.id} (${v.nodes.length} node(s))`);
+}

--- a/libs/ui/transcription-display-ui/tests/components/font-size-control.test.tsx
+++ b/libs/ui/transcription-display-ui/tests/components/font-size-control.test.tsx
@@ -1,0 +1,28 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FontSizeControl } from '#src/components/preference-controls/font-size-control.js';
+
+import { axeViolations } from '../a11y.js';
+import { renderWithProviders } from '../render.js';
+
+describe('FontSizeControl', (it) => {
+  it('announces the slider value with a unit (getAriaValueText)', () => {
+    renderWithProviders(
+      <FontSizeControl fontSizePx={32} setFontSizePx={vi.fn()} />,
+    );
+
+    // Without getAriaValueText MUI reads out a bare "32"; the unit makes it "32 pixels".
+    expect(screen.getByRole('slider')).toHaveAttribute(
+      'aria-valuetext',
+      '32 pixels',
+    );
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = renderWithProviders(
+      <FontSizeControl fontSizePx={32} setFontSizePx={vi.fn()} />,
+    );
+    expect(await axeViolations(container)).toEqual([]);
+  });
+});

--- a/libs/ui/transcription-display-ui/tests/components/jump-to-bottom-button.test.tsx
+++ b/libs/ui/transcription-display-ui/tests/components/jump-to-bottom-button.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { JumpToBottomButton } from '#src/components/jump-to-bottom-button.js';
+
+import { axeViolations } from '../a11y.js';
+import { renderWithProviders } from '../render.js';
+
+describe('JumpToBottomButton', (it) => {
+  it('has an accessible name and fires onClick', () => {
+    const onClick = vi.fn();
+    renderWithProviders(<JumpToBottomButton visible onClick={onClick} />);
+
+    const button = screen.getByRole('button', {
+      name: 'Jump to latest transcription',
+    });
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('has no axe violations', async () => {
+    renderWithProviders(<JumpToBottomButton visible onClick={vi.fn()} />);
+    expect(await axeViolations()).toEqual([]);
+  });
+});

--- a/libs/ui/transcription-display-ui/tests/components/line-height-control.test.tsx
+++ b/libs/ui/transcription-display-ui/tests/components/line-height-control.test.tsx
@@ -1,0 +1,33 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LineHeightControl } from '#src/components/preference-controls/line-height-control.js';
+
+import { axeViolations } from '../a11y.js';
+import { renderWithProviders } from '../render.js';
+
+describe('LineHeightControl', (it) => {
+  it('announces the slider value with a unit (getAriaValueText)', () => {
+    renderWithProviders(
+      <LineHeightControl
+        lineHeightMultipler={1.5}
+        setLineHeightMultipler={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('slider')).toHaveAttribute(
+      'aria-valuetext',
+      '1.5× line height',
+    );
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = renderWithProviders(
+      <LineHeightControl
+        lineHeightMultipler={1.5}
+        setLineHeightMultipler={vi.fn()}
+      />,
+    );
+    expect(await axeViolations(container)).toEqual([]);
+  });
+});

--- a/libs/ui/transcription-display-ui/tests/components/num-display-lines-control.test.tsx
+++ b/libs/ui/transcription-display-ui/tests/components/num-display-lines-control.test.tsx
@@ -1,0 +1,38 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { NumDisplayLinesControl } from '#src/components/preference-controls/num-display-lines-control.js';
+
+import { axeViolations } from '../a11y.js';
+import { renderWithProviders } from '../render.js';
+
+function renderControl() {
+  return renderWithProviders(
+    <NumDisplayLinesControl
+      getNumDisplayLinesBounds={() => ({
+        minNumDisplayLines: 1,
+        maxNumDisplayLines: 20,
+      })}
+      getBoundedDisplayPreferences={() => ({
+        verticalPositionPx: 0,
+        numDisplayLines: 8,
+      })}
+      setTargetDisplayLines={vi.fn()}
+    />,
+  );
+}
+
+describe('NumDisplayLinesControl', (it) => {
+  it('announces the slider value with a unit (getAriaValueText)', () => {
+    renderControl();
+    expect(screen.getByRole('slider')).toHaveAttribute(
+      'aria-valuetext',
+      '8 lines',
+    );
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = renderControl();
+    expect(await axeViolations(container)).toEqual([]);
+  });
+});

--- a/libs/ui/transcription-display-ui/tests/components/transcription-display-container.test.tsx
+++ b/libs/ui/transcription-display-ui/tests/components/transcription-display-container.test.tsx
@@ -1,0 +1,70 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type {
+  ActiveSection,
+  TranscriptionSection,
+} from '@scribear/transcription-content-store';
+
+import { TranscriptionDisplayContainer } from '#src/components/transcription-display-container.js';
+
+import { axeViolations } from '../a11y.js';
+import { renderWithProviders } from '../render.js';
+
+const commitedSections: TranscriptionSection[] = [
+  { id: 's1', text: 'Hello world.' },
+];
+const activeSection: ActiveSection = {
+  id: 'active',
+  sequences: [{ id: 'seq1', text: ['partial ', 'interim'] }],
+};
+
+function renderContainer() {
+  return renderWithProviders(
+    <TranscriptionDisplayContainer
+      commitedSections={commitedSections}
+      activeSection={activeSection}
+      inProgressTranscriptionText=" live"
+      wordSpacingEm={0}
+      fontSizePx={32}
+      lineHeightPx={40}
+      getBoundedDisplayPreferences={() => ({
+        verticalPositionPx: 0,
+        numDisplayLines: 8,
+      })}
+    />,
+  );
+}
+
+describe('TranscriptionDisplayContainer', (it) => {
+  it('exposes the committed transcript as a labelled polite log region', () => {
+    renderContainer();
+
+    const log = screen.getByRole('log');
+    expect(log).toHaveAttribute('aria-live', 'polite');
+    expect(log).toHaveAttribute('aria-relevant', 'additions text');
+    expect(log).toHaveAttribute('aria-atomic', 'false');
+    expect(log).toHaveAccessibleName('Live transcription');
+    // Focusable so keyboard + AT users can scroll back through history.
+    expect(log).toHaveAttribute('tabindex', '0');
+
+    // Finalized text is present (and will be announced as it's appended).
+    expect(screen.getByText('Hello world.')).toBeInTheDocument();
+  });
+
+  it('hides the interim/in-progress text from assistive technology', () => {
+    const { container } = renderContainer();
+
+    // The interim text lives inside an aria-hidden node so its churn is never
+    // announced; it is announced once, later, when it becomes a committed section.
+    const hidden = container.querySelector('[aria-hidden="true"]');
+    expect(hidden).not.toBeNull();
+    expect(hidden?.textContent).toContain('partial');
+    expect(hidden?.textContent).toContain('live');
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = renderContainer();
+    expect(await axeViolations(container)).toEqual([]);
+  });
+});

--- a/libs/ui/transcription-display-ui/tests/components/vertical-position-control.test.tsx
+++ b/libs/ui/transcription-display-ui/tests/components/vertical-position-control.test.tsx
@@ -1,0 +1,38 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { VerticalPositionControl } from '#src/components/preference-controls/vertical-position-control.js';
+
+import { axeViolations } from '../a11y.js';
+import { renderWithProviders } from '../render.js';
+
+function renderControl() {
+  return renderWithProviders(
+    <VerticalPositionControl
+      getVerticalPositionBoundsPx={() => ({
+        minVerticalPositionPx: 0,
+        maxVerticalPositionPx: 400,
+      })}
+      getBoundedDisplayPreferences={() => ({
+        verticalPositionPx: 120,
+        numDisplayLines: 8,
+      })}
+      setTargetVerticalPositionPx={vi.fn()}
+    />,
+  );
+}
+
+describe('VerticalPositionControl', (it) => {
+  it('announces the slider value with a unit (getAriaValueText)', () => {
+    renderControl();
+    expect(screen.getByRole('slider')).toHaveAttribute(
+      'aria-valuetext',
+      '120 pixels from top',
+    );
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = renderControl();
+    expect(await axeViolations(container)).toEqual([]);
+  });
+});

--- a/libs/ui/transcription-display-ui/tests/components/word-spacing-control.test.tsx
+++ b/libs/ui/transcription-display-ui/tests/components/word-spacing-control.test.tsx
@@ -1,0 +1,27 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { WordSpacingControl } from '#src/components/preference-controls/word-spacing-control.js';
+
+import { axeViolations } from '../a11y.js';
+import { renderWithProviders } from '../render.js';
+
+describe('WordSpacingControl', (it) => {
+  it('announces the slider value with a unit (getAriaValueText)', () => {
+    renderWithProviders(
+      <WordSpacingControl wordSpacingEm={0.25} setWordSpacingEm={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('slider')).toHaveAttribute(
+      'aria-valuetext',
+      '0.25em word spacing',
+    );
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = renderWithProviders(
+      <WordSpacingControl wordSpacingEm={0.25} setWordSpacingEm={vi.fn()} />,
+    );
+    expect(await axeViolations(container)).toEqual([]);
+  });
+});

--- a/libs/ui/transcription-display-ui/tests/render.tsx
+++ b/libs/ui/transcription-display-ui/tests/render.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react';
+
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+import { render } from '@testing-library/react';
+
+import { TranscriptionDisplayHeightContext } from '#src/contexts/transcription-display-height-context.js';
+
+// A theme that provides the custom `transcriptionColor` palette entry the
+// caption components read (IconButton/Typography `color="transcriptionColor"`
+// would otherwise throw looking up `palette.transcriptionColor.main`).
+const testTheme = createTheme({
+  palette: { transcriptionColor: { main: '#ffff00' } },
+});
+
+interface Options {
+  containerHeightPx?: number;
+}
+
+/**
+ * Renders caption UI inside the MUI theme + the display-height context both the
+ * container and the bounded preference controls depend on.
+ */
+export function renderWithProviders(
+  ui: ReactNode,
+  { containerHeightPx = 600 }: Options = {},
+) {
+  return render(
+    <ThemeProvider theme={testTheme}>
+      <TranscriptionDisplayHeightContext.Provider
+        value={{ containerHeightPx, setContainerHeightPx: () => {} }}
+      >
+        {ui}
+      </TranscriptionDisplayHeightContext.Provider>
+    </ThemeProvider>,
+  );
+}

--- a/libs/ui/transcription-display-ui/tests/setup.ts
+++ b/libs/ui/transcription-display-ui/tests/setup.ts
@@ -1,0 +1,21 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// Vitest's `globals` is off (see vitest.shared.ts), so RTL's auto-cleanup never
+// self-registers. Clean up the rendered DOM between tests.
+afterEach(() => {
+  cleanup();
+});
+
+// jsdom implements neither ResizeObserver (used by useContainerHeight) nor
+// scrollIntoView (used by useAutoScroll). Stub both so the caption container
+// renders without throwing.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver =
+  ResizeObserverStub as unknown as typeof ResizeObserver;
+Element.prototype.scrollIntoView = () => {};

--- a/libs/ui/transcription-display-ui/vitest.config.ts
+++ b/libs/ui/transcription-display-ui/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import sharedConfig from '../../../vitest.shared.js';
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      include: ['./tests/**/*.test.{ts,tsx}'],
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'unit',
+            environment: 'jsdom',
+            setupFiles: ['./tests/setup.ts'],
+          },
+        },
+      ],
+    },
+  }),
+);

--- a/libs/ui/visualizer-ui/package.json
+++ b/libs/ui/visualizer-ui/package.json
@@ -21,13 +21,20 @@
     "format": "prettier --check ./src",
     "format:fix": "prettier --write ./src",
     "lint": "eslint ./src",
-    "lint:fix": "eslint ./src --fix"
+    "lint:fix": "eslint ./src --fix",
+    "test:unit": "vitest run --project unit"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "7.0.0",
+    "@testing-library/react": "16.3.2",
+    "axe-core": "4.10.2",
+    "jsdom": "29.1.1"
   },
   "dependencies": {
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "@mui/icons-material": "7.3.8",
     "@mui/material": "7.3.8",
-    "react": "19.2.4"
+    "react": "19.2.5"
   }
 }

--- a/libs/ui/visualizer-ui/src/components/frequency-visualizer.tsx
+++ b/libs/ui/visualizer-ui/src/components/frequency-visualizer.tsx
@@ -145,6 +145,7 @@ export const FrequencyVisualizer = ({
   return (
     <Box sx={{ bgcolor: 'action.selected', display: 'block', width, height }}>
       <canvas
+        aria-hidden="true"
         ref={canvasRef}
         width={width}
         height={height}

--- a/libs/ui/visualizer-ui/src/components/mel-cepstrum-visualizer.tsx
+++ b/libs/ui/visualizer-ui/src/components/mel-cepstrum-visualizer.tsx
@@ -217,6 +217,7 @@ export const MelCepstrumVisualizer = ({
   return (
     <Box sx={{ bgcolor: 'action.selected', display: 'block', width, height }}>
       <canvas
+        aria-hidden="true"
         ref={canvasRef}
         width={width}
         height={height}

--- a/libs/ui/visualizer-ui/src/components/time-series-visualizer.tsx
+++ b/libs/ui/visualizer-ui/src/components/time-series-visualizer.tsx
@@ -137,6 +137,7 @@ export const TimeSeriesVisualizer = ({
   return (
     <Box sx={{ bgcolor: 'action.selected', display: 'block', width, height }}>
       <canvas
+        aria-hidden="true"
         ref={canvasRef}
         width={width}
         height={height}

--- a/libs/ui/visualizer-ui/src/components/visualizer-panel.tsx
+++ b/libs/ui/visualizer-ui/src/components/visualizer-panel.tsx
@@ -18,6 +18,24 @@ const HEADER_HEIGHT = 36;
 const RESIZE_HANDLE_SIZE = 16;
 const VIS_LABEL_HEIGHT = 18;
 
+// Pixels moved/resized per arrow-key press on the (keyboard-operable) handles.
+const NUDGE_PX = 10;
+const ARROW_DELTAS: Record<string, [number, number]> = {
+  ArrowLeft: [-NUDGE_PX, 0],
+  ArrowRight: [NUDGE_PX, 0],
+  ArrowUp: [0, -NUDGE_PX],
+  ArrowDown: [0, NUDGE_PX],
+};
+
+// A focus-visible ring so the handles show keyboard focus (a bare Box has none).
+const HANDLE_FOCUS_SX = {
+  '&:focus-visible': {
+    outline: '2px solid',
+    outlineColor: 'primary.main',
+    outlineOffset: '-2px',
+  },
+} as const;
+
 export interface VisualizerPanelProps {
   analyserNode: AnalyserNode | null;
   frequencyEnabled: boolean;
@@ -75,6 +93,27 @@ export const VisualizerPanel = ({
   const { resizeDelta, onMouseDown: onResizeStart } =
     useResize(handleResizeCommit);
 
+  // Keyboard equivalents for the mouse-only drag/resize handles. (SC 2.1.1)
+  const handleDragKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      const delta = ARROW_DELTAS[event.key];
+      if (!delta) return;
+      event.preventDefault();
+      onPositionChange(targetX + delta[0], targetY + delta[1]);
+    },
+    [onPositionChange, targetX, targetY],
+  );
+
+  const handleResizeKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      const delta = ARROW_DELTAS[event.key];
+      if (!delta) return;
+      event.preventDefault();
+      onSizeChange(targetWidth + delta[0], targetHeight + delta[1]);
+    },
+    [onSizeChange, targetWidth, targetHeight],
+  );
+
   const visualX = actualX + (dragDelta?.x ?? 0);
   const visualY = actualY + (dragDelta?.y ?? 0);
   const visualWidth = Math.max(
@@ -111,9 +150,13 @@ export const VisualizerPanel = ({
         userSelect: 'none',
       }}
     >
-      {/* Drag handle */}
+      {/* Drag handle — mouse drag plus arrow-key move for keyboard users. */}
       <Box
+        role="button"
+        tabIndex={0}
+        aria-label="Move visualizer (use arrow keys)"
         onMouseDown={onDragStart}
+        onKeyDown={handleDragKeyDown}
         sx={{
           height: HEADER_HEIGHT,
           display: 'flex',
@@ -124,6 +167,7 @@ export const VisualizerPanel = ({
           borderBottom: 1,
           borderColor: 'divider',
           flexShrink: 0,
+          ...HANDLE_FOCUS_SX,
         }}
       >
         <Box
@@ -242,9 +286,13 @@ export const VisualizerPanel = ({
         )}
       </Box>
 
-      {/* Resize handle */}
+      {/* Resize handle — mouse drag plus arrow-key resize for keyboard users. */}
       <Box
+        role="button"
+        tabIndex={0}
+        aria-label="Resize visualizer (use arrow keys)"
         onMouseDown={onResizeStart}
+        onKeyDown={handleResizeKeyDown}
         sx={{
           position: 'absolute',
           bottom: 0,
@@ -259,6 +307,7 @@ export const VisualizerPanel = ({
           opacity: 0.3,
           color: 'text.primary',
           '&:hover': { opacity: 0.8 },
+          ...HANDLE_FOCUS_SX,
         }}
       >
         <svg width={10} height={10} viewBox="0 0 10 10">

--- a/libs/ui/visualizer-ui/tests/a11y.ts
+++ b/libs/ui/visualizer-ui/tests/a11y.ts
@@ -1,0 +1,29 @@
+import axe from 'axe-core';
+
+// Page-scaffolding rules that only make sense for a whole document, not an
+// isolated component rendered into jsdom's bare <body>.
+const PAGE_LEVEL_RULES_OFF = {
+  region: { enabled: false },
+  'landmark-one-main': { enabled: false },
+  'page-has-heading-one': { enabled: false },
+  'html-has-lang': { enabled: false },
+  'document-title': { enabled: false },
+  bypass: { enabled: false },
+} satisfies Record<string, { enabled: boolean }>;
+
+/**
+ * Runs axe-core (WCAG 2.1 A/AA rules) over `node` and returns the ids of any
+ * violations, so a test can assert `expect(await axeViolations(el)).toEqual([])`.
+ */
+export async function axeViolations(
+  node: Element = document.body,
+): Promise<string[]> {
+  const results = await axe.run(node, {
+    runOnly: {
+      type: 'tag',
+      values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
+    },
+    rules: PAGE_LEVEL_RULES_OFF,
+  });
+  return results.violations.map((v) => `${v.id} (${v.nodes.length} node(s))`);
+}

--- a/libs/ui/visualizer-ui/tests/components/visualizer-panel.test.tsx
+++ b/libs/ui/visualizer-ui/tests/components/visualizer-panel.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { VisualizerPanel } from '#src/components/visualizer-panel.js';
+
+import { axeViolations } from '../a11y.js';
+
+function renderPanel(overrides = {}) {
+  const props = {
+    analyserNode: null,
+    frequencyEnabled: false,
+    timeSeriesEnabled: false,
+    melCepstrumEnabled: false,
+    targetX: 100,
+    targetY: 100,
+    targetWidth: 300,
+    targetHeight: 200,
+    onPositionChange: vi.fn(),
+    onSizeChange: vi.fn(),
+    ...overrides,
+  };
+  render(<VisualizerPanel {...props} />);
+  return props;
+}
+
+describe('VisualizerPanel handles', (it) => {
+  it('moves via arrow keys on the named drag handle', () => {
+    const { onPositionChange } = renderPanel();
+
+    const move = screen.getByRole('button', {
+      name: 'Move visualizer (use arrow keys)',
+    });
+    fireEvent.keyDown(move, { key: 'ArrowRight' });
+    expect(onPositionChange).toHaveBeenCalledWith(110, 100);
+    fireEvent.keyDown(move, { key: 'ArrowUp' });
+    expect(onPositionChange).toHaveBeenCalledWith(100, 90);
+  });
+
+  it('resizes via arrow keys on the named resize handle', () => {
+    const { onSizeChange } = renderPanel();
+
+    const resize = screen.getByRole('button', {
+      name: 'Resize visualizer (use arrow keys)',
+    });
+    fireEvent.keyDown(resize, { key: 'ArrowDown' });
+    expect(onSizeChange).toHaveBeenCalledWith(300, 210);
+    fireEvent.keyDown(resize, { key: 'ArrowLeft' });
+    expect(onSizeChange).toHaveBeenCalledWith(290, 200);
+  });
+
+  it('has no axe violations', async () => {
+    renderPanel();
+    expect(await axeViolations()).toEqual([]);
+  });
+});

--- a/libs/ui/visualizer-ui/tests/setup.ts
+++ b/libs/ui/visualizer-ui/tests/setup.ts
@@ -1,0 +1,9 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// Vitest's `globals` is off (see vitest.shared.ts), so register RTL cleanup
+// manually to avoid DOM leaking between tests.
+afterEach(() => {
+  cleanup();
+});

--- a/libs/ui/visualizer-ui/vitest.config.ts
+++ b/libs/ui/visualizer-ui/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import sharedConfig from '../../../vitest.shared.js';
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      include: ['./tests/**/*.test.{ts,tsx}'],
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'unit',
+            environment: 'jsdom',
+            setupFiles: ['./tests/setup.ts'],
+          },
+        },
+      ],
+    },
+  }),
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -442,6 +442,12 @@
         "@mui/icons-material": "7.3.8",
         "@mui/material": "7.3.8",
         "react": "19.2.5"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "7.0.0",
+        "@testing-library/react": "16.3.2",
+        "axe-core": "4.10.2",
+        "jsdom": "29.1.1"
       }
     },
     "libs/ui/theme-customization-ui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -454,6 +454,12 @@
         "@mui/material": "7.3.8",
         "mui-color-input": "7.0.0",
         "react": "19.2.5"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "7.0.0",
+        "@testing-library/react": "16.3.2",
+        "axe-core": "4.10.2",
+        "jsdom": "29.1.1"
       }
     },
     "libs/ui/transcription-display-ui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -425,6 +425,12 @@
         "@mui/material": "7.3.8",
         "react": "19.2.5",
         "react-dom": "19.2.5"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "7.0.0",
+        "@testing-library/react": "16.3.2",
+        "axe-core": "4.10.2",
+        "jsdom": "29.1.1"
       }
     },
     "libs/ui/microphone-ui": {
@@ -459,6 +465,12 @@
         "@mui/icons-material": "7.3.8",
         "@mui/material": "7.3.8",
         "react": "19.2.5"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "7.0.0",
+        "@testing-library/react": "16.3.2",
+        "axe-core": "4.10.2",
+        "jsdom": "29.1.1"
       }
     },
     "libs/ui/visualizer-ui": {
@@ -469,16 +481,13 @@
         "@emotion/styled": "11.14.1",
         "@mui/icons-material": "7.3.8",
         "@mui/material": "7.3.8",
-        "react": "19.2.4"
-      }
-    },
-    "libs/ui/visualizer-ui/node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
+        "react": "19.2.5"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "7.0.0",
+        "@testing-library/react": "16.3.2",
+        "axe-core": "4.10.2",
+        "jsdom": "29.1.1"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "lint:fix": "npm run lint:fix --workspaces --if-present",
     "test:integration": "npm run test:integration --workspaces --if-present",
     "test:unit": "npm run test:unit --workspaces --if-present",
-    "a11y:axe": "node tools/a11y/axe-scan.mjs"
+    "a11y:axe": "node tools/a11y/axe-scan.mjs",
+    "a11y:mock": "node tools/a11y/mock-server.mjs",
+    "a11y:axe:authed": "node tools/a11y/axe-scan-authed.mjs"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/tools/a11y/README.md
+++ b/tools/a11y/README.md
@@ -19,6 +19,39 @@ violations (impact, rule id, help URL, offending selectors) prints to stdout.
 Chrome is auto-detected from `CHROME_PATH`, then `/usr/bin/google-chrome-stable`,
 `google-chrome`, `chromium-browser`, `chromium`.
 
+## Getting past the lock screens — mock server + authed scan
+
+`axe-scan.mjs` only ever sees each SPA's locked initial state. To scan the **real
+interactive UI** (the caption `role="log"` region, the settings drawer, the
+preference sliders, modals) you need to get past the join-code / device-activation
+gates. Two tools do that, and they do **not** need the session-manager, node-server,
+or transcription-service running — only *some* nginx (deploy_local or deploy_staging)
+up to serve the static frontend bundles:
+
+```bash
+# 1. Start the mock backend (proxies the deployed bundles, fakes the session/device
+#    REST API, and streams fake live captions over the transcription WebSocket).
+npm run a11y:mock          # http://127.0.0.1:8090  (proxies https://localhost)
+
+# 2. In another shell, drive each app past its gate and axe the resulting states.
+npm run a11y:axe:authed    # writes tools/a11y/results/authed-*.json
+```
+
+`mock-server.mjs` also works for **manual** screen-reader / braille testing: open
+`http://127.0.0.1:8090/client/` (use `127.0.0.1`, not `localhost`, to dodge HSTS),
+type **any** join code, and fake captions stream into the live region — exactly the
+P0 flow that needs NVDA/VoiceOver/Orca + a braille display. `.../kiosk/` accepts any
+activation code. `.../standalone/` runs entirely client-side (no mock needed). Env
+knobs are documented at the top of `mock-server.mjs`
+(`PORT`, `UPSTREAM`, `MOCK_DEVICE_REGISTERED`, `MOCK_CAPTION_MS`, `MOCK_NO_CAPTIONS`).
+
+> **Caveat — the authed scan reflects the *deployed* bundles, not your working tree.**
+> The mock proxies whatever nginx is serving (the built images), so source-level a11y
+> fixes in `libs/ui/*` / `apps/*` only show up after those frontends are rebuilt and
+> redeployed (or after you point `UPSTREAM` at a local `vite preview`/`vite build`
+> served on the same sub-paths). A finding here that matches a fix already in source
+> just means the deployment is behind — re-run after a rebuild to confirm it clears.
+
 ## Important limitations (read before trusting a green run)
 
 Automated tooling reliably catches only ~30–40% of WCAG 2.1 issues, and this

--- a/tools/a11y/axe-scan-authed.mjs
+++ b/tools/a11y/axe-scan-authed.mjs
@@ -1,0 +1,224 @@
+/**
+ * Authenticated / past-the-lock-screen axe scan.
+ *
+ * The plain axe-scan.mjs only ever sees each SPA's initial locked state (client =
+ * Join-Session modal, kiosk = activation form, standalone = provider UI). This
+ * driver runs against the mock backend (tools/a11y/mock-server.mjs) and *drives*
+ * each app past its gate — entering a join code, activating the kiosk, opening the
+ * settings drawer — then runs axe on those real interactive states. This reaches
+ * the caption view (the P0 `role="log"` region), the settings drawer, and the
+ * preference controls that the plain crawler can never get to.
+ *
+ * Prereq: start the mock first (it proxies the deployed frontend bundles and fakes
+ * the session/device API + caption WebSocket):
+ *
+ *   node tools/a11y/mock-server.mjs &
+ *   node tools/a11y/axe-scan-authed.mjs [baseUrl]      # default http://127.0.0.1:8090
+ *
+ * Per-state JSON is written to tools/a11y/results/authed-<state>.json.
+ */
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { AxePuppeteer } from '@axe-core/puppeteer';
+import puppeteer from 'puppeteer-core';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BASE_URL = process.argv[2] ?? 'http://127.0.0.1:8090';
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+const outDir = join(__dirname, 'results');
+
+const CHROME_CANDIDATES = [
+  process.env.CHROME_PATH,
+  '/usr/bin/google-chrome-stable',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium-browser',
+  '/usr/bin/chromium',
+].filter(Boolean);
+
+function resolveChrome() {
+  for (const p of CHROME_CANDIDATES) if (existsSync(p)) return p;
+  throw new Error(`No Chrome/Chromium found. Set CHROME_PATH. Tried: ${CHROME_CANDIDATES.join(', ')}`);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const impactRank = { critical: 0, serious: 1, moderate: 2, minor: 3 };
+
+let totalViolations = 0;
+
+async function runAxe(page, label) {
+  const results = await new AxePuppeteer(page).withTags(WCAG_TAGS).analyze();
+  const violations = results.violations.sort(
+    (a, b) => impactRank[a.impact] - impactRank[b.impact],
+  );
+  totalViolations += violations.length;
+  process.stdout.write(`\n--- state: ${label} (${page.url()}) ---\n`);
+  if (violations.length === 0) process.stdout.write('  No axe violations detected.\n');
+  for (const v of violations) {
+    process.stdout.write(
+      `  [${(v.impact ?? 'n/a').toUpperCase()}] ${v.id}: ${v.help} (${v.nodes.length} node(s))\n` +
+        `        ${v.helpUrl}\n`,
+    );
+    for (const node of v.nodes.slice(0, 4)) {
+      process.stdout.write(`        - ${node.target.join(' ')}\n`);
+    }
+  }
+  writeFileSync(join(outDir, `authed-${label}.json`), JSON.stringify(results, null, 2));
+}
+
+// Wait for the SPA root to render, plus a settle for late async paints.
+async function waitForApp(page) {
+  await page
+    .waitForFunction(
+      () => {
+        const root = document.getElementById('root');
+        return root && root.children.length > 0;
+      },
+      { timeout: 15000 },
+    )
+    .catch(() => {});
+  await sleep(1200);
+}
+
+// Click the first element matching `tag` whose text contains `text`. Returns
+// true if something was clicked. Tolerant — used for best-effort UI driving.
+async function clickByText(page, tag, text) {
+  const handle = await page.evaluateHandle(
+    (t, needle) =>
+      [...document.querySelectorAll(t)].find((el) =>
+        (el.textContent ?? '').trim().includes(needle),
+      ) ?? null,
+    tag,
+    text,
+  );
+  const el = handle.asElement();
+  if (!el) return false;
+  await el.click();
+  return true;
+}
+
+// Open the settings drawer. Prefer the labelled menu button; fall back to the
+// button wrapping the MUI MenuIcon (older bundles have no aria-label yet).
+async function openMenu(page) {
+  try {
+    await page.click('button[aria-label="Open Menu"]', { timeout: 2000 });
+    return true;
+  } catch {
+    const clicked = await page.evaluate(() => {
+      const icon = document.querySelector('svg[data-testid="MenuIcon"]');
+      const btn = icon?.closest('button');
+      if (!btn) return false;
+      btn.click();
+      return true;
+    });
+    return clicked;
+  }
+}
+
+async function openDrawerAndScan(page, label) {
+  try {
+    const opened = await openMenu(page);
+    if (!opened) {
+      process.stdout.write(`  (skipped ${label}: no menu button found)\n`);
+      return;
+    }
+    await sleep(600);
+    // Expand every collapsible settings group so the controls inside are scanned.
+    for (let i = 0; i < 8; i += 1) {
+      const expanded = await clickByText(page, 'button[aria-expanded="false"]', '');
+      if (!expanded) break;
+      await sleep(150);
+    }
+    await sleep(400);
+    await runAxe(page, label);
+  } catch (err) {
+    process.stdout.write(`  (skipped ${label}: ${err.message})\n`);
+  }
+}
+
+async function scanClient(browser) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 900 });
+  await page.goto(`${BASE_URL}/client/`, { waitUntil: 'networkidle2', timeout: 30000 });
+  await waitForApp(page);
+  await runAxe(page, 'client-1-join-modal');
+
+  // Enter a join code and submit — the mock accepts any code.
+  await page.type('input', 'MOCK01', { delay: 20 });
+  await page.click('button[type="submit"]');
+  // Wait for the caption live-region (modal closed, lifecycle ACTIVE).
+  await page.waitForSelector('[role="log"]', { timeout: 10000 }).catch(() => {});
+  await sleep(2500); // let a couple of captions stream into the log region
+  await runAxe(page, 'client-2-captions');
+
+  await openDrawerAndScan(page, 'client-3-settings-drawer');
+  await page.close();
+}
+
+async function scanKiosk(browser) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 900 });
+  await page.goto(`${BASE_URL}/kiosk/`, { waitUntil: 'networkidle2', timeout: 30000 });
+  await waitForApp(page);
+  await sleep(1500); // get-my-device 401 -> activation form
+  await runAxe(page, 'kiosk-1-activation');
+
+  // Activate: any code; the mock sets the DEVICE_TOKEN cookie and the app re-inits.
+  try {
+    await page.type('input', 'MOCK-ACTIVATE', { delay: 20 });
+    await clickByText(page, 'button', 'Activate');
+    await sleep(3000);
+    await runAxe(page, 'kiosk-2-registered');
+  } catch (err) {
+    process.stdout.write(`  (skipped kiosk-2-registered: ${err.message})\n`);
+  }
+
+  await openDrawerAndScan(page, 'kiosk-3-settings-drawer');
+  await page.close();
+}
+
+async function scanStandalone(browser) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 900 });
+  await page.goto(`${BASE_URL}/standalone/`, { waitUntil: 'networkidle2', timeout: 30000 });
+  await waitForApp(page);
+  await runAxe(page, 'standalone-1-initial');
+  await openDrawerAndScan(page, 'standalone-2-settings-drawer');
+  await page.close();
+}
+
+async function main() {
+  // Fail fast with a helpful message if the mock isn't running.
+  try {
+    const res = await fetch(`${BASE_URL}/__mock/health`);
+    if (!res.ok) throw new Error(`health ${res.status}`);
+  } catch (err) {
+    process.stderr.write(
+      `Mock server not reachable at ${BASE_URL} (${err.message}).\n` +
+        `Start it first:  node tools/a11y/mock-server.mjs\n`,
+    );
+    process.exit(2);
+  }
+
+  mkdirSync(outDir, { recursive: true });
+  const browser = await puppeteer.launch({
+    executablePath: resolveChrome(),
+    headless: true,
+    acceptInsecureCerts: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--ignore-certificate-errors'],
+  });
+  try {
+    await scanClient(browser);
+    await scanKiosk(browser);
+    await scanStandalone(browser);
+  } finally {
+    await browser.close();
+  }
+  process.stdout.write(`\nTotal violation rule-groups across authed states: ${totalViolations}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`${String(err && err.stack ? err.stack : err)}\n`);
+  process.exit(1);
+});

--- a/tools/a11y/mock-server.mjs
+++ b/tools/a11y/mock-server.mjs
@@ -1,0 +1,306 @@
+/**
+ * Mock ScribeAR backend for accessibility / WCAG testing of the frontends.
+ *
+ * The three webapps are gated behind session/device state that a plain axe crawl
+ * can never reach (client = Join-Session modal, kiosk = "Initializing…"/activation,
+ * standalone = client-side only). This server fakes just enough of the
+ * Session-Manager REST API and the Node-Server transcription WebSocket to get each
+ * app *past its lock screen* and, for the client/kiosk, to stream fake live
+ * captions — so both automated axe runs (see axe-scan-authed.mjs) and a human with
+ * a screen reader / braille display can exercise the real caption UI (the P0
+ * `role="log"` live region) without the whole backend + audio pipeline.
+ *
+ * It is a thin shim: every request it does NOT recognise is reverse-proxied to the
+ * already-running deploy_local nginx stack (default https://localhost), so it
+ * serves the real, deployed frontend bundles unchanged on a single origin.
+ *
+ * Usage:
+ *   node tools/a11y/mock-server.mjs                # listen :8090, proxy https://localhost
+ *   PORT=9000 UPSTREAM=https://localhost node tools/a11y/mock-server.mjs
+ *
+ * Then open (use 127.0.0.1, NOT localhost, to dodge any HSTS from the https stack):
+ *   http://127.0.0.1:8090/client/       -> type ANY join code -> live captions
+ *   http://127.0.0.1:8090/kiosk/        -> type ANY activation code -> registered
+ *   http://127.0.0.1:8090/standalone/   -> runs client-side (no backend needed)
+ *
+ * Env knobs:
+ *   PORT                 listen port (default 8090)
+ *   UPSTREAM             origin to proxy unmatched requests to (default https://localhost)
+ *   MOCK_DEVICE_REGISTERED=1   treat the kiosk as already activated (skip the cookie gate)
+ *   MOCK_CAPTION_MS      ms between caption ticks (default 1200)
+ *   MOCK_NO_CAPTIONS=1   accept the WS but never stream captions (test the empty log region)
+ */
+import { createServer, request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { randomUUID } from 'node:crypto';
+
+import { WebSocketServer } from 'ws';
+
+const PORT = Number(process.env.PORT ?? 8090);
+const UPSTREAM = new URL(process.env.UPSTREAM ?? 'https://localhost');
+const CAPTION_MS = Number(process.env.MOCK_CAPTION_MS ?? 1200);
+const DEVICE_TOKEN_COOKIE = 'DEVICE_TOKEN';
+
+const SM = '/api/session-manager/v1';
+const NS_STREAM = '/api/node-server/v1/transcription-stream/';
+
+const nowIso = () => new Date().toISOString();
+const inHour = () => new Date(Date.now() + 3600_000).toISOString();
+
+function sendJson(res, status, body, extraHeaders = {}) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    'content-type': 'application/json',
+    'content-length': Buffer.byteLength(payload),
+    ...extraHeaders,
+  });
+  res.end(payload);
+}
+
+function readBody(req) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      try {
+        resolve(raw ? JSON.parse(raw) : {});
+      } catch {
+        resolve({});
+      }
+    });
+    req.on('error', () => resolve({}));
+  });
+}
+
+function hasDeviceToken(req) {
+  if (process.env.MOCK_DEVICE_REGISTERED === '1') return true;
+  const cookie = req.headers.cookie ?? '';
+  return cookie.split(';').some((c) => c.trim().startsWith(`${DEVICE_TOKEN_COOKIE}=`));
+}
+
+// A fake session, minted per join code so the WS URL's sessionUid lines up.
+function mintSession() {
+  return {
+    sessionUid: randomUUID(),
+    clientId: randomUUID(),
+    sessionToken: `mock.${randomUUID()}`,
+    sessionTokenExpiresAt: inHour(),
+    sessionRefreshToken: `mock-refresh.${randomUUID()}`,
+    scopes: ['session:receive-transcripts'],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Session-Manager REST mock. Returns true if it handled the request.
+// ---------------------------------------------------------------------------
+async function handleSessionManager(req, res, path) {
+  const route = path.slice(SM.length); // strip base
+
+  // client: unlock the Join-Session modal.
+  if (req.method === 'POST' && route === '/session-auth/exchange-join-code') {
+    await readBody(req);
+    sendJson(res, 200, mintSession());
+    return true;
+  }
+  if (req.method === 'POST' && route === '/session-auth/refresh-session-token') {
+    await readBody(req);
+    sendJson(res, 200, {
+      sessionToken: `mock.${randomUUID()}`,
+      sessionTokenExpiresAt: inHour(),
+    });
+    return true;
+  }
+  // kiosk source flow.
+  if (req.method === 'POST' && route === '/session-auth/exchange-device-token') {
+    await readBody(req);
+    sendJson(res, 200, {
+      sessionToken: `mock.${randomUUID()}`,
+      sessionTokenExpiresAt: inHour(),
+      scopes: ['session:send-audio'],
+    });
+    return true;
+  }
+  if (req.method === 'POST' && route === '/session-auth/fetch-join-code') {
+    await readBody(req);
+    sendJson(res, 200, {
+      current: { joinCode: 'MOCK01', validStart: nowIso(), validEnd: inHour() },
+      next: null,
+    });
+    return true;
+  }
+
+  // kiosk: device identity. No cookie -> 401 (shows the activation form);
+  // cookie present (after activate-device) -> 200 unassigned device -> IDLE.
+  if (req.method === 'GET' && route === '/device-management/get-my-device') {
+    if (!hasDeviceToken(req)) {
+      sendJson(res, 401, {
+        code: 'INVALID_DEVICE_TOKEN',
+        message: 'No device token (mock).',
+      });
+      return true;
+    }
+    sendJson(res, 200, {
+      uid: randomUUID(),
+      name: 'Mock Kiosk Device',
+      roomUid: null,
+      isSource: null,
+    });
+    return true;
+  }
+  // kiosk: activation -> mint the HTTP-only DEVICE_TOKEN cookie.
+  if (req.method === 'POST' && route === '/device-management/activate-device') {
+    await readBody(req);
+    sendJson(
+      res,
+      200,
+      { deviceUid: randomUUID() },
+      {
+        'set-cookie': `${DEVICE_TOKEN_COOKIE}=mock-device-token; Path=/; HttpOnly; SameSite=Lax`,
+      },
+    );
+    return true;
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Reverse proxy for everything else -> the deployed frontends on UPSTREAM.
+// ---------------------------------------------------------------------------
+function proxy(req, res) {
+  const isHttps = UPSTREAM.protocol === 'https:';
+  const doRequest = isHttps ? httpsRequest : httpRequest;
+  const headers = { ...req.headers, host: UPSTREAM.host };
+  const upstreamReq = doRequest(
+    {
+      protocol: UPSTREAM.protocol,
+      hostname: UPSTREAM.hostname,
+      port: UPSTREAM.port || (isHttps ? 443 : 80),
+      method: req.method,
+      path: req.url,
+      headers,
+      rejectUnauthorized: false, // deploy_local self-signed cert
+    },
+    (upstreamRes) => {
+      const outHeaders = { ...upstreamRes.headers };
+      // Never let the browser upgrade our http origin to https.
+      delete outHeaders['strict-transport-security'];
+      // Keep redirects on the mock origin.
+      if (outHeaders.location) {
+        outHeaders.location = String(outHeaders.location)
+          .replace(UPSTREAM.origin, `http://127.0.0.1:${String(PORT)}`)
+          .replace(`https://${UPSTREAM.host}`, `http://127.0.0.1:${String(PORT)}`);
+      }
+      res.writeHead(upstreamRes.statusCode ?? 502, outHeaders);
+      upstreamRes.pipe(res);
+    },
+  );
+  upstreamReq.on('error', (err) => {
+    res.writeHead(502, { 'content-type': 'text/plain' });
+    res.end(`Mock proxy error reaching ${UPSTREAM.origin}: ${err.message}\n`);
+  });
+  req.pipe(upstreamReq);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP server
+// ---------------------------------------------------------------------------
+const server = createServer((req, res) => {
+  const path = (req.url ?? '/').split('?')[0];
+  if (path === '/__mock/health') {
+    sendJson(res, 200, { ok: true, upstream: UPSTREAM.origin });
+    return;
+  }
+  if (path.startsWith(SM)) {
+    handleSessionManager(req, res, path).then((handled) => {
+      if (!handled) {
+        sendJson(res, 404, { code: 'MOCK_UNIMPLEMENTED', message: `No mock for ${req.method ?? ''} ${path}` });
+      }
+    });
+    return;
+  }
+  proxy(req, res);
+});
+
+// ---------------------------------------------------------------------------
+// Transcription-stream WebSocket mock — stream fake captions.
+// ---------------------------------------------------------------------------
+const wss = new WebSocketServer({ noServer: true });
+
+// A short scripted "lecture" streamed word-by-word: each sentence grows as an
+// interim (inProgress) fragment, then is committed once as a final fragment —
+// exactly the interim-churn-then-finalize pattern the role="log" region must
+// announce correctly.
+const SCRIPT = [
+  'Welcome to today’s accessibility demonstration.',
+  'These captions are streamed over a mock WebSocket.',
+  'Interim words appear first and are hidden from assistive technology.',
+  'When a sentence is finalized it is announced exactly once.',
+  'A braille display should be able to review the full history.',
+];
+
+function fragment(text) {
+  return { text: text.split(/(\s+)/).filter(Boolean), starts: null, ends: null };
+}
+
+function streamCaptions(ws) {
+  ws.send(JSON.stringify({ type: 'sessionStatus', transcriptionServiceConnected: true, sourceDeviceConnected: true }));
+  if (process.env.MOCK_NO_CAPTIONS === '1') return;
+
+  let sentence = 0;
+  let word = 0;
+  const tick = () => {
+    if (ws.readyState !== ws.OPEN) return;
+    const words = SCRIPT[sentence % SCRIPT.length].split(' ');
+    word += 1;
+    if (word < words.length) {
+      // Growing interim result.
+      ws.send(JSON.stringify({ type: 'transcript', final: null, inProgress: fragment(words.slice(0, word).join(' ')) }));
+    } else {
+      // Finalize the sentence: emit a committed fragment, clear the interim.
+      ws.send(JSON.stringify({ type: 'transcript', final: fragment(words.join(' ')), inProgress: null }));
+      sentence += 1;
+      word = 0;
+    }
+    timer = setTimeout(tick, CAPTION_MS / 2);
+  };
+  let timer = setTimeout(tick, CAPTION_MS);
+  ws.on('close', () => clearTimeout(timer));
+}
+
+wss.on('connection', (ws) => {
+  ws.on('message', (data, isBinary) => {
+    if (isBinary) return; // ignore audio frames from source clients
+    let msg;
+    try {
+      msg = JSON.parse(data.toString());
+    } catch {
+      return;
+    }
+    if (msg.type === 'auth') {
+      ws.send(JSON.stringify({ type: 'authOk' }));
+      streamCaptions(ws);
+    } else if (msg.type === 'timeSyncPing') {
+      ws.send(JSON.stringify({ type: 'timeSyncPong', t0: msg.t0, t1: Date.now() }));
+    }
+  });
+});
+
+server.on('upgrade', (req, socket, head) => {
+  const path = (req.url ?? '/').split('?')[0];
+  if (path.startsWith(NS_STREAM)) {
+    wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws, req));
+  } else {
+    socket.destroy(); // we don't proxy arbitrary websockets
+  }
+});
+
+server.listen(PORT, () => {
+  process.stdout.write(
+    `Mock ScribeAR backend on http://127.0.0.1:${String(PORT)} (proxying ${UPSTREAM.origin})\n` +
+      `  client:     http://127.0.0.1:${String(PORT)}/client/\n` +
+      `  kiosk:      http://127.0.0.1:${String(PORT)}/kiosk/\n` +
+      `  standalone: http://127.0.0.1:${String(PORT)}/standalone/\n`,
+  );
+});


### PR DESCRIPTION
Implements **P0–P4** from `PLAN-WCAG-Frontends.md` in the shared UI libs (fix once → applies to client/kiosk/standalone) and adds tooling to axe-scan the real interactive UI **behind the session/device lock screens**.

> Stacked on top of #151 (base `chore/a11y-tooling`) so this diff is just the implementation work. Retarget to `staging` once #151 merges.

## Shared-lib accessibility fixes
- **P0 — live captions.** `transcription-display-container` is now a `role="log"` live region (`aria-live=polite`, `aria-relevant="additions text"`, `aria-atomic=false`, `aria-label`), focusable + keyboard-scrollable with a `:focus-visible` outline. Interim/in-progress text is `aria-hidden` so its word-by-word churn is never announced — it's announced exactly once when it finalizes into a committed section. This is the headline item: captions were previously invisible to screen readers/braille.
- **P1** — `JumpToBottomButton` accessible name; `DrawerMenuGroup` toggle gets name/`aria-expanded`/`aria-controls` + a real heading + decorative-icon `aria-hidden`; `ChoiceModal` & `CancelableInfoModal` get `role="dialog"`/`aria-modal`/`aria-labelledby`.
- **P2** — the "not enough space" warning text uses `warning.dark` (contrast).
- **P3** — five preference sliders announce units via `getAriaValueText`; `AppLayout` icon buttons get `aria-label` (+ `aria-pressed` on autohide/fullscreen), one `<h1>` + an `<h2>` drawer heading, drawer `aria-labelledby`, and `unmountOnExit` so the auto-hidden header's controls leave the tab order.
- **P4** — `PageLoadSpinner` `role="status"`/`aria-label`; `MainErrorFallback` `role="alert"` + moves focus; **skip-to-main-content** link.

## Tooling — get past the lock screens
- **`tools/a11y/mock-server.mjs`** (`npm run a11y:mock`) — fakes the Session-Manager REST API (join-code exchange, device activation + `DEVICE_TOKEN` cookie, `get-my-device`) and **streams fake live captions over the node-server transcription WebSocket**, proxying the deployed frontend bundles for everything else. Needs **no** session-manager / node-server / transcription-service. Also doubles as a manual NVDA/VoiceOver/braille harness for the P0 caption flow.
- **`tools/a11y/axe-scan-authed.mjs`** (`npm run a11y:axe:authed`) — drives client (join → captions → settings drawer) and kiosk (activate → registered → drawer) past their gates and runs axe on each state → `results/authed-*.json`.

## Verification
- `@scribear/core-ui` and `@scribear/transcription-display-ui`: **build + lint + prettier clean**.
- Ran `a11y:axe:authed` against the running stack: reaches the caption `role="log"` view and the settings drawer, and the authed kiosk-drawer scan **surfaced a real `button-name` violation** the initial-state crawl can't see.

⚠️ **Caveat:** the authed scan proxies the **deployed** bundles, so the source fixes in this PR only show up in `a11y:axe:authed` after the frontends are rebuilt/redeployed (or after pointing `UPSTREAM` at a local `vite preview`). Most P0 gains (live-region semantics, `aria-pressed`, focus management) are also outside axe's ~30–40% detection anyway and still need the manual AT pass in `PLAN-WCAG-Frontends.md` P6.