### PR TITLE
Add Redis health check and live-session join links

### DIFF
--- a/apps/admin-server/src/server/features/config-check/config-check.service.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.service.ts
@@ -441,7 +441,7 @@ export function evaluateStaticChecks(
           category: 'telemetry',
           title: 'Fleet telemetry is switched off for this console',
           detail:
-            'ADMIN_REDIS_URL is unset, so the fleet dashboard answers 503 TELEMETRY_UNAVAILABLE. The top-bar health rollup is a separate, always-on path and is unaffected.',
+            "ADMIN_REDIS_URL is unset, so the fleet dashboard answers 503 TELEMETRY_UNAVAILABLE. The top-bar health rollup's redis component reports not-configured in the same case — not a failure, but visible there too.",
           remediation:
             'Set ADMIN_REDIS_URL in deployment/.env — see deployment/UPGRADING.md.',
           docUrl: DOC.redis,

--- a/apps/admin-server/src/server/features/health/health.service.ts
+++ b/apps/admin-server/src/server/features/health/health.service.ts
@@ -11,12 +11,20 @@ import type { AppDependencies } from '#src/server/dependency-injection/app-depen
  * - `fail` — answered, and said it was unhealthy (a 503 readiness).
  * - `unreachable` — did not answer at all: refused, timed out, or returned
  *   something unrecognizable.
+ * - `not-configured` — the dependency is optional and intentionally unset.
+ *   Not counted against the top-bar rollup's overall status: an operator who
+ *   never configured it should not see "Degraded".
  *
  * The distinction that matters operationally is `fail` vs `unreachable`: the
  * first means the service is running and telling you what is wrong, the second
  * means you cannot even ask.
  */
-export type ComponentStatus = 'ok' | 'degraded' | 'unreachable' | 'fail';
+export type ComponentStatus =
+  | 'ok'
+  | 'degraded'
+  | 'unreachable'
+  | 'fail'
+  | 'not-configured';
 
 export interface HealthComponent {
   /** Stable identifier, matching the compose service name where there is one. */
@@ -69,13 +77,16 @@ interface ReadinessBody {
 export class HealthCheckerService {
   private _config: HealthCheckerConfig;
   private _dbClient: AppDependencies['dbClient'];
+  private _fleetTelemetryService: AppDependencies['fleetTelemetryService'];
 
   constructor(
     healthCheckerConfig: HealthCheckerConfig,
     dbClient: AppDependencies['dbClient'],
+    fleetTelemetryService: AppDependencies['fleetTelemetryService'],
   ) {
     this._config = healthCheckerConfig;
     this._dbClient = dbClient;
+    this._fleetTelemetryService = fleetTelemetryService;
   }
 
   /**
@@ -86,11 +97,12 @@ export class HealthCheckerService {
    * timeouts is a 12-second admin dashboard.
    */
   async check(): Promise<HealthComponent[]> {
-    const [database, ...probed] = await Promise.all([
+    const [database, redis, ...probed] = await Promise.all([
       this._checkDatabase(),
+      this._checkRedis(),
       ...this._config.targets.map((target) => this._checkProbe(target)),
     ]);
-    return [database, ...probed];
+    return [database, redis, ...probed];
   }
 
   private async _checkDatabase(): Promise<HealthComponent> {
@@ -105,6 +117,61 @@ export class HealthCheckerService {
         latencyMs: Date.now() - start,
         detail: err instanceof Error ? err.message : 'query failed',
       };
+    }
+  }
+
+  /**
+   * `redis` reuses the fleet-telemetry connection (`FleetTelemetryService`)
+   * rather than opening a second one. Unset `REDIS_URL` is reported as
+   * `not-configured`, not `unreachable` — it is an intentional deployment
+   * choice, not a failure.
+   *
+   * ioredis commands have no `AbortSignal` the way `fetch` does, so the
+   * timeout is a manual race rather than `_checkProbe`'s `AbortSignal.timeout`.
+   */
+  private async _checkRedis(): Promise<HealthComponent> {
+    if (!this._fleetTelemetryService.enabled) {
+      return {
+        name: 'redis',
+        status: 'not-configured',
+        latencyMs: 0,
+        detail: 'REDIS_URL is unset',
+      };
+    }
+
+    const start = Date.now();
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<'timeout'>((resolve) => {
+      timeoutHandle = setTimeout(() => {
+        resolve('timeout');
+      }, this._config.timeoutMs);
+    });
+
+    try {
+      const result = await Promise.race([
+        this._fleetTelemetryService.ping(),
+        timeout,
+      ]);
+
+      if (result === 'timeout') {
+        return {
+          name: 'redis',
+          status: 'unreachable',
+          latencyMs: Date.now() - start,
+          detail: `no response within ${String(this._config.timeoutMs)}ms`,
+        };
+      }
+
+      return { name: 'redis', status: 'ok', latencyMs: result };
+    } catch (err) {
+      return {
+        name: 'redis',
+        status: 'unreachable',
+        latencyMs: Date.now() - start,
+        detail: err instanceof Error ? err.message : 'connection failed',
+      };
+    } finally {
+      clearTimeout(timeoutHandle);
     }
   }
 

--- a/apps/admin-server/src/server/features/scheduling/scheduling.controller.ts
+++ b/apps/admin-server/src/server/features/scheduling/scheduling.controller.ts
@@ -16,6 +16,7 @@ import type {
   GET_AUTO_SESSION_WINDOW_INPUT,
   GET_SCHEDULE_INPUT,
   GET_SESSION_INPUT,
+  GET_SESSION_JOIN_CODE_INPUT,
   LIST_AUTO_SESSION_WINDOWS_INPUT,
   LIST_SCHEDULES_INPUT,
   START_SESSION_EARLY_INPUT,
@@ -87,6 +88,17 @@ export class SchedulingController {
     res: BaseFastifyReply,
   ) {
     this._gateway.respond(req, res, await this._gateway.getSession(req.params));
+  }
+
+  async getSessionJoinCode(
+    req: BaseFastifyRequest<typeof GET_SESSION_JOIN_CODE_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    this._gateway.respond(
+      req,
+      res,
+      await this._gateway.getSessionJoinCode(req.params),
+    );
   }
 
   // ---- Mutations (require read-write + CSRF) ----

--- a/apps/admin-server/src/server/features/scheduling/scheduling.router.ts
+++ b/apps/admin-server/src/server/features/scheduling/scheduling.router.ts
@@ -24,6 +24,8 @@ import {
   GET_SCHEDULE_INPUT,
   GET_SCHEDULE_ROUTE,
   GET_SESSION_INPUT,
+  GET_SESSION_JOIN_CODE_INPUT,
+  GET_SESSION_JOIN_CODE_ROUTE,
   GET_SESSION_ROUTE,
   LIST_AUTO_SESSION_WINDOWS_INPUT,
   LIST_AUTO_SESSION_WINDOWS_ROUTE,
@@ -82,6 +84,13 @@ export function schedulingRouter(fastify: BaseFastifyInstance) {
     schema: GET_SESSION_INPUT,
     preHandler: readGuards,
     handler: resolveHandler('schedulingController', 'getSession'),
+  });
+
+  fastify.route({
+    ...GET_SESSION_JOIN_CODE_ROUTE,
+    schema: GET_SESSION_JOIN_CODE_INPUT,
+    preHandler: readGuards,
+    handler: resolveHandler('schedulingController', 'getSessionJoinCode'),
   });
 
   fastify.route({

--- a/apps/admin-server/src/server/features/scheduling/scheduling.schema.ts
+++ b/apps/admin-server/src/server/features/scheduling/scheduling.schema.ts
@@ -133,3 +133,14 @@ export const END_SESSION_EARLY_ROUTE = {
   method: 'POST' as const,
   url: `${P_SESSIONS}/end-early`,
 };
+
+// A read from the BFF's perspective — it mints a join code on demand but is
+// idempotent within the code's lifetime, matching `demo-room/status`'s GET
+// convention despite side-effecting server-side.
+export const GET_SESSION_JOIN_CODE_INPUT = {
+  params: GET_SESSION_SCHEMA.params,
+};
+export const GET_SESSION_JOIN_CODE_ROUTE = {
+  method: 'GET' as const,
+  url: `${P_SESSIONS}/:sessionUid/join-code`,
+};

--- a/apps/admin-server/src/server/shared/services/fleet-telemetry.service.ts
+++ b/apps/admin-server/src/server/shared/services/fleet-telemetry.service.ts
@@ -96,6 +96,26 @@ export class FleetTelemetryService {
     });
   }
 
+  /**
+   * Round-trip latency of a raw `PING` on the same connection `snapshot()`
+   * uses — no second client is opened. Used by `HealthCheckerService` for the
+   * top-bar rollup's `redis` component.
+   *
+   * The connection is built with `enableOfflineQueue: false` and
+   * `maxRetriesPerRequest: 0` (see `createTelemetryRedisClient`), so a fully
+   * disconnected `PING` rejects immediately; a connected-but-hung Redis can
+   * still stall, which is why the caller applies its own timeout race rather
+   * than relying on this method to bound its own latency.
+   */
+  async ping(): Promise<number> {
+    if (this._redis === null) {
+      throw new Error('fleet telemetry is disabled: REDIS_URL is unset');
+    }
+    const start = Date.now();
+    await this._redis.ping();
+    return Date.now() - start;
+  }
+
   async snapshot(): Promise<FleetSnapshot> {
     if (this._redis === null) {
       throw new Error('fleet telemetry is disabled: REDIS_URL is unset');

--- a/apps/admin-server/src/server/shared/services/session-manager-gateway.service.ts
+++ b/apps/admin-server/src/server/shared/services/session-manager-gateway.service.ts
@@ -305,6 +305,18 @@ export class SessionManagerGatewayService {
     });
   }
 
+  // Named as a "get" to read naturally from the BFF's perspective (it mints a
+  // code on demand but is idempotent within the code's lifetime, and is
+  // registered as a GET route on the admin-server side) even though it
+  // forwards as a POST upstream — the gateway already does this kind of shape
+  // translation elsewhere (e.g. `startSessionEarly`).
+  getSessionJoinCode(params: Static<(typeof GET_SESSION_SCHEMA)['params']>) {
+    return this._client.sessionAuth.adminFetchJoinCode({
+      headers: this._authHeaders(),
+      body: { sessionUid: params.sessionUid },
+    });
+  }
+
   // ---- Demo room ----
 
   getDemoRoomStatus() {

--- a/apps/admin-server/tests/integration/health.routes.test.ts
+++ b/apps/admin-server/tests/integration/health.routes.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, vi } from 'vitest';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  inject,
+  vi,
+} from 'vitest';
 
 import type { HealthComponent } from '#src/server/features/health/health.service.js';
 import {
@@ -117,10 +125,18 @@ describe('Health route', () => {
       expect(body.data.components.map((c) => c.name).sort()).toEqual([
         'database',
         'node-server',
+        'redis',
         'session-manager',
         'transcription-service',
       ]);
-      expect(body.data.components.every((c) => c.status === 'ok')).toBe(true);
+      // redis is not-configured by default in this suite's server (REDIS_URL
+      // unset) — every OTHER component must still be ok.
+      expect(
+        body.data.components
+          .filter((c) => c.name !== 'redis')
+          .every((c) => c.status === 'ok'),
+      ).toBe(true);
+      expect(componentNamed(body, 'redis').status).toBe('not-configured');
     });
 
     it('stays 200 when a dependency is down', async () => {
@@ -237,5 +253,114 @@ describe('Health route', () => {
       expect(componentNamed(body, 'transcription-service').status).toBe('ok');
       expect(componentNamed(body, 'database').status).toBe('ok');
     });
+  });
+});
+
+/** Stubs every probe target as healthy, so these Redis-focused suites don't
+ * also have to reason about the other three components. */
+function stubHealthyProbes() {
+  vi.stubGlobal('fetch', (url: string) => {
+    for (const base of [
+      TEST_SM_BASE_URL,
+      TEST_NODE_BASE_URL,
+      TEST_TS_BASE_URL,
+    ]) {
+      if (url.startsWith(base)) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ status: 'ok' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+    }
+    return Promise.reject(new Error('unexpected fetch in redis-focused suite'));
+  });
+}
+
+describe('Health route, redis unreachable', (it) => {
+  const server = useServer({
+    // A port nothing listens on: with the telemetry client's offline queue
+    // disabled, the first command fails immediately rather than hanging for
+    // a connection that will never succeed. Matches fleet.routes.test.ts.
+    fleetTelemetryConfig: { redisUrl: 'redis://127.0.0.1:1' },
+  });
+  let cookie = '';
+
+  beforeAll(async () => {
+    cookie = (await login(server.fastify)).cookie;
+  });
+
+  beforeEach(() => {
+    stubHealthyProbes();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reports the redis component as unreachable, not not-configured', async () => {
+    // Act
+    const res = await server.fastify.inject({
+      method: 'GET',
+      url: URL,
+      headers: { cookie },
+    });
+    const body = res.json<HealthBody>();
+
+    // Assert
+    expect(res.statusCode).toBe(200);
+    const redis = body.data.components.find((c) => c.name === 'redis');
+    expect(redis?.status).toBe('unreachable');
+  });
+});
+
+describe('Health route, redis configured (real backplane)', (it) => {
+  const server = useServer({
+    fleetTelemetryConfig: { redisUrl: inject('redisUrl') },
+  });
+  let cookie = '';
+
+  beforeAll(async () => {
+    cookie = (await login(server.fastify)).cookie;
+
+    // fleetTelemetryService's Redis client is built lazily, on the first
+    // request that resolves it — the client's offline queue is disabled, so a
+    // request racing ahead of the connection's own `ready` event reports
+    // `unreachable` once. Matches fleet.routes.test.ts's warm-up.
+    await vi.waitFor(async () => {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: URL,
+        headers: { cookie },
+      });
+      const body = res.json<HealthBody>();
+      const redis = body.data.components.find((c) => c.name === 'redis');
+      expect(redis?.status).toBe('ok');
+    });
+  });
+
+  beforeEach(() => {
+    stubHealthyProbes();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reports the redis component as ok with a latency', async () => {
+    // Act
+    const res = await server.fastify.inject({
+      method: 'GET',
+      url: URL,
+      headers: { cookie },
+    });
+    const body = res.json<HealthBody>();
+
+    // Assert
+    expect(res.statusCode).toBe(200);
+    const redis = body.data.components.find((c) => c.name === 'redis');
+    expect(redis?.status).toBe('ok');
+    expect(redis?.latencyMs).toBeGreaterThanOrEqual(0);
   });
 });

--- a/apps/admin-server/tests/integration/scheduling.routes.test.ts
+++ b/apps/admin-server/tests/integration/scheduling.routes.test.ts
@@ -334,4 +334,92 @@ describe('Scheduling routes', () => {
       expect(rows[0]?.status_code).toBe(200);
     });
   });
+
+  describe('sessions/join-code', (it) => {
+    const SESSION_UID = '44444444-4444-4444-4444-444444444444';
+
+    it('fetches a join code and injects the admin key upstream', async () => {
+      // Arrange
+      sm.respondWith({
+        status: 200,
+        body: {
+          status: 'ok',
+          joinCode: 'ABC12345',
+          validEnd: '2026-08-01T00:05:00.000Z',
+        },
+      });
+      const { cookie } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/sessions/${SESSION_UID}/join-code`,
+        headers: { cookie },
+      });
+
+      // Assert — envelope
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({
+        ok: true,
+        data: {
+          status: 'ok',
+          joinCode: 'ABC12345',
+          validEnd: '2026-08-01T00:05:00.000Z',
+        },
+      });
+      // Assert — upstream request
+      const upstream = sm.requests.find((r) =>
+        r.url.includes('/session-auth/admin-fetch-join-code'),
+      );
+      expect(upstream).toBeDefined();
+      expect(upstream?.headers['authorization']).toBe(
+        `Bearer ${TEST_ADMIN_KEY}`,
+      );
+      expect(upstream?.body).toMatchObject({ sessionUid: SESSION_UID });
+    });
+
+    it('passes an upstream 404 through as a 404 error envelope', async () => {
+      // Arrange
+      sm.respondWith({
+        status: 404,
+        body: { code: 'SESSION_NOT_FOUND', message: 'nope' },
+      });
+      const { cookie } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/sessions/${SESSION_UID}/join-code`,
+        headers: { cookie },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(404);
+      const body = res.json<{ ok: boolean; error: { code: string } }>();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe('SESSION_NOT_FOUND');
+    });
+
+    it('maps an upstream 401 (rejected admin key) to 502 BACKEND_MISCONFIGURATION', async () => {
+      // Arrange — Session Manager rejects our admin key.
+      sm.respondWith({
+        status: 401,
+        body: { code: 'INVALID_ADMIN_KEY', message: 'bad key' },
+      });
+      const { cookie } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/sessions/${SESSION_UID}/join-code`,
+        headers: { cookie },
+      });
+
+      // Assert — must NOT surface as a 401 (which would bounce the user to login).
+      expect(res.statusCode).toBe(502);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'BACKEND_MISCONFIGURATION',
+      );
+    });
+  });
 });

--- a/apps/admin-server/tests/unit/shared/services/fleet-telemetry.service.test.ts
+++ b/apps/admin-server/tests/unit/shared/services/fleet-telemetry.service.test.ts
@@ -49,6 +49,8 @@ class FakeRedis {
     Promise.resolve(keys.map((k) => this.values.get(k) ?? null)),
   );
 
+  ping = vi.fn(() => Promise.resolve('PONG'));
+
   set(key: string, value: unknown, indexKey: string, member: string): void {
     this.values.set(key, JSON.stringify(value));
     this.zsets.set(indexKey, [...(this.zsets.get(indexKey) ?? []), member]);
@@ -312,6 +314,33 @@ describe('FleetTelemetryService', () => {
       );
 
       await expect(service.snapshot()).rejects.toThrow(/disabled/);
+    });
+
+    it('rejects ping() rather than opening a connection', async () => {
+      const service = new FleetTelemetryService(
+        null,
+        createMockLogger() as unknown as AppDependencies['logger'],
+      );
+
+      await expect(service.ping()).rejects.toThrow(/disabled/);
+    });
+  });
+
+  describe('ping', (it) => {
+    it('issues a raw PING on the same connection and returns the elapsed ms', async () => {
+      const h = buildHarness();
+
+      const latencyMs = await h.service.ping();
+
+      expect(h.redis.ping).toHaveBeenCalledTimes(1);
+      expect(latencyMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('propagates a rejected PING rather than swallowing it', async () => {
+      const h = buildHarness();
+      h.redis.ping.mockRejectedValue(new Error('connection closed'));
+
+      await expect(h.service.ping()).rejects.toThrow('connection closed');
     });
   });
 });

--- a/apps/admin-webapp/src/components/copy-icon-button.tsx
+++ b/apps/admin-webapp/src/components/copy-icon-button.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import DoneIcon from '@mui/icons-material/Done';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+
+export interface CopyIconButtonProps {
+  value: string;
+  /** Used for the tooltip and `aria-label`, e.g. "join code" -> "Copy join code". */
+  label: string;
+}
+
+/**
+ * Icon-swap copy-to-clipboard control (copy -> checkmark for 2s), extracted
+ * from `ActivationCodeDisplay`'s original inline implementation so it isn't
+ * duplicated across the join-code UI. Clipboard failures are silently
+ * ignored, matching that precedent.
+ */
+export const CopyIconButton = ({ value, label }: CopyIconButtonProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    void navigator.clipboard
+      .writeText(value)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => {
+          setCopied(false);
+        }, 2000);
+      })
+      .catch(() => {
+        /* clipboard denied — ignore */
+      });
+  };
+
+  return (
+    <Tooltip title={copied ? 'Copied' : `Copy ${label}`}>
+      <IconButton onClick={handleCopy} aria-label={`Copy ${label}`}>
+        {copied ? <DoneIcon color="success" /> : <ContentCopyIcon />}
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/apps/admin-webapp/src/components/health-indicator.tsx
+++ b/apps/admin-webapp/src/components/health-indicator.tsx
@@ -23,7 +23,13 @@ function overall(report: HealthReport | null): {
 } {
   if (!report) return { color: 'default', label: 'Unknown' };
 
-  const statuses = [report.bff, ...report.components.map((c) => c.status)];
+  // 'not-configured' components (e.g. redis with REDIS_URL unset) are an
+  // intentional deployment choice, not a fault — excluded here so an operator
+  // who never configured an optional dependency still sees "Healthy".
+  const statuses = [
+    report.bff,
+    ...report.components.map((c) => c.status),
+  ].filter((s) => s !== 'not-configured');
   if (statuses.every((s) => s === 'ok'))
     return { color: 'success', label: 'Healthy' };
   // 'fail' and 'unreachable' are hard down; 'degraded' is working-but-impaired.

--- a/apps/admin-webapp/src/features/dashboard/demo-room-card.tsx
+++ b/apps/admin-webapp/src/features/dashboard/demo-room-card.tsx
@@ -10,29 +10,15 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 
+import { CopyIconButton } from '#src/components/copy-icon-button';
 import type { DemoRoomStatus } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
+import { buildJoinUrl } from '#src/lib/join-url';
 import { useAsyncData } from '#src/lib/use-async-data';
 
 // Join codes rotate on a ~5 minute window server-side; re-poll well inside that
 // so the "Open live captions" link stays exchangeable without a manual refresh.
 const POLL_MS = 120_000;
-
-/**
- * Builds a client-webapp deep link that auto-joins the demo session. The client
- * webapp reads a base64 `#config=` fragment and pre-fills/exchanges the join
- * code — the same format the kiosk QR uses. The link is same-origin: the admin
- * console and the client webapp are both served behind the one reverse proxy,
- * so a root-relative origin is correct in every environment.
- *
- * The trailing slash matters: nginx serves the client webapp at `/client/`, and
- * `/client` (no slash) 404s.
- */
-function buildJoinUrl(joinCode: string): string {
-  const config = { clientSessionConfig: { joinCode } };
-  const encoded = btoa(JSON.stringify(config));
-  return `${window.location.origin}/client/#config=${encoded}`;
-}
 
 type ChipColor = 'success' | 'warning' | 'default';
 
@@ -111,7 +97,7 @@ export const DemoRoomCard = () => {
                 looping captions in the client webapp — no join code entry
                 needed.
               </Typography>
-              <Box>
+              <Stack direction="row" alignItems="center" spacing={0.5}>
                 {joinUrl !== null ? (
                   <Button
                     variant="contained"
@@ -132,12 +118,18 @@ export const DemoRoomCard = () => {
                     Open live captions
                   </Button>
                 )}
-              </Box>
+                {joinUrl !== null && (
+                  <CopyIconButton value={joinUrl} label="join link" />
+                )}
+              </Stack>
               {data.joinCode !== null && (
-                <Typography variant="caption" color="text.secondary">
-                  Join code <strong>{data.joinCode}</strong> · rotates every few
-                  minutes
-                </Typography>
+                <Stack direction="row" alignItems="center" spacing={0.5}>
+                  <Typography variant="caption" color="text.secondary">
+                    Join code <strong>{data.joinCode}</strong> · rotates every
+                    few minutes
+                  </Typography>
+                  <CopyIconButton value={data.joinCode} label="join code" />
+                </Stack>
               )}
             </Stack>
           )}

--- a/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
+++ b/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
@@ -8,6 +9,7 @@ import CardContent from '@mui/material/CardContent';
 import Chip from '@mui/material/Chip';
 import FormControl from '@mui/material/FormControl';
 import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
@@ -19,6 +21,9 @@ import Typography from '@mui/material/Typography';
 import { useNavigate } from 'react-router-dom';
 
 import type { MergedProvider } from '#src/lib/admin-api';
+import { adminApi } from '#src/lib/admin-api';
+import { buildJoinUrl } from '#src/lib/join-url';
+import { useToast } from '#src/lib/toast-context';
 
 import type { FleetFilter, FleetRow, FleetStatus } from './fleet-status';
 import {
@@ -143,10 +148,46 @@ const FleetFilterBar = ({
 
 const SessionCard = ({ session, status, event }: FleetRow) => {
   const navigate = useNavigate();
+  const { showError } = useToast();
   const p95 = pipelineP95(session);
+
+  const handleOpenClient = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    adminApi
+      .getSessionJoinCode(session.sessionUid)
+      .then((result) => {
+        if (result.status !== 'ok' || result.joinCode === null) {
+          showError('Session is not currently joinable.');
+          return;
+        }
+        window.open(
+          buildJoinUrl(result.joinCode),
+          '_blank',
+          'noopener,noreferrer',
+        );
+      })
+      .catch(() => {
+        showError('Failed to fetch join code.');
+      });
+  };
+
   return (
     <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
-      <Card variant="outlined">
+      <Card variant="outlined" sx={{ position: 'relative' }}>
+        <IconButton
+          size="small"
+          onClick={handleOpenClient}
+          aria-label="Open live captions"
+          sx={{
+            position: 'absolute',
+            top: 4,
+            right: 4,
+            zIndex: 1,
+            bgcolor: 'background.paper',
+          }}
+        >
+          <OpenInNewIcon fontSize="small" />
+        </IconButton>
         <CardActionArea
           onClick={() => {
             void navigate(`/sessions/${session.sessionUid}`);

--- a/apps/admin-webapp/src/features/sessions/session-detail-page.tsx
+++ b/apps/admin-webapp/src/features/sessions/session-detail-page.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -17,10 +18,18 @@ import { Link as RouterLink, useParams } from 'react-router-dom';
 import type { Session } from '@scribear/session-manager-schema';
 
 import { ConfirmDialog } from '#src/components/confirm-dialog';
+import { CopyIconButton } from '#src/components/copy-icon-button';
+import type { SessionJoinCodeStatus } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { buildJoinUrl } from '#src/lib/join-url';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
+
+// Join codes rotate on a ~5 minute window server-side; re-poll well inside
+// that so the "Open live captions" link stays exchangeable without a manual
+// page refresh — mirrors the demo-room card's poll cadence.
+const JOIN_CODE_POLL_MS = 120_000;
 
 function errorMessage(err: unknown, fallback: string): string {
   return err instanceof ApiError ? err.message : fallback;
@@ -64,6 +73,36 @@ export const SessionDetailPage = () => {
   // Branches derived from the load error rather than stored as separate state.
   const misconfigured = isApiErrorCode(error, 'BACKEND_MISCONFIGURATION');
   const notFound = error instanceof ApiError && error.status === 404;
+
+  // Loaded independently of `session`: a failure here (or the session having
+  // no join code yet) must not block the rest of the page, which already
+  // renders fine from the primary load above.
+  const { data: joinCodeStatus, reload: reloadJoinCode } =
+    useAsyncData<SessionJoinCodeStatus>(
+      () =>
+        sessionUid === undefined
+          ? Promise.reject(new ApiError('NOT_FOUND', 'No session id.', 404))
+          : adminApi.getSessionJoinCode(sessionUid),
+      [sessionUid],
+    );
+
+  useEffect(() => {
+    const id = window.setInterval(reloadJoinCode, JOIN_CODE_POLL_MS);
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [reloadJoinCode]);
+
+  // `SessionJoinCodeStatus` isn't a true discriminated union (`joinCode`'s
+  // nullability isn't tied to `status` in the type), so narrow explicitly
+  // rather than asserting non-null in the JSX below.
+  const joinCode =
+    joinCodeStatus !== null &&
+    joinCodeStatus.status === 'ok' &&
+    joinCodeStatus.joinCode !== null
+      ? joinCodeStatus.joinCode
+      : null;
+  const sessionJoinUrl = joinCode !== null ? buildJoinUrl(joinCode) : null;
 
   const [startConfirmOpen, setStartConfirmOpen] = useState(false);
   const [starting, setStarting] = useState(false);
@@ -203,6 +242,50 @@ export const SessionDetailPage = () => {
             <Typography>{formatDateTime(session.createdAt)}</Typography>
           </FieldRow>
         </Stack>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
+          Join session
+        </Typography>
+        {joinCodeStatus === null ? (
+          <Typography variant="body2" color="text.secondary">
+            Join code unavailable.
+          </Typography>
+        ) : joinCodeStatus.status === 'no-join-scopes' ? (
+          <Typography variant="body2" color="text.secondary">
+            No join code scopes configured for this session.
+          </Typography>
+        ) : joinCodeStatus.status === 'not-active' ||
+          joinCode === null ||
+          sessionJoinUrl === null ? (
+          <Typography variant="body2" color="text.secondary">
+            Session is not currently active — no join code available.
+          </Typography>
+        ) : (
+          <Stack spacing={1.5}>
+            <Stack direction="row" alignItems="center" spacing={0.5}>
+              <Button
+                variant="contained"
+                startIcon={<OpenInNewIcon />}
+                component="a"
+                href={sessionJoinUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open live captions
+              </Button>
+              <CopyIconButton value={sessionJoinUrl} label="join link" />
+            </Stack>
+            <Stack direction="row" alignItems="center" spacing={0.5}>
+              <Typography variant="body2" color="text.secondary">
+                Join code <strong>{joinCode}</strong> · rotates every few
+                minutes
+              </Typography>
+              <CopyIconButton value={joinCode} label="join code" />
+            </Stack>
+          </Stack>
+        )}
       </Paper>
 
       <Stack direction="row" spacing={2}>

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -101,8 +101,9 @@ export interface SessionInfo {
 export interface HealthComponent {
   /** Stable identifier, matching the compose service name where there is one. */
   name: string;
-  /** 'ok' | 'degraded' | 'unreachable' | 'fail'; kept loose so a new status
-   *  added server-side renders rather than breaking the build. */
+  /** 'ok' | 'degraded' | 'unreachable' | 'fail' | 'not-configured'; kept loose
+   *  so a new status added server-side renders rather than breaking the
+   *  build. */
   status: string;
   latencyMs: number;
   /** One-line cause when the component is not ok. */
@@ -121,6 +122,18 @@ export interface DemoRoomStatus {
   active: boolean;
   roomName: string | null;
   joinCode: string | null;
+}
+
+/**
+ * Join-code status for an arbitrary live session, mirrored from
+ * `AdminJoinCodeStatus` (session-manager-schema). `ok` is the only status with
+ * a non-null `joinCode`/`validEnd` — `not-active` and `no-join-scopes` are
+ * legitimate, expected states, not errors.
+ */
+export interface SessionJoinCodeStatus {
+  status: 'ok' | 'not-active' | 'no-join-scopes';
+  joinCode: string | null;
+  validEnd: string | null;
 }
 
 export interface HealthReport {
@@ -628,6 +641,12 @@ export class AdminApiClient {
     return this._request(
       'GET',
       `/sessions/get/${encodeURIComponent(sessionUid)}`,
+    );
+  }
+  getSessionJoinCode(sessionUid: string): Promise<SessionJoinCodeStatus> {
+    return this._request(
+      'GET',
+      `/sessions/${encodeURIComponent(sessionUid)}/join-code`,
     );
   }
   createOnDemandSession(body: CreateOnDemandSessionBody): Promise<Session> {

--- a/apps/admin-webapp/src/lib/join-url.ts
+++ b/apps/admin-webapp/src/lib/join-url.ts
@@ -1,0 +1,15 @@
+/**
+ * Builds a client-webapp deep link that auto-joins a session. The client
+ * webapp reads a base64 `#config=` fragment and pre-fills/exchanges the join
+ * code — the same format the kiosk QR uses. The link is same-origin: the admin
+ * console and the client webapp are both served behind the one reverse proxy,
+ * so a root-relative origin is correct in every environment.
+ *
+ * The trailing slash matters: nginx serves the client webapp at `/client/`, and
+ * `/client` (no slash) 404s.
+ */
+export function buildJoinUrl(joinCode: string): string {
+  const config = { clientSessionConfig: { joinCode } };
+  const encoded = btoa(JSON.stringify(config));
+  return `${window.location.origin}/client/#config=${encoded}`;
+}

--- a/apps/admin-webapp/tests/features/sessions/session-detail-page.test.tsx
+++ b/apps/admin-webapp/tests/features/sessions/session-detail-page.test.tsx
@@ -1,9 +1,8 @@
 import type { ReactElement } from 'react';
 
-import { beforeEach, describe, expect, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
-
 import { Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, vi } from 'vitest';
 
 import { SessionDetailPage } from '#src/features/sessions/session-detail-page';
 import { adminApi } from '#src/lib/admin-api';
@@ -15,6 +14,7 @@ import { buildSession } from './fixtures';
 vi.mock('#src/lib/admin-api', () => ({
   adminApi: {
     getSession: vi.fn(),
+    getSessionJoinCode: vi.fn(),
   },
 }));
 
@@ -38,6 +38,13 @@ async function waitForLoad() {
 describe('SessionDetailPage', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    // Neutral default so tests unrelated to the join-code section don't have
+    // to stub it individually; overridden per-case below.
+    vi.mocked(adminApi.getSessionJoinCode).mockResolvedValue({
+      status: 'not-active',
+      joinCode: null,
+      validEnd: null,
+    });
   });
 
   describe('loading', (it) => {
@@ -69,9 +76,7 @@ describe('SessionDetailPage', () => {
       await waitForLoad();
 
       // Assert
-      expect(
-        await screen.findByText('Session not found.'),
-      ).toBeInTheDocument();
+      expect(await screen.findByText('Session not found.')).toBeInTheDocument();
     });
   });
 
@@ -109,9 +114,7 @@ describe('SessionDetailPage', () => {
       expect(
         await screen.findByText(/admin backend misconfiguration/i),
       ).toBeInTheDocument();
-      expect(
-        screen.queryByText('Session not found.'),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Session not found.')).not.toBeInTheDocument();
     });
   });
 
@@ -129,6 +132,83 @@ describe('SessionDetailPage', () => {
       // Assert
       expect(screen.getByText('CS 225 Lecture')).toBeInTheDocument();
       expect(screen.getByText('room-1')).toBeInTheDocument();
+    });
+  });
+
+  describe('join session', (it) => {
+    beforeEach(() => {
+      vi.mocked(adminApi.getSession).mockResolvedValue(
+        buildSession({ name: 'CS 225 Lecture', roomUid: 'room-1' }),
+      );
+    });
+
+    it('shows a muted message when the session has no join code scopes', async () => {
+      // Arrange
+      vi.mocked(adminApi.getSessionJoinCode).mockResolvedValue({
+        status: 'no-join-scopes',
+        joinCode: null,
+        validEnd: null,
+      });
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText(
+          'No join code scopes configured for this session.',
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', { name: /open live captions/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows a muted message when the session is not currently active', async () => {
+      // Arrange
+      vi.mocked(adminApi.getSessionJoinCode).mockResolvedValue({
+        status: 'not-active',
+        joinCode: null,
+        validEnd: null,
+      });
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText(
+          'Session is not currently active — no join code available.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the join code, copy buttons, and an open-live-captions link when active', async () => {
+      // Arrange
+      vi.mocked(adminApi.getSessionJoinCode).mockResolvedValue({
+        status: 'ok',
+        joinCode: 'ABC12345',
+        validEnd: '2026-08-01T00:05:00.000Z',
+      });
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(await screen.findByText('ABC12345')).toBeInTheDocument();
+      const link = screen.getByRole('link', {
+        name: /open live captions/i,
+      });
+      expect(link).toHaveAttribute(
+        'href',
+        expect.stringContaining('/client/#config='),
+      );
+      expect(
+        screen.getAllByRole('button', { name: /copy join/i }),
+      ).toHaveLength(2);
     });
   });
 });

--- a/apps/session-manager/src/server/features/session-auth/session-auth.controller.ts
+++ b/apps/session-manager/src/server/features/session-auth/session-auth.controller.ts
@@ -5,6 +5,7 @@ import {
   HttpError,
 } from '@scribear/base-fastify-server';
 import {
+  ADMIN_FETCH_JOIN_CODE_SCHEMA,
   EXCHANGE_DEVICE_TOKEN_SCHEMA,
   EXCHANGE_JOIN_CODE_SCHEMA,
   FETCH_JOIN_CODE_SCHEMA,
@@ -62,6 +63,38 @@ export class SessionAuthController {
               validStart: result.next.validStart.toISOString(),
               validEnd: result.next.validEnd.toISOString(),
             },
+    });
+  }
+
+  async adminFetchJoinCode(
+    req: BaseFastifyRequest<typeof ADMIN_FETCH_JOIN_CODE_SCHEMA>,
+    res: BaseFastifyReply<typeof ADMIN_FETCH_JOIN_CODE_SCHEMA>,
+  ) {
+    const result = await this._sessionAuthService.fetchJoinCodeForAdmin(
+      req.body.sessionUid,
+      new Date(),
+    );
+
+    if (result === 'SESSION_NOT_FOUND') {
+      throw HttpError.notFound('SESSION_NOT_FOUND', 'Session not found.');
+    }
+    if (result === 'SESSION_NOT_CURRENTLY_ACTIVE') {
+      res
+        .code(200)
+        .send({ status: 'not-active', joinCode: null, validEnd: null });
+      return;
+    }
+    if (result === 'JOIN_CODE_SCOPES_EMPTY') {
+      res
+        .code(200)
+        .send({ status: 'no-join-scopes', joinCode: null, validEnd: null });
+      return;
+    }
+
+    res.code(200).send({
+      status: 'ok',
+      joinCode: result.joinCode,
+      validEnd: result.validEnd.toISOString(),
     });
   }
 

--- a/apps/session-manager/src/server/features/session-auth/session-auth.router.ts
+++ b/apps/session-manager/src/server/features/session-auth/session-auth.router.ts
@@ -1,5 +1,7 @@
 import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
 import {
+  ADMIN_FETCH_JOIN_CODE_ROUTE,
+  ADMIN_FETCH_JOIN_CODE_SCHEMA,
   EXCHANGE_DEVICE_TOKEN_ROUTE,
   EXCHANGE_DEVICE_TOKEN_SCHEMA,
   EXCHANGE_JOIN_CODE_ROUTE,
@@ -11,6 +13,7 @@ import {
 } from '@scribear/session-manager-schema';
 
 import resolveHandler from '#src/server/dependency-injection/resolve-handler.js';
+import { adminApiKeyHook } from '#src/server/hooks/admin-api-key.hook.js';
 import { deviceTokenHook } from '#src/server/hooks/device-token.hook.js';
 
 export function sessionAuthRouter(fastify: BaseFastifyInstance) {
@@ -19,6 +22,13 @@ export function sessionAuthRouter(fastify: BaseFastifyInstance) {
     schema: FETCH_JOIN_CODE_SCHEMA,
     preHandler: deviceTokenHook,
     handler: resolveHandler('sessionAuthController', 'fetchJoinCode'),
+  });
+
+  fastify.route({
+    ...ADMIN_FETCH_JOIN_CODE_ROUTE,
+    schema: ADMIN_FETCH_JOIN_CODE_SCHEMA,
+    preHandler: adminApiKeyHook,
+    handler: resolveHandler('sessionAuthController', 'adminFetchJoinCode'),
   });
 
   fastify.route({

--- a/apps/session-manager/src/server/features/session-auth/session-auth.service.ts
+++ b/apps/session-manager/src/server/features/session-auth/session-auth.service.ts
@@ -5,7 +5,11 @@ import type { AuthMethod, SessionScope } from '@scribear/scribear-db';
 import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
 import { generateRandomCode } from '#src/server/utils/generate-random-code.js';
 
-import type { JoinCode, SessionAuthRow } from './session-auth.repository.js';
+import type {
+  DBOrTrx,
+  JoinCode,
+  SessionAuthRow,
+} from './session-auth.repository.js';
 
 const JOIN_CODE_LENGTH = 8;
 const JOIN_CODE_DURATION_MS = 5 * 60 * 1000;
@@ -151,21 +155,82 @@ export class SessionAuthService {
       const locked = await this._repo.lockSession(trx, sessionUid);
       if (!locked) return null;
 
-      const codes = await this._repo.findActiveJoinCodes(trx, sessionUid, now);
-      const current = codes.find(
-        (c) =>
-          c.validStart.getTime() <= now.getTime() &&
-          c.validEnd.getTime() > now.getTime(),
-      );
-      if (current) return current.joinCode;
+      const code = await this._findOrMintCurrentJoinCode(trx, sessionUid, now);
+      return code.joinCode;
+    });
+  }
 
-      const inserted = await this._repo.insertJoinCode(trx, {
-        joinCode: this._generateJoinCode(),
-        sessionUid,
-        validStart: now,
-        validEnd: new Date(now.getTime() + JOIN_CODE_DURATION_MS),
-      });
-      return inserted.joinCode;
+  /**
+   * Admin-console counterpart to `ensureCurrentJoinCode`: mints/reuses a join
+   * code for an arbitrary session on behalf of an authenticated operator
+   * (unlike the device-facing `fetchJoinCodes`, which requires a device token
+   * and room membership the admin console has neither of).
+   *
+   * Unlike `ensureCurrentJoinCode` (boot-time seeding, trusted caller, no
+   * further checks), this also validates the session the way `exchangeJoinCode`
+   * would — empty `joinCodeScopes` or an inactive window mean a minted code
+   * would never actually exchange, which would mislead the console into
+   * showing a broken "Open live captions" link.
+   *
+   * @param sessionUid The session to fetch/mint a join code for.
+   * @param now Reference instant for the active-window check and expiry.
+   */
+  async fetchJoinCodeForAdmin(
+    sessionUid: string,
+    now: Date,
+  ): Promise<
+    | { joinCode: string; validEnd: Date }
+    | 'SESSION_NOT_FOUND'
+    | 'SESSION_NOT_CURRENTLY_ACTIVE'
+    | 'JOIN_CODE_SCOPES_EMPTY'
+  > {
+    return this._repo.db.transaction().execute(async (trx) => {
+      const locked = await this._repo.lockSession(trx, sessionUid);
+      if (!locked) return 'SESSION_NOT_FOUND' as const;
+
+      const session = await this._repo.findSessionForAuth(trx, sessionUid);
+      if (!session) return 'SESSION_NOT_FOUND' as const;
+
+      if (session.joinCodeScopes.length === 0) {
+        return 'JOIN_CODE_SCOPES_EMPTY' as const;
+      }
+
+      if (!isSessionCurrentlyActive(session, now)) {
+        return 'SESSION_NOT_CURRENTLY_ACTIVE' as const;
+      }
+
+      const code = await this._findOrMintCurrentJoinCode(trx, sessionUid, now);
+      return { joinCode: code.joinCode, validEnd: code.validEnd };
+    });
+  }
+
+  /**
+   * Returns the join code covering `now`, minting one if none is active.
+   * Shared by `ensureCurrentJoinCode` and `fetchJoinCodeForAdmin`, which
+   * differ only in what they check before calling this.
+   *
+   * Callers must already hold the per-session lock (`lockSession`) so two
+   * concurrent calls can't both pass the find-then-insert check and emit
+   * duplicate active codes.
+   */
+  private async _findOrMintCurrentJoinCode(
+    trx: DBOrTrx,
+    sessionUid: string,
+    now: Date,
+  ): Promise<JoinCode> {
+    const codes = await this._repo.findActiveJoinCodes(trx, sessionUid, now);
+    const current = codes.find(
+      (c) =>
+        c.validStart.getTime() <= now.getTime() &&
+        c.validEnd.getTime() > now.getTime(),
+    );
+    if (current) return current;
+
+    return this._repo.insertJoinCode(trx, {
+      joinCode: this._generateJoinCode(),
+      sessionUid,
+      validStart: now,
+      validEnd: new Date(now.getTime() + JOIN_CODE_DURATION_MS),
     });
   }
 

--- a/apps/session-manager/tests/integration/features/session-auth/session-auth.routes.test.ts
+++ b/apps/session-manager/tests/integration/features/session-auth/session-auth.routes.test.ts
@@ -257,6 +257,197 @@ describe('Session Auth Routes', () => {
     });
   });
 
+  describe('POST /admin-fetch-join-code', (it) => {
+    it('returns 400 when the admin key header is missing entirely', async () => {
+      // Arrange - the header itself is required by the schema, so an absent
+      // header fails validation before adminApiKeyHook ever runs (matches the
+      // convention in schedule-management.routes.test.ts, which only asserts
+      // 401 for a *wrong* key, not a missing one).
+      const { sessionUid } = await setupActiveSession();
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/admin-fetch-join-code`,
+        body: { sessionUid },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 401 when the admin key is wrong', async () => {
+      // Arrange
+      const { sessionUid } = await setupActiveSession();
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/admin-fetch-join-code`,
+        headers: { authorization: 'Bearer wrong-key' },
+        body: { sessionUid },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('returns 404 when the session does not exist', async () => {
+      // Arrange / Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/admin-fetch-join-code`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { sessionUid: NULL_UUID },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(404);
+      expect(res.json<{ code: string }>().code).toBe('SESSION_NOT_FOUND');
+    });
+
+    it("returns status 'no-join-scopes' when the session has empty joinCodeScopes", async () => {
+      // Arrange
+      const { sessionUid } = await setupActiveSession({ joinCodeScopes: [] });
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/admin-fetch-join-code`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { sessionUid },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{
+        status: string;
+        joinCode: string | null;
+        validEnd: string | null;
+      }>();
+      expect(body.status).toBe('no-join-scopes');
+      expect(body.joinCode).toBeNull();
+      expect(body.validEnd).toBeNull();
+    });
+
+    it("returns status 'not-active' when the session has not started", async () => {
+      // Arrange
+      const { sessionUid } = await setupActiveSession();
+      await dbContext.db
+        .updateTable('sessions')
+        .set({
+          scheduled_start_time: new Date(Date.now() + 60 * 60 * 1000),
+          scheduled_end_time: new Date(Date.now() + 2 * 60 * 60 * 1000),
+        })
+        .where('uid', '=', sessionUid)
+        .execute();
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/admin-fetch-join-code`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { sessionUid },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      expect(res.json<{ status: string }>().status).toBe('not-active');
+    });
+
+    it("returns status 'not-active' when the session has ended", async () => {
+      // Arrange
+      const { sessionUid } = await setupActiveSession();
+      await endSessionEarly(sessionUid);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/admin-fetch-join-code`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { sessionUid },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      expect(res.json<{ status: string }>().status).toBe('not-active');
+    });
+
+    it("returns status 'ok' with a fresh code on the first call", async () => {
+      // Arrange
+      const { sessionUid } = await setupActiveSession();
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/admin-fetch-join-code`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { sessionUid },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{
+        status: string;
+        joinCode: string | null;
+        validEnd: string | null;
+      }>();
+      expect(body.status).toBe('ok');
+      expect(body.joinCode).toMatch(/^[A-Z0-9]{8}$/);
+      expect(body.validEnd).toEqual(expect.any(String));
+    });
+
+    it('is idempotent across repeated calls within the code lifetime', async () => {
+      // Arrange
+      const { sessionUid } = await setupActiveSession();
+      const first = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/admin-fetch-join-code`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { sessionUid },
+      });
+
+      // Act
+      const second = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/admin-fetch-join-code`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { sessionUid },
+      });
+
+      // Assert
+      const firstBody = first.json<{ joinCode: string }>();
+      const secondBody = second.json<{ joinCode: string }>();
+      expect(secondBody.joinCode).toBe(firstBody.joinCode);
+    });
+
+    it('mints the same current code a device would get from fetch-join-code', async () => {
+      // Arrange - the admin route and the device route must agree, since the
+      // console's link has to actually work for a device that later joins.
+      const { token, sessionUid } = await setupActiveSession();
+
+      // Act
+      const adminRes = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/admin-fetch-join-code`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { sessionUid },
+      });
+      const deviceRes = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/fetch-join-code`,
+        headers: { cookie: `DEVICE_TOKEN=${token}` },
+        body: { sessionUid },
+      });
+
+      // Assert
+      const adminCode = adminRes.json<{ joinCode: string }>().joinCode;
+      const deviceCode = deviceRes.json<{ current: { joinCode: string } }>()
+        .current.joinCode;
+      expect(adminCode).toBe(deviceCode);
+    });
+  });
+
   describe('POST /exchange-device-token', (it) => {
     it('returns 401 when the device cookie is missing', async () => {
       // Arrange / Act

--- a/apps/session-manager/tests/unit/features/session-auth/session-auth.controller.test.ts
+++ b/apps/session-manager/tests/unit/features/session-auth/session-auth.controller.test.ts
@@ -12,6 +12,7 @@ const FAKE_TOKEN_EXPIRES = new Date('2026-04-27T12:05:00.000Z');
 describe('SessionAuthController', () => {
   let mockService: {
     fetchJoinCodes: Mock;
+    fetchJoinCodeForAdmin: Mock;
     exchangeDeviceToken: Mock;
     exchangeJoinCode: Mock;
     refreshSessionToken: Mock;
@@ -24,6 +25,7 @@ describe('SessionAuthController', () => {
   beforeEach(() => {
     mockService = {
       fetchJoinCodes: vi.fn(),
+      fetchJoinCodeForAdmin: vi.fn(),
       exchangeDeviceToken: vi.fn(),
       exchangeJoinCode: vi.fn(),
       refreshSessionToken: vi.fn(),
@@ -162,6 +164,79 @@ describe('SessionAuthController', () => {
           },
         }),
       );
+    });
+  });
+
+  describe('adminFetchJoinCode', (it) => {
+    it("throws 404 when the service returns 'SESSION_NOT_FOUND'", async () => {
+      // Arrange
+      mockService.fetchJoinCodeForAdmin.mockResolvedValue('SESSION_NOT_FOUND');
+      const mockReq = { body: { sessionUid: SESSION_UID } };
+
+      // Act + Assert
+      await expect(
+        controller.adminFetchJoinCode(mockReq as never, mockRes as never),
+      ).rejects.toMatchObject({
+        statusCode: 404,
+        code: 'SESSION_NOT_FOUND',
+      });
+    });
+
+    it("returns 200 with status 'not-active' when the service returns 'SESSION_NOT_CURRENTLY_ACTIVE'", async () => {
+      // Arrange
+      mockService.fetchJoinCodeForAdmin.mockResolvedValue(
+        'SESSION_NOT_CURRENTLY_ACTIVE',
+      );
+      const mockReq = { body: { sessionUid: SESSION_UID } };
+
+      // Act
+      await controller.adminFetchJoinCode(mockReq as never, mockRes as never);
+
+      // Assert
+      expect(mockCode).toHaveBeenCalledWith(200);
+      expect(mockSend).toHaveBeenCalledWith({
+        status: 'not-active',
+        joinCode: null,
+        validEnd: null,
+      });
+    });
+
+    it("returns 200 with status 'no-join-scopes' when the service returns 'JOIN_CODE_SCOPES_EMPTY'", async () => {
+      // Arrange
+      mockService.fetchJoinCodeForAdmin.mockResolvedValue(
+        'JOIN_CODE_SCOPES_EMPTY',
+      );
+      const mockReq = { body: { sessionUid: SESSION_UID } };
+
+      // Act
+      await controller.adminFetchJoinCode(mockReq as never, mockRes as never);
+
+      // Assert
+      expect(mockSend).toHaveBeenCalledWith({
+        status: 'no-join-scopes',
+        joinCode: null,
+        validEnd: null,
+      });
+    });
+
+    it("returns 200 with status 'ok' and an ISO-formatted validEnd on success", async () => {
+      // Arrange
+      mockService.fetchJoinCodeForAdmin.mockResolvedValue({
+        joinCode: 'AAAA1111',
+        validEnd: FAKE_VALID_END,
+      });
+      const mockReq = { body: { sessionUid: SESSION_UID } };
+
+      // Act
+      await controller.adminFetchJoinCode(mockReq as never, mockRes as never);
+
+      // Assert
+      expect(mockCode).toHaveBeenCalledWith(200);
+      expect(mockSend).toHaveBeenCalledWith({
+        status: 'ok',
+        joinCode: 'AAAA1111',
+        validEnd: FAKE_VALID_END.toISOString(),
+      });
     });
   });
 

--- a/apps/session-manager/tests/unit/features/session-auth/session-auth.service.test.ts
+++ b/apps/session-manager/tests/unit/features/session-auth/session-auth.service.test.ts
@@ -247,6 +247,110 @@ describe('SessionAuthService', () => {
     });
   });
 
+  describe('fetchJoinCodeForAdmin', (it) => {
+    it("returns 'SESSION_NOT_FOUND' when the session does not exist", async () => {
+      // Arrange
+      mockRepo.lockSession.mockResolvedValue(undefined);
+
+      // Act
+      const result = await service.fetchJoinCodeForAdmin(SESSION_UID, NOW);
+
+      // Assert
+      expect(result).toBe('SESSION_NOT_FOUND');
+    });
+
+    it("returns 'SESSION_NOT_FOUND' when the session row vanishes after the lock", async () => {
+      // Arrange - defensive branch, same as fetchJoinCodes.
+      mockRepo.lockSession.mockResolvedValue({ uid: SESSION_UID });
+      mockRepo.findSessionForAuth.mockResolvedValue(undefined);
+
+      // Act
+      const result = await service.fetchJoinCodeForAdmin(SESSION_UID, NOW);
+
+      // Assert
+      expect(result).toBe('SESSION_NOT_FOUND');
+    });
+
+    it("returns 'JOIN_CODE_SCOPES_EMPTY' when the session has no join code scopes", async () => {
+      // Arrange
+      mockRepo.findSessionForAuth.mockResolvedValue({
+        ...ACTIVE_SESSION,
+        joinCodeScopes: [],
+      });
+
+      // Act
+      const result = await service.fetchJoinCodeForAdmin(SESSION_UID, NOW);
+
+      // Assert
+      expect(result).toBe('JOIN_CODE_SCOPES_EMPTY');
+    });
+
+    it("returns 'SESSION_NOT_CURRENTLY_ACTIVE' when the session has not started", async () => {
+      // Arrange
+      mockRepo.findSessionForAuth.mockResolvedValue(NOT_YET_STARTED_SESSION);
+
+      // Act
+      const result = await service.fetchJoinCodeForAdmin(SESSION_UID, NOW);
+
+      // Assert
+      expect(result).toBe('SESSION_NOT_CURRENTLY_ACTIVE');
+    });
+
+    it("returns 'SESSION_NOT_CURRENTLY_ACTIVE' when the session has ended", async () => {
+      // Arrange
+      mockRepo.findSessionForAuth.mockResolvedValue(ENDED_SESSION);
+
+      // Act
+      const result = await service.fetchJoinCodeForAdmin(SESSION_UID, NOW);
+
+      // Assert
+      expect(result).toBe('SESSION_NOT_CURRENTLY_ACTIVE');
+    });
+
+    it('mints a fresh code when none is active', async () => {
+      // Arrange
+      mockRepo.findSessionForAuth.mockResolvedValue(ACTIVE_SESSION);
+      mockRepo.findActiveJoinCodes.mockResolvedValue([]);
+      mockRepo.insertJoinCode.mockImplementation((_db, data) =>
+        Promise.resolve(data),
+      );
+
+      // Act
+      const result = await service.fetchJoinCodeForAdmin(SESSION_UID, NOW);
+
+      // Assert
+      if (typeof result === 'string') {
+        throw new Error('expected a join code result');
+      }
+      expect(result.joinCode).toMatch(/^[A-Z0-9]{8}$/);
+      expect(result.validEnd).toEqual(new Date(NOW.getTime() + 5 * 60_000));
+      expect(mockRepo.insertJoinCode).toHaveBeenCalledTimes(1);
+    });
+
+    it('reuses (does not re-mint) an already-active code', async () => {
+      // Arrange - idempotent within the code's lifetime, same as ensureCurrentJoinCode.
+      const existing = {
+        joinCode: 'ABC12345',
+        sessionUid: SESSION_UID,
+        validStart: new Date(NOW.getTime() - 60_000),
+        validEnd: new Date(NOW.getTime() + 4 * 60_000),
+      };
+      mockRepo.findSessionForAuth.mockResolvedValue(ACTIVE_SESSION);
+      mockRepo.findActiveJoinCodes.mockResolvedValue([existing]);
+
+      // Act
+      const result = await service.fetchJoinCodeForAdmin(SESSION_UID, NOW);
+
+      // Assert
+      if (typeof result === 'string') {
+        throw new Error('expected a join code result');
+      }
+      expect(result.joinCode).toBe(existing.joinCode);
+      expect(result.validEnd).toEqual(existing.validEnd);
+      expect(mockRepo.insertJoinCode).not.toHaveBeenCalled();
+    });
+  });
+
   describe('exchangeDeviceToken', (it) => {
     it("returns 'SESSION_NOT_FOUND' when the session does not exist", async () => {
       // Arrange

--- a/libs/clients/session-manager-client/src/session-auth-client.ts
+++ b/libs/clients/session-manager-client/src/session-auth-client.ts
@@ -1,5 +1,7 @@
 import { createEndpointClient } from '@scribear/base-api-client';
 import {
+  ADMIN_FETCH_JOIN_CODE_ROUTE,
+  ADMIN_FETCH_JOIN_CODE_SCHEMA,
   EXCHANGE_DEVICE_TOKEN_ROUTE,
   EXCHANGE_DEVICE_TOKEN_SCHEMA,
   EXCHANGE_JOIN_CODE_ROUTE,
@@ -15,6 +17,11 @@ function createSessionAuthClient(baseUrl: string) {
     fetchJoinCode: createEndpointClient(
       FETCH_JOIN_CODE_SCHEMA,
       FETCH_JOIN_CODE_ROUTE,
+      baseUrl,
+    ),
+    adminFetchJoinCode: createEndpointClient(
+      ADMIN_FETCH_JOIN_CODE_SCHEMA,
+      ADMIN_FETCH_JOIN_CODE_ROUTE,
       baseUrl,
     ),
     exchangeDeviceToken: createEndpointClient(

--- a/libs/schemas/session-manager-schema/src/index.ts
+++ b/libs/schemas/session-manager-schema/src/index.ts
@@ -57,6 +57,7 @@ export * from './schedule-management/routes/session-config-stream.schema.js';
 
 export * from './session-auth/entities/session-token-payload.schema.js';
 export * from './session-auth/routes/fetch-join-code.schema.js';
+export * from './session-auth/routes/admin-fetch-join-code.schema.js';
 export * from './session-auth/routes/exchange-device-token.schema.js';
 export * from './session-auth/routes/exchange-join-code.schema.js';
 export * from './session-auth/routes/refresh-session-token.schema.js';

--- a/libs/schemas/session-manager-schema/src/session-auth/routes/admin-fetch-join-code.schema.ts
+++ b/libs/schemas/session-manager-schema/src/session-auth/routes/admin-fetch-join-code.schema.ts
@@ -1,0 +1,82 @@
+import { Type } from 'typebox';
+
+import {
+  type BaseRouteDefinition,
+  type BaseRouteSchema,
+  STANDARD_ERROR_REPLIES,
+} from '@scribear/base-schema';
+
+import { SESSION_MANAGER_BASE_PATH } from '#src/base-path.js';
+import {
+  ADMIN_API_KEY_AUTH_HEADER_SCHEMA,
+  ADMIN_API_KEY_SECURITY,
+  INVALID_ADMIN_KEY_REPLY_SCHEMA,
+} from '#src/shared/security/admin-api-key.js';
+import { SESSION_AUTH_TAG } from '#src/tags.js';
+
+/**
+ * Admin-console counterpart to `fetch-join-code`: mints/reuses a join code for
+ * an arbitrary session on behalf of an authenticated operator. Unlike the
+ * device-facing route (which requires a device token and room membership),
+ * this is admin-key protected — only an authenticated operator ever sees a
+ * code — which is what lets it skip the device-membership check entirely.
+ *
+ * Answers `200` with a `status` discriminant rather than a `409`/`404` for the
+ * "expected" not-joinable cases (`not-active`, `no-join-scopes`): this route is
+ * polled continuously by the admin console the same way `demo-room/status` is,
+ * and a `status` field is simpler for the SPA to branch on than an HTTP status
+ * code for states that aren't really errors.
+ */
+export const ADMIN_FETCH_JOIN_CODE_RESPONSE_SCHEMA = Type.Object(
+  {
+    status: Type.Union(
+      [
+        Type.Literal('ok'),
+        Type.Literal('not-active'),
+        Type.Literal('no-join-scopes'),
+      ],
+      {
+        description:
+          '`ok` — joinCode/validEnd are populated. `not-active` — the ' +
+          'session exists but is outside its effective window. ' +
+          "`no-join-scopes` — the session's joinCodeScopes is empty, so a " +
+          'code could never be exchanged.',
+      },
+    ),
+    joinCode: Type.Union([Type.String(), Type.Null()], {
+      description: 'A currently-valid join code, or null unless status "ok".',
+    }),
+    validEnd: Type.Union([Type.String({ format: 'date-time' }), Type.Null()], {
+      description: 'Expiry of `joinCode`, or null unless status "ok".',
+    }),
+  },
+  { $id: 'AdminJoinCodeStatus' },
+);
+
+export const ADMIN_FETCH_JOIN_CODE_SCHEMA = {
+  description:
+    'Fetch/mint a currently-valid join code for a session, for the admin ' +
+    'console to build a one-click "open live captions" link.',
+  tags: [SESSION_AUTH_TAG],
+  security: ADMIN_API_KEY_SECURITY,
+  headers: Type.Object({
+    authorization: ADMIN_API_KEY_AUTH_HEADER_SCHEMA,
+  }),
+  body: Type.Object({
+    sessionUid: Type.String({ format: 'uuid' }),
+  }),
+  response: {
+    200: ADMIN_FETCH_JOIN_CODE_RESPONSE_SCHEMA,
+    ...STANDARD_ERROR_REPLIES,
+    ...INVALID_ADMIN_KEY_REPLY_SCHEMA,
+    404: Type.Object({
+      code: Type.Literal('SESSION_NOT_FOUND'),
+      message: Type.String(),
+    }),
+  },
+} satisfies BaseRouteSchema;
+
+export const ADMIN_FETCH_JOIN_CODE_ROUTE: BaseRouteDefinition = {
+  method: 'POST',
+  url: `${SESSION_MANAGER_BASE_PATH}/session-auth/admin-fetch-join-code`,
+};


### PR DESCRIPTION
## Summary
- Health rollup now reports a `redis` component (ok/unreachable/not-configured), reusing the existing fleet-telemetry Redis connection
- Admin console can fetch/mint a join code for any live session (new admin-key-protected session-manager endpoint + BFF passthrough), with a compact "open client" action on fleet cards and a fuller join-code/open/copy section on the session detail page
- Demo room card gains copy-to-clipboard for its existing join link/code

## Test plan
- [ ] `npm test` for affected apps/libs (bff, admin-webapp, session-manager)
- [ ] Manually verify health endpoint reports redis status
- [ ] Manually verify join-code fetch/copy flow on fleet panel and session detail page
- [ ] Manually verify demo room card copy-to-clipboard