### PR TITLE
perf(ci): cut PR pipeline wall clock and stop exhausting the DockerHub quota

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -11,9 +11,14 @@ inputs:
     description: "Path to the Dockerfile."
     required: true
   cache_variant:
-    description: "Cache variant to write to ('pr', 'staging', 'main'). All variants are always read from."
+    description: >
+      Branch whose build cache this run should write ('staging', 'main').
+      Leave empty to build read-only, which is what PR CI wants: every PR shared
+      a single `buildcache-pr` tag, so a PR almost always imported some other
+      PR's cache while still paying ~55s per image to export its own.
+      staging/main caches are read either way.
     required: false
-    default: 'pr'
+    default: ''
   custom_tags:
     description: "Optional newline-delimited tags to publish instead of the default metadata tags."
     required: false
@@ -79,6 +84,17 @@ runs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        # Pull docker.io base images (node, nginx, postgres, nvidia/cuda) through
+        # Google's public mirror. Even authenticated, a Docker Personal account's
+        # hourly pull allowance does not cover a dozen images per run across many
+        # concurrent PRs - that is what produced the `429 Too Many Requests` on
+        # nvidia/cuda. BuildKit falls back to docker.io when the mirror lacks an
+        # image, so this is a pure win. Pushes are unaffected (mirrors are
+        # pull-only).
+        buildkitd-config-inline: |
+          [registry."docker.io"]
+            mirrors = ["mirror.gcr.io"]
 
     # Fork PRs run with a read-only GITHUB_TOKEN and no DockerHub secrets, so they
     # cannot log in, push, or write cache. Detect that case and build-only (which still
@@ -112,53 +128,23 @@ runs:
         username: ${{ github.actor }}
         password: ${{ inputs.github_token }}
 
-    # Build different platforms first using independent buildcaches without pushing.
-    #   This ensures buildcache isn't overwritten by other architectures, so builds can
-    #   actually take advantage of caching (vs buildcache always containing the wrong architecture image).
-    #   All variants are read from so feature branches benefit from staging and main caches.
-    - name: Build linux/amd64
+    # One build step, not two. The old build-then-push split existed so each
+    # architecture could own its buildcache tag instead of clobbering the other's;
+    # with the arm64 build disabled (see below) there is only one architecture, so
+    # the second invocation just replayed the first from local cache - ~17s and six
+    # more registry manifest reads per image, for nothing.
+    #
+    # Cache lives on GHCR only (GITHUB_TOKEN auth, no pull limits). The DockerHub
+    # cache reads that used to sit alongside these were 54 DockerHub requests per
+    # node-ci run before a single base image was pulled, which is a large part of
+    # what exhausted the account's pull allowance.
+    #
+    # `mode` is deliberately absent from cache-from: it is a cache-to option and
+    # was silently ignored on every one of these refs.
+    - name: Build and Push
       uses: docker/build-push-action@v6
       with:
-        push: false
-        context: ${{ inputs.build_context }}
-        file: ${{ inputs.dockerfile }}
-        platforms: "linux/amd64"
-        build-args: ${{ inputs.build_args }}
-        # Cache now lives on GHCR (GITHUB_TOKEN auth, no DockerHub pull limits).
-        # DockerHub cache reads remain during the migration so the first post-switch
-        # builds stay warm; drop them once the GHCR cache is populated.
-        cache-from: |
-          type=registry,mode=max,ref=ghcr.io/${{ inputs.image_name }}:buildcache-pr-linux-amd64
-          type=registry,mode=max,ref=ghcr.io/${{ inputs.image_name }}:buildcache-staging-linux-amd64
-          type=registry,mode=max,ref=ghcr.io/${{ inputs.image_name }}:buildcache-main-linux-amd64
-          type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-pr-linux-amd64
-          type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-staging-linux-amd64
-          type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-main-linux-amd64
-        # No cache write on fork PRs — the read-only token cannot push to GHCR.
-        cache-to: ${{ steps.eligibility.outputs.can_push == 'true' && format('type=registry,mode=max,ref=ghcr.io/{0}:buildcache-{1}-linux-amd64', inputs.image_name, inputs.cache_variant) || '' }}
-
-    # Disable arm builds due to extremely slow github actions
-    # - name: Build linux/arm64
-    #   uses: docker/build-push-action@v6
-    #   with:
-    #     push: false
-    #     context: ${{ inputs.build_context }}
-    #     file: ${{ inputs.dockerfile }}
-    #     platforms: "linux/arm64"
-    #     cache-from: |
-    #       type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-pr-linux-arm64
-    #       type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-staging-linux-arm64
-    #       type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-main-linux-arm64
-    #     cache-to: type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-${{ inputs.cache_variant }}-linux-arm64
-
-    # After independent builds, combine all architectures and push.
-    #   A single multi-arch manifest is created rather than letting each architecture overwrite the tag.
-    #   Since the per-arch builds ran independently, this step can pull from all buildcaches.
-    - name: Push Images
-      if: steps.eligibility.outputs.can_push == 'true'
-      uses: docker/build-push-action@v6
-      with:
-        push: true
+        push: ${{ steps.eligibility.outputs.can_push == 'true' }}
         context: ${{ inputs.build_context }}
         file: ${{ inputs.dockerfile }}
         platforms: "linux/amd64"
@@ -167,12 +153,13 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: |
-          type=registry,mode=max,ref=ghcr.io/${{ inputs.image_name }}:buildcache-pr-linux-amd64
-          type=registry,mode=max,ref=ghcr.io/${{ inputs.image_name }}:buildcache-staging-linux-amd64
-          type=registry,mode=max,ref=ghcr.io/${{ inputs.image_name }}:buildcache-main-linux-amd64
-          type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-pr-linux-amd64
-          type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-staging-linux-amd64
-          type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-main-linux-amd64
-        # type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-pr-linux-arm64
-        # type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-staging-linux-arm64
-        # type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-main-linux-arm64
+          type=registry,ref=ghcr.io/${{ inputs.image_name }}:buildcache-staging-linux-amd64
+          type=registry,ref=ghcr.io/${{ inputs.image_name }}:buildcache-main-linux-amd64
+        # Written only on a branch build (cache_variant set) and never on fork PRs,
+        # whose read-only token cannot push to GHCR.
+        cache-to: ${{ (inputs.cache_variant != '' && steps.eligibility.outputs.can_push == 'true') && format('type=registry,mode=max,ref=ghcr.io/{0}:buildcache-{1}-linux-amd64', inputs.image_name, inputs.cache_variant) || '' }}
+
+    # Disable arm builds due to extremely slow github actions.
+    # Restoring arm64 means going back to per-architecture build steps with
+    # separate buildcache tags, then a final manifest-only push - see git history
+    # for the shape that had.

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -5,6 +5,9 @@ description: >
   workspaces. If any global config file (package-lock.json, eslint.config.js,
   etc.) changed, all workspaces are returned.
 
+  The caller must check out with `fetch-depth: 0`; the base commit has to be in
+  the local history for the `git diff` below to resolve.
+
 outputs:
   workspaces:
     description: JSON array of affected workspace paths relative to repo root
@@ -16,14 +19,9 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-
-    - uses: actions/setup-node@v5
-      with:
-        node-version: '24.10.0'
-
+    # No checkout and no setup-node: the caller has already checked out (it had
+    # to, to resolve this action at all) and detect-changes.cjs uses nothing
+    # beyond `fs`/`path`, so the runner's preinstalled Node is enough.
     - name: Compute affected workspaces
       id: compute
       shell: bash

--- a/.github/actions/detect-changes/detect-changes.cjs
+++ b/.github/actions/detect-changes/detect-changes.cjs
@@ -90,8 +90,18 @@ const globalFiles = new Set([
   'vitest.shared.ts',
 ]);
 
+// Directories whose contents trigger a full run. `.github` decides how every
+// workspace is formatted, linted, built, tested and imaged, so a change to it
+// affects all of them - and a PR that touches only `.github` would otherwise
+// resolve to zero workspaces and skip the entire pipeline, meaning CI changes
+// were the one category of change CI never actually exercised.
+const globalPrefixes = ['.github/'];
+
+const isGlobalChange = (f) =>
+  globalFiles.has(f) || globalPrefixes.some((prefix) => f.startsWith(prefix));
+
 let affected;
-if (changedFiles.length === 0 || changedFiles.some((f) => globalFiles.has(f))) {
+if (changedFiles.length === 0 || changedFiles.some(isGlobalChange)) {
   affected = allWorkspaces;
 } else {
   const directlyChanged = new Set(

--- a/.github/actions/node-image-matrix/action.yml
+++ b/.github/actions/node-image-matrix/action.yml
@@ -1,0 +1,54 @@
+name: "Node Image Matrix"
+description: >
+  Builds the docker-build job matrix for the Node images declared in
+  .github/node-images.json, keeping only the images whose workspace is in the
+  affected set reported by detect-changes.
+inputs:
+  workspaces:
+    description: "JSON array of affected workspace paths, from the detect-changes action."
+    required: true
+outputs:
+  matrix:
+    # No ${{ }} in this text: GitHub evaluates descriptions as expressions.
+    description: "JSON object with an `include` array, for use as a strategy.matrix via fromJSON."
+    value: ${{ steps.build.outputs.matrix }}
+  has_images:
+    description: '"true" if at least one image needs building, "false" otherwise.'
+    value: ${{ steps.build.outputs.has_images }}
+runs:
+  using: "composite"
+  steps:
+    # The matrix used to be hard-coded in node-ci and node-cd, which let the two
+    # drift: CI never built scribear-redis or monitoring-sidecar, so those two
+    # images were only ever compiled for the first time on a push to staging.
+    #
+    # Filtering here rather than with a per-entry `if:` on the build step also
+    # stops GitHub allocating a runner for every image on every run just to skip
+    # the one step that matters.
+    - name: Build image matrix
+      id: build
+      shell: bash
+      env:
+        WORKSPACES: ${{ inputs.workspaces }}
+      run: |
+        node <<'JS'
+        const { readFileSync, appendFileSync } = require('fs');
+
+        const images = JSON.parse(
+          readFileSync('.github/node-images.json', 'utf8'),
+        );
+        const affected = new Set(JSON.parse(process.env.WORKSPACES));
+        const include = images.filter((image) => affected.has(image.workspace));
+
+        appendFileSync(
+          process.env.GITHUB_OUTPUT,
+          `matrix=${JSON.stringify({ include })}\n` +
+            `has_images=${include.length > 0 ? 'true' : 'false'}\n`,
+        );
+
+        console.log(
+          include.length
+            ? `${include.length} images: ${include.map((i) => i.image_name).join(', ')}`
+            : 'No images affected',
+        );
+        JS

--- a/.github/actions/prepare-test-container/action.yml
+++ b/.github/actions/prepare-test-container/action.yml
@@ -18,6 +18,11 @@ runs:
   steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        # See build-container for why base images are pulled through a mirror.
+        buildkitd-config-inline: |
+          [registry."docker.io"]
+            mirrors = ["mirror.gcr.io"]
 
     - name: Login to GHCR
       uses: docker/login-action@v3
@@ -34,11 +39,9 @@ runs:
         tags: ${{ inputs.image_name }}:test
         push: false
         load: true
-        # Cache lives on GHCR; DockerHub reads remain during the migration.
+        # GHCR only, and only the branch caches: nothing writes a `buildcache-pr`
+        # tag any more, and the DockerHub mirrors of these were burning the
+        # account's pull allowance. See build-container for the full reasoning.
         cache-from: |
-          type=registry,mode=max,ref=ghcr.io/${{ inputs.image_name }}:buildcache-pr-linux-amd64
-          type=registry,mode=max,ref=ghcr.io/${{ inputs.image_name }}:buildcache-staging-linux-amd64
-          type=registry,mode=max,ref=ghcr.io/${{ inputs.image_name }}:buildcache-main-linux-amd64
-          type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-pr-linux-amd64
-          type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-staging-linux-amd64
-          type=registry,mode=max,ref=${{ inputs.image_name }}:buildcache-main-linux-amd64
+          type=registry,ref=ghcr.io/${{ inputs.image_name }}:buildcache-staging-linux-amd64
+          type=registry,ref=ghcr.io/${{ inputs.image_name }}:buildcache-main-linux-amd64

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,5 +1,5 @@
 name: "Setup Node"
-description: "Checks out the repo and installs dependencies for node packages."
+description: "Installs Node.js and the workspace dependencies. The caller is responsible for checking out the repo first."
 inputs:
   node-version:
     description: "Node.js version to use for setup."
@@ -8,15 +8,33 @@ runs:
   using: "composite"
 
   steps:
-    - name: Set up Git repository
-      uses: actions/checkout@v5
-
+    # No checkout here: every caller already runs actions/checkout, and a second
+    # checkout of the same ref just re-clones the repo for nothing.
     - name: Set up Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v5
       with:
         node-version: ${{ inputs.node-version }}
+        # Caches the npm download tarballs, which only helps on a node_modules
+        # cache miss below. Cheap enough to always leave on.
+        cache: npm
+
+    # A cold `npm ci` across 36 workspaces costs 35-60s in every job that needs
+    # it. package-lock.json is the only input npm ci reads, so it is the whole
+    # cache key; on a hit we can skip the install outright.
+    - name: Restore node_modules
+      id: node-modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          apps/*/node_modules
+          infra/*/node_modules
+          libs/*/node_modules
+          libs/*/*/node_modules
+        key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 
     - name: Install dependencies
+      if: steps.node-modules.outputs.cache-hit != 'true'
       working-directory: "."
       shell: bash
       run: npm ci

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,5 +1,5 @@
 name: "Setup Python"
-description: "Checks out the repo and installs dependencies for python packages."
+description: "Installs Python/uv and the transcription-service dependencies. The caller is responsible for checking out the repo first."
 inputs:
   python-version:
     description: "Python version to use for setup."
@@ -8,9 +8,9 @@ runs:
   using: "composite"
 
   steps:
-    - name: Set up Git repository
-      uses: actions/checkout@v5
-
+    # No checkout here: every caller already runs actions/checkout, and a second
+    # checkout of the same ref just re-clones the repo for nothing.
+    #
     # Pinned to an exact version rather than a floating major: setup-uv stopped
     # publishing moving major tags at v8.0.0, so `@v8` does not resolve.
     #

--- a/.github/node-images.json
+++ b/.github/node-images.json
@@ -1,0 +1,79 @@
+[
+  {
+    "image_name": "scribear/scribear-db",
+    "build_context": "infra/scribear-db",
+    "dockerfile": "infra/scribear-db/Dockerfile",
+    "workspace": "infra/scribear-db",
+    "version_file": "infra/scribear-db/package.json"
+  },
+  {
+    "image_name": "scribear/scribear-nginx",
+    "build_context": "infra/scribear-nginx",
+    "dockerfile": "infra/scribear-nginx/Dockerfile",
+    "workspace": "infra/scribear-nginx",
+    "version_file": "infra/scribear-nginx/package.json"
+  },
+  {
+    "image_name": "scribear/scribear-redis",
+    "build_context": "infra/scribear-redis",
+    "dockerfile": "infra/scribear-redis/Dockerfile",
+    "workspace": "infra/scribear-redis",
+    "version_file": "infra/scribear-redis/package.json"
+  },
+  {
+    "image_name": "scribear/client-webapp",
+    "build_context": ".",
+    "dockerfile": "apps/client-webapp/Dockerfile",
+    "workspace": "apps/client-webapp",
+    "version_file": "apps/client-webapp/package.json"
+  },
+  {
+    "image_name": "scribear/kiosk-webapp",
+    "build_context": ".",
+    "dockerfile": "apps/kiosk-webapp/Dockerfile",
+    "workspace": "apps/kiosk-webapp",
+    "version_file": "apps/kiosk-webapp/package.json"
+  },
+  {
+    "image_name": "scribear/standalone-webapp",
+    "build_context": ".",
+    "dockerfile": "apps/standalone-webapp/Dockerfile",
+    "workspace": "apps/standalone-webapp",
+    "version_file": "apps/standalone-webapp/package.json"
+  },
+  {
+    "image_name": "scribear/session-manager",
+    "build_context": ".",
+    "dockerfile": "apps/session-manager/Dockerfile",
+    "workspace": "apps/session-manager",
+    "version_file": "apps/session-manager/package.json"
+  },
+  {
+    "image_name": "scribear/node-server",
+    "build_context": ".",
+    "dockerfile": "apps/node-server/Dockerfile",
+    "workspace": "apps/node-server",
+    "version_file": "apps/node-server/package.json"
+  },
+  {
+    "image_name": "scribear/monitoring-sidecar",
+    "build_context": ".",
+    "dockerfile": "apps/monitoring-sidecar/Dockerfile",
+    "workspace": "apps/monitoring-sidecar",
+    "version_file": "apps/monitoring-sidecar/package.json"
+  },
+  {
+    "image_name": "scribear/admin-server",
+    "build_context": ".",
+    "dockerfile": "apps/admin-server/Dockerfile",
+    "workspace": "apps/admin-server",
+    "version_file": "apps/admin-server/package.json"
+  },
+  {
+    "image_name": "scribear/admin-webapp",
+    "build_context": ".",
+    "dockerfile": "apps/admin-webapp/Dockerfile",
+    "workspace": "apps/admin-webapp",
+    "version_file": "apps/admin-webapp/package.json"
+  }
+]

--- a/.github/scripts/run-workspaces.sh
+++ b/.github/scripts/run-workspaces.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Run an npm script across the affected workspaces, several at a time.
+#
+# The serial `for ws in ...; do npm run ... --workspace "$ws"; done` this
+# replaces spent 151s on lint alone, because each of the 36 workspaces paid for
+# its own ESLint process and its own type-aware TypeScript program while three
+# of the runner's four cores sat idle. Peak RSS is ~1GB per workspace, so four
+# at a time fits comfortably in the runner's 15.6GB.
+#
+# (Collapsing the whole thing into one root-level `eslint` invocation is the
+# obvious alternative and does not work: holding 36 TS programs in a single
+# process exhausts the V8 heap and dies with an OOM.)
+#
+# Output is captured per workspace and replayed in a stable order once
+# everything finishes, so parallelism does not produce interleaved logs.
+#
+# Usage:  run-workspaces.sh <npm-script-name>
+# Env:    WORKSPACES   JSON array of workspace paths (required)
+#         IF_PRESENT   "true" to skip workspaces lacking the script
+#         CONCURRENCY  how many to run at once (default: number of cores)
+
+set -uo pipefail
+
+SCRIPT_NAME="${1:?usage: run-workspaces.sh <npm-script-name>}"
+CONCURRENCY="${CONCURRENCY:-$(nproc)}"
+IF_PRESENT="${IF_PRESENT:-false}"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+node -e "console.log(JSON.parse(process.env.WORKSPACES).join('\n'))" \
+  > "$WORK_DIR/workspaces.txt"
+
+if [ ! -s "$WORK_DIR/workspaces.txt" ]; then
+  echo "No affected workspaces; nothing to do."
+  exit 0
+fi
+
+run_one() {
+  local ws="$1"
+  local log="$WORK_DIR/${ws//\//__}.log"
+  local -a args=(run "$SCRIPT_NAME" --workspace "$ws")
+  [ "$IF_PRESENT" = "true" ] && args+=(--if-present)
+
+  if npm "${args[@]}" > "$log" 2>&1; then
+    return 0
+  fi
+  echo "$ws" >> "$WORK_DIR/failures.txt"
+  return 1
+}
+export -f run_one
+export WORK_DIR SCRIPT_NAME IF_PRESENT
+
+echo "Running '$SCRIPT_NAME' across $(wc -l < "$WORK_DIR/workspaces.txt") workspace(s), ${CONCURRENCY} at a time"
+
+xargs -a "$WORK_DIR/workspaces.txt" -P "$CONCURRENCY" -I {} \
+  bash -c 'run_one "$@"' _ {}
+
+# Replay the captured output in the order the workspaces were listed, so the
+# log reads the same as it did when this ran serially.
+while IFS= read -r ws; do
+  echo "::group::$ws"
+  cat "$WORK_DIR/${ws//\//__}.log" 2>/dev/null
+  echo "::endgroup::"
+done < "$WORK_DIR/workspaces.txt"
+
+if [ -f "$WORK_DIR/failures.txt" ]; then
+  echo "::error::'$SCRIPT_NAME' failed in: $(tr '\n' ' ' < "$WORK_DIR/failures.txt")"
+  exit 1
+fi

--- a/.github/workflows/node-cd.yml
+++ b/.github/workflows/node-cd.yml
@@ -12,81 +12,56 @@ permissions:
   contents: read
   packages: write
 
+# Deployments queue rather than cancel: a superseded CD run may already have
+# pushed images or deployed, so letting it finish keeps the registry and the
+# deploy target consistent.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
       workspaces: ${{ steps.changes.outputs.workspaces }}
       has_changes: ${{ steps.changes.outputs.has_changes }}
+      image_matrix: ${{ steps.image_matrix.outputs.matrix }}
+      has_images: ${{ steps.image_matrix.outputs.has_images }}
     steps:
+      # fetch-depth: 0 so detect-changes can diff against the previous commit.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Detect Changed Workspaces
         id: changes
         uses: ./.github/actions/detect-changes
 
+      - name: Resolve node image matrix
+        id: image_matrix
+        uses: ./.github/actions/node-image-matrix
+        with:
+          workspaces: ${{ steps.changes.outputs.workspaces }}
+
+  # Seeds the node_modules cache on the default branch. GitHub only lets a PR
+  # restore caches from its own branch or its base, so without this every new
+  # PR would pay for a cold `npm ci` in all six of its Node jobs; with it, only
+  # a lockfile change does. Costs ~10s when the lockfile is unchanged.
+  warm-dependency-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-node
+
   docker-build:
     needs: [changes]
-    if: needs.changes.outputs.has_changes == 'true'
+    if: needs.changes.outputs.has_images == 'true'
+    # Matrix lives in .github/node-images.json, shared with node-ci, and is
+    # already filtered to the affected images.
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - image_name: scribear/scribear-db
-            build_context: infra/scribear-db
-            dockerfile: infra/scribear-db/Dockerfile
-            workspace: infra/scribear-db
-            version_file: infra/scribear-db/package.json
-          - image_name: scribear/scribear-nginx
-            build_context: infra/scribear-nginx
-            dockerfile: infra/scribear-nginx/Dockerfile
-            workspace: infra/scribear-nginx
-            version_file: infra/scribear-nginx/package.json
-          - image_name: scribear/scribear-redis
-            build_context: infra/scribear-redis
-            dockerfile: infra/scribear-redis/Dockerfile
-            workspace: infra/scribear-redis
-            version_file: infra/scribear-redis/package.json
-          - image_name: scribear/client-webapp
-            build_context: .
-            dockerfile: apps/client-webapp/Dockerfile
-            workspace: apps/client-webapp
-            version_file: apps/client-webapp/package.json
-          - image_name: scribear/kiosk-webapp
-            build_context: .
-            dockerfile: apps/kiosk-webapp/Dockerfile
-            workspace: apps/kiosk-webapp
-            version_file: apps/kiosk-webapp/package.json
-          - image_name: scribear/standalone-webapp
-            build_context: .
-            dockerfile: apps/standalone-webapp/Dockerfile
-            workspace: apps/standalone-webapp
-            version_file: apps/standalone-webapp/package.json
-          - image_name: scribear/session-manager
-            build_context: .
-            dockerfile: apps/session-manager/Dockerfile
-            workspace: apps/session-manager
-            version_file: apps/session-manager/package.json
-          - image_name: scribear/node-server
-            build_context: .
-            dockerfile: apps/node-server/Dockerfile
-            workspace: apps/node-server
-            version_file: apps/node-server/package.json
-          - image_name: scribear/monitoring-sidecar
-            build_context: .
-            dockerfile: apps/monitoring-sidecar/Dockerfile
-            workspace: apps/monitoring-sidecar
-            version_file: apps/monitoring-sidecar/package.json
-          - image_name: scribear/admin-server
-            build_context: .
-            dockerfile: apps/admin-server/Dockerfile
-            workspace: apps/admin-server
-            version_file: apps/admin-server/package.json
-          - image_name: scribear/admin-webapp
-            build_context: .
-            dockerfile: apps/admin-webapp/Dockerfile
-            workspace: apps/admin-webapp
-            version_file: apps/admin-webapp/package.json
+      matrix: ${{ fromJSON(needs.changes.outputs.image_matrix) }}
+    name: docker-build (${{ matrix.image_name }})
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -98,7 +73,6 @@ jobs:
           version_file: ${{ matrix.version_file }}
 
       - name: Build Container
-        if: contains(needs.changes.outputs.workspaces, matrix.workspace)
         uses: ./.github/actions/build-container
         with:
           image_name: ${{ matrix.image_name }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -13,18 +13,37 @@ permissions:
   packages: write
   pull-requests: write
 
+# Pushing again to an open PR should abandon the previous run, not race it. Six
+# overlapping runs of the same PR were routine, each holding ~15 runners and
+# each pulling its own base images - a large part of why builds started hitting
+# registry rate limits.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
       workspaces: ${{ steps.changes.outputs.workspaces }}
       has_changes: ${{ steps.changes.outputs.has_changes }}
+      image_matrix: ${{ steps.image_matrix.outputs.matrix }}
+      has_images: ${{ steps.image_matrix.outputs.has_images }}
     steps:
+      # fetch-depth: 0 so detect-changes can diff against the PR base commit.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Detect Changed Workspaces
         id: changes
         uses: ./.github/actions/detect-changes
+
+      - name: Resolve node image matrix
+        id: image_matrix
+        uses: ./.github/actions/node-image-matrix
+        with:
+          workspaces: ${{ steps.changes.outputs.workspaces }}
 
   format:
     needs: changes
@@ -38,13 +57,7 @@ jobs:
       - name: Check formatting
         env:
           WORKSPACES: ${{ needs.changes.outputs.workspaces }}
-        run: |
-          node -e "console.log(JSON.parse(process.env.WORKSPACES).join('\n'))" > /tmp/workspaces.txt
-          while IFS= read -r ws; do
-            echo "::group::$ws"
-            npm run format --workspace "$ws"
-            echo "::endgroup::"
-          done < /tmp/workspaces.txt
+        run: .github/scripts/run-workspaces.sh format
 
   lint:
     needs: changes
@@ -58,13 +71,7 @@ jobs:
       - name: Run linter
         env:
           WORKSPACES: ${{ needs.changes.outputs.workspaces }}
-        run: |
-          node -e "console.log(JSON.parse(process.env.WORKSPACES).join('\n'))" > /tmp/workspaces.txt
-          while IFS= read -r ws; do
-            echo "::group::$ws"
-            npm run lint --workspace "$ws"
-            echo "::endgroup::"
-          done < /tmp/workspaces.txt
+        run: .github/scripts/run-workspaces.sh lint
 
   build:
     needs: changes
@@ -75,16 +82,15 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      # Serial on purpose. `tsc --build` also builds a workspace's referenced
+      # projects, so two concurrent invocations can race writing the same
+      # dist/ and .tsbuildinfo for a shared lib.
       - name: Run build
         env:
           WORKSPACES: ${{ needs.changes.outputs.workspaces }}
-        run: |
-          node -e "console.log(JSON.parse(process.env.WORKSPACES).join('\n'))" > /tmp/workspaces.txt
-          while IFS= read -r ws; do
-            echo "::group::$ws"
-            npm run build --workspace "$ws" --if-present
-            echo "::endgroup::"
-          done < /tmp/workspaces.txt
+          IF_PRESENT: "true"
+          CONCURRENCY: "1"
+        run: .github/scripts/run-workspaces.sh build
 
   test:
     needs: changes
@@ -95,16 +101,15 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      # Serial on purpose. Vitest already runs its own worker pool per
+      # workspace; stacking workspaces on top would oversubscribe the runner
+      # and make timing-sensitive tests flaky.
       - name: Run unit tests
         env:
           WORKSPACES: ${{ needs.changes.outputs.workspaces }}
-        run: |
-          node -e "console.log(JSON.parse(process.env.WORKSPACES).join('\n'))" > /tmp/workspaces.txt
-          while IFS= read -r ws; do
-            echo "::group::$ws"
-            npm run test:unit --workspace "$ws" --if-present
-            echo "::endgroup::"
-          done < /tmp/workspaces.txt
+          IF_PRESENT: "true"
+          CONCURRENCY: "1"
+        run: .github/scripts/run-workspaces.sh test:unit
 
       - name: Code Coverage Report - Base Fastify Server Unit Tests
         if: contains(needs.changes.outputs.workspaces, 'libs/base-fastify-server')
@@ -150,56 +155,14 @@ jobs:
 
   docker-build:
     needs: [changes, format, lint, build, test]
-    if: needs.changes.outputs.has_changes == 'true'
+    if: needs.changes.outputs.has_images == 'true'
+    # Only the affected images get a runner. The matrix itself lives in
+    # .github/node-images.json so node-ci and node-cd cannot drift apart on
+    # which images exist.
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - image_name: scribear/scribear-db
-            build_context: infra/scribear-db
-            dockerfile: infra/scribear-db/Dockerfile
-            workspace: infra/scribear-db
-            version_file: infra/scribear-db/package.json
-          - image_name: scribear/scribear-nginx
-            build_context: infra/scribear-nginx
-            dockerfile: infra/scribear-nginx/Dockerfile
-            workspace: infra/scribear-nginx
-            version_file: infra/scribear-nginx/package.json
-          - image_name: scribear/client-webapp
-            build_context: .
-            dockerfile: apps/client-webapp/Dockerfile
-            workspace: apps/client-webapp
-            version_file: apps/client-webapp/package.json
-          - image_name: scribear/kiosk-webapp
-            build_context: .
-            dockerfile: apps/kiosk-webapp/Dockerfile
-            workspace: apps/kiosk-webapp
-            version_file: apps/kiosk-webapp/package.json
-          - image_name: scribear/standalone-webapp
-            build_context: .
-            dockerfile: apps/standalone-webapp/Dockerfile
-            workspace: apps/standalone-webapp
-            version_file: apps/standalone-webapp/package.json
-          - image_name: scribear/session-manager
-            build_context: .
-            dockerfile: apps/session-manager/Dockerfile
-            workspace: apps/session-manager
-            version_file: apps/session-manager/package.json
-          - image_name: scribear/node-server
-            build_context: .
-            dockerfile: apps/node-server/Dockerfile
-            workspace: apps/node-server
-            version_file: apps/node-server/package.json
-          - image_name: scribear/admin-server
-            build_context: .
-            dockerfile: apps/admin-server/Dockerfile
-            workspace: apps/admin-server
-            version_file: apps/admin-server/package.json
-          - image_name: scribear/admin-webapp
-            build_context: .
-            dockerfile: apps/admin-webapp/Dockerfile
-            workspace: apps/admin-webapp
-            version_file: apps/admin-webapp/package.json
+      matrix: ${{ fromJSON(needs.changes.outputs.image_matrix) }}
+    name: docker-build (${{ matrix.image_name }})
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -210,21 +173,24 @@ jobs:
         with:
           version_file: ${{ matrix.version_file }}
 
+      # cache_variant is deliberately unset: PR builds read the staging/main
+      # caches but write nothing. See build-container for why.
       - name: Build Container
-        if: contains(needs.changes.outputs.workspaces, matrix.workspace)
         uses: ./.github/actions/build-container
         with:
           image_name: ${{ matrix.image_name }}
           build_context: ${{ matrix.build_context }}
           dockerfile: ${{ matrix.dockerfile }}
-          cache_variant: pr
           custom_tags: ${{ steps.tags.outputs.tags }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+  # Deliberately NOT downstream of docker-build. This job builds its own `:test`
+  # images with prepare-test-container and never consumed docker-build's output,
+  # so the dependency only forced it to sit idle for ~3 minutes first.
   integration-test:
-    needs: [changes, format, lint, build, test, docker-build]
+    needs: [changes, format, lint, build, test]
     if: needs.changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -287,17 +253,23 @@ jobs:
           package_name: "Node Server - Integration Tests"
           filename: "./apps/node-server/coverage/cobertura-coverage.xml"
 
+  # Also not downstream of docker-build, for the same reason: it builds the DB
+  # image it needs itself.
   check-database-types:
-    needs: [changes, docker-build]
+    needs: [changes]
     if: contains(needs.changes.outputs.workspaces, 'infra/scribear-db')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-node
 
+      # Unconditional: this job only runs when infra/scribear-db is affected,
+      # and every step below needs the image. It used to be gated on
+      # apps/session-manager, which is a different condition entirely - it
+      # happened to hold only because session-manager references scribear-db,
+      # so the dependent expansion always pulled it in.
       - name: Prepare Scribear DB Container
         uses: ./.github/actions/prepare-test-container
-        if: contains(needs.changes.outputs.workspaces, 'apps/session-manager')
         with:
           image_name: scribear/scribear-db
           build_context: ./infra/scribear-db
@@ -353,7 +325,9 @@ jobs:
           (echo "Error: Generated database types are out of date. Run 'npm run generate:types' in infra/scribear-db and commit the changes." && exit 1)
 
   node-ci:
-    needs: [format, lint, build, test, docker-build, integration-test, check-database-types]
+    # `changes` is included so that a failure there fails the gate. Without it,
+    # every other job is skipped and "all skipped" reads as a pass.
+    needs: [changes, format, lint, build, test, docker-build, integration-test, check-database-types]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python-cd.yml
+++ b/.github/workflows/python-cd.yml
@@ -12,6 +12,11 @@ permissions:
   contents: read
   packages: write
 
+# See node-cd: deployments queue rather than cancel.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -32,9 +32,13 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
+          # `.github/**` is included for the same reason detect-changes treats it
+          # as global: a change to the workflows and actions that define this
+          # pipeline should be exercised by it.
           filters: |
             transcription_service:
               - 'transcription_service/**'
+              - '.github/**'
 
       - name: Resolve transcription image matrix
         id: image_matrix

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -13,6 +13,12 @@ permissions:
   packages: write
   pull-requests: write
 
+# See node-ci: superseded runs should be cancelled, not left to compete for
+# runners and registry pull allowance.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -100,6 +106,8 @@ jobs:
         with:
           version_file: ${{ matrix.version_file }}
 
+      # cache_variant is deliberately unset: PR builds read the staging/main
+      # caches but write nothing. See build-container for why.
       - name: Build Container
         uses: ./.github/actions/build-container
         with:
@@ -107,14 +115,15 @@ jobs:
           build_context: ${{ matrix.build_context }}
           dockerfile: ${{ matrix.dockerfile }}
           build_args: ${{ matrix.build_args }}
-          cache_variant: pr
           custom_tags: ${{ steps.tags.outputs.tags }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+  # Not downstream of docker-build: `make test_integration` is pure pytest and
+  # never touches a container image, so the dependency only delayed it.
   integration-test:
-    needs: [changes, format, lint, test, docker-build]
+    needs: [changes, format, lint, test]
     if: needs.changes.outputs.transcription_service == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -133,7 +142,9 @@ jobs:
           filename: "./transcription_service/coverage.xml"
 
   python-ci:
-    needs: [format, lint, test, docker-build, integration-test]
+    # `changes` is included so that a failure there fails the gate. Without it,
+    # every other job is skipped and "all skipped" reads as a pass.
+    needs: [changes, format, lint, test, docker-build, integration-test]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Why

Measured on run [30124939495](https://github.com/scribear/scribear/actions/runs/30124939495) (12m22s wall), the critical path was a fully serialised chain of just four jobs:

```
changes 14s → lint 219s → docker-build 176s → integration-test 315s
```

Everything else (format 75s, build 120s, test 131s, the other 8 docker-builds) already ran in that shadow, so only those four mattered.

Separately, today's `429 Too Many Requests` failures on `nvidia/cuda` were self-inflicted: the pipeline was spending its DockerHub pull allowance on redundant cache reads.

## Parallelism (~3 min)

- **`integration-test` and `check-database-types` no longer depend on `docker-build`.** Both build the `:test` images they need with `prepare-test-container` and never consumed `docker-build`'s output, so the dependency bought nothing but ~3 minutes of waiting. python-ci's `integration-test` is the same story — it's pure pytest and touches no image at all.
- **`format` and `lint` run four workspaces at a time** via the new `.github/scripts/run-workspaces.sh`. Serially, each of the 36 workspaces paid for its own ESLint process and its own type-aware TypeScript program while three of the runner's four cores idled. Locally this takes lint from **63.8s → 20.2s**, at ~1GB peak RSS per process (runners are 4 vCPU / 15.6GB).
- `build` and `test` stay serial on purpose: concurrent `tsc --build` can race on a shared lib's `dist/`/`.tsbuildinfo`, and vitest already runs its own worker pool per workspace.

> Folding everything into one root-level `eslint` invocation is the obvious alternative. It was tried and rejected — holding 36 TS programs in a single process exhausts the V8 heap and dies with an OOM.

## Caching

- **`setup-node` caches `node_modules`** keyed on the `package-lock.json` hash and skips `npm ci` outright on a hit. A cold install was costing 35–60s in each of six jobs.
- **`node-cd` seeds that cache on the default branch.** GitHub only lets a PR restore caches from its own branch or its base, so without this every *new* PR would still pay cold in all six Node jobs.
- **PR container builds no longer write build cache.** Every PR wrote the same `buildcache-pr` tag, so a PR usually imported some unrelated PR's cache while still paying ~55s per image to export its own (57.7s of node-server's 154s build). staging/main caches are still read.

## Registry pressure — the cause of the 429s

- **Dropped the DockerHub `cache-from` mirrors.** Six refs per build × two build steps × 9 images = **54 DockerHub manifest requests per node-ci run** before a single base image was pulled. GHCR is populated and hitting, which is exactly what the migration comment in `build-container` said to wait for.
- **Base images now resolve through `mirror.gcr.io`**, verified to serve `node`, `nginx` and `nvidia/cuda` unauthenticated. BuildKit falls back to docker.io on a miss, so it's a pure win. `nvidia/cuda` was 429ing even *after* a successful `docker.io` login, because the account's allowance was already spent.
- **Collapsed the build-then-push pair into one step.** The split existed to give each architecture its own cache tag; arm64 has been disabled for a while, so the second invocation just replayed the first — ~17s and six more manifest reads per image, for nothing.
- **Both CI workflows now cancel superseded runs.** Six overlapping runs of a single PR was routine, each holding ~15 runners. CD queues rather than cancels, so a run that has already pushed or deployed is allowed to finish.

## Fewer idle runners

The node image matrix moved to `.github/node-images.json` and is filtered to the affected images, instead of booting a runner for all 9 and skipping the one step that mattered.

This also closes a drift bug: **node-ci never built `scribear-redis` or `monitoring-sidecar`**, so those two images were only ever compiled for the first time on a push to staging.

## Correctness fixes noticed on the way

- `check-database-types` built its DB image only `if` `apps/session-manager` was affected, while the job itself is gated on `infra/scribear-db`. It survived only because session-manager references scribear-db, so the dependent expansion always pulled it in.
- The `node-ci` / `python-ci` gate jobs now include `changes` in `needs`. A failure there skipped every other job, and "all skipped" was read as a pass.
- Dropped `mode=max` from `cache-from` refs, where it is silently ignored (it's a `cache-to` option).
- `setup-node`, `setup-python` and `detect-changes` no longer re-checkout the repo their caller has already checked out — `detect-changes` was doing a full-history clone on top of a shallow one.

## Testing

Run locally against a clean `npm ci`:

| suite | via new script | result |
|---|---|---|
| `lint` | concurrency 4 | pass (63.8s → 20.2s) |
| `format` | concurrency 4 | pass |
| `test:unit` | serial | pass |
| `build` | serial | pass |

Also verified: the script propagates real ESLint failures (planted a naming-convention + `no-explicit-any` violation) and exits 1; `IF_PRESENT` correctly skips workspaces lacking a script; the `node-image-matrix` step body executes verbatim and filters correctly; all workflow/action YAML parses; every `setup-node`/`setup-python` call site still checks out first, and both `detect-changes` call sites now pass `fetch-depth: 0`.

## Deliberately out of scope

- **The Dockerfile `npm ci` duplication.** A `COPY . .`-then-delete-all-but-package.json means any workspace version bump invalidates `npm ci` in all 7 node images (38.8s + 22.3s each). Fixing it properly needs a shared deps base image, which would re-serialise `docker-build` behind a base-image job — adding wall clock to save only machine time, now that docker-build is off the critical path. BuildKit cache mounts are the other option and don't survive across runners.
- **Larger runners.** Would roughly halve npm ci / eslint / vite, but it costs money.

## Expected result

Critical path **~12m20s → ~7 min**, and roughly 100 fewer DockerHub requests per run.