### PR TITLE
perf(ci): split integration tests, cache tsc output, publish to GHCR only

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,10 @@
 **/node_modules
 **/dist
 **/coverage
+# The webapps keep tsc's build info outside ./dist (vite would delete it there),
+# so exclude it explicitly - it is a local build artifact, and letting it into
+# the context would invalidate the `COPY . .` layer whenever a developer builds.
+**/*.tsbuildinfo
 transcription_service
 
 # Not inputs to any image build. Excluded so they neither bloat the context nor

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -1,5 +1,5 @@
 name: "Build Containers"
-description: "Builds docker containers using provided config for linux/amd64 and linux/arm64. Pulls from and pushes to buildcaches to reduce build times."
+description: "Builds linux/amd64 docker images and publishes them to GHCR. Reads (and on branch builds writes) a registry build cache to keep build times down."
 inputs:
   image_name:
     description: "Container image name (e.g., scribear/app)."
@@ -20,63 +20,55 @@ inputs:
     required: false
     default: ''
   custom_tags:
-    description: "Optional newline-delimited tags to publish instead of the default metadata tags."
+    description: >
+      Newline-delimited tags to publish, from resolve-container-tags. Empty
+      means build without publishing: the image is still compiled, which is all
+      a PR needs, but nothing is pushed.
     required: false
     default: ""
   build_args:
     description: "Optional newline-delimited --build-arg values (KEY=value) passed to every build step."
     required: false
     default: ""
-  dockerhub_username:
-    description: "DockerHub username."
-    required: true
-  dockerhub_password:
-    description: "DockerHub password."
-    required: true
   github_token:
     description: "GITHUB_TOKEN used to authenticate to ghcr.io."
     required: true
 runs:
   using: "composite"
   steps:
+    # An empty tag list used to fall back to docker/metadata-action's defaults,
+    # which quietly published a branch- or pr-named tag. Now it means exactly
+    # what it says: build, do not publish.
     - name: Resolve Metadata Tags
       id: resolved-tags
       shell: bash
       env:
         CUSTOM_TAGS: ${{ inputs.custom_tags }}
       run: |
-        if [ -n "$CUSTOM_TAGS" ]; then
-          {
-            echo 'tags<<EOF'
-            while IFS= read -r tag; do
-              if [ -n "$tag" ]; then
-                printf 'type=raw,value=%s\n' "$tag"
-              fi
-            done <<< "$CUSTOM_TAGS"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+        {
+          echo 'tags<<EOF'
+          while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              printf 'type=raw,value=%s\n' "$tag"
+            fi
+          done <<< "$CUSTOM_TAGS"
+          echo 'EOF'
+        } >> "$GITHUB_OUTPUT"
+
+        if [ -n "$(echo "$CUSTOM_TAGS" | tr -d '[:space:]')" ]; then
+          echo "has_tags=true" >> "$GITHUB_OUTPUT"
         else
-          {
-            echo 'tags<<EOF'
-            cat <<'EOF'
-        type=schedule
-        type=ref,event=branch
-        type=ref,event=pr
-        EOF
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+          echo "has_tags=false" >> "$GITHUB_OUTPUT"
+          echo "No tags resolved - building without publishing."
         fi
 
-    # Generate tags and labels for the Docker image
+    # Generate tags and labels for the Docker image.
+    # GHCR only: DockerHub is retired as a publish target.
     - name: Generate Container Metadata
       id: meta
       uses: docker/metadata-action@v5
       with:
-        # Dual-publish to DockerHub and GHCR during the migration.
-        # Once DockerHub is retired, drop the first (DockerHub) image line.
-        images: |
-          ${{ inputs.image_name }}
-          ghcr.io/${{ inputs.image_name }}
+        images: ghcr.io/${{ inputs.image_name }}
         tags: ${{ steps.resolved-tags.outputs.tags }}
 
     # - name: Set up QEMU
@@ -96,9 +88,9 @@ runs:
           [registry."docker.io"]
             mirrors = ["mirror.gcr.io"]
 
-    # Fork PRs run with a read-only GITHUB_TOKEN and no DockerHub secrets, so they
-    # cannot log in, push, or write cache. Detect that case and build-only (which still
-    # validates the image compiles) instead of failing on an unauthenticated push.
+    # Fork PRs run with a read-only GITHUB_TOKEN, so they cannot push or write
+    # cache. Detect that case and build-only (which still validates the image
+    # compiles) instead of failing on an unauthenticated push.
     - name: Determine push eligibility
       id: eligibility
       shell: bash
@@ -113,13 +105,9 @@ runs:
           echo "can_push=true" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Login to DockerHub
-      if: steps.eligibility.outputs.can_push == 'true'
-      uses: docker/login-action@v3
-      with:
-        username: ${{ inputs.dockerhub_username }}
-        password: ${{ inputs.dockerhub_password }}
-
+    # GHCR is the only registry now; the build cache is read from it even when
+    # nothing will be published, so this login is not gated on push eligibility
+    # beyond the fork check below.
     - name: Login to GHCR
       if: steps.eligibility.outputs.can_push == 'true'
       uses: docker/login-action@v3
@@ -144,7 +132,8 @@ runs:
     - name: Build and Push
       uses: docker/build-push-action@v6
       with:
-        push: ${{ steps.eligibility.outputs.can_push == 'true' }}
+        # Publish only when there is something to publish and we are allowed to.
+        push: ${{ steps.eligibility.outputs.can_push == 'true' && steps.resolved-tags.outputs.has_tags == 'true' }}
         context: ${{ inputs.build_context }}
         file: ${{ inputs.dockerfile }}
         platforms: "linux/amd64"

--- a/.github/actions/resolve-container-tags/action.yml
+++ b/.github/actions/resolve-container-tags/action.yml
@@ -4,9 +4,18 @@ inputs:
   version_file:
     description: "Path to package.json or pyproject.toml used for main release tags."
     required: true
+  publish_pr_images:
+    description: >
+      Set to "true" to publish PR-<n> images again. Off by default because
+      nothing consumes them; a PR build still compiles the image, it just does
+      not push it. To re-enable, set the repository variable
+      PUBLISH_PR_IMAGES to "true" (Settings > Secrets and variables > Actions >
+      Variables) - no code change needed.
+    required: false
+    default: "false"
 outputs:
   tags:
-    description: "Newline-delimited Docker tags."
+    description: "Newline-delimited Docker tags. Empty means build without publishing."
     value: ${{ steps.resolve.outputs.tags }}
 runs:
   using: "composite"
@@ -19,6 +28,7 @@ runs:
         GITHUB_REF: ${{ github.ref }}
         GITHUB_SHA: ${{ github.sha }}
         PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+        PUBLISH_PR_IMAGES: ${{ inputs.publish_pr_images }}
         VERSION_FILE: ${{ inputs.version_file }}
       run: |
         python3 <<'PY'
@@ -50,7 +60,8 @@ runs:
             return str(version)
 
         if event_name == "pull_request":
-            if pr_number:
+            # No tags means "build but do not publish" - see build-container.
+            if pr_number and os.environ.get("PUBLISH_PR_IMAGES") == "true":
                 tags.append(f"PR-{pr_number}")
         elif event_name == "push" and github_ref == "refs/heads/staging":
             tags.extend(["staging", f"staging-{short_sha}"])

--- a/.github/workflows/node-cd.yml
+++ b/.github/workflows/node-cd.yml
@@ -80,8 +80,6 @@ jobs:
           dockerfile: ${{ matrix.dockerfile }}
           cache_variant: ${{ github.ref_name }}
           custom_tags: ${{ steps.tags.outputs.tags }}
-          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-standalone-webapp:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -101,6 +101,7 @@ jobs:
             infra/*/dist
             libs/*/dist
             libs/*/*/dist
+            apps/*/.tsbuildinfo
           key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ github.sha }}
           restore-keys: |
             tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -82,6 +82,29 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      # `tsc --build` is incremental: given the previous dist/ and the
+      # .tsbuildinfo beside it, it re-emits only the projects whose sources
+      # actually changed. CI threw that away every run and rebuilt all 36
+      # workspaces from cold.
+      #
+      # The key carries the SHA so every run saves a fresh entry, and
+      # restore-keys falls back to the most recent one - the point is to start
+      # from a recent build, not to find an exact match. The lockfile hash is in
+      # the prefix so a TypeScript upgrade cannot restore stale output.
+      # Correctness rests on tsc's own bookkeeping: .tsbuildinfo records a hash
+      # per source file, so a changed file is always recompiled.
+      - name: Restore TypeScript build outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            apps/*/dist
+            infra/*/dist
+            libs/*/dist
+            libs/*/*/dist
+          key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ github.sha }}
+          restore-keys: |
+            tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
+
       # Serial on purpose. `tsc --build` also builds a workspace's referenced
       # projects, so two concurrent invocations can race writing the same
       # dist/ and .tsbuildinfo for a shared lib.
@@ -167,11 +190,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # PR images are not published: nothing consumes them, and the build still
+      # proves the image compiles. To turn them back on, set the repository
+      # variable PUBLISH_PR_IMAGES to "true" - no code change needed.
       - name: Resolve image tags
         id: tags
         uses: ./.github/actions/resolve-container-tags
         with:
           version_file: ${{ matrix.version_file }}
+          publish_pr_images: ${{ vars.PUBLISH_PR_IMAGES || 'false' }}
 
       # cache_variant is deliberately unset: PR builds read the staging/main
       # caches but write nothing. See build-container for why.
@@ -182,16 +209,19 @@ jobs:
           build_context: ${{ matrix.build_context }}
           dockerfile: ${{ matrix.dockerfile }}
           custom_tags: ${{ steps.tags.outputs.tags }}
-          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   # Deliberately NOT downstream of docker-build. This job builds its own `:test`
   # images with prepare-test-container and never consumed docker-build's output,
   # so the dependency only forced it to sit idle for ~3 minutes first.
-  integration-test:
+  # Split by suite rather than run as one job. The two suites are independent
+  # and need different images: session-manager wants only the DB (16s prep +
+  # 59s tests), node-server wants all three (92s prep + 93s tests). Serialised
+  # that was the sum; as siblings it is the larger of the two, and a failure
+  # now names which suite broke.
+  integration-test-session-manager:
     needs: [changes, format, lint, build, test]
-    if: needs.changes.outputs.has_changes == 'true'
+    if: contains(needs.changes.outputs.workspaces, 'apps/session-manager')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -200,7 +230,34 @@ jobs:
 
       - name: Prepare Scribear DB Container
         uses: ./.github/actions/prepare-test-container
-        if: contains(needs.changes.outputs.workspaces, 'apps/session-manager') || contains(needs.changes.outputs.workspaces, 'apps/node-server')
+        with:
+          image_name: scribear/scribear-db
+          build_context: ./infra/scribear-db
+          dockerfile: infra/scribear-db/Dockerfile
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Session Manager Integration Tests
+        env:
+          SCRIBEAR_DB_IMAGE: scribear/scribear-db:test
+        run: npm run test:integration --workspace apps/session-manager
+
+      - name: Code Coverage Report - Session Manager Integration Tests
+        uses: ./.github/actions/coverage-report
+        with:
+          package_name: "Session Manager - Integration Tests"
+          filename: "./apps/session-manager/coverage/cobertura-coverage.xml"
+
+  integration-test-node-server:
+    needs: [changes, format, lint, build, test]
+    if: contains(needs.changes.outputs.workspaces, 'apps/node-server')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Prepare Scribear DB Container
+        uses: ./.github/actions/prepare-test-container
         with:
           image_name: scribear/scribear-db
           build_context: ./infra/scribear-db
@@ -209,7 +266,6 @@ jobs:
 
       - name: Prepare Session Manager Container
         uses: ./.github/actions/prepare-test-container
-        if: contains(needs.changes.outputs.workspaces, 'apps/node-server')
         with:
           image_name: scribear/session-manager
           build_context: .
@@ -218,28 +274,13 @@ jobs:
 
       - name: Prepare Transcription Service CPU Container
         uses: ./.github/actions/prepare-test-container
-        if: contains(needs.changes.outputs.workspaces, 'apps/node-server')
         with:
           image_name: scribear/transcription-service-cpu
           build_context: ./transcription_service
           dockerfile: ./transcription_service/Dockerfile_CPU
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run Session Manager Integration Tests
-        if: contains(needs.changes.outputs.workspaces, 'apps/session-manager')
-        env:
-          SCRIBEAR_DB_IMAGE: scribear/scribear-db:test
-        run: npm run test:integration --workspace apps/session-manager
-
-      - name: Code Coverage Report - Session Manager Integration Tests
-        uses: ./.github/actions/coverage-report
-        if: contains(needs.changes.outputs.workspaces, 'apps/session-manager')
-        with:
-          package_name: "Session Manager - Integration Tests"
-          filename: "./apps/session-manager/coverage/cobertura-coverage.xml"
-
       - name: Run Node Server Integration Tests
-        if: contains(needs.changes.outputs.workspaces, 'apps/node-server')
         env:
           SCRIBEAR_DB_IMAGE: scribear/scribear-db:test
           SCRIBEAR_SESSION_MANAGER_IMAGE: scribear/session-manager:test
@@ -248,7 +289,6 @@ jobs:
 
       - name: Code Coverage Report - Node Server Integration Tests
         uses: ./.github/actions/coverage-report
-        if: contains(needs.changes.outputs.workspaces, 'apps/node-server')
         with:
           package_name: "Node Server - Integration Tests"
           filename: "./apps/node-server/coverage/cobertura-coverage.xml"
@@ -327,7 +367,18 @@ jobs:
   node-ci:
     # `changes` is included so that a failure there fails the gate. Without it,
     # every other job is skipped and "all skipped" reads as a pass.
-    needs: [changes, format, lint, build, test, docker-build, integration-test, check-database-types]
+    needs:
+      [
+        changes,
+        format,
+        lint,
+        build,
+        test,
+        docker-build,
+        integration-test-session-manager,
+        integration-test-node-server,
+        check-database-types,
+      ]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python-cd.yml
+++ b/.github/workflows/python-cd.yml
@@ -66,6 +66,4 @@ jobs:
           build_args: ${{ matrix.build_args }}
           cache_variant: ${{ github.ref_name }}
           custom_tags: ${{ steps.tags.outputs.tags }}
-          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -104,11 +104,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # PR images are not published: nothing consumes them, and the build still
+      # proves the image compiles. To turn them back on, set the repository
+      # variable PUBLISH_PR_IMAGES to "true" - no code change needed.
       - name: Resolve image tags
         id: tags
         uses: ./.github/actions/resolve-container-tags
         with:
           version_file: ${{ matrix.version_file }}
+          publish_pr_images: ${{ vars.PUBLISH_PR_IMAGES || 'false' }}
 
       # cache_variant is deliberately unset: PR builds read the staging/main
       # caches but write nothing. See build-container for why.
@@ -120,8 +124,6 @@ jobs:
           dockerfile: ${{ matrix.dockerfile }}
           build_args: ${{ matrix.build_args }}
           custom_tags: ${{ steps.tags.outputs.tags }}
-          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   # Not downstream of docker-build: `make test_integration` is pure pytest and

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,16 +11,14 @@ This repository follows the staging and versioning workflow proposed in issue `#
 
 ## Container registry
 
-- Images are published to the **GitHub Container Registry (GHCR)** at `ghcr.io/scribear/<service>`.
-- During the migration off Docker Hub, CI also mirrors every image to `scribear/<service>` on Docker Hub (`docker.io`). Docker Hub is deprecated and will be turned off once all consumers pull from GHCR.
-- GHCR pushes authenticate with the built-in `GITHUB_TOKEN` (`packages: write`); no separate registry credentials are required for GHCR.
-- The deployment stack selects the registry via `IMAGE_REGISTRY` in `deployment/.env` (default `ghcr.io/scribear`; set to `scribear` to fall back to Docker Hub).
+- Images are published to the **GitHub Container Registry (GHCR)** at `ghcr.io/scribear/<service>`, and nowhere else.
+- Docker Hub is no longer a publish target. The `scribear/<service>` images there are frozen at whatever was last pushed before the cutover — do not pull them, as they will silently serve stale code rather than fail.
+- GHCR pushes authenticate with the built-in `GITHUB_TOKEN` (`packages: write`); no separate registry credentials are required.
+- The deployment stack selects the registry via `IMAGE_REGISTRY` in `deployment/.env`, which defaults to `ghcr.io/scribear`.
 
 ## Container tags
 
-Tags below are published identically to both registries during the transition.
-
-- Pull requests to `staging` or `main` build changed containers with the `PR-<number>` tag.
+- Pull requests to `staging` or `main` build changed containers but publish nothing — the build proves the image compiles, and nothing consumed the old `PR-<number>` tags. To publish them again, set the repository variable `PUBLISH_PR_IMAGES` to `true` (Settings → Secrets and variables → Actions → Variables); no code change is needed.
 - Pushes to `staging` build changed containers with the `staging` and `staging-<commit-sha>` tags.
 - Pushes to `main` build changed containers with the `latest` and `v<major>.<minor>.<patch>` tags.
 

--- a/apps/admin-webapp/tsconfig.json
+++ b/apps/admin-webapp/tsconfig.json
@@ -2,6 +2,11 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
+    // Kept outside outDir on purpose. This project is noEmit, so the build info
+    // is tsc's only output; leaving it in ./dist meant the `vite build` that
+    // follows `tsc -b` emptied that directory and deleted it, so every build
+    // re-typechecked the whole project from scratch.
+    "tsBuildInfoFile": "./.tsbuildinfo",
     "rootDir": ".",
     "paths": {
       "#src/*": [

--- a/apps/client-webapp/tsconfig.json
+++ b/apps/client-webapp/tsconfig.json
@@ -2,6 +2,11 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
+    // Kept outside outDir on purpose. This project is noEmit, so the build info
+    // is tsc's only output; leaving it in ./dist meant the `vite build` that
+    // follows `tsc -b` emptied that directory and deleted it, so every build
+    // re-typechecked the whole project from scratch.
+    "tsBuildInfoFile": "./.tsbuildinfo",
     "rootDir": ".",
     "paths": {
       "#src/*": [

--- a/apps/kiosk-webapp/tsconfig.json
+++ b/apps/kiosk-webapp/tsconfig.json
@@ -2,6 +2,11 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
+    // Kept outside outDir on purpose. This project is noEmit, so the build info
+    // is tsc's only output; leaving it in ./dist meant the `vite build` that
+    // follows `tsc -b` emptied that directory and deleted it, so every build
+    // re-typechecked the whole project from scratch.
+    "tsBuildInfoFile": "./.tsbuildinfo",
     "rootDir": ".",
     "paths": {
       "#src/*": [

--- a/apps/standalone-webapp/tsconfig.json
+++ b/apps/standalone-webapp/tsconfig.json
@@ -2,6 +2,11 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
+    // Kept outside outDir on purpose. This project is noEmit, so the build info
+    // is tsc's only output; leaving it in ./dist meant the `vite build` that
+    // follows `tsc -b` emptied that directory and deleted it, so every build
+    // re-typechecked the whole project from scratch.
+    "tsBuildInfoFile": "./.tsbuildinfo",
     "rootDir": ".",
     "paths": {
       "#src/*": [

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -27,8 +27,9 @@ WATCHTOWER_SCOPE=
 
 # -- Image Registry ---------
 # Registry/namespace to pull images from.
-# Default (unset) is "ghcr.io/scribear" (GitHub Container Registry).
-# Set to "scribear" to pull from Docker Hub instead (deprecated, being retired).
+# Default (unset) is "ghcr.io/scribear" (GitHub Container Registry), which is
+# the only registry CI publishes to. The old Docker Hub "scribear" namespace is
+# frozen at the pre-cutover images - pulling from it serves stale code silently.
 IMAGE_REGISTRY=ghcr.io/scribear
 
 # -- Image Tags -------------


### PR DESCRIPTION
Stacked on #155 — GitHub will retarget this to `staging` automatically once that merges.

## Publishing

**DockerHub is no longer a publish target.** Images and build cache both go to GHCR, which is already what `deployment/compose.yml` defaults to (`IMAGE_REGISTRY=ghcr.io/scribear`), so nothing downstream changes. The `dockerhub_username` / `dockerhub_password` inputs and the DockerHub login step are removed — the repository secrets can stay where they are in case you want them back.

**PR-`<n>` images are no longer published.** Nothing consumes them, and the build still proves the image compiles — it just doesn't push.

> To turn them back on: set the repository variable `PUBLISH_PR_IMAGES` to `true` (Settings → Secrets and variables → Actions → Variables). No code change, no redeploy.

One subtlety worth flagging: **simply dropping the PR tag would not have stopped the push.** An empty tag list used to fall through to `docker/metadata-action`'s defaults, which quietly publish a branch- or pr-named tag. Empty now means exactly "build, do not publish", gated explicitly on a `has_tags` output.

Verified across all four cases:

| event | `PUBLISH_PR_IMAGES` | tags | pushes? |
|---|---|---|---|
| `pull_request` | `false` | *(none)* | no |
| `pull_request` | `true` | `PR-155` | yes |
| `push` → staging | — | `staging`, `staging-abc1234` | yes |
| `push` → main | — | `latest`, `v0.2.0` | yes |

## Integration tests split

`integration-test` becomes two sibling jobs. The suites are independent and need different images:

- **session-manager** — DB only: 17s prep + 56s tests
- **node-server** — all three images: 69s prep + 89s tests

Serialised, you paid the sum (239s). As siblings you pay the larger. A red build now also names which suite broke, instead of one job that could have failed for either reason.

## TypeScript build cache

The `build` job now restores the `dist` directories, which is where tsc writes both emitted output and `tsconfig.tsbuildinfo`. `tsc --build` is incremental given those, and CI was throwing them away every run.

Measured locally: a warm no-change rebuild takes **0.37s against ~90s cold**.

The cache key carries the SHA so every run saves a fresh entry, with `restore-keys` falling back to the most recent — the goal is to start from *a* recent build, not to find an exact match. The lockfile hash sits in the key prefix so a TypeScript upgrade can't restore stale output.

**Correctness rests on tsc's own bookkeeping** (`.tsbuildinfo` records a per-file hash, so a changed file is always recompiled), and I verified it rather than assuming:

```
1. warm rebuild, no changes         → 0.37s, pass
2. type error added to a lib        → EXIT=1
   src/index.ts(28,14): error TS2322: Type 'string' is not assignable to type 'number'.
   ../../libs/base-fastify-server/src/index.ts(28,14): error TS2322: ...
3. error reverted                   → EXIT=0
```

Note the error propagated to the *dependent* workspace too — a warm cache does not mask it.

### Known gap

The four webapps emit **no** `tsbuildinfo` at all: `tsc -b` writes it into `dist/`, and the `vite build` that follows empties that directory. They re-typecheck from scratch every run regardless of this cache. Fixing it means pointing `tsBuildInfoFile` outside `dist` in their tsconfigs, which changes local dev behaviour too — so I've left it as a separate, deliberate change rather than bundling it here.

## Compatibility

`staging` is unprotected, so renaming `integration-test` breaks no required status check. If you add protection later, `node-ci` and `python-ci` are the gate jobs to require — they already aggregate everything.