### PR TITLE
feat(deployment): report what each container was built from

### DIFF
--- a/.changeset/deployment-build-versions.md
+++ b/.changeset/deployment-build-versions.md
@@ -1,0 +1,59 @@
+---
+'@scribear/base-fastify-server': minor
+'@scribear/admin-server': minor
+'@scribear/admin-webapp': minor
+'@scribear/session-manager': patch
+'@scribear/node-server': patch
+'@scribear/monitoring-sidecar': patch
+'@scribear/client-webapp': patch
+'@scribear/standalone-webapp': patch
+'@scribear/kiosk-webapp': patch
+'@scribear/scribear-nginx': patch
+---
+
+Deployment Check now shows what each container was built from, so an operator
+can confirm what is actually deployed and running.
+
+- **Every image is stamped at build time.** `BUILD_COMMIT`, `BUILD_REF`,
+  `BUILD_TIME`, `BUILD_VERSION`, `BUILD_TAGS`, `BUILD_PR` and `BUILD_ORIGIN`
+  become `SCRIBEAR_BUILD_*` environment variables and OCI image labels
+  (`org.opencontainers.image.revision`/`.version`/`.created`, plus
+  `org.scribear.build.pull-request`/`.origin`), so `docker inspect` answers the
+  same question as the console. The block sits last in every Dockerfile, so
+  changing commit invalidates no expensive layer.
+- **Every container reports it.** The four Node services answer
+  `GET /build-info` from a route `createBaseServer` registers for them;
+  transcription-service answers the same path from FastAPI; the four webapps and
+  the reverse proxy serve an identical `build-info.json` generated at image
+  build time by `tools/build-info/write-build-info.sh`. All of these are
+  reachable only inside the compose network — nginx proxies none of them, and
+  the proxy's own document is served on its plain-HTTP listener only, so no
+  commit hash is published to the internet.
+- **Admin console — Deployment Check → Deployed versions.**
+  `GET /api/admin/v1/deployment-versions` probes every container concurrently
+  and renders a table of version, commit, branch, build time and image tags.
+  Version skew is the headline: the commit the most containers report is taken
+  as the deployment's, and any container that disagrees is named in a warning.
+  This is the only place in the console that can see a half-finished upgrade —
+  a stale container is a perfectly healthy container, so the health rollup stays
+  green throughout.
+- **Old and local builds are distinguished, not blanked.** A container running
+  an image from before this release answers 404 and is reported as
+  `old image` rather than as unreachable — it is stale, not down.
+  `build-containers.sh` stamps the real commit for local builds, marks them
+  `origin: local`, and appends `-dirty` when the working tree has uncommitted
+  changes; a stack started straight from a checkout (`npm run dev`) reports
+  "nothing here was built by CI" instead of a table of blanks.
+- **`scribear-db` and `redis`** appear in the table as `n/a` with the reason:
+  neither has an HTTP surface to report a build on.
+
+- **PR images are published again.** A pull request into `main` or `staging`
+  pushes `ghcr.io/scribear/<image>:PR-<n>`, so a reviewer can pull the exact
+  build under review rather than rebuilding it — and the image says which
+  commit it is. The tag moves with the PR head. Set the repository variable
+  `PUBLISH_PR_IMAGES` to `false` to switch it off, or `true` to publish for
+  every base branch. Fork PRs still build without publishing, since their
+  `GITHUB_TOKEN` cannot push.
+
+Nothing new is required in `deployment/.env`. The six new admin-server base-URL
+variables all default to their compose service names.

--- a/.github/actions/resolve-container-tags/action.yml
+++ b/.github/actions/resolve-container-tags/action.yml
@@ -1,22 +1,33 @@
 name: "Resolve Container Tags"
-description: "Resolves event-specific Docker tags for PR, staging, and main builds."
+description: "Resolves event-specific Docker tags for PR, staging, and main builds, and the build provenance args every image is stamped with."
 inputs:
   version_file:
     description: "Path to package.json or pyproject.toml used for main release tags."
     required: true
   publish_pr_images:
     description: >
-      Set to "true" to publish PR-<n> images again. Off by default because
-      nothing consumes them; a PR build still compiles the image, it just does
-      not push it. To re-enable, set the repository variable
-      PUBLISH_PR_IMAGES to "true" (Settings > Secrets and variables > Actions >
-      Variables) - no code change needed.
+      Override for whether a pull_request build publishes a PR-<n> image.
+      Leave empty (the default) to use the base-branch rule: PRs into main or
+      staging publish, anything else does not. "false" switches PR images off
+      entirely; "true" publishes them whatever the base branch is. Wired to the
+      repository variable PUBLISH_PR_IMAGES (Settings > Secrets and variables >
+      Actions > Variables), so either override is a one-field change with no
+      code edit - which is what you want when the registry needs draining in a
+      hurry.
     required: false
-    default: "false"
+    default: ""
 outputs:
   tags:
     description: "Newline-delimited Docker tags. Empty means build without publishing."
     value: ${{ steps.resolve.outputs.tags }}
+  build_args:
+    description: >
+      Newline-delimited BUILD_* --build-arg values stamped into every image and
+      reported by its /build-info surface, which the admin console's Deployment
+      Check aggregates. Emitted here rather than by an action of its own because
+      the tag list and the version file are inputs to it, and re-deriving either
+      somewhere else is how the two would drift.
+    value: ${{ steps.resolve.outputs.build_args }}
 runs:
   using: "composite"
   steps:
@@ -30,16 +41,25 @@ runs:
         PR_NUMBER: ${{ github.event.pull_request.number || '' }}
         PUBLISH_PR_IMAGES: ${{ inputs.publish_pr_images }}
         VERSION_FILE: ${{ inputs.version_file }}
+        # The branch a PR would merge into. Empty on every other event.
+        PR_BASE_REF: ${{ github.base_ref }}
+        # On a pull_request event GITHUB_REF_NAME is "<n>/merge", which names
+        # the synthetic merge ref rather than anything a human would recognize.
+        # github.head_ref is the source branch and is set only for that event,
+        # so this picks the branch on PRs and the pushed branch everywhere else.
+        BUILD_REF: ${{ github.head_ref || github.ref_name }}
       run: |
         python3 <<'PY'
         import json
         import os
+        from datetime import datetime, timezone
         from pathlib import Path
         import tomllib
 
         event_name = os.environ["EVENT_NAME"]
         github_ref = os.environ["GITHUB_REF"]
-        short_sha = os.environ["GITHUB_SHA"][:7]
+        commit = os.environ["GITHUB_SHA"]
+        short_sha = commit[:7]
         pr_number = os.environ.get("PR_NUMBER", "")
         version_file = Path(os.environ["VERSION_FILE"])
         tags: list[str] = []
@@ -59,9 +79,24 @@ runs:
 
             return str(version)
 
+        # Base branches whose PRs get a published image. Both, not just main:
+        # main only ever receives release merges from staging, so a main-only
+        # rule would publish an image for almost no PR - and a PR image is
+        # wanted precisely while a change is still being reviewed.
+        PR_IMAGE_BASE_BRANCHES = {"main", "staging"}
+
+        def publishes_pr_image() -> bool:
+            """Whether this PR build should push a PR-<n> image."""
+            override = os.environ.get("PUBLISH_PR_IMAGES", "").strip().lower()
+            if override in ("true", "false"):
+                return override == "true"
+            return os.environ.get("PR_BASE_REF", "") in PR_IMAGE_BASE_BRANCHES
+
         if event_name == "pull_request":
             # No tags means "build but do not publish" - see build-container.
-            if pr_number and os.environ.get("PUBLISH_PR_IMAGES") == "true":
+            # A fork PR resolves a tag here and still does not push: its
+            # GITHUB_TOKEN is read-only, which build-container detects.
+            if pr_number and publishes_pr_image():
                 tags.append(f"PR-{pr_number}")
         elif event_name == "push" and github_ref == "refs/heads/staging":
             tags.extend(["staging", f"staging-{short_sha}"])
@@ -69,8 +104,31 @@ runs:
             version = read_version(version_file)
             tags.extend(["latest", f"v{version}"])
 
+        # Read on every event, unlike the release tag above: the version is
+        # stamped into the image whether or not this build publishes anything,
+        # so a PR image an operator is handed can still name itself.
+        build_version = read_version(version_file)
+
+        # A --build-arg cannot be an array, so the tag list crosses as one
+        # comma-joined string and each reader splits it back out. Empty on a PR
+        # build, which publishes nothing.
+        build_args = {
+            "BUILD_COMMIT": commit,
+            "BUILD_REF": os.environ.get("BUILD_REF", ""),
+            "BUILD_TIME": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "BUILD_VERSION": build_version,
+            "BUILD_TAGS": ",".join(tags),
+            "BUILD_PR": pr_number,
+            "BUILD_ORIGIN": "ci",
+        }
+
         with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_file:
             output_file.write("tags<<EOF\n")
             output_file.write("\n".join(tags))
+            output_file.write("\nEOF\n")
+            output_file.write("build_args<<EOF\n")
+            output_file.write(
+                "\n".join(f"{name}={value}" for name, value in build_args.items())
+            )
             output_file.write("\nEOF\n")
         PY

--- a/.github/node-images.json
+++ b/.github/node-images.json
@@ -8,7 +8,7 @@
   },
   {
     "image_name": "scribear/scribear-nginx",
-    "build_context": "infra/scribear-nginx",
+    "build_context": ".",
     "dockerfile": "infra/scribear-nginx/Dockerfile",
     "workspace": "infra/scribear-nginx",
     "version_file": "infra/scribear-nginx/package.json"

--- a/.github/workflows/node-cd.yml
+++ b/.github/workflows/node-cd.yml
@@ -78,6 +78,7 @@ jobs:
           image_name: ${{ matrix.image_name }}
           build_context: ${{ matrix.build_context }}
           dockerfile: ${{ matrix.dockerfile }}
+          build_args: ${{ steps.tags.outputs.build_args }}
           cache_variant: ${{ github.ref_name }}
           custom_tags: ${{ steps.tags.outputs.tags }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -191,15 +191,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # PR images are not published: nothing consumes them, and the build still
-      # proves the image compiles. To turn them back on, set the repository
-      # variable PUBLISH_PR_IMAGES to "true" - no code change needed.
+      # PRs into main or staging publish a PR-<n> image, so a reviewer can pull
+      # the exact build under review instead of rebuilding it. The tag moves
+      # with the PR head - `PR-157` is always that PR's latest push, and the
+      # image says which commit it is via GET /build-info.
+      #
+      # Set the repository variable PUBLISH_PR_IMAGES to "false" to switch this
+      # off (or "true" to publish for every base branch); either is a one-field
+      # change with no code edit. Fork PRs never push whatever it says - their
+      # GITHUB_TOKEN is read-only, and build-container detects that and builds
+      # without publishing.
       - name: Resolve image tags
         id: tags
         uses: ./.github/actions/resolve-container-tags
         with:
           version_file: ${{ matrix.version_file }}
-          publish_pr_images: ${{ vars.PUBLISH_PR_IMAGES || 'false' }}
+          publish_pr_images: ${{ vars.PUBLISH_PR_IMAGES }}
 
       # cache_variant is deliberately unset: PR builds read the staging/main
       # caches but write nothing. See build-container for why.
@@ -209,6 +216,7 @@ jobs:
           image_name: ${{ matrix.image_name }}
           build_context: ${{ matrix.build_context }}
           dockerfile: ${{ matrix.dockerfile }}
+          build_args: ${{ steps.tags.outputs.build_args }}
           custom_tags: ${{ steps.tags.outputs.tags }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/python-cd.yml
+++ b/.github/workflows/python-cd.yml
@@ -63,7 +63,9 @@ jobs:
           image_name: ${{ matrix.image_name }}
           build_context: ${{ matrix.build_context }}
           dockerfile: ${{ matrix.dockerfile }}
-          build_args: ${{ matrix.build_args }}
+          build_args: |
+            ${{ matrix.build_args }}
+            ${{ steps.tags.outputs.build_args }}
           cache_variant: ${{ github.ref_name }}
           custom_tags: ${{ steps.tags.outputs.tags }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -104,15 +104,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # PR images are not published: nothing consumes them, and the build still
-      # proves the image compiles. To turn them back on, set the repository
-      # variable PUBLISH_PR_IMAGES to "true" - no code change needed.
+      # PRs into main or staging publish a PR-<n> image, so a reviewer can pull
+      # the exact build under review instead of rebuilding it. The tag moves
+      # with the PR head - `PR-157` is always that PR's latest push, and the
+      # image says which commit it is via GET /build-info.
+      #
+      # Set the repository variable PUBLISH_PR_IMAGES to "false" to switch this
+      # off (or "true" to publish for every base branch); either is a one-field
+      # change with no code edit. Fork PRs never push whatever it says - their
+      # GITHUB_TOKEN is read-only, and build-container detects that and builds
+      # without publishing.
       - name: Resolve image tags
         id: tags
         uses: ./.github/actions/resolve-container-tags
         with:
           version_file: ${{ matrix.version_file }}
-          publish_pr_images: ${{ vars.PUBLISH_PR_IMAGES || 'false' }}
+          publish_pr_images: ${{ vars.PUBLISH_PR_IMAGES }}
 
       # cache_variant is deliberately unset: PR builds read the staging/main
       # caches but write nothing. See build-container for why.
@@ -122,7 +129,9 @@ jobs:
           image_name: ${{ matrix.image_name }}
           build_context: ${{ matrix.build_context }}
           dockerfile: ${{ matrix.dockerfile }}
-          build_args: ${{ matrix.build_args }}
+          build_args: |
+            ${{ matrix.build_args }}
+            ${{ steps.tags.outputs.build_args }}
           custom_tags: ${{ steps.tags.outputs.tags }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/apps/admin-server/Dockerfile
+++ b/apps/admin-server/Dockerfile
@@ -41,6 +41,36 @@ WORKDIR /app/apps/admin-server
 ENV HOST=0.0.0.0
 ENV PORT=80
 
+# Build provenance. Baked in here and reported at runtime by GET /build-info,
+# which the admin console's Deployment Check aggregates across the whole stack —
+# it is how an operator confirms every container came from one commit. Empty
+# defaults so a plain `docker build` still works and simply reports "unknown";
+# CI and build-containers.sh supply the real values. Last in the file because
+# these change on every commit and nothing expensive may sit below them.
+ARG BUILD_COMMIT=""
+ARG BUILD_REF=""
+ARG BUILD_TIME=""
+ARG BUILD_VERSION=""
+ARG BUILD_TAGS=""
+ARG BUILD_PR=""
+ARG BUILD_ORIGIN=""
+
+ENV SCRIBEAR_BUILD_SERVICE=admin-server \
+    SCRIBEAR_BUILD_COMMIT=${BUILD_COMMIT} \
+    SCRIBEAR_BUILD_REF=${BUILD_REF} \
+    SCRIBEAR_BUILD_TIME=${BUILD_TIME} \
+    SCRIBEAR_BUILD_VERSION=${BUILD_VERSION} \
+    SCRIBEAR_BUILD_TAGS=${BUILD_TAGS} \
+    SCRIBEAR_BUILD_PR=${BUILD_PR} \
+    SCRIBEAR_BUILD_ORIGIN=${BUILD_ORIGIN}
+
+LABEL org.opencontainers.image.title="scribear/admin-server" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      org.scribear.build.pull-request="${BUILD_PR}" \
+      org.scribear.build.origin="${BUILD_ORIGIN}"
+
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --start-interval=1s --retries=3 CMD wget -qO- http://127.0.0.1:80/api/admin/v1/probes/liveness || exit 1
 
 ENTRYPOINT ["dumb-init", "--"]

--- a/apps/admin-server/src/app-config/app-config.ts
+++ b/apps/admin-server/src/app-config/app-config.ts
@@ -3,10 +3,11 @@ import { randomBytes } from 'node:crypto';
 import { Type } from 'typebox';
 import type { Static } from 'typebox';
 
-import { LogLevel } from '@scribear/base-fastify-server';
+import { BUILD_INFO_PATH, LogLevel } from '@scribear/base-fastify-server';
 
 import type { AdminDbClientConfig } from '#src/db/admin-db-client.js';
 import type { ConfigCheckConfig } from '#src/server/features/config-check/config-check.service.js';
+import type { DeploymentVersionsConfig } from '#src/server/features/deployment-versions/deployment-versions.service.js';
 import type { HealthCheckerConfig } from '#src/server/features/health/health.service.js';
 import type { RateLimitConfig } from '#src/server/plugins/rate-limit.plugin.js';
 import type { AzureAuthConfig } from '#src/server/shared/services/azure-oidc-auth.service.js';
@@ -17,6 +18,14 @@ import type { SessionConfig } from '#src/server/shared/services/session.service.
 
 const MINUTE_MS = 60_000;
 const SECOND_MS = 1_000;
+
+/**
+ * Where the nginx-served containers keep their build document.
+ *
+ * `BUILD_INFO_PATH` plus a `.json` extension, so that nginx serves it with the
+ * right content type off its default mime map and no per-image config.
+ */
+const BUILD_INFO_FILE = `${BUILD_INFO_PATH}.json`;
 
 const CONFIG_SCHEMA = Type.Object({
   LOG_LEVEL: Type.Enum(LogLevel),
@@ -45,6 +54,29 @@ const CONFIG_SCHEMA = Type.Object({
   // Per-component, and the components are checked concurrently, so this is
   // also the worst case for the whole rollup. Kept short: an admin is waiting.
   HEALTH_CHECK_TIMEOUT_SEC: Type.Integer({ minimum: 1, default: 3 }),
+
+  // Deployment Check's per-container version table. In-cluster base URLs of the
+  // containers the health rollup does not already name, reached only for their
+  // unauthenticated build documents.
+  //
+  // All defaulted to their compose service names, unlike the two above: these
+  // exist so an unusual deployment *can* redirect them, not because anyone has
+  // to set them. A deployment that renames a service overrides the one URL
+  // rather than gaining a required variable, and an .env written before this
+  // release needs no edit at all.
+  MONITORING_SIDECAR_BASE_URL: Type.String({
+    default: 'http://monitoring-sidecar:80',
+  }),
+  CLIENT_WEBAPP_BASE_URL: Type.String({ default: 'http://client-webapp:80' }),
+  STANDALONE_WEBAPP_BASE_URL: Type.String({
+    default: 'http://standalone-webapp:80',
+  }),
+  KIOSK_WEBAPP_BASE_URL: Type.String({ default: 'http://kiosk-webapp:80' }),
+  ADMIN_WEBAPP_BASE_URL: Type.String({ default: 'http://admin-webapp:80' }),
+  // Plain HTTP, and port 80 specifically: the proxy answers its build document
+  // only on its unencrypted listener, so that publishing it on 443 does not put
+  // the deployment's commit hash on the public web. See infra/scribear-nginx.
+  NGINX_BASE_URL: Type.String({ default: 'http://nginx:80' }),
 
   // Fleet telemetry backplane (B1.7 §2.5). Defaulted, unlike the URLs above:
   // an unset value means this deployment predates B1.7 or has not opted in,
@@ -133,6 +165,81 @@ export class AppConfig {
           // /api/<service>/v1 prefix, unlike every Node service.
           name: 'transcription-service',
           readinessUrl: `${this._env.TRANSCRIPTION_SERVICE_BASE_URL}/probes/readiness`,
+        },
+      ],
+    };
+  }
+
+  /**
+   * Which container to ask for its build, and where its build document lives.
+   *
+   * admin-server is absent deliberately — the service reads its own in-process
+   * rather than making a request to itself.
+   *
+   * The path differs by container kind and that is not incidental: the Node
+   * services and transcription-service serve `/build-info` from a route, while
+   * the webapps and the proxy are nginx serving a static `build-info.json`
+   * generated at image build time. One path would have meant one of those two
+   * groups doing something unnatural.
+   */
+  get deploymentVersionsConfig(): DeploymentVersionsConfig {
+    return {
+      // Shared with the health rollup: both ask sibling containers a question
+      // an operator is waiting on, so one knob should bound both.
+      timeoutMs: this._env.HEALTH_CHECK_TIMEOUT_SEC * SECOND_MS,
+      targets: [
+        {
+          name: 'session-manager',
+          url: `${this._env.SESSION_MANAGER_BASE_URL}${BUILD_INFO_PATH}`,
+        },
+        {
+          name: 'node-server',
+          url: `${this._env.NODE_SERVER_BASE_URL}${BUILD_INFO_PATH}`,
+        },
+        {
+          name: 'transcription-service',
+          url: `${this._env.TRANSCRIPTION_SERVICE_BASE_URL}${BUILD_INFO_PATH}`,
+        },
+        {
+          name: 'monitoring-sidecar',
+          url: `${this._env.MONITORING_SIDECAR_BASE_URL}${BUILD_INFO_PATH}`,
+        },
+        {
+          name: 'client-webapp',
+          url: `${this._env.CLIENT_WEBAPP_BASE_URL}${BUILD_INFO_FILE}`,
+        },
+        {
+          name: 'standalone-webapp',
+          url: `${this._env.STANDALONE_WEBAPP_BASE_URL}${BUILD_INFO_FILE}`,
+        },
+        {
+          name: 'kiosk-webapp',
+          url: `${this._env.KIOSK_WEBAPP_BASE_URL}${BUILD_INFO_FILE}`,
+        },
+        {
+          name: 'admin-webapp',
+          url: `${this._env.ADMIN_WEBAPP_BASE_URL}${BUILD_INFO_FILE}`,
+        },
+        {
+          name: 'nginx',
+          url: `${this._env.NGINX_BASE_URL}${BUILD_INFO_FILE}`,
+        },
+      ],
+      // Listed rather than omitted. An operator scanning this table for what is
+      // deployed needs to see every container in compose.yml, and a service
+      // that is simply absent reads as an oversight; a service that says why it
+      // is blank does not. Both are stock upstream images with a thin wrapper,
+      // and neither speaks a protocol this console could ask the question in.
+      nonReporting: [
+        {
+          name: 'scribear-db',
+          detail:
+            'Postgres has no HTTP surface to report a build on. Its version moves with IMAGE_TAG like every other image — check it with `docker compose images scribear-db`.',
+        },
+        {
+          name: 'redis',
+          detail:
+            'Redis has no HTTP surface to report a build on. Its version moves with IMAGE_TAG like every other image — check it with `docker compose images redis`.',
         },
       ],
     };

--- a/apps/admin-server/src/server/create-server.ts
+++ b/apps/admin-server/src/server/create-server.ts
@@ -13,6 +13,7 @@ import { auditRouter } from './features/audit/audit.router.js';
 import { authRouter } from './features/auth/auth.router.js';
 import { configCheckRouter } from './features/config-check/config-check.router.js';
 import { demoRoomRouter } from './features/demo-room/demo-room.router.js';
+import { deploymentVersionsRouter } from './features/deployment-versions/deployment-versions.router.js';
 import { devicesRouter } from './features/devices/devices.router.js';
 import { fleetRouter } from './features/fleet/fleet.router.js';
 import { healthRouter } from './features/health/health.router.js';
@@ -50,6 +51,7 @@ async function createServer(config: AppConfig) {
   fastify.register(probesRouter);
   fastify.register(healthRouter);
   fastify.register(configCheckRouter);
+  fastify.register(deploymentVersionsRouter);
   fastify.register(authRouter, {
     loginMax: config.rateLimitConfig.loginMax,
     loginWindowMs: config.rateLimitConfig.loginWindowMs,

--- a/apps/admin-server/src/server/dependency-injection/app-dependencies.ts
+++ b/apps/admin-server/src/server/dependency-injection/app-dependencies.ts
@@ -16,6 +16,11 @@ import type {
   ConfigCheckService,
 } from '#src/server/features/config-check/config-check.service.js';
 import type { DemoRoomController } from '#src/server/features/demo-room/demo-room.controller.js';
+import type { DeploymentVersionsController } from '#src/server/features/deployment-versions/deployment-versions.controller.js';
+import type {
+  DeploymentVersionsConfig,
+  DeploymentVersionsService,
+} from '#src/server/features/deployment-versions/deployment-versions.service.js';
 import type { DevicesController } from '#src/server/features/devices/devices.controller.js';
 import type { FleetController } from '#src/server/features/fleet/fleet.controller.js';
 import type { HealthController } from '#src/server/features/health/health.controller.js';
@@ -94,6 +99,11 @@ interface AppDependencies extends BaseDependencies {
   configCheckConfig: ConfigCheckConfig;
   configCheckService: ConfigCheckService;
   configCheckController: ConfigCheckController;
+
+  // Deployment versions
+  deploymentVersionsConfig: DeploymentVersionsConfig;
+  deploymentVersionsService: DeploymentVersionsService;
+  deploymentVersionsController: DeploymentVersionsController;
 
   // Rooms
   roomsController: RoomsController;

--- a/apps/admin-server/src/server/dependency-injection/register-dependencies.ts
+++ b/apps/admin-server/src/server/dependency-injection/register-dependencies.ts
@@ -19,6 +19,8 @@ import { AuthController } from '#src/server/features/auth/auth.controller.js';
 import { ConfigCheckController } from '#src/server/features/config-check/config-check.controller.js';
 import { ConfigCheckService } from '#src/server/features/config-check/config-check.service.js';
 import { DemoRoomController } from '#src/server/features/demo-room/demo-room.controller.js';
+import { DeploymentVersionsController } from '#src/server/features/deployment-versions/deployment-versions.controller.js';
+import { DeploymentVersionsService } from '#src/server/features/deployment-versions/deployment-versions.service.js';
 import { DevicesController } from '#src/server/features/devices/devices.controller.js';
 import { FleetController } from '#src/server/features/fleet/fleet.controller.js';
 import { HealthController } from '#src/server/features/health/health.controller.js';
@@ -108,6 +110,17 @@ function registerDependencies(
       lifetime: Lifetime.SINGLETON,
     }),
     configCheckController: asClass(ConfigCheckController, {
+      lifetime: Lifetime.SCOPED,
+    }),
+
+    // Deployment versions. SINGLETON like the health checker and for the same
+    // reason: it holds only its target list, and rebuilding that per request
+    // would buy nothing.
+    deploymentVersionsConfig: asValue(config.deploymentVersionsConfig),
+    deploymentVersionsService: asClass(DeploymentVersionsService, {
+      lifetime: Lifetime.SINGLETON,
+    }),
+    deploymentVersionsController: asClass(DeploymentVersionsController, {
       lifetime: Lifetime.SCOPED,
     }),
 

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.controller.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.controller.ts
@@ -1,0 +1,35 @@
+import type {
+  BaseFastifyReply,
+  BaseFastifyRequest,
+} from '@scribear/base-fastify-server';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+import { okEnvelope } from '#src/server/shared/envelope/envelope.js';
+
+export class DeploymentVersionsController {
+  private _deploymentVersionsService: AppDependencies['deploymentVersionsService'];
+
+  constructor(
+    deploymentVersionsService: AppDependencies['deploymentVersionsService'],
+  ) {
+    this._deploymentVersionsService = deploymentVersionsService;
+  }
+
+  /**
+   * What each container in this deployment was built from. Requires a session.
+   *
+   * Always 200, like the health rollup and the config check: the probe ran, and
+   * what it found is the payload. A container that did not answer is a row with
+   * a status, not a failed request — a non-200 here would hide the nine
+   * containers that did answer behind the one that did not.
+   *
+   * Session-gated because it discloses commit hashes and build times for the
+   * whole stack. Individually each container's `/build-info` is unauthenticated,
+   * but it is also unreachable from outside the compose network; this route is
+   * the one place all of them are readable from a browser.
+   */
+  async deploymentVersions(_req: BaseFastifyRequest, res: BaseFastifyReply) {
+    const report = await this._deploymentVersionsService.report();
+    res.code(200).send(okEnvelope(report));
+  }
+}

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.router.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.router.ts
@@ -1,0 +1,17 @@
+import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
+
+import resolveHandler from '#src/server/dependency-injection/resolve-handler.js';
+import { requireSessionHook } from '#src/server/shared/hooks/require-session.hook.js';
+
+import { DEPLOYMENT_VERSIONS_ROUTE } from './deployment-versions.schema.js';
+
+export function deploymentVersionsRouter(fastify: BaseFastifyInstance) {
+  fastify.route({
+    ...DEPLOYMENT_VERSIONS_ROUTE,
+    preHandler: [requireSessionHook],
+    handler: resolveHandler(
+      'deploymentVersionsController',
+      'deploymentVersions',
+    ),
+  });
+}

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.schema.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.schema.ts
@@ -1,0 +1,6 @@
+import { ADMIN_BASE_PATH } from '#src/server/base-path.js';
+
+export const DEPLOYMENT_VERSIONS_ROUTE = {
+  method: 'GET' as const,
+  url: `${ADMIN_BASE_PATH}/deployment-versions`,
+};

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
@@ -1,0 +1,330 @@
+import type { BuildInfo } from '@scribear/base-fastify-server';
+import {
+  UNKNOWN_BUILD_FIELD,
+  readBuildInfo,
+} from '@scribear/base-fastify-server';
+
+/**
+ * Outcome of asking one container what it was built from.
+ *
+ * - `ok` — answered with a build document.
+ * - `unsupported` — answered, and does not have the route. The container is
+ *   running an image from before build reporting existed, which is itself the
+ *   answer: it is older than this admin-server and has not been recreated.
+ * - `unreachable` — no answer, or an answer nothing could be made of.
+ * - `not-reported` — has no way to report and is not expected to. Postgres and
+ *   Redis speak neither HTTP nor anything else this console could ask.
+ *
+ * `unsupported` is kept apart from `unreachable` deliberately. They look
+ * identical from the socket up (both are "no build document"), and they mean
+ * opposite things to an operator: one container is stale, the other is down.
+ */
+export type VersionProbeStatus =
+  | 'ok'
+  | 'unsupported'
+  | 'unreachable'
+  | 'not-reported';
+
+export interface ContainerVersion {
+  /** Compose service name, matching the health rollup's component names. */
+  service: string;
+  status: VersionProbeStatus;
+  /** The build document, or null for every status other than `ok`. */
+  build: BuildInfo | null;
+  /** One line of elaboration when the container did not report. */
+  detail?: string | undefined;
+}
+
+export interface DeploymentVersionsReport {
+  containers: ContainerVersion[];
+  /**
+   * The commit this deployment is taken to be, or null when nothing reported
+   * one. Every `mismatched` entry is measured against it.
+   */
+  expectedCommit: string | null;
+  /** Services whose commit is not `expectedCommit`. The headline of the page. */
+  mismatched: string[];
+  /** Services built on someone's machine rather than by a CI run. */
+  locallyBuilt: string[];
+  /** Services built from a working tree with uncommitted changes. */
+  dirty: string[];
+  /**
+   * True when containers answered but not one of them knows its own commit —
+   * the signature of a stack started straight from a checkout (`npm run dev`,
+   * or images built by hand) rather than from published artifacts.
+   */
+  unstamped: boolean;
+  checkedAt: string;
+}
+
+/** One container to ask, and where its build document lives. */
+export interface VersionProbeTarget {
+  name: string;
+  /**
+   * Absolute URL of the build document. The Node services and
+   * transcription-service serve it from a route; the webapps and the reverse
+   * proxy serve it as a static `build-info.json`, which is why this is a full
+   * URL per target rather than a base URL plus one shared path.
+   */
+  url: string;
+}
+
+/** A container that cannot be asked, and the reason to show instead. */
+export interface NonReportingContainer {
+  name: string;
+  detail: string;
+}
+
+export interface DeploymentVersionsConfig {
+  /**
+   * Per-container timeout. The containers are probed concurrently, so this is
+   * also the worst case for the whole table. Kept short: an admin is waiting,
+   * and a container that cannot answer in a second is itself the finding.
+   */
+  timeoutMs: number;
+  targets: VersionProbeTarget[];
+  nonReporting: NonReportingContainer[];
+}
+
+/**
+ * Narrows a foreign JSON body to a `BuildInfo`.
+ *
+ * Every field is checked rather than trusted. Four of these documents are
+ * produced outside this codebase's type system — one by a Python service, three
+ * by a shell script baked into an nginx image — so "it deserialized" is not
+ * evidence that it has the shape the console renders. A body that does not fit
+ * is treated as no answer at all, which surfaces as `unreachable` with the
+ * reason attached, rather than as a row of `undefined`.
+ */
+function parseBuildInfo(raw: unknown): BuildInfo | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const body = raw as Record<string, unknown>;
+
+  const service = body['service'];
+  const version = body['version'];
+  const commit = body['commit'];
+  const ref = body['ref'];
+  const builtAt = body['builtAt'];
+  const imageTags = body['imageTags'];
+  const pullRequest = body['pullRequest'];
+  const origin = body['origin'];
+  const dirty = body['dirty'];
+
+  if (
+    typeof service !== 'string' ||
+    typeof version !== 'string' ||
+    typeof commit !== 'string' ||
+    typeof ref !== 'string' ||
+    typeof builtAt !== 'string' ||
+    typeof dirty !== 'boolean'
+  ) {
+    return null;
+  }
+
+  if (!Array.isArray(imageTags)) return null;
+  if (!imageTags.every((tag) => typeof tag === 'string')) return null;
+
+  if (origin !== 'ci' && origin !== 'local' && origin !== 'unknown')
+    return null;
+
+  if (pullRequest !== null && typeof pullRequest !== 'number') return null;
+
+  return {
+    service,
+    version,
+    commit,
+    ref,
+    builtAt,
+    imageTags,
+    pullRequest,
+    origin,
+    dirty,
+  };
+}
+
+/** True when a container reported a commit it actually knows. */
+function hasKnownCommit(container: ContainerVersion): boolean {
+  return (
+    container.status === 'ok' &&
+    container.build !== null &&
+    container.build.commit !== UNKNOWN_BUILD_FIELD
+  );
+}
+
+/**
+ * The commit the deployment is taken to be: whichever one the most containers
+ * report.
+ *
+ * Modal rather than "whatever admin-server itself is", which was the obvious
+ * alternative and reads badly in the common case. When one container is missed
+ * by an upgrade, the majority is the intended version and the straggler is the
+ * exception — and that stays true whether or not the straggler is the admin
+ * console. Anchoring on admin-server would report nine mismatches and one
+ * healthy container when it is admin-server that was left behind.
+ *
+ * Ties break towards admin-server's own commit, which is the only tie-break
+ * available that does not depend on probe ordering: a two-versus-two split has
+ * no majority to find, and the container rendering the page is at least a
+ * commit an operator can identify.
+ */
+function resolveExpectedCommit(
+  containers: ContainerVersion[],
+  selfCommit: string,
+): string | null {
+  const counts = new Map<string, number>();
+  for (const container of containers) {
+    if (!hasKnownCommit(container)) continue;
+    const commit = container.build?.commit ?? '';
+    counts.set(commit, (counts.get(commit) ?? 0) + 1);
+  }
+
+  let winner: string | null = null;
+  let winningCount = 0;
+  for (const [commit, count] of counts) {
+    const beatsWinner =
+      count > winningCount || (count === winningCount && commit === selfCommit);
+    if (beatsWinner) {
+      winner = commit;
+      winningCount = count;
+    }
+  }
+
+  return winner;
+}
+
+/**
+ * Answers "what is actually deployed here?" by asking every container.
+ *
+ * This is the one question no other part of the console can answer. Each
+ * service knows its own build and no service knows anyone else's, so a
+ * half-finished upgrade — one image pulled, another not — is invisible from
+ * inside any single container, including this one. The health rollup would show
+ * every component green throughout, because a stale container is a perfectly
+ * healthy container.
+ *
+ * admin-server's own row is read in-process rather than over a loopback
+ * request: it is the same value the route would return, and a console that
+ * could not reach itself would drop the one row it can always speak for.
+ */
+export class DeploymentVersionsService {
+  private _config: DeploymentVersionsConfig;
+
+  constructor(deploymentVersionsConfig: DeploymentVersionsConfig) {
+    this._config = deploymentVersionsConfig;
+  }
+
+  async report(): Promise<DeploymentVersionsReport> {
+    const self: ContainerVersion = {
+      service: 'admin-server',
+      status: 'ok',
+      build: readBuildInfo(),
+    };
+
+    // Concurrent, for the same reason the health rollup is: sequential probes
+    // would make the slowest container set the floor for the whole page.
+    const probed = await Promise.all(
+      this._config.targets.map((target) => this._probe(target)),
+    );
+
+    const nonReporting: ContainerVersion[] = this._config.nonReporting.map(
+      (container) => ({
+        service: container.name,
+        status: 'not-reported' as const,
+        build: null,
+        detail: container.detail,
+      }),
+    );
+
+    const containers = [self, ...probed, ...nonReporting];
+    const expectedCommit = resolveExpectedCommit(
+      containers,
+      self.build?.commit ?? UNKNOWN_BUILD_FIELD,
+    );
+
+    const reporting = containers.filter((c) => c.status === 'ok');
+
+    return {
+      containers,
+      expectedCommit,
+      mismatched: containers
+        .filter((c) => hasKnownCommit(c) && c.build?.commit !== expectedCommit)
+        .map((c) => c.service),
+      locallyBuilt: reporting
+        .filter((c) => c.build?.origin === 'local')
+        .map((c) => c.service),
+      dirty: reporting
+        .filter((c) => c.build?.dirty === true)
+        .map((c) => c.service),
+      // Containers answered, and none of them knows what it was built from.
+      unstamped: reporting.length > 0 && expectedCommit === null,
+      checkedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Asks one container, mapping every way it can fail onto a status an
+   * operator can act on.
+   *
+   * Raw `fetch` rather than a generated client, and a hard `AbortSignal`
+   * timeout on every request — the same reasoning as the health rollup: these
+   * are two-field unauthenticated documents, and one hung container must not be
+   * able to hold this page open.
+   */
+  private async _probe(target: VersionProbeTarget): Promise<ContainerVersion> {
+    let response: Response;
+    try {
+      response = await fetch(target.url, {
+        signal: AbortSignal.timeout(this._config.timeoutMs),
+      });
+    } catch (err) {
+      return {
+        service: target.name,
+        status: 'unreachable',
+        build: null,
+        detail:
+          err instanceof Error && err.name === 'TimeoutError'
+            ? `no response within ${String(this._config.timeoutMs)}ms`
+            : 'connection failed',
+      };
+    }
+
+    // A 404 from a container that answered at all means the image predates
+    // build reporting. That is not a fault to investigate, it is the answer:
+    // this container is older than the one asking.
+    if (response.status === 404) {
+      return {
+        service: target.name,
+        status: 'unsupported',
+        build: null,
+        detail:
+          'running an image from before build reporting, so it was not recreated by the last upgrade',
+      };
+    }
+
+    if (!response.ok) {
+      return {
+        service: target.name,
+        status: 'unreachable',
+        build: null,
+        detail: `HTTP ${String(response.status)}`,
+      };
+    }
+
+    const body = await response
+      .json()
+      .then((parsed: unknown) => parsed)
+      .catch(() => null);
+
+    const build = parseBuildInfo(body);
+    if (build === null) {
+      return {
+        service: target.name,
+        status: 'unreachable',
+        build: null,
+        detail: 'answered with something that is not a build document',
+      };
+    }
+
+    return { service: target.name, status: 'ok', build };
+  }
+}

--- a/apps/admin-server/tests/integration/deployment-versions.routes.test.ts
+++ b/apps/admin-server/tests/integration/deployment-versions.routes.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, vi } from 'vitest';
+
+import type { BuildInfo } from '@scribear/base-fastify-server';
+
+import type { DeploymentVersionsReport } from '#src/server/features/deployment-versions/deployment-versions.service.js';
+import {
+  TEST_CLIENT_WEBAPP_BASE_URL,
+  TEST_NODE_BASE_URL,
+  TEST_SM_BASE_URL,
+  login,
+  useServer,
+} from '#tests/utils/use-server.js';
+
+const URL = '/api/admin/v1/deployment-versions';
+
+const COMMIT = 'def6e68f0b3c4a1d9e2f5a7b8c0d1e2f3a4b5c6d';
+const OLDER = '17db8150a2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7';
+
+interface DeploymentVersionsBody {
+  ok: boolean;
+  data: DeploymentVersionsReport;
+}
+
+function build(overrides: Partial<BuildInfo> = {}): BuildInfo {
+  return {
+    service: 'session-manager',
+    version: '1.4.2',
+    commit: COMMIT,
+    ref: 'staging',
+    builtAt: '2026-07-24T12:03:11Z',
+    imageTags: ['staging'],
+    pullRequest: null,
+    origin: 'ci',
+    dirty: false,
+    ...overrides,
+  };
+}
+
+describe('Deployment versions route', () => {
+  const server = useServer();
+  // Logged in once: the login route is rate limited to 5 per minute.
+  let cookie = '';
+
+  beforeAll(async () => {
+    cookie = (await login(server.fastify)).cookie;
+  });
+
+  /** Every probed container answers with the same build. */
+  function stubAllOnOneCommit() {
+    vi.stubGlobal('fetch', (url: string) => {
+      const service = url.startsWith(TEST_SM_BASE_URL)
+        ? 'session-manager'
+        : url.startsWith(TEST_NODE_BASE_URL)
+          ? 'node-server'
+          : url.startsWith(TEST_CLIENT_WEBAPP_BASE_URL)
+            ? 'client-webapp'
+            : null;
+
+      if (service === null) {
+        return Promise.reject(new Error('connect ECONNREFUSED'));
+      }
+
+      return Promise.resolve(
+        new Response(JSON.stringify(build({ service })), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    });
+  }
+
+  beforeEach(() => {
+    stubAllOnOneCommit();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('authentication', (it) => {
+    // The individual /build-info surfaces are unauthenticated because nothing
+    // outside the compose network can reach them. This route is the one place
+    // all of them are readable from a browser, so it is session-gated.
+    it('rejects an unauthenticated caller', async () => {
+      const res = await server.fastify.inject({ method: 'GET', url: URL });
+
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  describe('a stack on one commit', (it) => {
+    it('reports every container, the ones that cannot answer included', async () => {
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: URL,
+        headers: { cookie },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      const { data } = res.json<DeploymentVersionsBody>();
+
+      expect(data.containers.map((c) => c.service)).toEqual([
+        'admin-server',
+        'session-manager',
+        'node-server',
+        'client-webapp',
+        'scribear-db',
+      ]);
+      expect(data.mismatched).toEqual([]);
+      expect(data.expectedCommit).toBe(COMMIT);
+    });
+  });
+
+  describe('a half-finished upgrade', (it) => {
+    // The failure this page exists for, and the only place in the console that
+    // can see it: a stale container is a perfectly healthy container, so the
+    // health rollup stays green throughout.
+    it('names the container the rest of the stack disagrees with', async () => {
+      // Arrange
+      vi.stubGlobal('fetch', (url: string) =>
+        url.startsWith(TEST_NODE_BASE_URL)
+          ? Promise.resolve(
+              new Response(
+                JSON.stringify(
+                  build({ service: 'node-server', commit: OLDER }),
+                ),
+                {
+                  status: 200,
+                  headers: { 'content-type': 'application/json' },
+                },
+              ),
+            )
+          : Promise.resolve(
+              new Response(JSON.stringify(build()), {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+              }),
+            ),
+      );
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: URL,
+        headers: { cookie },
+      });
+
+      // Assert
+      const { data } = res.json<DeploymentVersionsBody>();
+      expect(data.expectedCommit).toBe(COMMIT);
+      expect(data.mismatched).toEqual(['node-server']);
+    });
+  });
+
+  describe('containers that do not answer', (it) => {
+    // Always 200: a container that did not answer is a row with a status, not a
+    // failed request. A non-200 would hide every container that did answer
+    // behind the one that did not.
+    it('still answers 200 when every probe fails', async () => {
+      // Arrange
+      vi.stubGlobal('fetch', () =>
+        Promise.reject(new Error('connect ECONNREFUSED')),
+      );
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: URL,
+        headers: { cookie },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      const { data } = res.json<DeploymentVersionsBody>();
+
+      // admin-server reads its own build in-process, so it reports even when
+      // it can reach nothing at all.
+      const self = data.containers.find((c) => c.service === 'admin-server');
+      expect(self?.status).toBe('ok');
+      expect(
+        data.containers
+          .filter((c) => c.service !== 'admin-server' && c.build !== null)
+          .map((c) => c.service),
+      ).toEqual([]);
+    });
+  });
+});

--- a/apps/admin-server/tests/unit/features/deployment-versions/deployment-versions.service.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/deployment-versions.service.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+
+import type { BuildInfo } from '@scribear/base-fastify-server';
+
+import type { DeploymentVersionsConfig } from '#src/server/features/deployment-versions/deployment-versions.service.js';
+import { DeploymentVersionsService } from '#src/server/features/deployment-versions/deployment-versions.service.js';
+
+const COMMIT = 'def6e68f0b3c4a1d9e2f5a7b8c0d1e2f3a4b5c6d';
+const OLDER = '17db8150a2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7';
+
+/** A build document as a container would serve it. */
+function build(overrides: Partial<BuildInfo> = {}): BuildInfo {
+  return {
+    service: 'session-manager',
+    version: '1.4.2',
+    commit: COMMIT,
+    ref: 'staging',
+    builtAt: '2026-07-24T12:03:11Z',
+    imageTags: ['staging', 'staging-def6e68'],
+    pullRequest: null,
+    origin: 'ci',
+    dirty: false,
+    ...overrides,
+  };
+}
+
+function config(
+  overrides: Partial<DeploymentVersionsConfig> = {},
+): DeploymentVersionsConfig {
+  return {
+    timeoutMs: 3_000,
+    targets: [
+      { name: 'session-manager', url: 'http://session-manager:80/build-info' },
+      { name: 'node-server', url: 'http://node-server:80/build-info' },
+    ],
+    nonReporting: [{ name: 'scribear-db', detail: 'no HTTP surface' }],
+    ...overrides,
+  };
+}
+
+/**
+ * Answers each target URL from a map, so a test names what each container said
+ * rather than the order they happen to be probed in.
+ */
+function respondWith(
+  responses: Record<string, Response | Error>,
+): ReturnType<typeof vi.fn> {
+  return vi.fn((url: string) => {
+    const response = responses[url];
+    if (response === undefined) throw new Error(`unexpected fetch: ${url}`);
+    if (response instanceof Error) return Promise.reject(response);
+    return Promise.resolve(response);
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('DeploymentVersionsService', (it) => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // admin-server's own row is read in-process, not fetched, so its build is
+    // set here rather than stubbed as a response.
+    process.env['SCRIBEAR_BUILD_SERVICE'] = 'admin-server';
+    process.env['SCRIBEAR_BUILD_VERSION'] = '1.4.2';
+    process.env['SCRIBEAR_BUILD_COMMIT'] = COMMIT;
+    process.env['SCRIBEAR_BUILD_REF'] = 'staging';
+    process.env['SCRIBEAR_BUILD_TIME'] = '2026-07-24T12:03:11Z';
+    process.env['SCRIBEAR_BUILD_TAGS'] = 'staging';
+    process.env['SCRIBEAR_BUILD_ORIGIN'] = 'ci';
+    delete process.env['SCRIBEAR_BUILD_PR'];
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.unstubAllGlobals();
+  });
+
+  it('reports every container, including the ones that cannot answer', async () => {
+    // Arrange
+    vi.stubGlobal(
+      'fetch',
+      respondWith({
+        'http://session-manager:80/build-info': jsonResponse(build()),
+        'http://node-server:80/build-info': jsonResponse(
+          build({ service: 'node-server' }),
+        ),
+      }),
+    );
+
+    // Act
+    const report = await new DeploymentVersionsService(config()).report();
+
+    // Assert
+    expect(report.containers.map((c) => c.service)).toEqual([
+      'admin-server',
+      'session-manager',
+      'node-server',
+      'scribear-db',
+    ]);
+    expect(report.containers.map((c) => c.status)).toEqual([
+      'ok',
+      'ok',
+      'ok',
+      'not-reported',
+    ]);
+    expect(report.expectedCommit).toBe(COMMIT);
+    expect(report.mismatched).toEqual([]);
+    expect(report.unstamped).toBe(false);
+  });
+
+  // The whole point of the page: one image was not pulled, and nothing else in
+  // the console can see it, because a stale container is a healthy container.
+  it('names the container the majority disagrees with', async () => {
+    // Arrange
+    vi.stubGlobal(
+      'fetch',
+      respondWith({
+        'http://session-manager:80/build-info': jsonResponse(build()),
+        'http://node-server:80/build-info': jsonResponse(
+          build({ service: 'node-server', commit: OLDER }),
+        ),
+      }),
+    );
+
+    // Act
+    const report = await new DeploymentVersionsService(config()).report();
+
+    // Assert
+    expect(report.expectedCommit).toBe(COMMIT);
+    expect(report.mismatched).toEqual(['node-server']);
+  });
+
+  // Anchoring on admin-server's own commit would report every other container
+  // as wrong when it is the console that was left behind. The majority is the
+  // intended version whichever container is the straggler.
+  it('takes the majority commit even when admin-server is the odd one out', async () => {
+    // Arrange
+    process.env['SCRIBEAR_BUILD_COMMIT'] = OLDER;
+    vi.stubGlobal(
+      'fetch',
+      respondWith({
+        'http://session-manager:80/build-info': jsonResponse(build()),
+        'http://node-server:80/build-info': jsonResponse(
+          build({ service: 'node-server' }),
+        ),
+      }),
+    );
+
+    // Act
+    const report = await new DeploymentVersionsService(config()).report();
+
+    // Assert
+    expect(report.expectedCommit).toBe(COMMIT);
+    expect(report.mismatched).toEqual(['admin-server']);
+  });
+
+  // A 404 means the container answered and has no such route: it is running an
+  // image from before build reporting, which is itself the answer. Reporting it
+  // as unreachable would send an operator to look for a container that is down.
+  it('distinguishes an image that predates build reporting from one that is down', async () => {
+    // Arrange
+    vi.stubGlobal(
+      'fetch',
+      respondWith({
+        'http://session-manager:80/build-info': jsonResponse(
+          { error: 'ROUTE_NOT_FOUND' },
+          404,
+        ),
+        'http://node-server:80/build-info': new Error('ECONNREFUSED'),
+      }),
+    );
+
+    // Act
+    const report = await new DeploymentVersionsService(config()).report();
+
+    // Assert
+    const byName = new Map(report.containers.map((c) => [c.service, c]));
+    expect(byName.get('session-manager')?.status).toBe('unsupported');
+    expect(byName.get('node-server')?.status).toBe('unreachable');
+    expect(byName.get('node-server')?.detail).toBe('connection failed');
+  });
+
+  // Four of these documents are produced outside this codebase's type system -
+  // one by a Python service, three by a shell script in an nginx image - so
+  // "it deserialized" is not evidence it has the shape the console renders.
+  it('rejects a body that is not a build document', async () => {
+    // Arrange
+    vi.stubGlobal(
+      'fetch',
+      respondWith({
+        'http://session-manager:80/build-info': jsonResponse({
+          ...build(),
+          imageTags: 'staging',
+        }),
+        'http://node-server:80/build-info': jsonResponse(
+          build({ service: 'node-server' }),
+        ),
+      }),
+    );
+
+    // Act
+    const report = await new DeploymentVersionsService(config()).report();
+
+    // Assert
+    const sessionManager = report.containers.find(
+      (c) => c.service === 'session-manager',
+    );
+    expect(sessionManager?.status).toBe('unreachable');
+    expect(sessionManager?.detail).toBe(
+      'answered with something that is not a build document',
+    );
+  });
+
+  // The `npm run dev` case: containers answer, and not one of them knows what
+  // it was built from, because nothing built them.
+  it('reports an unstamped stack rather than a table of blanks', async () => {
+    // Arrange
+    process.env = { ...originalEnv };
+    vi.stubGlobal(
+      'fetch',
+      respondWith({
+        'http://session-manager:80/build-info': jsonResponse(
+          build({ commit: 'unknown', origin: 'unknown', imageTags: [] }),
+        ),
+        'http://node-server:80/build-info': jsonResponse(
+          build({
+            service: 'node-server',
+            commit: 'unknown',
+            origin: 'unknown',
+            imageTags: [],
+          }),
+        ),
+      }),
+    );
+
+    // Act
+    const report = await new DeploymentVersionsService(config()).report();
+
+    // Assert
+    expect(report.unstamped).toBe(true);
+    expect(report.expectedCommit).toBeNull();
+    expect(report.mismatched).toEqual([]);
+  });
+
+  it('flags containers built locally and from a modified working tree', async () => {
+    // Arrange
+    vi.stubGlobal(
+      'fetch',
+      respondWith({
+        'http://session-manager:80/build-info': jsonResponse(
+          build({ origin: 'local', dirty: true }),
+        ),
+        'http://node-server:80/build-info': jsonResponse(
+          build({ service: 'node-server', origin: 'local' }),
+        ),
+      }),
+    );
+
+    // Act
+    const report = await new DeploymentVersionsService(config()).report();
+
+    // Assert
+    expect(report.locallyBuilt).toEqual(['session-manager', 'node-server']);
+    expect(report.dirty).toEqual(['session-manager']);
+  });
+
+  it('carries the pull request a PR-built image came from', async () => {
+    // Arrange
+    vi.stubGlobal(
+      'fetch',
+      respondWith({
+        'http://session-manager:80/build-info': jsonResponse(
+          build({ pullRequest: 157, imageTags: ['PR-157'] }),
+        ),
+        'http://node-server:80/build-info': jsonResponse(
+          build({ service: 'node-server' }),
+        ),
+      }),
+    );
+
+    // Act
+    const report = await new DeploymentVersionsService(config()).report();
+
+    // Assert
+    const sessionManager = report.containers.find(
+      (c) => c.service === 'session-manager',
+    );
+    expect(sessionManager?.build?.pullRequest).toBe(157);
+    expect(sessionManager?.build?.imageTags).toEqual(['PR-157']);
+  });
+
+  // One hung container must not be able to hold the page open, so every probe
+  // carries a hard timeout rather than waiting on the OS TCP timeout.
+  it('bounds every probe with the configured timeout', async () => {
+    // Arrange
+    const fetchMock = respondWith({
+      'http://session-manager:80/build-info': jsonResponse(build()),
+      'http://node-server:80/build-info': jsonResponse(
+        build({ service: 'node-server' }),
+      ),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Act
+    await new DeploymentVersionsService(config({ timeoutMs: 1_500 })).report();
+
+    // Assert
+    for (const call of fetchMock.mock.calls) {
+      expect((call[1] as RequestInit).signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+});

--- a/apps/admin-server/tests/utils/use-server.ts
+++ b/apps/admin-server/tests/utils/use-server.ts
@@ -12,6 +12,7 @@ export const TEST_LOCAL_CREDENTIALS = `${TEST_USERNAME} ${TEST_PASSWORD}`;
 export const TEST_SM_BASE_URL = 'http://session-manager.test';
 export const TEST_NODE_BASE_URL = 'http://node-server.test';
 export const TEST_TS_BASE_URL = 'http://transcription-service.test';
+export const TEST_CLIENT_WEBAPP_BASE_URL = 'http://client-webapp.test';
 export const TEST_COOKIE_SECRET =
   'test-cookie-secret-at-least-32-characters-long!!';
 
@@ -26,6 +27,7 @@ export interface TestAppConfigOverrides {
   rateLimitConfig?: Partial<AppConfig['rateLimitConfig']>;
   dbClientConfig?: Partial<AppConfig['dbClientConfig']>;
   healthCheckerConfig?: Partial<AppConfig['healthCheckerConfig']>;
+  deploymentVersionsConfig?: Partial<AppConfig['deploymentVersionsConfig']>;
   fleetTelemetryConfig?: Partial<AppConfig['fleetTelemetryConfig']>;
   configCheckConfig?: Partial<AppConfig['configCheckConfig']>;
   cookieSecret?: string;
@@ -98,6 +100,22 @@ export function buildTestAppConfig(
         },
       ],
       ...overrides.healthCheckerConfig,
+    },
+    // The two Node services the health rollup above already stubs, plus one
+    // static-file container, so a test can exercise both shapes of build
+    // document without listing all eleven of the real stack's containers.
+    deploymentVersionsConfig: {
+      timeoutMs: 500,
+      targets: [
+        { name: 'session-manager', url: `${TEST_SM_BASE_URL}/build-info` },
+        { name: 'node-server', url: `${TEST_NODE_BASE_URL}/build-info` },
+        {
+          name: 'client-webapp',
+          url: `${TEST_CLIENT_WEBAPP_BASE_URL}/build-info.json`,
+        },
+      ],
+      nonReporting: [{ name: 'scribear-db', detail: 'no HTTP surface' }],
+      ...overrides.deploymentVersionsConfig,
     },
     dbClientConfig: { ...dbConfig, ...overrides.dbClientConfig },
     // Disabled by default, like a deployment that predates B1.7 — tests that

--- a/apps/admin-webapp/Dockerfile
+++ b/apps/admin-webapp/Dockerfile
@@ -54,6 +54,36 @@ EOF
 
 COPY --from=build-env /app/apps/admin-webapp/dist/ ./
 
+# Build provenance. A webapp is static files behind nginx, so there is no
+# process to ask: the same document the Node services answer GET /build-info
+# with is generated here at image build time and served as a file. The admin
+# console's Deployment Check reads it from every container, which is how an
+# operator confirms the whole stack came from one commit.
+#
+# Empty defaults so a plain `docker build` still works and reports "unknown"
+# rather than failing; CI and build-containers.sh supply the real values. Last
+# in the file because these change on every commit and nothing expensive may
+# sit below them.
+COPY tools/build-info/write-build-info.sh /tmp/write-build-info.sh
+
+ARG BUILD_COMMIT=""
+ARG BUILD_REF=""
+ARG BUILD_TIME=""
+ARG BUILD_VERSION=""
+ARG BUILD_TAGS=""
+ARG BUILD_PR=""
+ARG BUILD_ORIGIN=""
+
+RUN sh /tmp/write-build-info.sh admin-webapp /usr/share/nginx/html/build-info.json \
+  && rm /tmp/write-build-info.sh
+
+LABEL org.opencontainers.image.title="scribear/admin-webapp" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      org.scribear.build.pull-request="${BUILD_PR}" \
+      org.scribear.build.origin="${BUILD_ORIGIN}"
+
 EXPOSE 80
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --start-interval=1s --retries=3 CMD wget --quiet --tries=1 --spider http://127.0.0.1/healthcheck || exit 1

--- a/apps/admin-webapp/src/features/config-check/config-check-page.tsx
+++ b/apps/admin-webapp/src/features/config-check/config-check-page.tsx
@@ -28,6 +28,8 @@ import { ApiError } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 
+import { DeploymentVersionsTable } from './deployment-versions-table';
+
 /**
  * Severity presentation, most severe first. The order of this array is the
  * order of the page.
@@ -168,6 +170,17 @@ export const ConfigCheckPage = () => {
     reload,
   } = useAsyncData(() => adminApi.configCheck(), []);
 
+  // A second request rather than a field on the report above. The two answer
+  // different questions — how this deployment is configured, and which build
+  // each container is running — and each has its own fan-out of upstream
+  // probes, so folding them together would make the slower one gate the other.
+  const {
+    data: versions,
+    loading: versionsLoading,
+    error: versionsError,
+    reload: reloadVersions,
+  } = useAsyncData(() => adminApi.deploymentVersions(), []);
+
   // A failed run is surfaced as a toast; `report` keeps its last value (or null).
   useEffect(() => {
     if (error !== null) {
@@ -175,6 +188,20 @@ export const ConfigCheckPage = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [error]);
+
+  useEffect(() => {
+    if (versionsError !== null) {
+      showError(
+        errorMessage(versionsError, 'Failed to read the container versions.'),
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
+  }, [versionsError]);
+
+  const reloadAll = () => {
+    reload();
+    reloadVersions();
+  };
 
   if (loading && report === null) {
     return (
@@ -217,8 +244,8 @@ export const ConfigCheckPage = () => {
         />
         <Button
           startIcon={<RefreshIcon />}
-          onClick={reload}
-          disabled={loading}
+          onClick={reloadAll}
+          disabled={loading || versionsLoading}
           size="small"
         >
           Re-run
@@ -231,7 +258,8 @@ export const ConfigCheckPage = () => {
         {report.environmentSource === 'inferred'
           ? 'DEPLOYMENT_ENV is not set, so this was inferred — set it in deployment/.env to judge against a different standard.'
           : 'Set by DEPLOYMENT_ENV in deployment/.env.'}{' '}
-        Checked {new Date(report.checkedAt).toLocaleString()}.
+        Checked {new Date(report.checkedAt).toLocaleString()}. Per-container
+        build versions are in <strong>Deployed versions</strong>, below.
       </Typography>
 
       {/* The promotion question, answered before the reader has to ask it. A
@@ -306,6 +334,24 @@ export const ConfigCheckPage = () => {
           </Stack>
         </>
       )}
+
+      {/* Below the findings, not above them: this is reference data, and
+          floating a green "every container is on one commit" banner over three
+          critical misconfigurations would bury the thing that needs acting on.
+          The intro paragraph points here so a reader knows it exists. */}
+      <Divider sx={{ mt: 4, mb: 2 }} />
+
+      <Typography variant="h6" sx={{ mb: 0.5 }}>
+        Deployed versions
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        What each container was built from. Every service knows its own build
+        and none knows anyone else&apos;s, so an upgrade that pulled some images
+        and not others is invisible everywhere except here — a stale container
+        stays green in the health rollup.
+      </Typography>
+
+      <DeploymentVersionsTable report={versions} loading={versionsLoading} />
 
       <Typography
         variant="caption"

--- a/apps/admin-webapp/src/features/config-check/deployment-versions-table.tsx
+++ b/apps/admin-webapp/src/features/config-check/deployment-versions-table.tsx
@@ -1,0 +1,313 @@
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
+import WarningIcon from '@mui/icons-material/Warning';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+
+import type {
+  ContainerVersion,
+  DeploymentVersionsReport,
+  VersionProbeStatus,
+} from '#src/lib/admin-api';
+
+/**
+ * The literal every reporter substitutes for a field its build did not supply.
+ * Never rendered as-is: a cell that says "unknown" twice tells an operator less
+ * than an em dash and one explanation at the top of the table.
+ */
+const UNKNOWN = 'unknown';
+
+const SHORT_COMMIT_LENGTH = 7;
+
+const STATUS_META: Record<
+  VersionProbeStatus,
+  { label: string; color: 'success' | 'warning' | 'error' | 'default' }
+> = {
+  ok: { label: 'reporting', color: 'success' },
+  unsupported: { label: 'old image', color: 'warning' },
+  unreachable: { label: 'no answer', color: 'error' },
+  'not-reported': { label: 'n/a', color: 'default' },
+};
+
+function shortCommit(commit: string): string {
+  return commit === UNKNOWN ? '—' : commit.slice(0, SHORT_COMMIT_LENGTH);
+}
+
+function formatBuiltAt(builtAt: string): string {
+  if (builtAt === UNKNOWN) return '—';
+  const parsed = new Date(builtAt);
+  return Number.isNaN(parsed.getTime())
+    ? builtAt
+    : parsed.toLocaleString(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      });
+}
+
+/**
+ * One container's row.
+ *
+ * The commit is the column that matters and is therefore the one that carries
+ * the mismatch marker: an operator scanning this table is looking for the row
+ * that does not match the others, and asking them to compare eight
+ * seven-character hashes by eye is how a stale container gets missed.
+ */
+const ContainerRow = ({
+  container,
+  isMismatched,
+}: {
+  container: ContainerVersion;
+  isMismatched: boolean;
+}) => {
+  const { build, status } = container;
+  const meta = STATUS_META[status];
+
+  return (
+    <TableRow hover>
+      <TableCell sx={{ fontWeight: 500 }}>{container.service}</TableCell>
+
+      <TableCell>
+        {build?.version === UNKNOWN ? '—' : (build?.version ?? '—')}
+      </TableCell>
+
+      <TableCell>
+        {build === null ? (
+          '—'
+        ) : (
+          <Stack direction="row" spacing={0.75} alignItems="center">
+            <Box component="code" sx={{ fontFamily: 'monospace' }}>
+              {shortCommit(build.commit)}
+            </Box>
+            {isMismatched && (
+              <Tooltip title="This container is not on the commit the rest of the stack reports. It was almost certainly missed by the last upgrade.">
+                <WarningIcon color="warning" fontSize="small" />
+              </Tooltip>
+            )}
+            {build.dirty && (
+              <Tooltip title="Built from a working tree with uncommitted changes, so this commit does not describe what is running.">
+                <Chip
+                  size="small"
+                  color="warning"
+                  variant="outlined"
+                  label="dirty"
+                />
+              </Tooltip>
+            )}
+          </Stack>
+        )}
+      </TableCell>
+
+      <TableCell>
+        {build?.ref === UNKNOWN ? '—' : (build?.ref ?? '—')}
+      </TableCell>
+
+      <TableCell>
+        {build === null ? '—' : formatBuiltAt(build.builtAt)}
+      </TableCell>
+
+      <TableCell>
+        {build === null || build.imageTags.length === 0 ? (
+          '—'
+        ) : (
+          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+            {build.imageTags.map((tag) => (
+              <Chip key={tag} size="small" variant="outlined" label={tag} />
+            ))}
+          </Stack>
+        )}
+      </TableCell>
+
+      <TableCell>
+        <Stack
+          direction="row"
+          spacing={0.5}
+          alignItems="center"
+          flexWrap="wrap"
+          useFlexGap
+        >
+          <Chip
+            size="small"
+            color={meta.color}
+            variant="outlined"
+            label={meta.label}
+          />
+          {build?.pullRequest !== null && build?.pullRequest !== undefined && (
+            <Chip
+              size="small"
+              color="info"
+              variant="outlined"
+              label={`PR #${String(build.pullRequest)}`}
+            />
+          )}
+          {build?.origin === 'local' && (
+            <Tooltip title="Built by build-containers.sh on someone's machine, not published by CI. Two deployments reporting this commit are not necessarily running the same bytes.">
+              <Chip size="small" variant="outlined" label="local build" />
+            </Tooltip>
+          )}
+          {container.detail !== undefined && (
+            <Tooltip title={container.detail}>
+              <HelpOutlineIcon fontSize="small" color="disabled" />
+            </Tooltip>
+          )}
+        </Stack>
+      </TableCell>
+    </TableRow>
+  );
+};
+
+/**
+ * What each container in this deployment was built from.
+ *
+ * This is the only place in the console that can answer the question, and the
+ * reason is worth stating: every service knows its own build and no service
+ * knows anyone else's, so a half-finished upgrade — one image pulled, another
+ * not — is invisible from inside any single container. The health rollup shows
+ * every component green throughout, because a stale container is a perfectly
+ * healthy container.
+ */
+export const DeploymentVersionsTable = ({
+  report,
+  loading,
+}: {
+  report: DeploymentVersionsReport | null;
+  loading: boolean;
+}) => {
+  if (loading && report === null) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  if (report === null) {
+    return (
+      <Alert severity="warning">
+        The per-container versions could not be read. The findings above are
+        unaffected — they come from a separate check.
+      </Alert>
+    );
+  }
+
+  const mismatched = new Set(report.mismatched);
+  const stale = report.containers.filter((c) => c.status === 'unsupported');
+
+  return (
+    <Box>
+      {/* The answer, before the table that supports it. An operator opening
+          this page has one question, and eleven rows of hashes is not it. */}
+      {report.unstamped ? (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          <AlertTitle>Nothing here was built by CI</AlertTitle>
+          Containers answered, and none of them knows what it was built from —
+          the signature of a stack running local code (<code>npm run dev</code>,
+          or images built by hand). Build with{' '}
+          <code>./build-containers.sh</code> to stamp the commit in.
+        </Alert>
+      ) : mismatched.size > 0 ? (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          <AlertTitle>
+            {mismatched.size} container{mismatched.size === 1 ? '' : 's'} not on{' '}
+            {report.expectedCommit === null
+              ? 'the deployed commit'
+              : report.expectedCommit.slice(0, SHORT_COMMIT_LENGTH)}
+          </AlertTitle>
+          {report.mismatched.join(', ')} —{' '}
+          {mismatched.size === 1 ? 'it is' : 'they are'} running a different
+          build from the rest of the stack, which is what an upgrade that only
+          partly completed looks like. Run <code>docker compose up -d</code> in{' '}
+          <code>deployment/</code> and re-check.
+        </Alert>
+      ) : (
+        <Alert severity="success" icon={<CheckCircleIcon />} sx={{ mb: 2 }}>
+          <AlertTitle>Every reporting container is on one commit</AlertTitle>
+          {report.expectedCommit === null
+            ? 'No commit was reported.'
+            : `This deployment is running ${report.expectedCommit.slice(0, SHORT_COMMIT_LENGTH)}.`}
+        </Alert>
+      )}
+
+      {stale.length > 0 && (
+        <Alert severity="warning" icon={<ErrorIcon />} sx={{ mb: 2 }}>
+          <AlertTitle>
+            {stale.length} container{stale.length === 1 ? '' : 's'} predate
+            {stale.length === 1 ? 's' : ''} build reporting
+          </AlertTitle>
+          {stale.map((c) => c.service).join(', ')} answered but has no build
+          document at all, so its image is older than this admin-server and was
+          not recreated by the last upgrade.
+        </Alert>
+      )}
+
+      {report.locallyBuilt.length > 0 && !report.unstamped && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          <AlertTitle>Locally built images are running here</AlertTitle>
+          {report.locallyBuilt.join(', ')} came from{' '}
+          <code>build-containers.sh</code> rather than from a published CI
+          build, so the commit identifies the source but not the artifact.
+          {report.dirty.length > 0 && (
+            <>
+              {' '}
+              {report.dirty.join(', ')}{' '}
+              {report.dirty.length === 1 ? 'was' : 'were'} built from a working
+              tree with uncommitted changes, so even the commit does not
+              describe what is running.
+            </>
+          )}
+        </Alert>
+      )}
+
+      <TableContainer component={Paper} variant="outlined">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Container</TableCell>
+              <TableCell>Version</TableCell>
+              <TableCell>Commit</TableCell>
+              <TableCell>Branch</TableCell>
+              <TableCell>Built</TableCell>
+              <TableCell>Image tags</TableCell>
+              <TableCell>Status</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {report.containers.map((container) => (
+              <ContainerRow
+                key={container.service}
+                container={container}
+                isMismatched={mismatched.has(container.service)}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 1 }}
+      >
+        <RemoveCircleOutlineIcon fontSize="inherit" />
+        Every value is baked into the image at build time, so it describes the
+        artifact rather than the source tree it sits next to. An em dash means
+        the build did not supply that field. Read{' '}
+        {new Date(report.checkedAt).toLocaleString()}.
+      </Typography>
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -184,6 +184,60 @@ export interface ConfigCheckReport {
   checkedAt: string;
 }
 
+// ---- Deployment versions ----
+// Mirrors `DeploymentVersionsReport` in
+// apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts.
+
+/** Where the image a container is running came from. Kept loose for the same
+ *  reason `HealthComponent.status` is. */
+export type BuildOrigin = 'ci' | 'local' | 'unknown';
+
+/** What one container reports about the artifact it was built from. Every
+ *  string field is the literal 'unknown' when the build did not supply it —
+ *  never blank, so a missing value cannot be read as a failed probe. */
+export interface ContainerBuildInfo {
+  service: string;
+  version: string;
+  commit: string;
+  ref: string;
+  builtAt: string;
+  imageTags: string[];
+  pullRequest: number | null;
+  origin: BuildOrigin;
+  /** Built from a working tree with uncommitted changes. */
+  dirty: boolean;
+}
+
+/** 'ok' | 'unsupported' (image predates build reporting) | 'unreachable' |
+ *  'not-reported' (no surface to ask, by design). */
+export type VersionProbeStatus =
+  | 'ok'
+  | 'unsupported'
+  | 'unreachable'
+  | 'not-reported';
+
+export interface ContainerVersion {
+  service: string;
+  status: VersionProbeStatus;
+  /** Null for every status other than 'ok'. */
+  build: ContainerBuildInfo | null;
+  detail?: string;
+}
+
+export interface DeploymentVersionsReport {
+  containers: ContainerVersion[];
+  /** The commit the deployment is taken to be — whichever the most containers
+   *  report. Null when nothing reported one. */
+  expectedCommit: string | null;
+  /** Services whose commit is not `expectedCommit`. */
+  mismatched: string[];
+  locallyBuilt: string[];
+  dirty: string[];
+  /** Containers answered, and none knows its own commit. */
+  unstamped: boolean;
+  checkedAt: string;
+}
+
 // ---- Fleet telemetry (B1.7 §2.5) ----
 // Mirrors `FleetSnapshot` in
 // apps/admin-server/src/server/shared/services/fleet-telemetry.service.ts and
@@ -497,6 +551,15 @@ export class AdminApiClient {
   // ---- Config check ----
   configCheck(): Promise<ConfigCheckReport> {
     return this._request('GET', '/config-check');
+  }
+
+  // ---- Deployment versions ----
+  /** Probes every container concurrently server-side, so this is one request
+   *  whatever the stack's size. Separate from `configCheck` deliberately: the
+   *  two answer different questions and neither should wait on the other's
+   *  probes. */
+  deploymentVersions(): Promise<DeploymentVersionsReport> {
+    return this._request('GET', '/deployment-versions');
   }
 
   // ---- Demo caption room ----

--- a/apps/client-webapp/Dockerfile
+++ b/apps/client-webapp/Dockerfile
@@ -54,6 +54,36 @@ EOF
 
 COPY --from=build-env /app/apps/client-webapp/dist/ ./
 
+# Build provenance. A webapp is static files behind nginx, so there is no
+# process to ask: the same document the Node services answer GET /build-info
+# with is generated here at image build time and served as a file. The admin
+# console's Deployment Check reads it from every container, which is how an
+# operator confirms the whole stack came from one commit.
+#
+# Empty defaults so a plain `docker build` still works and reports "unknown"
+# rather than failing; CI and build-containers.sh supply the real values. Last
+# in the file because these change on every commit and nothing expensive may
+# sit below them.
+COPY tools/build-info/write-build-info.sh /tmp/write-build-info.sh
+
+ARG BUILD_COMMIT=""
+ARG BUILD_REF=""
+ARG BUILD_TIME=""
+ARG BUILD_VERSION=""
+ARG BUILD_TAGS=""
+ARG BUILD_PR=""
+ARG BUILD_ORIGIN=""
+
+RUN sh /tmp/write-build-info.sh client-webapp /usr/share/nginx/html/build-info.json \
+  && rm /tmp/write-build-info.sh
+
+LABEL org.opencontainers.image.title="scribear/client-webapp" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      org.scribear.build.pull-request="${BUILD_PR}" \
+      org.scribear.build.origin="${BUILD_ORIGIN}"
+
 EXPOSE 80
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --start-interval=1s --retries=3 CMD wget --quiet --tries=1 --spider http://127.0.0.1/healthcheck || exit 1

--- a/apps/kiosk-webapp/Dockerfile
+++ b/apps/kiosk-webapp/Dockerfile
@@ -54,6 +54,36 @@ EOF
 
 COPY --from=build-env /app/apps/kiosk-webapp/dist/ ./
 
+# Build provenance. A webapp is static files behind nginx, so there is no
+# process to ask: the same document the Node services answer GET /build-info
+# with is generated here at image build time and served as a file. The admin
+# console's Deployment Check reads it from every container, which is how an
+# operator confirms the whole stack came from one commit.
+#
+# Empty defaults so a plain `docker build` still works and reports "unknown"
+# rather than failing; CI and build-containers.sh supply the real values. Last
+# in the file because these change on every commit and nothing expensive may
+# sit below them.
+COPY tools/build-info/write-build-info.sh /tmp/write-build-info.sh
+
+ARG BUILD_COMMIT=""
+ARG BUILD_REF=""
+ARG BUILD_TIME=""
+ARG BUILD_VERSION=""
+ARG BUILD_TAGS=""
+ARG BUILD_PR=""
+ARG BUILD_ORIGIN=""
+
+RUN sh /tmp/write-build-info.sh kiosk-webapp /usr/share/nginx/html/build-info.json \
+  && rm /tmp/write-build-info.sh
+
+LABEL org.opencontainers.image.title="scribear/kiosk-webapp" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      org.scribear.build.pull-request="${BUILD_PR}" \
+      org.scribear.build.origin="${BUILD_ORIGIN}"
+
 EXPOSE 80
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --start-interval=1s --retries=3 CMD wget --quiet --tries=1 --spider http://127.0.0.1/healthcheck || exit 1

--- a/apps/monitoring-sidecar/Dockerfile
+++ b/apps/monitoring-sidecar/Dockerfile
@@ -54,6 +54,37 @@ WORKDIR /app/apps/monitoring-sidecar
 ENV HOST=0.0.0.0
 ENV PORT=80
 
+# Build provenance. Baked in here and reported at runtime by GET /build-info,
+# which the admin console's Deployment Check aggregates across the whole stack —
+# it is how an operator confirms every container came from one commit. Empty
+# defaults so a plain `docker build` still works and reports "unknown" rather
+# than failing; CI and build-containers.sh supply the real values. Last in the
+# file because these change on every commit and nothing expensive may sit below
+# them.
+ARG BUILD_COMMIT=""
+ARG BUILD_REF=""
+ARG BUILD_TIME=""
+ARG BUILD_VERSION=""
+ARG BUILD_TAGS=""
+ARG BUILD_PR=""
+ARG BUILD_ORIGIN=""
+
+ENV SCRIBEAR_BUILD_SERVICE=monitoring-sidecar \
+    SCRIBEAR_BUILD_COMMIT=${BUILD_COMMIT} \
+    SCRIBEAR_BUILD_REF=${BUILD_REF} \
+    SCRIBEAR_BUILD_TIME=${BUILD_TIME} \
+    SCRIBEAR_BUILD_VERSION=${BUILD_VERSION} \
+    SCRIBEAR_BUILD_TAGS=${BUILD_TAGS} \
+    SCRIBEAR_BUILD_PR=${BUILD_PR} \
+    SCRIBEAR_BUILD_ORIGIN=${BUILD_ORIGIN}
+
+LABEL org.opencontainers.image.title="scribear/monitoring-sidecar" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      org.scribear.build.pull-request="${BUILD_PR}" \
+      org.scribear.build.origin="${BUILD_ORIGIN}"
+
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --start-interval=1s --retries=3 CMD wget -qO- http://127.0.0.1:80/api/monitoring/v1/probes/liveness || exit 1
 
 ENTRYPOINT ["dumb-init", "--"]

--- a/apps/node-server/Dockerfile
+++ b/apps/node-server/Dockerfile
@@ -41,6 +41,37 @@ WORKDIR /app/apps/node-server
 ENV HOST=0.0.0.0
 ENV PORT=80
 
+# Build provenance. Baked in here and reported at runtime by GET /build-info,
+# which the admin console's Deployment Check aggregates across the whole stack —
+# it is how an operator confirms every container came from one commit. Empty
+# defaults so a plain `docker build` still works and reports "unknown" rather
+# than failing; CI and build-containers.sh supply the real values. Last in the
+# file because these change on every commit and nothing expensive may sit below
+# them.
+ARG BUILD_COMMIT=""
+ARG BUILD_REF=""
+ARG BUILD_TIME=""
+ARG BUILD_VERSION=""
+ARG BUILD_TAGS=""
+ARG BUILD_PR=""
+ARG BUILD_ORIGIN=""
+
+ENV SCRIBEAR_BUILD_SERVICE=node-server \
+    SCRIBEAR_BUILD_COMMIT=${BUILD_COMMIT} \
+    SCRIBEAR_BUILD_REF=${BUILD_REF} \
+    SCRIBEAR_BUILD_TIME=${BUILD_TIME} \
+    SCRIBEAR_BUILD_VERSION=${BUILD_VERSION} \
+    SCRIBEAR_BUILD_TAGS=${BUILD_TAGS} \
+    SCRIBEAR_BUILD_PR=${BUILD_PR} \
+    SCRIBEAR_BUILD_ORIGIN=${BUILD_ORIGIN}
+
+LABEL org.opencontainers.image.title="scribear/node-server" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      org.scribear.build.pull-request="${BUILD_PR}" \
+      org.scribear.build.origin="${BUILD_ORIGIN}"
+
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --start-interval=1s --retries=3 CMD wget -qO- http://127.0.0.1:80/api/node-server/v1/probes/liveness || exit 1
 
 ENTRYPOINT ["dumb-init", "--"]

--- a/apps/session-manager/Dockerfile
+++ b/apps/session-manager/Dockerfile
@@ -46,6 +46,36 @@ WORKDIR /app/apps/session-manager
 ENV HOST=0.0.0.0
 ENV PORT=80
 
+# Build provenance. Baked in here and reported at runtime by GET /build-info,
+# which the admin console's Deployment Check aggregates across the whole stack —
+# it is how an operator confirms every container came from one commit. Empty
+# defaults so a plain `docker build` still works and simply reports "unknown";
+# CI and build-containers.sh supply the real values. Last in the file because
+# these change on every commit and nothing expensive may sit below them.
+ARG BUILD_COMMIT=""
+ARG BUILD_REF=""
+ARG BUILD_TIME=""
+ARG BUILD_VERSION=""
+ARG BUILD_TAGS=""
+ARG BUILD_PR=""
+ARG BUILD_ORIGIN=""
+
+ENV SCRIBEAR_BUILD_SERVICE=session-manager \
+    SCRIBEAR_BUILD_COMMIT=${BUILD_COMMIT} \
+    SCRIBEAR_BUILD_REF=${BUILD_REF} \
+    SCRIBEAR_BUILD_TIME=${BUILD_TIME} \
+    SCRIBEAR_BUILD_VERSION=${BUILD_VERSION} \
+    SCRIBEAR_BUILD_TAGS=${BUILD_TAGS} \
+    SCRIBEAR_BUILD_PR=${BUILD_PR} \
+    SCRIBEAR_BUILD_ORIGIN=${BUILD_ORIGIN}
+
+LABEL org.opencontainers.image.title="scribear/session-manager" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      org.scribear.build.pull-request="${BUILD_PR}" \
+      org.scribear.build.origin="${BUILD_ORIGIN}"
+
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --start-interval=1s --retries=3 CMD wget -qO- http://127.0.0.1:80/api/session-manager/v1/probes/liveness || exit 1
 
 ENTRYPOINT ["dumb-init", "--"]

--- a/apps/standalone-webapp/Dockerfile
+++ b/apps/standalone-webapp/Dockerfile
@@ -54,6 +54,36 @@ EOF
 
 COPY --from=build-env /app/apps/standalone-webapp/dist/ ./
 
+# Build provenance. A webapp is static files behind nginx, so there is no
+# process to ask: the same document the Node services answer GET /build-info
+# with is generated here at image build time and served as a file. The admin
+# console's Deployment Check reads it from every container, which is how an
+# operator confirms the whole stack came from one commit.
+#
+# Empty defaults so a plain `docker build` still works and reports "unknown"
+# rather than failing; CI and build-containers.sh supply the real values. Last
+# in the file because these change on every commit and nothing expensive may
+# sit below them.
+COPY tools/build-info/write-build-info.sh /tmp/write-build-info.sh
+
+ARG BUILD_COMMIT=""
+ARG BUILD_REF=""
+ARG BUILD_TIME=""
+ARG BUILD_VERSION=""
+ARG BUILD_TAGS=""
+ARG BUILD_PR=""
+ARG BUILD_ORIGIN=""
+
+RUN sh /tmp/write-build-info.sh standalone-webapp /usr/share/nginx/html/build-info.json \
+  && rm /tmp/write-build-info.sh
+
+LABEL org.opencontainers.image.title="scribear/standalone-webapp" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      org.scribear.build.pull-request="${BUILD_PR}" \
+      org.scribear.build.origin="${BUILD_ORIGIN}"
+
 EXPOSE 80
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --start-interval=1s --retries=3 CMD wget --quiet --tries=1 --spider http://127.0.0.1/healthcheck || exit 1

--- a/build-containers.sh
+++ b/build-containers.sh
@@ -4,6 +4,72 @@ set -euo pipefail
 TAG="${1:-dev}"
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 
+# Build provenance, stamped into every image below and reported by its
+# /build-info surface, which the admin console's Deployment Check aggregates.
+# CI computes the same set in .github/actions/resolve-container-tags.
+#
+# Worth doing for a local build and not only in CI: the alternative is a table
+# of "unknown", which tells an operator nothing and — worse — looks identical
+# whether the stack was built here or is simply failing to report. With this,
+# a locally-built stack names its real commit and says plainly that it came
+# from a machine rather than a published build.
+#
+# Everything here degrades rather than fails. Building from a tarball with no
+# .git, or with git absent entirely, leaves the fields empty and the images
+# report "unknown" — the same as they would have without this block.
+BUILD_COMMIT=""
+BUILD_REF=""
+if git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  BUILD_COMMIT="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || true)"
+  BUILD_REF="$(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+
+  # The `git describe --dirty` convention. This is the field that matters most
+  # in a local build: an image built from a modified working tree contains code
+  # that exists nowhere else, so its commit names a commit it does not hold.
+  # Carried on the commit rather than as an arg of its own so that
+  # `docker inspect`'s revision label says so too.
+  if [ -n "$BUILD_COMMIT" ] && [ -n "$(git -C "$ROOT" status --porcelain 2>/dev/null)" ]; then
+    BUILD_COMMIT="${BUILD_COMMIT}-dirty"
+  fi
+fi
+
+BUILD_ARGS=(
+  --build-arg "BUILD_COMMIT=$BUILD_COMMIT"
+  --build-arg "BUILD_REF=$BUILD_REF"
+  --build-arg "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)"
+  # The tag this script was asked for. Unlike CI, nothing is published, so this
+  # is the local image's name rather than a registry tag - but it is what a
+  # deployment puts in IMAGE_TAG, which is the question being answered.
+  --build-arg "BUILD_TAGS=$TAG"
+  --build-arg "BUILD_PR="
+  --build-arg "BUILD_ORIGIN=local"
+)
+
+# The version each image reports, from the same file CI reads for it (see
+# `version_file` in .github/node-images.json). Per image rather than once per
+# run: the root package.json is the private monorepo root at 0.0.0, and
+# stamping that into all eleven images would report a version that looks real
+# and is not. Unreadable leaves it empty, which reports as "unknown".
+image_version() {
+  local dir="$1"
+  if [ -f "$dir/package.json" ]; then
+    node -p "require('$dir/package.json').version" 2>/dev/null || true
+  elif [ -f "$dir/pyproject.toml" ]; then
+    python3 -c "import sys, tomllib; print(tomllib.load(open(sys.argv[1], 'rb'))['project']['version'])" \
+      "$dir/pyproject.toml" 2>/dev/null || true
+  fi
+}
+
+# `docker build` with this run's provenance and the image's own version.
+# Everything after the workspace directory is passed to docker untouched.
+build_image() {
+  local workspace="$1"
+  shift
+  docker build "${BUILD_ARGS[@]}" \
+    --build-arg "BUILD_VERSION=$(image_version "$workspace")" \
+    "$@"
+}
+
 # One CUDA image per entry in transcription_service/cuda-variants.json, named
 # for the value a deployment puts in TRANSCRIPTION_DEVICE. CI builds the same
 # list in parallel (.github/workflows/python-{ci,cd}.yml via the
@@ -39,20 +105,27 @@ PY
 )"
 fi
 
-docker build -f "$ROOT/apps/node-server/Dockerfile"       "$ROOT" -t "scribear/node-server:$TAG"
-docker build -f "$ROOT/apps/session-manager/Dockerfile"    "$ROOT" -t "scribear/session-manager:$TAG"
-docker build -f "$ROOT/apps/client-webapp/Dockerfile"      "$ROOT" -t "scribear/client-webapp:$TAG"
-docker build -f "$ROOT/apps/standalone-webapp/Dockerfile"  "$ROOT" -t "scribear/standalone-webapp:$TAG"
-docker build -f "$ROOT/apps/kiosk-webapp/Dockerfile"       "$ROOT" -t "scribear/kiosk-webapp:$TAG"
-docker build -f "$ROOT/apps/admin-webapp/Dockerfile"       "$ROOT" -t "scribear/admin-webapp:$TAG"
-docker build -f "$ROOT/apps/admin-server/Dockerfile"       "$ROOT" -t "scribear/admin-server:$TAG"
-docker build -f "$ROOT/apps/monitoring-sidecar/Dockerfile" "$ROOT" -t "scribear/monitoring-sidecar:$TAG"
+build_image "$ROOT/apps/node-server"       -f "$ROOT/apps/node-server/Dockerfile"       "$ROOT" -t "scribear/node-server:$TAG"
+build_image "$ROOT/apps/session-manager"    -f "$ROOT/apps/session-manager/Dockerfile"    "$ROOT" -t "scribear/session-manager:$TAG"
+build_image "$ROOT/apps/client-webapp"      -f "$ROOT/apps/client-webapp/Dockerfile"      "$ROOT" -t "scribear/client-webapp:$TAG"
+build_image "$ROOT/apps/standalone-webapp"  -f "$ROOT/apps/standalone-webapp/Dockerfile"  "$ROOT" -t "scribear/standalone-webapp:$TAG"
+build_image "$ROOT/apps/kiosk-webapp"       -f "$ROOT/apps/kiosk-webapp/Dockerfile"       "$ROOT" -t "scribear/kiosk-webapp:$TAG"
+build_image "$ROOT/apps/admin-webapp"       -f "$ROOT/apps/admin-webapp/Dockerfile"       "$ROOT" -t "scribear/admin-webapp:$TAG"
+build_image "$ROOT/apps/admin-server"       -f "$ROOT/apps/admin-server/Dockerfile"       "$ROOT" -t "scribear/admin-server:$TAG"
+build_image "$ROOT/apps/monitoring-sidecar" -f "$ROOT/apps/monitoring-sidecar/Dockerfile" "$ROOT" -t "scribear/monitoring-sidecar:$TAG"
 
+# scribear-db and scribear-redis are the two images with no build provenance:
+# Postgres and Redis have no HTTP surface to report it on, so the admin
+# console lists them as "not reported" rather than pretending otherwise.
 docker build "$ROOT/infra/scribear-db"    -t "scribear/scribear-db:$TAG"
-docker build "$ROOT/infra/scribear-nginx" -t "scribear/scribear-nginx:$TAG"
 docker build "$ROOT/infra/scribear-redis" -t "scribear/scribear-redis:$TAG"
 
-docker build -f "$ROOT/transcription_service/Dockerfile_CPU"  "$ROOT/transcription_service" -t "scribear/transcription-service-cpu:$TAG"
+# From the repository root, unlike its two neighbours above: it shares the
+# webapps' build-info generator (tools/build-info) rather than keeping a copy,
+# so it needs a context that can reach it.
+build_image "$ROOT/infra/scribear-nginx" -f "$ROOT/infra/scribear-nginx/Dockerfile" "$ROOT" -t "scribear/scribear-nginx:$TAG"
+
+build_image "$ROOT/transcription_service" -f "$ROOT/transcription_service/Dockerfile_CPU"  "$ROOT/transcription_service" -t "scribear/transcription-service-cpu:$TAG"
 
 if [ -z "$CUDA_BUILDS" ]; then
   echo "Skipping CUDA images"
@@ -60,7 +133,7 @@ else
   while IFS=$'\t' read -r device base_image; do
     [ -n "$device" ] || continue
     echo "Building transcription-service-$device from $base_image"
-    docker build -f "$ROOT/transcription_service/Dockerfile_CUDA" \
+    build_image "$ROOT/transcription_service" -f "$ROOT/transcription_service/Dockerfile_CUDA" \
       --build-arg "CUDA_BASE_IMAGE=$base_image" \
       "$ROOT/transcription_service" -t "scribear/transcription-service-$device:$TAG"
   done <<< "$CUDA_BUILDS"

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,70 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — every container reports what it was built from
+
+The admin console's **Deployment Check** page gained a **Deployed versions**
+table: one row per container, showing the version, commit, branch, build time
+and image tags it was built from. Nothing to add to `.env` — the six new
+admin-server variables all default to their compose service names.
+
+### Why it exists
+
+Every service knows its own build and no service knows anyone else's, so an
+upgrade that pulled some images and not others has been invisible from inside
+the stack. The health rollup cannot see it either: a container running last
+month's image is a perfectly healthy container, and it stays green.
+
+The table takes the commit the most containers report as the deployment's, and
+names any container that disagrees. That is the case worth watching for — it is
+what a `docker compose up -d` that half-failed, or a service pinned to a
+different `IMAGE_TAG`, looks like from the outside.
+
+### What the statuses mean
+
+| Status | What happened |
+| --- | --- |
+| `reporting` | Answered with its build. |
+| `old image` | Answered, and has no build document — the image predates this release, so it was **not** recreated by your last upgrade. |
+| `no answer` | Could not be reached at all. The container is down, not stale. |
+| `n/a` | `scribear-db` and `redis` have no HTTP surface to report a build on. Their versions still move with `IMAGE_TAG`; read them with `docker compose images`. |
+
+The first upgrade to this release is the one time `old image` is expected: it
+appears for anything that has not been recreated yet. Run `docker compose up -d`
+in `deployment/` and re-check — every row should turn to `reporting`.
+
+### Locally built images
+
+`build-containers.sh` now stamps the commit it built from, marks the image as a
+local build, and appends `-dirty` when the working tree had uncommitted
+changes. A stack started straight from a checkout (`npm run dev`) has no image
+to stamp and says so, rather than showing a table of blanks.
+
+### Reading it without the console
+
+Every value is also an image label, so a shell on the host answers the same
+question:
+
+```
+docker compose images
+docker inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' \
+  ghcr.io/scribear/admin-server:latest
+```
+
+### Note for anyone building images by hand
+
+`scribear-nginx` now builds from the repository root rather than from
+`infra/scribear-nginx`, because it shares the webapps' build-info generator:
+
+```
+docker build -f infra/scribear-nginx/Dockerfile .
+```
+
+`build-containers.sh` and CI already do this; only a hand-rolled `docker build`
+needs changing.
+
+---
+
 ## 0.3.0 — migrations run themselves
 
 Every deploy now applies the database schema as part of `docker compose up

--- a/infra/scribear-nginx/Dockerfile
+++ b/infra/scribear-nginx/Dockerfile
@@ -1,9 +1,46 @@
+# Build from the repository root using:
+#   docker build -f infra/scribear-nginx/Dockerfile .
+#
+# The root, not this directory: the build provenance step below shares one
+# generator with the webapp images (tools/build-info/write-build-info.sh)
+# rather than keeping a fifth copy of it here.
+
 FROM nginx:1.29.7-alpine3.23
 
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY infra/scribear-nginx/nginx.conf /etc/nginx/nginx.conf
 
 # 127.0.0.1, not localhost: on alpine/busybox "localhost" resolves to ::1 first
 # and nginx listens only on IPv4, so localhost gives "connection refused". Hit
 # the dedicated /healthz (root "/" returns 404, which wget reads as failure).
 HEALTHCHECK --interval=5s --timeout=5s --retries=5 \
     CMD wget --no-check-certificate -qO- https://127.0.0.1:443/healthz || exit 1
+
+# Build provenance. The proxy is nginx serving files, so there is no process to
+# ask: the same document the Node services answer GET /build-info with is
+# generated here at image build time. nginx.conf serves it from the plain-HTTP
+# listener only — see the `location = /build-info.json` block there for why it
+# must not be published on 443.
+#
+# Empty defaults so a plain `docker build` still works and reports "unknown"
+# rather than failing; CI and build-containers.sh supply the real values. Last
+# in the file because these change on every commit and nothing expensive may
+# sit below them.
+COPY tools/build-info/write-build-info.sh /tmp/write-build-info.sh
+
+ARG BUILD_COMMIT=""
+ARG BUILD_REF=""
+ARG BUILD_TIME=""
+ARG BUILD_VERSION=""
+ARG BUILD_TAGS=""
+ARG BUILD_PR=""
+ARG BUILD_ORIGIN=""
+
+RUN sh /tmp/write-build-info.sh scribear-nginx /usr/share/nginx/build-info/build-info.json \
+  && rm /tmp/write-build-info.sh
+
+LABEL org.opencontainers.image.title="scribear/scribear-nginx" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      org.scribear.build.pull-request="${BUILD_PR}" \
+      org.scribear.build.origin="${BUILD_ORIGIN}"

--- a/infra/scribear-nginx/nginx.conf
+++ b/infra/scribear-nginx/nginx.conf
@@ -29,7 +29,33 @@ http {
     server {
         listen 80;
         server_name _;
-        return 301 https://$host$request_uri;
+
+        # This proxy's own build provenance, for the admin console's Deployment
+        # Check. Generated at image build time by
+        # tools/build-info/write-build-info.sh.
+        #
+        # On the plain-HTTP listener only, and deliberately so. Every other
+        # container answers this question on a port that is not published to the
+        # internet; nginx is the one that is, and repeating this block in the
+        # 443 server would put the deployment's commit hash on the public web.
+        # admin-server reaches it over the compose network as
+        # http://nginx:80/build-info.json, which never leaves the host.
+        #
+        location = /build-info.json {
+            access_log off;
+            default_type application/json;
+            root /usr/share/nginx/build-info;
+        }
+
+        # The redirect lives in `location /`, not at server level. A
+        # server-level `return` runs in the rewrite phase, before nginx picks a
+        # location at all, so it would short-circuit the exact match above and
+        # 301 the build document too. Inside `location /` it is the fallback it
+        # reads as: longest-prefix matching gives /build-info.json to the block
+        # above and everything else to this one.
+        location / {
+            return 301 https://$host$request_uri;
+        }
     }
 
     server {

--- a/libs/base-fastify-server/src/index.ts
+++ b/libs/base-fastify-server/src/index.ts
@@ -1,3 +1,5 @@
+import type { BuildInfo, BuildOrigin } from './server/build-info.js';
+import { UNKNOWN_BUILD_FIELD, readBuildInfo } from './server/build-info.js';
 import createBaseServer from './server/create-base-server.js';
 import type { BaseLogger } from './server/create-logger.js';
 import { LogLevel } from './server/create-logger.js';
@@ -7,6 +9,7 @@ import {
   HttpError,
   type HttpErrorStatus,
 } from './server/errors/http-errors.js';
+import { BUILD_INFO_PATH } from './server/plugins/build-info-route.js';
 import type { BaseDependencies } from './server/types/base-dependencies.js';
 import type {
   BaseFastifyInstance,
@@ -14,8 +17,18 @@ import type {
   BaseFastifyRequest,
 } from './server/types/base-fastify-types.js';
 
-export { createBaseServer, LogLevel, BaseHttpError, HttpError };
+export {
+  createBaseServer,
+  LogLevel,
+  BaseHttpError,
+  HttpError,
+  readBuildInfo,
+  BUILD_INFO_PATH,
+  UNKNOWN_BUILD_FIELD,
+};
 export type {
+  BuildInfo,
+  BuildOrigin,
   BaseLogger,
   BaseDependencies,
   BaseFastifyInstance,

--- a/libs/base-fastify-server/src/server/build-info.ts
+++ b/libs/base-fastify-server/src/server/build-info.ts
@@ -1,0 +1,133 @@
+/**
+ * Where the image a container is running came from.
+ *
+ * - `ci` — built and published by a GitHub Actions run. The only origin whose
+ *   commit can be trusted to exist on a branch someone else can check out.
+ * - `local` — built on someone's machine by `build-containers.sh`. The commit
+ *   is real, but the image was never published, so two boxes reporting the same
+ *   commit are not necessarily running the same bytes.
+ * - `unknown` — nothing stamped the build. Either a hand-rolled `docker build`,
+ *   or a process started straight from a checkout (`npm run dev`), where there
+ *   is no image at all.
+ *
+ * Kept distinct from `dirty` deliberately: a CI build is never dirty, but a
+ * clean local build is still a local build, and an operator chasing "why does
+ * staging not match main" needs to know which of those they are looking at.
+ */
+export type BuildOrigin = 'ci' | 'local' | 'unknown';
+
+/**
+ * What a running container can say about the artifact it was built from.
+ *
+ * Every field is baked in at image build time (see each service's Dockerfile)
+ * and read back from the environment here. Nothing is derived at runtime, which
+ * is the point: an operator asking "what is actually deployed?" needs the
+ * identity of the *image*, not of the source tree the container happens to be
+ * sitting next to.
+ *
+ * The same shape is produced by every container in the stack, including the
+ * ones that are not Node services — the webapps ship it as a static
+ * `build-info.json` and transcription-service builds it in Python — so the
+ * admin console can render one table rather than one renderer per language.
+ */
+export interface BuildInfo {
+  /** Compose service name, matching the health rollup's component names. */
+  service: string;
+  /** Version from the image's `package.json` / `pyproject.toml`. */
+  version: string;
+  /** Full commit SHA the image was built from, without any `-dirty` suffix. */
+  commit: string;
+  /** Branch or tag the build ran on, e.g. `staging`. */
+  ref: string;
+  /** ISO 8601 instant the image was built. */
+  builtAt: string;
+  /** Registry tags this image was published under, e.g. `staging`, `v1.4.2`. */
+  imageTags: string[];
+  /** Pull request the image was built from, or null outside a PR build. */
+  pullRequest: number | null;
+  origin: BuildOrigin;
+  /**
+   * True when the working tree had uncommitted changes at build time, so
+   * `commit` names a commit the image does *not* faithfully contain.
+   */
+  dirty: boolean;
+}
+
+/**
+ * Stand-in for a field the build did not supply.
+ *
+ * A literal rather than an empty string or `null` so that a locally-built image
+ * reads as "built outside CI" everywhere it is displayed, instead of as a blank
+ * cell that could equally mean the request failed.
+ */
+export const UNKNOWN_BUILD_FIELD = 'unknown';
+
+/**
+ * Suffix `build-containers.sh` appends to a commit built from a working tree
+ * with uncommitted changes, following the `git describe --dirty` convention.
+ *
+ * Carried in the commit string rather than in a build arg of its own so that
+ * `org.opencontainers.image.revision` — which an operator reads with
+ * `docker inspect`, far from this code — says so too.
+ */
+const DIRTY_SUFFIX = '-dirty';
+
+function readField(value: string | undefined): string {
+  const trimmed = value?.trim() ?? '';
+  return trimmed === '' ? UNKNOWN_BUILD_FIELD : trimmed;
+}
+
+function readOrigin(value: string | undefined): BuildOrigin {
+  const trimmed = value?.trim().toLowerCase() ?? '';
+  return trimmed === 'ci' || trimmed === 'local' ? trimmed : 'unknown';
+}
+
+/**
+ * Parses a PR number, or null when there was not one.
+ *
+ * Anything unparseable is null rather than `NaN` or a thrown error: this is
+ * decoration on a page whose job is to work when the deployment does not.
+ */
+function readPullRequest(value: string | undefined): number | null {
+  const trimmed = value?.trim() ?? '';
+  if (!/^\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+/**
+ * Reads the `SCRIBEAR_BUILD_*` variables the Dockerfile bakes in.
+ *
+ * Tolerant by construction — every field falls back to `unknown` rather than
+ * throwing. This runs on the way to answering an operator's "what is deployed?"
+ * question, and a container that cannot describe itself must still start and
+ * still answer, or the one situation the page exists for (a half-finished
+ * upgrade) is also the situation where it goes blank.
+ */
+export function readBuildInfo(
+  env: Record<string, string | undefined> = process.env,
+): BuildInfo {
+  // Indexed rather than dot-accessed: `noPropertyAccessFromIndexSignature` is
+  // on, and one accessor reads better than a bracket on every line.
+  const get = (name: string): string | undefined => env[name];
+
+  const rawCommit = readField(get('SCRIBEAR_BUILD_COMMIT'));
+  const dirty = rawCommit.endsWith(DIRTY_SUFFIX);
+
+  const tags = (get('SCRIBEAR_BUILD_TAGS') ?? '')
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter((tag) => tag !== '');
+
+  return {
+    service: readField(get('SCRIBEAR_BUILD_SERVICE')),
+    version: readField(get('SCRIBEAR_BUILD_VERSION')),
+    commit: dirty ? rawCommit.slice(0, -DIRTY_SUFFIX.length) : rawCommit,
+    ref: readField(get('SCRIBEAR_BUILD_REF')),
+    builtAt: readField(get('SCRIBEAR_BUILD_TIME')),
+    imageTags: tags,
+    pullRequest: readPullRequest(get('SCRIBEAR_BUILD_PR')),
+    origin: readOrigin(get('SCRIBEAR_BUILD_ORIGIN')),
+    dirty,
+  };
+}

--- a/libs/base-fastify-server/src/server/create-base-server.ts
+++ b/libs/base-fastify-server/src/server/create-base-server.ts
@@ -14,6 +14,7 @@ import type { BaseLogger, LogLevel } from './create-logger.js';
 import { createLogger } from './create-logger.js';
 import scopeLogger from './hooks/on-request/scope-logger.js';
 import setRequestIdHeader from './hooks/on-send/set-request-id-header.js';
+import buildInfoRoute from './plugins/build-info-route.js';
 import errorHandler from './plugins/error-handler.js';
 import jsonParser from './plugins/json-parser.js';
 import notFoundHandler from './plugins/not-found-handler.js';
@@ -66,6 +67,7 @@ function createBaseServer(
   fastify.register(jsonParser);
   fastify.register(notFoundHandler);
   fastify.register(schemaValidator);
+  fastify.register(buildInfoRoute);
 
   // Register hooks
   fastify.register(scopeLogger);

--- a/libs/base-fastify-server/src/server/plugins/build-info-route.ts
+++ b/libs/base-fastify-server/src/server/plugins/build-info-route.ts
@@ -1,0 +1,38 @@
+import fastifyPlugin from 'fastify-plugin';
+
+import { readBuildInfo } from '../build-info.js';
+import type { BaseFastifyInstance } from '../types/base-fastify-types.js';
+
+/** Path every container in the stack answers build metadata on. */
+export const BUILD_INFO_PATH = '/build-info';
+
+/**
+ * `GET /build-info` — which artifact this container was built from.
+ *
+ * Registered here rather than per service so that all four Node services answer
+ * the same path with the same body, and so that adding a fifth needs no route
+ * of its own. Mounted at the root, deliberately outside each service's
+ * `/api/<service>/v1` prefix: the static webapps and transcription-service
+ * cannot honour a Node service's prefix, and one path across the whole stack is
+ * what lets the admin console probe every container with one loop.
+ *
+ * **Unauthenticated, and reachable only in-cluster.** nginx proxies only the
+ * `/api/...` prefixes to these services, so nothing outside the compose network
+ * can reach this route. That is the reason it can be unauthenticated at all,
+ * and the reason it must stay at the root: moving it under `/api` would publish
+ * every service's commit hash to the internet.
+ *
+ * The payload is computed once, at registration: the environment it reads is
+ * baked into the image and cannot change while the process lives.
+ */
+export default fastifyPlugin((fastify: BaseFastifyInstance) => {
+  const buildInfo = readBuildInfo();
+
+  fastify.route({
+    method: 'GET',
+    url: BUILD_INFO_PATH,
+    handler: (_req, res) => {
+      res.code(200).send(buildInfo);
+    },
+  });
+});

--- a/libs/base-fastify-server/tests/integration/build-info-route.test.ts
+++ b/libs/base-fastify-server/tests/integration/build-info-route.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect } from 'vitest';
+
+import { BUILD_INFO_PATH, LogLevel } from '#src/index.js';
+import createBaseServer from '#src/server/create-base-server.js';
+import type { BaseFastifyInstance } from '#src/server/types/base-fastify-types.js';
+
+/**
+ * Every Node service inherits this route from `createBaseServer`, so these
+ * tests stand in for four services rather than one.
+ */
+describe('Integration Tests - Build Info Route', (it) => {
+  const originalEnv = { ...process.env };
+  let fastify: BaseFastifyInstance;
+
+  beforeEach(() => {
+    process.env['SCRIBEAR_BUILD_SERVICE'] = 'session-manager';
+    process.env['SCRIBEAR_BUILD_VERSION'] = '1.4.2';
+    process.env['SCRIBEAR_BUILD_COMMIT'] = 'def6e68';
+    process.env['SCRIBEAR_BUILD_REF'] = 'staging';
+    process.env['SCRIBEAR_BUILD_TIME'] = '2026-07-24T12:03:11Z';
+    process.env['SCRIBEAR_BUILD_TAGS'] = 'staging,staging-def6e68';
+    process.env['SCRIBEAR_BUILD_ORIGIN'] = 'ci';
+    delete process.env['SCRIBEAR_BUILD_PR'];
+
+    fastify = createBaseServer(LogLevel.SILENT).fastify;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('reports the build the image was made from', async () => {
+    // Act
+    const response = await fastify.inject({
+      method: 'GET',
+      url: BUILD_INFO_PATH,
+    });
+
+    // Assert
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      service: 'session-manager',
+      version: '1.4.2',
+      commit: 'def6e68',
+      ref: 'staging',
+      builtAt: '2026-07-24T12:03:11Z',
+      imageTags: ['staging', 'staging-def6e68'],
+      pullRequest: null,
+      origin: 'ci',
+      dirty: false,
+    });
+  });
+
+  // The route sits at the root, outside every service's `/api/<service>/v1`
+  // prefix, because nginx proxies only the `/api` prefixes - which is what
+  // keeps commit hashes off the public internet. A move under `/api` would be
+  // an information disclosure, so the path is asserted rather than assumed.
+  it('is served at the root, not under an /api prefix', () => {
+    // Assert
+    expect(BUILD_INFO_PATH).toBe('/build-info');
+  });
+});

--- a/libs/base-fastify-server/tests/unit/server/build-info.test.ts
+++ b/libs/base-fastify-server/tests/unit/server/build-info.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect } from 'vitest';
+
+import { UNKNOWN_BUILD_FIELD, readBuildInfo } from '#src/server/build-info.js';
+
+describe('readBuildInfo', (it) => {
+  it('reads every field a CI build bakes in', () => {
+    // Arrange
+    const env = {
+      SCRIBEAR_BUILD_SERVICE: 'admin-server',
+      SCRIBEAR_BUILD_VERSION: '1.4.2',
+      SCRIBEAR_BUILD_COMMIT: 'def6e68f0b3c4a1d9e2f5a7b8c0d1e2f3a4b5c6d',
+      SCRIBEAR_BUILD_REF: 'staging',
+      SCRIBEAR_BUILD_TIME: '2026-07-24T12:03:11Z',
+      SCRIBEAR_BUILD_TAGS: 'staging,staging-def6e68',
+      SCRIBEAR_BUILD_ORIGIN: 'ci',
+    };
+
+    // Act
+    const info = readBuildInfo(env);
+
+    // Assert
+    expect(info).toEqual({
+      service: 'admin-server',
+      version: '1.4.2',
+      commit: 'def6e68f0b3c4a1d9e2f5a7b8c0d1e2f3a4b5c6d',
+      ref: 'staging',
+      builtAt: '2026-07-24T12:03:11Z',
+      imageTags: ['staging', 'staging-def6e68'],
+      pullRequest: null,
+      origin: 'ci',
+      dirty: false,
+    });
+  });
+
+  // A stack started straight from a checkout (`npm run dev`) has no image and
+  // so stamps nothing. It must still describe itself, and must do so in a way
+  // the console can distinguish from a probe that failed - hence `unknown`
+  // rather than an empty string, and `origin: unknown` rather than `local`.
+  it('reports origin "unknown" when nothing stamped the build', () => {
+    // Arrange
+    const env = { SCRIBEAR_BUILD_VERSION: '   ' };
+
+    // Act
+    const info = readBuildInfo(env);
+
+    // Assert
+    expect(info).toEqual({
+      service: UNKNOWN_BUILD_FIELD,
+      version: UNKNOWN_BUILD_FIELD,
+      commit: UNKNOWN_BUILD_FIELD,
+      ref: UNKNOWN_BUILD_FIELD,
+      builtAt: UNKNOWN_BUILD_FIELD,
+      imageTags: [],
+      pullRequest: null,
+      origin: 'unknown',
+      dirty: false,
+    });
+  });
+
+  // build-containers.sh stamps a real commit from the host checkout, so a
+  // locally-built image is far more informative than an unstamped one - it just
+  // must not be mistaken for something CI published.
+  it('reports a local build with its real commit', () => {
+    // Arrange
+    const env = {
+      SCRIBEAR_BUILD_COMMIT: 'def6e68',
+      SCRIBEAR_BUILD_REF: 'feat/versions',
+      SCRIBEAR_BUILD_ORIGIN: 'local',
+    };
+
+    // Act
+    const info = readBuildInfo(env);
+
+    // Assert
+    expect(info.origin).toBe('local');
+    expect(info.commit).toBe('def6e68');
+    expect(info.dirty).toBe(false);
+  });
+
+  // The `-dirty` suffix rides on the commit rather than in a build arg of its
+  // own so `docker inspect`'s revision label carries it too. It is split back
+  // out here so the console can flag it without string-matching.
+  it('splits a -dirty suffix out of the commit', () => {
+    // Arrange
+    const env = {
+      SCRIBEAR_BUILD_COMMIT: 'def6e68-dirty',
+      SCRIBEAR_BUILD_ORIGIN: 'local',
+    };
+
+    // Act
+    const info = readBuildInfo(env);
+
+    // Assert
+    expect(info.commit).toBe('def6e68');
+    expect(info.dirty).toBe(true);
+  });
+
+  it('reads the pull request a PR build came from', () => {
+    // Act
+    const info = readBuildInfo({ SCRIBEAR_BUILD_PR: '157' });
+
+    // Assert
+    expect(info.pullRequest).toBe(157);
+  });
+
+  // Every non-PR build passes this arg empty rather than omitting it, so the
+  // empty case is the common one; the rest is refusing to render `NaN`.
+  it.each([[''], ['   '], ['abc'], ['0'], ['-3'], ['1.5']])(
+    'reports no pull request for %o',
+    (raw: string) => {
+      // Act
+      const info = readBuildInfo({ SCRIBEAR_BUILD_PR: raw });
+
+      // Assert
+      expect(info.pullRequest).toBeNull();
+    },
+  );
+
+  // The build args arrive as one comma-joined string, and CI produces an empty
+  // one on a PR build (nothing is published), so the empty and ragged cases are
+  // the normal ones rather than defensive padding.
+  it('splits, trims and drops empty image tags', () => {
+    // Arrange
+    const env = { SCRIBEAR_BUILD_TAGS: ' latest , , v1.4.2 ' };
+
+    // Act
+    const info = readBuildInfo(env);
+
+    // Assert
+    expect(info.imageTags).toEqual(['latest', 'v1.4.2']);
+  });
+
+  it('treats an unrecognized origin as unknown', () => {
+    // Act
+    const info = readBuildInfo({ SCRIBEAR_BUILD_ORIGIN: 'jenkins' });
+
+    // Assert
+    expect(info.origin).toBe('unknown');
+  });
+});

--- a/tools/build-info/write-build-info.sh
+++ b/tools/build-info/write-build-info.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+#
+# Writes the build-info.json that the static images in the stack report.
+#
+# The Node services answer GET /build-info from a route `createBaseServer`
+# registers for them, and transcription-service builds the same payload in
+# Python. The webapps and the reverse proxy have no process to ask - they are
+# nginx serving files - so the identical document is generated here at image
+# build time and served as a static file.
+#
+# One script rather than a copy of this logic per Dockerfile: five hand-written
+# JSON serializers in shell is five places for the stack's containers to start
+# disagreeing about their own shape, which is precisely the failure the
+# Deployment Check exists to catch.
+#
+# Usage: write-build-info.sh <service-name> <output-path>
+#
+# Reads BUILD_COMMIT, BUILD_REF, BUILD_TIME, BUILD_VERSION, BUILD_TAGS,
+# BUILD_PR and BUILD_ORIGIN from the environment, all optional. See any
+# service Dockerfile for where they come from.
+
+set -eu
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <service-name> <output-path>" >&2
+  exit 2
+fi
+
+service="$1"
+output="$2"
+
+# Minimal JSON string escaping. Every input is a git ref, a SHA, an ISO
+# timestamp, a semver string or an image tag, so backslash and double quote are
+# the only characters that can realistically appear and break the document.
+escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+# Missing fields become the same "unknown" literal the Node and Python readers
+# use, so an unstamped image reads identically whichever container answered.
+default() {
+  if [ -z "${1:-}" ]; then printf 'unknown'; else printf '%s' "$1"; fi
+}
+
+# The `-dirty` suffix rides on the commit (the `git describe --dirty`
+# convention) so that `docker inspect`'s revision label carries it too. It is
+# split back out here into a boolean the console can render without
+# string-matching.
+commit="$(default "${BUILD_COMMIT:-}")"
+dirty=false
+case "$commit" in
+  *-dirty)
+    dirty=true
+    commit="${commit%-dirty}"
+    ;;
+esac
+
+# A JSON number or null, never a string: the console shows "PR #123" only when
+# this is genuinely a number, and every non-PR build passes the arg empty.
+pull_request=null
+case "${BUILD_PR:-}" in
+  '' | 0 | *[!0-9]*) ;;
+  *) pull_request="${BUILD_PR}" ;;
+esac
+
+origin="${BUILD_ORIGIN:-}"
+case "$origin" in
+  ci | local) ;;
+  *) origin=unknown ;;
+esac
+
+# BUILD_TAGS arrives comma-joined, because a --build-arg cannot be an array.
+# Empty is the normal case on a PR build, which publishes nothing. Globbing is
+# disabled around the split so a tag containing `*` or `?` is not expanded
+# against the image's filesystem.
+tags=''
+set -f
+old_ifs="$IFS"
+IFS=','
+for tag in ${BUILD_TAGS:-}; do
+  [ -n "$tag" ] || continue
+  if [ -z "$tags" ]; then
+    tags="\"$(escape "$tag")\""
+  else
+    tags="$tags,\"$(escape "$tag")\""
+  fi
+done
+IFS="$old_ifs"
+set +f
+
+mkdir -p "$(dirname "$output")"
+
+printf '{"service":"%s","version":"%s","commit":"%s","ref":"%s","builtAt":"%s","imageTags":[%s],"pullRequest":%s,"origin":"%s","dirty":%s}\n' \
+  "$(escape "$service")" \
+  "$(escape "$(default "${BUILD_VERSION:-}")")" \
+  "$(escape "$commit")" \
+  "$(escape "$(default "${BUILD_REF:-}")")" \
+  "$(escape "$(default "${BUILD_TIME:-}")")" \
+  "$tags" \
+  "$pull_request" \
+  "$(escape "$origin")" \
+  "$dirty" \
+  >"$output"

--- a/transcription_service/Dockerfile_CPU
+++ b/transcription_service/Dockerfile_CPU
@@ -32,6 +32,41 @@ ENV HOST=0.0.0.0
 ENV PORT=80
 ENV PROVIDER_CONFIG_PATH=/app/provider_config.json
 
+# Build provenance. Baked in here and reported at runtime by GET /build-info,
+# which the admin console's Deployment Check aggregates across the whole stack —
+# it is how an operator confirms every container came from one commit. Empty
+# defaults so a plain `docker build` still works and reports "unknown" rather
+# than failing; CI and build-containers.sh supply the real values. Last in the
+# file because these change on every commit and nothing expensive may sit below
+# them.
+#
+# SCRIBEAR_BUILD_SERVICE is the compose service name, which is the same for
+# every device variant; the published image name is what carries the -cpu /
+# -cuda<n> suffix.
+ARG BUILD_COMMIT=""
+ARG BUILD_REF=""
+ARG BUILD_TIME=""
+ARG BUILD_VERSION=""
+ARG BUILD_TAGS=""
+ARG BUILD_PR=""
+ARG BUILD_ORIGIN=""
+
+ENV SCRIBEAR_BUILD_SERVICE=transcription-service \
+    SCRIBEAR_BUILD_COMMIT=${BUILD_COMMIT} \
+    SCRIBEAR_BUILD_REF=${BUILD_REF} \
+    SCRIBEAR_BUILD_TIME=${BUILD_TIME} \
+    SCRIBEAR_BUILD_VERSION=${BUILD_VERSION} \
+    SCRIBEAR_BUILD_TAGS=${BUILD_TAGS} \
+    SCRIBEAR_BUILD_PR=${BUILD_PR} \
+    SCRIBEAR_BUILD_ORIGIN=${BUILD_ORIGIN}
+
+LABEL org.opencontainers.image.title="scribear/transcription-service" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      org.scribear.build.pull-request="${BUILD_PR}" \
+      org.scribear.build.origin="${BUILD_ORIGIN}"
+
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --start-interval=1s --retries=3 CMD curl -f http://localhost:80/probes/liveness || exit 1
 
 CMD ["python", "src/index.py"]

--- a/transcription_service/Dockerfile_CUDA
+++ b/transcription_service/Dockerfile_CUDA
@@ -62,6 +62,41 @@ ENV HOST=0.0.0.0
 ENV PORT=80
 ENV PROVIDER_CONFIG_PATH=/app/provider_config.json
 
+# Build provenance. Baked in here and reported at runtime by GET /build-info,
+# which the admin console's Deployment Check aggregates across the whole stack —
+# it is how an operator confirms every container came from one commit. Empty
+# defaults so a plain `docker build` still works and reports "unknown" rather
+# than failing; CI and build-containers.sh supply the real values. Last in the
+# file because these change on every commit and nothing expensive may sit below
+# them.
+#
+# SCRIBEAR_BUILD_SERVICE is the compose service name, which is the same for
+# every device variant; the published image name is what carries the -cpu /
+# -cuda<n> suffix.
+ARG BUILD_COMMIT=""
+ARG BUILD_REF=""
+ARG BUILD_TIME=""
+ARG BUILD_VERSION=""
+ARG BUILD_TAGS=""
+ARG BUILD_PR=""
+ARG BUILD_ORIGIN=""
+
+ENV SCRIBEAR_BUILD_SERVICE=transcription-service \
+    SCRIBEAR_BUILD_COMMIT=${BUILD_COMMIT} \
+    SCRIBEAR_BUILD_REF=${BUILD_REF} \
+    SCRIBEAR_BUILD_TIME=${BUILD_TIME} \
+    SCRIBEAR_BUILD_VERSION=${BUILD_VERSION} \
+    SCRIBEAR_BUILD_TAGS=${BUILD_TAGS} \
+    SCRIBEAR_BUILD_PR=${BUILD_PR} \
+    SCRIBEAR_BUILD_ORIGIN=${BUILD_ORIGIN}
+
+LABEL org.opencontainers.image.title="scribear/transcription-service" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIME}" \
+      org.scribear.build.pull-request="${BUILD_PR}" \
+      org.scribear.build.origin="${BUILD_ORIGIN}"
+
 HEALTHCHECK --interval=30s --timeout=30s --start-period=30s --start-interval=1s --retries=3 CMD curl -f http://localhost:80/probes/liveness || exit 1
 
 CMD ["/app/.venv/bin/python", "src/index.py"]

--- a/transcription_service/src/webserver/create_webserver.py
+++ b/transcription_service/src/webserver/create_webserver.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from src.shared.config import Config
 from src.shared.logger import Logger
 
+from .features.build_info import build_info_router
 from .features.metrics import metrics_router
 from .features.probes import probes_router
 from .features.providers import providers_router
@@ -116,6 +117,7 @@ def create_webserver(config: Config, logger: Logger):
     app = FastAPI(lifespan=lifespan)
 
     app.include_router(probes_router(provider_registry))
+    app.include_router(build_info_router())
     app.include_router(
         metrics_router(
             logger, metrics_auth_service, metrics_registry, provider_registry

--- a/transcription_service/src/webserver/features/build_info/__init__.py
+++ b/transcription_service/src/webserver/features/build_info/__init__.py
@@ -1,0 +1,6 @@
+"""
+Public exports for build info API
+"""
+
+from .build_info_controller import UNKNOWN, BuildInfo, read_build_info
+from .build_info_router import build_info_router

--- a/transcription_service/src/webserver/features/build_info/build_info_controller.py
+++ b/transcription_service/src/webserver/features/build_info/build_info_controller.py
@@ -1,0 +1,147 @@
+"""
+Reads the build provenance the image was stamped with
+"""
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+# Stand-in for a field the build did not supply. A literal rather than an empty
+# string or null so that an unstamped image reads as "built outside CI"
+# everywhere it is displayed, instead of as a blank cell that could equally
+# mean the request failed. Matches the Node reader in
+# libs/base-fastify-server/src/server/build-info.ts.
+UNKNOWN = "unknown"
+
+# Suffix appended to the commit when the working tree had uncommitted changes,
+# following the `git describe --dirty` convention. Carried in the commit string
+# rather than in a variable of its own so that
+# `org.opencontainers.image.revision` - which an operator reads with
+# `docker inspect`, far from this code - says so too.
+DIRTY_SUFFIX = "-dirty"
+
+_ORIGINS = ("ci", "local")
+_DIGITS = re.compile(r"^\d+$")
+
+
+@dataclass(frozen=True)
+class BuildInfo:
+    """
+    What this container can say about the artifact it was built from
+
+    The same shape every other container in the stack reports, so the admin
+    console's Deployment Check renders one table rather than one renderer per
+    language.
+    """
+
+    service: str
+    version: str
+    commit: str
+    ref: str
+    built_at: str
+    image_tags: list[str] = field(default_factory=list)
+    pull_request: Optional[int] = None
+    origin: str = UNKNOWN
+    dirty: bool = False
+
+    def to_json(self) -> dict:
+        """
+        Serializes to the stack's shared build-info document
+
+        Keys are camelCase because this crosses a language boundary and the
+        consumer is TypeScript; the field names above stay snake_case because
+        this side is Python.
+
+        Returns:
+            dict ready to be returned from the /build-info route
+        """
+        return {
+            "service": self.service,
+            "version": self.version,
+            "commit": self.commit,
+            "ref": self.ref,
+            "builtAt": self.built_at,
+            "imageTags": self.image_tags,
+            "pullRequest": self.pull_request,
+            "origin": self.origin,
+            "dirty": self.dirty,
+        }
+
+
+def _field(value: Optional[str]) -> str:
+    """
+    Normalizes one stamped value, defaulting a missing or blank one
+
+    Args:
+        value - Raw environment value, possibly absent
+
+    Returns:
+        The trimmed value, or UNKNOWN
+    """
+    trimmed = (value or "").strip()
+    return trimmed or UNKNOWN
+
+
+def _pull_request(value: Optional[str]) -> Optional[int]:
+    """
+    Parses the pull request number a PR build was stamped with
+
+    Anything unparseable is None rather than an error: this is decoration on a
+    page whose job is to work when the deployment does not. Every non-PR build
+    passes the variable empty, so the empty case is the common one.
+
+    Args:
+        value - Raw environment value, possibly absent
+
+    Returns:
+        Positive PR number, or None
+    """
+    trimmed = (value or "").strip()
+    if not _DIGITS.match(trimmed):
+        return None
+    parsed = int(trimmed)
+    return parsed if parsed > 0 else None
+
+
+def read_build_info(env: Optional[dict] = None) -> BuildInfo:
+    """
+    Reads the SCRIBEAR_BUILD_* variables the Dockerfile baked in
+
+    Tolerant by construction - every field falls back to UNKNOWN rather than
+    raising. This answers an operator's "what is deployed?" question, and a
+    container that cannot describe itself must still start and still answer, or
+    the one situation the page exists for (a half-finished upgrade) is also the
+    situation where it goes blank.
+
+    Args:
+        env - Environment to read; defaults to the process environment
+
+    Returns:
+        BuildInfo
+    """
+    source = os.environ if env is None else env
+
+    raw_commit = _field(source.get("SCRIBEAR_BUILD_COMMIT"))
+    dirty = raw_commit.endswith(DIRTY_SUFFIX)
+    commit = raw_commit[: -len(DIRTY_SUFFIX)] if dirty else raw_commit
+
+    origin = (source.get("SCRIBEAR_BUILD_ORIGIN") or "").strip().lower()
+
+    tags = [
+        tag.strip()
+        for tag in (source.get("SCRIBEAR_BUILD_TAGS") or "").split(",")
+        if tag.strip()
+    ]
+
+    return BuildInfo(
+        service=_field(source.get("SCRIBEAR_BUILD_SERVICE")),
+        version=_field(source.get("SCRIBEAR_BUILD_VERSION")),
+        commit=commit,
+        ref=_field(source.get("SCRIBEAR_BUILD_REF")),
+        built_at=_field(source.get("SCRIBEAR_BUILD_TIME")),
+        image_tags=tags,
+        pull_request=_pull_request(source.get("SCRIBEAR_BUILD_PR")),
+        origin=origin if origin in _ORIGINS else UNKNOWN,
+        dirty=dirty,
+    )

--- a/transcription_service/src/webserver/features/build_info/build_info_router.py
+++ b/transcription_service/src/webserver/features/build_info/build_info_router.py
@@ -1,0 +1,38 @@
+"""
+Defines FastAPI router for the /build-info http endpoint
+"""
+
+from fastapi import APIRouter
+
+from .build_info_controller import read_build_info
+
+
+def build_info_router():
+    """
+    Creates FastAPI router for the GET /build-info endpoint
+
+    Which artifact this container was built from. Answered on the same path,
+    with the same body, as every other container in the stack - the Node
+    services get theirs from `createBaseServer`, the webapps and the reverse
+    proxy ship theirs as a static file - so the admin console's Deployment
+    Check can probe the whole stack with one loop.
+
+    Unauthenticated, unlike /metrics/* and /providers/health, and for the same
+    reason /probes/* is: nginx proxies nothing on this service to the outside,
+    so the route is reachable only from inside the compose network, and the
+    body names no provider, endpoint or key.
+
+    The payload is read once, at registration: the environment it comes from is
+    baked into the image and cannot change while the process lives.
+
+    Returns:
+        FastAPI router
+    """
+    router = APIRouter()
+    build_info = read_build_info().to_json()
+
+    @router.get("/build-info")
+    async def get_build_info():
+        return build_info
+
+    return router

--- a/transcription_service/tests/integration/build_info/build_info_test.py
+++ b/transcription_service/tests/integration/build_info/build_info_test.py
@@ -1,0 +1,112 @@
+"""
+Integration tests for the /build-info endpoint
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+
+from src.shared.config import Config
+from src.shared.logger import ContextLogger, Logger
+from src.webserver.create_webserver import create_webserver
+
+BUILD_ENV = {
+    "SCRIBEAR_BUILD_SERVICE": "transcription-service",
+    "SCRIBEAR_BUILD_VERSION": "0.2.0",
+    "SCRIBEAR_BUILD_COMMIT": "def6e68",
+    "SCRIBEAR_BUILD_REF": "staging",
+    "SCRIBEAR_BUILD_TIME": "2026-07-24T12:03:11Z",
+    "SCRIBEAR_BUILD_TAGS": "staging,staging-def6e68",
+    "SCRIBEAR_BUILD_ORIGIN": "ci",
+    "SCRIBEAR_BUILD_PR": "",
+}
+
+
+@pytest.fixture
+def mock_logger():
+    """
+    Create a mocked logger instance for testing
+    """
+    underlying_logger = MagicMock(spec=logging.Logger)
+    underlying_logger.level = 10
+    return ContextLogger(underlying_logger)
+
+
+@pytest.fixture
+def mock_config():
+    """
+    Create mock config object for testing
+    """
+    mock = MagicMock(spec=Config)
+    # Telemetry publishing off: a MagicMock's `redis_url` is otherwise a truthy
+    # mock, which sends the lifespan into opening a Redis connection to a
+    # nonsense URL and hangs startup.
+    mock.redis_url = ""
+    mock.provider_config.num_workers = 2
+    return mock
+
+
+@pytest_asyncio.fixture
+async def test_client(
+    mock_config: Config, mock_logger: Logger, monkeypatch: pytest.MonkeyPatch
+):
+    """
+    Create fresh FastAPI test client for each test
+
+    The build variables are set before the app is created, deliberately: the
+    route reads them once at registration, because they are baked into the
+    image and cannot change while the process lives.
+    """
+    for name, value in BUILD_ENV.items():
+        monkeypatch.setenv(name, value)
+
+    with TestClient(create_webserver(mock_config, mock_logger)) as client:
+        yield client
+
+
+@pytest.mark.timeout(3)
+def test_build_info_reports_the_build_the_image_was_made_from(
+    test_client: TestClient,
+):
+    """
+    Test that /build-info answers the stack's shared build document
+
+    The key names are asserted in full because they cross a language boundary:
+    admin-server parses this with the same TypeScript type it uses for the Node
+    services' responses, so a rename on this side is a silent blank row there.
+    """
+    # Arrange / Act
+    response = test_client.get("/build-info")
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {
+        "service": "transcription-service",
+        "version": "0.2.0",
+        "commit": "def6e68",
+        "ref": "staging",
+        "builtAt": "2026-07-24T12:03:11Z",
+        "imageTags": ["staging", "staging-def6e68"],
+        "pullRequest": None,
+        "origin": "ci",
+        "dirty": False,
+    }
+
+
+@pytest.mark.timeout(3)
+def test_build_info_needs_no_credentials(test_client: TestClient):
+    """
+    Test that /build-info is unauthenticated, like /probes/*
+
+    Unlike /metrics/* and /providers/health it names no provider, endpoint or
+    key, and nginx proxies nothing on this service to the outside - so it is
+    reachable only from inside the compose network.
+    """
+    # Arrange / Act
+    response = test_client.get("/build-info", headers={})
+
+    # Assert
+    assert response.status_code == 200

--- a/transcription_service/tests/unit/webserver/build_info/build_info_controller_test.py
+++ b/transcription_service/tests/unit/webserver/build_info/build_info_controller_test.py
@@ -1,0 +1,107 @@
+"""
+Unit tests for reading the build provenance stamped into the image
+"""
+
+import pytest
+
+from src.webserver.features.build_info import UNKNOWN, read_build_info
+
+
+def test_reads_every_field_a_ci_build_bakes_in():
+    """
+    A fully stamped CI image reports every field it was given
+    """
+    env = {
+        "SCRIBEAR_BUILD_SERVICE": "transcription-service",
+        "SCRIBEAR_BUILD_VERSION": "0.2.0",
+        "SCRIBEAR_BUILD_COMMIT": "def6e68f0b3c4a1d9e2f5a7b8c0d1e2f3a4b5c6d",
+        "SCRIBEAR_BUILD_REF": "staging",
+        "SCRIBEAR_BUILD_TIME": "2026-07-24T12:03:11Z",
+        "SCRIBEAR_BUILD_TAGS": "staging,staging-def6e68",
+        "SCRIBEAR_BUILD_ORIGIN": "ci",
+    }
+
+    assert read_build_info(env).to_json() == {
+        "service": "transcription-service",
+        "version": "0.2.0",
+        "commit": "def6e68f0b3c4a1d9e2f5a7b8c0d1e2f3a4b5c6d",
+        "ref": "staging",
+        "builtAt": "2026-07-24T12:03:11Z",
+        "imageTags": ["staging", "staging-def6e68"],
+        "pullRequest": None,
+        "origin": "ci",
+        "dirty": False,
+    }
+
+
+def test_reports_origin_unknown_when_nothing_stamped_the_build():
+    """
+    A service started straight from a checkout has no image and stamps nothing
+
+    It must still describe itself, and must do so in a way the console can
+    distinguish from a probe that failed - hence UNKNOWN rather than empty
+    strings, and an origin of "unknown" rather than "local".
+    """
+    assert read_build_info({"SCRIBEAR_BUILD_VERSION": "   "}).to_json() == {
+        "service": UNKNOWN,
+        "version": UNKNOWN,
+        "commit": UNKNOWN,
+        "ref": UNKNOWN,
+        "builtAt": UNKNOWN,
+        "imageTags": [],
+        "pullRequest": None,
+        "origin": UNKNOWN,
+        "dirty": False,
+    }
+
+
+def test_splits_a_dirty_suffix_out_of_the_commit():
+    """
+    The -dirty suffix rides on the commit so docker inspect carries it too
+
+    It is split back out here so the console can flag an image built from a
+    modified working tree without string-matching.
+    """
+    info = read_build_info(
+        {
+            "SCRIBEAR_BUILD_COMMIT": "def6e68-dirty",
+            "SCRIBEAR_BUILD_ORIGIN": "local",
+        }
+    )
+
+    assert info.commit == "def6e68"
+    assert info.dirty is True
+    assert info.origin == "local"
+
+
+def test_reads_the_pull_request_a_pr_build_came_from():
+    """
+    A PR build reports the PR number as a number, for a "PR #157" chip
+    """
+    assert read_build_info({"SCRIBEAR_BUILD_PR": "157"}).pull_request == 157
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "abc", "0", "-3", "1.5"])
+def test_reports_no_pull_request_for_unparseable_values(raw: str):
+    """
+    Every non-PR build passes this variable empty, so empty is the common case
+    """
+    assert read_build_info({"SCRIBEAR_BUILD_PR": raw}).pull_request is None
+
+
+def test_splits_trims_and_drops_empty_image_tags():
+    """
+    Tags arrive comma-joined because a --build-arg cannot be an array
+    """
+    info = read_build_info({"SCRIBEAR_BUILD_TAGS": " latest , , v0.2.0 "})
+
+    assert info.image_tags == ["latest", "v0.2.0"]
+
+
+def test_treats_an_unrecognized_origin_as_unknown():
+    """
+    Only the two origins the build system stamps are accepted
+    """
+    assert (
+        read_build_info({"SCRIBEAR_BUILD_ORIGIN": "jenkins"}).origin == UNKNOWN
+    )


### PR DESCRIPTION
## Why

An operator has had no way to confirm what is actually deployed. Every service knows its own build and none knows anyone else's, so an upgrade that pulled some images and not others is invisible from inside the stack — and invisible to the health rollup too, because a container running last month's image is a perfectly healthy container and stays green.

## What this adds

**Deployment Check → Deployed versions.** A table of one row per container: version, commit, branch, build time, image tags, status.

| Container | Version | Commit | Branch | Built | Image tags | Status |
| --- | --- | --- | --- | --- | --- | --- |
| admin-server | 0.2.0 | `def6e68` | staging | 24 Jul 2026, 12:03 | `staging` | reporting |
| node-server | 0.2.0 | `17db815` ⚠️ | staging | 23 Jul 2026, 09:14 | `staging` | reporting |
| scribear-db | — | — | — | — | — | n/a |

The commit the **most** containers report is taken as the deployment's, and anything disagreeing is named in a warning. Modal rather than anchored on admin-server: when it is the console an upgrade left behind, anchoring would report nine mismatches and one healthy container.

**Every image is stamped at build time** with commit, branch, build time, version, image tags, PR number and origin — as `SCRIBEAR_BUILD_*` env vars *and* OCI labels, so `docker inspect` on the host answers the same question:

```
docker inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' \
  ghcr.io/scribear/admin-server:latest
```

The block sits last in every Dockerfile, so a new commit invalidates no expensive layer.

**Each container reports in whatever way suits it.** The four Node services answer `GET /build-info` from a route `createBaseServer` registers once for all of them; transcription-service answers the same path from FastAPI; the webapps and the reverse proxy are nginx serving files, so they get an identical `build-info.json` generated at image build by one shared script. All produce the same document, so the console has one renderer rather than one per language.

## Statuses, and why they are distinct

| Status | Meaning |
| --- | --- |
| `reporting` | Answered with its build. |
| `old image` | Answered, and has no build document — the image predates this PR, so it was **not** recreated by the last upgrade. |
| `no answer` | Could not be reached. Down, not stale. |
| `n/a` | `scribear-db` / `redis` — no HTTP surface to report on. Listed with the reason rather than quietly omitted. |

`old image` vs `no answer` look identical from the socket up and mean opposite things to an operator, so they are kept apart.

## Local builds

`build-containers.sh` stamps the real commit, marks the image `origin: local`, and appends `-dirty` (the `git describe` convention, so the revision label carries it too) when the working tree has uncommitted changes. A stack started straight from a checkout reports "nothing here was built by CI" instead of a table of blanks. Version is read per image, not from the root `package.json` — that is `0.0.0` and would have looked like a real version on all eleven images.

## PR images

A PR into `main` or `staging` publishes `ghcr.io/scribear/<image>:PR-<n>` again, so a reviewer can pull the exact build under review and the image identifies itself. `PUBLISH_PR_IMAGES` is now tri-state — unset uses the base-branch rule, `false` switches PR images off, `true` publishes for every base branch — so the one-field kill switch survives. Fork PRs still build without publishing; their `GITHUB_TOKEN` cannot push.

`PR-<n>` is a moving tag. I deliberately did **not** add an immutable `PR-<n>-<sha>` companion (mirroring `staging-<sha>`): that would be a second tag per push × 11 images × every PR, and GHCR will not reclaim them. Easy to add if the retention cost is acceptable.

## Security

No commit hash is published to the internet. nginx proxies only the `/api` prefixes, so every service's `/build-info` is reachable in-cluster only — which is why it can be unauthenticated and why it must stay off `/api`. The proxy's own document is served on its **plain-HTTP listener only**; repeating it on 443 would publish it. The aggregate route is session-gated, since it is the one place all of them are readable from a browser. There is a test asserting the path, so a later move under `/api` fails rather than silently discloses.

## Verification

Built real images with provenance args and queried them, rather than reasoning about it:

- **admin-server** — `/build-info` returns the baked payload; 404 under the `/api` prefix nginx proxies; `/deployment-versions` 401s without a session.
- **client-webapp** — serves its document with `Content-Type: application/json`; SPA deep-link fallback unaffected.
- **scribear-nginx** — `/build-info.json` 200 on `:80`, everything else still 301s, `:443` → 404, `/healthz` unaffected.

**This caught a real bug.** My first proxy config put `location = /build-info.json` alongside the server-level `return 301`, assuming the exact match would win. It does not — a server-level `return` runs in the rewrite phase, before nginx picks a location at all, so the document was being redirected with everything else. The redirect now lives in `location /`. Inspection would not have found this.

The tag resolver was tested by extracting the actual Python from the action and running it across seven cases (PR into staging/main/other, both override values, and both push paths) to confirm the existing `staging` / `latest` publishing is unchanged.

**Tests:** base-fastify-server 54, admin-server 123 unit + 63 integration, admin-webapp 156, transcription webserver 166 — all passing. Lint and format clean across every touched workspace.

## Breaking change for hand-rolled builds

`scribear-nginx` now builds from the repository root, so it can share the webapps' build-info generator instead of carrying a fifth copy of a JSON serializer written in shell:

```
docker build -f infra/scribear-nginx/Dockerfile .
```

`build-containers.sh`, `node-images.json` and CI already do this; only a manual `docker build infra/scribear-nginx` needs changing. Noted in `UPGRADING.md`.

## Deploying this

Nothing new in `deployment/.env` — the six new admin-server base-URL variables all default to their compose service names.

On the first upgrade, `old image` is expected for anything not yet recreated. Run `docker compose up -d` in `deployment/` and re-check; every row should turn to `reporting`.
