### PR TITLE
feat(admin): a Documentation view linking out to the project wiki

### DIFF
--- a/apps/admin-webapp/src/app/router.tsx
+++ b/apps/admin-webapp/src/app/router.tsx
@@ -8,6 +8,7 @@ import { ConfigCheckPage } from '#src/features/config-check/config-check-page';
 import { DashboardPage } from '#src/features/dashboard/dashboard-page';
 import { DeviceDetailPage } from '#src/features/devices/device-detail-page';
 import { DevicesListPage } from '#src/features/devices/devices-list-page';
+import { DocumentationPage } from '#src/features/documentation/documentation-page';
 import { KioskWizardPage } from '#src/features/kiosk-setup/kiosk-wizard-page';
 import { RoomDetailPage } from '#src/features/rooms/room-detail-page';
 import { RoomsListPage } from '#src/features/rooms/rooms-list-page';
@@ -32,6 +33,7 @@ export const AppRoutes = () => (
         <Route path="/kiosk-setup" element={<KioskWizardPage />} />
         <Route path="/audit" element={<AuditPage />} />
         <Route path="/config-check" element={<ConfigCheckPage />} />
+        <Route path="/documentation" element={<DocumentationPage />} />
       </Route>
     </Route>
     <Route path="*" element={<Navigate to="/" replace />} />

--- a/apps/admin-webapp/src/components/app-layout.tsx
+++ b/apps/admin-webapp/src/components/app-layout.tsx
@@ -6,6 +6,7 @@ import GraphicEqIcon from '@mui/icons-material/GraphicEq';
 import HistoryIcon from '@mui/icons-material/History';
 import LogoutIcon from '@mui/icons-material/Logout';
 import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SpaceDashboardIcon from '@mui/icons-material/SpaceDashboard';
 import TabletIcon from '@mui/icons-material/Tablet';
@@ -66,6 +67,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'Set up a kiosk', to: '/kiosk-setup', icon: <TabletIcon /> },
   { label: 'Audit log', to: '/audit', icon: <HistoryIcon /> },
   { label: 'Deployment Check', to: '/config-check', icon: <FactCheckIcon /> },
+  { label: 'Documentation', to: '/documentation', icon: <MenuBookIcon /> },
   {
     label: 'Audio meter (this device)',
     href: audioMeterHref(),

--- a/apps/admin-webapp/src/features/documentation/documentation-page.tsx
+++ b/apps/admin-webapp/src/features/documentation/documentation-page.tsx
@@ -1,0 +1,131 @@
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import GraphicEqIcon from '@mui/icons-material/GraphicEq';
+import InsightsIcon from '@mui/icons-material/Insights';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
+import CardContent from '@mui/material/CardContent';
+import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import { OpensInNewTab } from '#src/components/opens-in-new-tab';
+
+/**
+ * The wiki lives outside the deployment, so these are absolute github.com URLs
+ * rather than anything routed through the BFF. Slugs, not titles: GitHub
+ * resolves `Audio-Telemetry`, and a page renamed on the wiki leaves the old
+ * slug redirecting, so a stale entry here degrades to a redirect rather than
+ * a 404.
+ */
+const WIKI_BASE = 'https://github.com/scribear/scribear/wiki';
+
+interface DocLink {
+  /** Wiki page title as it renders on GitHub, used as the card heading. */
+  title: string;
+  /** Wiki slug appended to WIKI_BASE. */
+  slug: string;
+  description: string;
+  icon: React.ReactNode;
+}
+
+const DOC_LINKS: DocLink[] = [
+  {
+    title: 'Deployment',
+    slug: 'Deployment',
+    description:
+      'Bringing the production Docker Compose stack up from the prebuilt GHCR images, and what to configure before you do.',
+    icon: <RocketLaunchIcon color="primary" />,
+  },
+  {
+    title: 'Audio Monitoring',
+    slug: 'Audio-Monitoring',
+    description:
+      "The audio engineer's guide to the level meters and VAD readouts: what the numbers mean, and how to fix caption quality at the source.",
+    icon: <GraphicEqIcon color="primary" />,
+  },
+  {
+    title: 'Audio Telemetry',
+    slug: 'Audio-Telemetry',
+    description:
+      'Developer reference for the telemetry pipeline: the measurement points, the flow through Redis to this console, and the schema contracts.',
+    icon: <InsightsIcon color="primary" />,
+  },
+  {
+    title: 'Admin Website',
+    slug: 'Admin-Website',
+    description:
+      'Operator guide to this console — signing in, and managing rooms, devices, and kiosks.',
+    icon: <AdminPanelSettingsIcon color="primary" />,
+  },
+  {
+    title: 'Documentation',
+    slug: 'Documentation',
+    description:
+      'Architecture overview and API reference: Session Manager, the admin BFF, and the node-server websocket protocol.',
+    icon: <MenuBookIcon color="primary" />,
+  },
+];
+
+/**
+ * Link hub for the project wiki.
+ *
+ * Every card opens in a new tab: the wiki is a different site, and an operator
+ * reading a runbook is usually mid-task in the console — navigating away would
+ * cost them the page they are working on. That makes each card an `<a>` (via
+ * `CardActionArea component="a"`) rather than a click handler, so middle-click
+ * and "copy link address" behave the way they do anywhere else, and it carries
+ * the same `OpenInNewIcon` + `OpensInNewTab` affordance pair as the audio meter
+ * link in the side nav.
+ */
+export const DocumentationPage = () => {
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        Documentation
+      </Typography>
+      <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
+        Project documentation lives in the{' '}
+        <strong>scribear/scribear GitHub wiki</strong>. Each card below opens
+        there in a new tab.
+      </Typography>
+
+      <Grid container spacing={2}>
+        {DOC_LINKS.map((link) => (
+          <Grid key={link.slug} size={{ xs: 12, sm: 6, md: 4 }}>
+            <Card sx={{ height: '100%' }}>
+              <CardActionArea
+                component="a"
+                href={`${WIKI_BASE}/${link.slug}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ height: '100%', alignItems: 'stretch' }}
+              >
+                <CardContent>
+                  <Stack
+                    direction="row"
+                    spacing={1}
+                    sx={{ alignItems: 'center', mb: 1 }}
+                  >
+                    {link.icon}
+                    <Typography variant="subtitle1" sx={{ flexGrow: 1 }}>
+                      {link.title}
+                    </Typography>
+                    <OpenInNewIcon fontSize="small" color="action" />
+                    <OpensInNewTab />
+                  </Stack>
+                  <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                    {link.description}
+                  </Typography>
+                </CardContent>
+              </CardActionArea>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+};

--- a/apps/admin-webapp/tests/components/app-layout.test.tsx
+++ b/apps/admin-webapp/tests/components/app-layout.test.tsx
@@ -46,6 +46,20 @@ describe('AppLayout', (it) => {
     expect(results.violations).toHaveLength(0);
   });
 
+  it('routes the Documentation nav item in-app rather than straight to the wiki', () => {
+    // The item sits between two very different kinds of link — Deployment Check
+    // (in-app) and the audio meter (external) — and the wiki cards it leads to
+    // are themselves `target="_blank"`. Pin that this one navigates the SPA, so
+    // it cannot drift into being a sixth external link.
+    renderLayout();
+
+    const link = document.querySelector('a[href="/documentation"]');
+
+    expect(link).not.toBeNull();
+    expect(link).not.toHaveAttribute('target');
+    expect(link?.textContent).toContain('Documentation');
+  });
+
   it('renders the audio meter nav item as an external link that opens a new tab', () => {
     renderLayout();
 

--- a/apps/admin-webapp/tests/features/documentation/documentation-page.test.tsx
+++ b/apps/admin-webapp/tests/features/documentation/documentation-page.test.tsx
@@ -1,0 +1,74 @@
+import { screen, within } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect } from 'vitest';
+
+import { DocumentationPage } from '#src/features/documentation/documentation-page';
+
+import { renderWithProviders } from '../../utils/render-with-providers';
+
+/**
+ * Title as rendered on the card, and the wiki URL it must resolve to. Written
+ * out in full rather than composed from a shared base, so a typo in the page's
+ * own `WIKI_BASE`/slug join is something these assertions can actually catch.
+ */
+const EXPECTED_LINKS: [title: string, href: string][] = [
+  ['Deployment', 'https://github.com/scribear/scribear/wiki/Deployment'],
+  [
+    'Audio Monitoring',
+    'https://github.com/scribear/scribear/wiki/Audio-Monitoring',
+  ],
+  [
+    'Audio Telemetry',
+    'https://github.com/scribear/scribear/wiki/Audio-Telemetry',
+  ],
+  ['Admin Website', 'https://github.com/scribear/scribear/wiki/Admin-Website'],
+  ['Documentation', 'https://github.com/scribear/scribear/wiki/Documentation'],
+];
+
+describe('DocumentationPage', (it) => {
+  it('has no a11y violations', async () => {
+    const { container } = renderWithProviders(<DocumentationPage />);
+
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
+  });
+
+  it('renders one card per wiki page, pointing at the right page', () => {
+    renderWithProviders(<DocumentationPage />);
+
+    for (const [title, href] of EXPECTED_LINKS) {
+      const link = screen.getByRole('link', { name: new RegExp(`^${title}`) });
+
+      expect(link).toHaveAttribute('href', href);
+    }
+  });
+
+  it('opens every card in a new window, with the opener detached', () => {
+    renderWithProviders(<DocumentationPage />);
+
+    const links = screen.getAllByRole('link');
+
+    // Every link on this page is a wiki card; none of them navigate in place.
+    expect(links).toHaveLength(EXPECTED_LINKS.length);
+    for (const link of links) {
+      expect(link).toHaveAttribute('target', '_blank');
+      // `noopener` is the load-bearing half: without it the wiki tab gets a
+      // handle on `window.opener` and can navigate this authed console.
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    }
+  });
+
+  it('announces that the cards open a new tab (SC 3.2.5)', () => {
+    renderWithProviders(<DocumentationPage />);
+
+    // Inside the anchor, so it lands in the computed accessible name — the
+    // OpenInNewIcon on each card is decorative and carries no text alternative,
+    // so a screen reader user has nothing else to go on.
+    for (const link of screen.getAllByRole('link')) {
+      expect(
+        within(link).getByText('(opens in a new tab)'),
+      ).toBeInTheDocument();
+    }
+  });
+});


### PR DESCRIPTION
Adds a **Documentation** entry to the admin console's side nav, directly under Deployment Check, opening a new `/documentation` view of link cards to the project wiki.

> **Stacked on #165.** Based on `feat/Audio-Viz`, not `staging` — it imports `OpensInNewTab` and extends `app-layout.test.tsx`, neither of which exists on `staging` yet. Retarget to `staging` once #165 merges; the diff here is the single commit `de745f3`.

## Cards

| Card | Wiki page |
|---|---|
| Deployment | [`/wiki/Deployment`](https://github.com/scribear/scribear/wiki/Deployment) |
| Audio Monitoring | [`/wiki/Audio-Monitoring`](https://github.com/scribear/scribear/wiki/Audio-Monitoring) |
| Audio Telemetry | [`/wiki/Audio-Telemetry`](https://github.com/scribear/scribear/wiki/Audio-Telemetry) |
| Admin Website | [`/wiki/Admin-Website`](https://github.com/scribear/scribear/wiki/Admin-Website) |
| Documentation | [`/wiki/Documentation`](https://github.com/scribear/scribear/wiki/Documentation) |

Every slug was checked against the live wiki rather than inferred from the title, and each card's description is written from that page's own opening paragraph — a card that describes the wrong page is worse than no card, since the reader cannot tell before clicking.

Cards are titled as the wiki renders them (`Admin Website`, not the `Admin-Website` slug): a heading that disagrees with the page it lands on reads as a broken link even when it is not.

## Decisions worth a reviewer's attention

- **Anchors, not click handlers.** `CardActionArea component="a"` keeps middle-click, cmd-click and "copy link address" working — a click handler breaks all three silently.
- **`rel="noopener noreferrer"` on every card.** `noopener` is the load-bearing half: without it the wiki tab holds a live `window.opener` handle on an authenticated console.
- **New tab, deliberately.** These pages are read *alongside* the console — an operator following the Admin Website runbook, or reading Audio Monitoring while watching a live meter, needs both on screen.
- **The nav item routes in-app** while every card on the page it opens is external. That distinction is the kind that drifts, so `app-layout.test.tsx` pins it.

## Testing

- New `tests/features/documentation/documentation-page.test.tsx`: axe a11y, one card per page pointing at the right URL, new-tab attributes on all five, and the SC 3.2.5 visually-hidden announcement inside each anchor.
- One added case in `tests/components/app-layout.test.tsx`.
- Full admin-webapp suite: 272 passed / 20 files. `lint`, `format`, and `tsc -b && vite build` all clean.