### PR TITLE
fix(audio-viz): make the meter page run under the /admin/ CSP, and stop the session card hiding its own numbers

### DIFF
--- a/.changeset/deployment-compose-file-version.md
+++ b/.changeset/deployment-compose-file-version.md
@@ -1,0 +1,38 @@
+---
+'@scribear/admin-server': minor
+'@scribear/admin-webapp': minor
+---
+
+Deployment Check now notices when a stack is running an out-of-date
+`deployment/compose.yml`.
+
+`compose.yml` is not part of any image, so `docker compose pull` never updates
+it: a deployment could run this month's images against last month's file —
+missing services, missing environment variables, changed wiring — with every
+container reporting green. Nothing in the stack could see it, and nothing could
+be made to: reading the file from a container would mean mounting the Docker
+socket (root-equivalent host access, for the one service on the public path) or
+bind-mounting the file itself, which cannot work, because the stale compose file
+is precisely the one that lacks the mount.
+
+- **`compose.yml` carries its own version.** `COMPOSE_FILE_VERSION` is a plain
+  literal in the `admin-server` service's `environment:`, deliberately not a
+  `${...}` interpolation from `.env`: the point is the identity of the file, and
+  an `.env` carried over from an older release is exactly the thing that goes
+  stale. Nothing to add to `.env`, and it is not `:?`-guarded — it changes what
+  is *reported*, never what runs, so it cannot stop a stack from starting.
+- **admin-server compares it against the value baked into its image.**
+  `GET /api/admin/v1/deployment-versions` gains a `composeFile` section:
+  `match`, `stale` (the file is older than the images), `ahead` (the images are
+  older than the file) and `unknown` (the file predates this check, so it is at
+  least that old). `stale` and `ahead` are separate because the remedy differs —
+  copy a file, or pull images — and `unknown` is separate from both because it
+  is the absence of a measurement rather than a measured mismatch.
+- **Deployment Check → Deployed versions** shows it as one more row beside the
+  containers, with an icon and a word rather than a colour, plus a banner naming
+  the fix whenever the file and the images disagree.
+- **A unit test fails if the version stops being maintained.** It asserts the
+  literal matches admin-server's constant and pins the sha256 of
+  `deployment/compose.yml`, so any change to that file forces an author to
+  decide whether operators must redeploy for it — a version nobody remembers to
+  bump reports a match that was never verified.

--- a/apps/admin-server/src/app-config/app-config.ts
+++ b/apps/admin-server/src/app-config/app-config.ts
@@ -41,6 +41,19 @@ const CONFIG_SCHEMA = Type.Object({
   // asymmetry is the safe direction.
   DEPLOYMENT_ENV: Type.String({ default: '' }),
 
+  // Which `deployment/compose.yml` is running this stack. Set as a literal in
+  // that file rather than interpolated from .env, so it describes the file
+  // itself; Deployment Check compares it against the `EXPECTED_COMPOSE_FILE_
+  // VERSION` baked into this image.
+  //
+  // Optional, and a plain string rather than an integer, for the same reason
+  // DEPLOYMENT_ENV above is: absent means the running compose file predates
+  // this check, which is a finding to report and not a reason to refuse to
+  // boot — and a deployment whose compose file is out of date is exactly the
+  // one that must still start so an operator can read the console and find
+  // out why.
+  COMPOSE_FILE_VERSION: Type.String({ default: '' }),
+
   // Session Manager gateway
   ADMIN_API_KEY: Type.String({ minLength: 1 }),
   SESSION_MANAGER_BASE_URL: Type.String({ minLength: 1 }),
@@ -187,6 +200,10 @@ export class AppConfig {
       // Shared with the health rollup: both ask sibling containers a question
       // an operator is waiting on, so one knob should bound both.
       timeoutMs: this._env.HEALTH_CHECK_TIMEOUT_SEC * SECOND_MS,
+      // Passed through raw. The service decides what an unset or unparseable
+      // value means, so that this getter stays a description of the
+      // environment rather than a second place the rule lives.
+      reportedComposeFileVersion: this._env.COMPOSE_FILE_VERSION,
       targets: [
         {
           name: 'session-manager',

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
@@ -35,8 +35,69 @@ export interface ContainerVersion {
   detail?: string | undefined;
 }
 
+/**
+ * The `compose.yml` this image expects to be run by.
+ *
+ * Baked in here rather than read from anywhere at runtime, which is the whole
+ * mechanism: this number travels inside the image, the number in
+ * `deployment/compose.yml` travels with the file, and comparing them is the
+ * only way a container can notice that the two were upgraded separately.
+ *
+ * Bump it — and the literal in `deployment/compose.yml` — whenever a change to
+ * that file is one an operator must redeploy for: a new service, a new or
+ * renamed environment variable, changed wiring. Leave both alone for a comment
+ * or a doc tweak. `tests/unit/features/deployment-versions/compose-file-
+ * version.test.ts` fails if the two ever disagree, or if that file changes
+ * without someone having made that call.
+ */
+export const EXPECTED_COMPOSE_FILE_VERSION = 1;
+
+/**
+ * How the running `compose.yml` compares to the one this image was built for.
+ *
+ * - `match` — the file and the images agree.
+ * - `stale` — the file is older than the images: someone pulled without
+ *   copying the new `deployment/compose.yml`, so services, variables or wiring
+ *   the new images expect are simply absent.
+ * - `ahead` — the images are older than the file: the file was copied but the
+ *   images were not pulled, or only some were.
+ * - `unknown` — the file reported nothing, so it predates this check entirely
+ *   and is at least that old.
+ *
+ * `stale` and `ahead` are kept apart even though both are "the deployment is
+ * inconsistent", for the same reason `unsupported` and `unreachable` are: the
+ * remedy differs. One operator needs to copy a file, the other needs to pull
+ * images, and telling either of them only that something is out of step leaves
+ * them to guess which.
+ *
+ * `unknown` is kept apart from both for a different reason: it is not a
+ * measured mismatch but the *absence* of a measurement. Reporting it as a
+ * mismatch would assert something this check cannot see, and reporting it as a
+ * match would be a false all-clear on the one deployment most likely to be out
+ * of date — a compose file old enough to predate this variable.
+ */
+export type ComposeFileStatus = 'match' | 'stale' | 'ahead' | 'unknown';
+
+/** How the running `compose.yml` compares to the one this image expects. */
+export interface ComposeFileVersion {
+  /** What this image was built for — `EXPECTED_COMPOSE_FILE_VERSION`. */
+  expected: number;
+  /**
+   * What the running compose file said, or null when it said nothing — either
+   * because it predates this check, or because it named something that is not
+   * a version number, which this check cannot tell apart and does not try to.
+   */
+  reported: number | null;
+  status: ComposeFileStatus;
+}
+
 export interface DeploymentVersionsReport {
   containers: ContainerVersion[];
+  /**
+   * The compose file itself, which is the one part of a deployment that is not
+   * an image and therefore never moves when images are pulled.
+   */
+  composeFile: ComposeFileVersion;
   /**
    * The commit this deployment is taken to be, or null when nothing reported
    * one. Every `mismatched` entry is measured against it.
@@ -84,6 +145,36 @@ export interface DeploymentVersionsConfig {
   timeoutMs: number;
   targets: VersionProbeTarget[];
   nonReporting: NonReportingContainer[];
+  /**
+   * `COMPOSE_FILE_VERSION` exactly as the environment gave it — a raw string,
+   * empty when unset, and not trusted to be a number. It is compared against
+   * `EXPECTED_COMPOSE_FILE_VERSION`, never used for anything else.
+   */
+  reportedComposeFileVersion: string;
+}
+
+/**
+ * Compares the running compose file's version against this image's.
+ *
+ * Everything that is not a plain non-negative integer is `unknown` rather than
+ * an error: an absent variable, a blank one and a typo all mean the same thing
+ * here — nothing can be concluded — and none of them is worth failing a page an
+ * operator opened to diagnose a deployment.
+ */
+export function resolveComposeFileVersion(raw: string): ComposeFileVersion {
+  const trimmed = raw.trim();
+  const reported = /^\d+$/.test(trimmed) ? Number(trimmed) : null;
+
+  const status: ComposeFileStatus =
+    reported === null
+      ? 'unknown'
+      : reported === EXPECTED_COMPOSE_FILE_VERSION
+        ? 'match'
+        : reported < EXPECTED_COMPOSE_FILE_VERSION
+          ? 'stale'
+          : 'ahead';
+
+  return { expected: EXPECTED_COMPOSE_FILE_VERSION, reported, status };
 }
 
 /**
@@ -205,6 +296,13 @@ function resolveExpectedCommit(
  * admin-server's own row is read in-process rather than over a loopback
  * request: it is the same value the route would return, and a console that
  * could not reach itself would drop the one row it can always speak for.
+ *
+ * The compose file is reported alongside them because it is the one part of a
+ * deployment that is not an image: pulling images cannot update it, no
+ * container can read it, and a stack running new images against an old
+ * `compose.yml` is missing services and variables while every row above says
+ * `ok`. It is compared by version number rather than read, which is why it is
+ * an environment variable — see `EXPECTED_COMPOSE_FILE_VERSION`.
  */
 export class DeploymentVersionsService {
   private _config: DeploymentVersionsConfig;
@@ -245,6 +343,12 @@ export class DeploymentVersionsService {
 
     return {
       containers,
+      // Not probed and not awaited: the compose file cannot be asked anything,
+      // so this is a comparison between one environment variable and one
+      // constant, and it answers even when every container above is down.
+      composeFile: resolveComposeFileVersion(
+        this._config.reportedComposeFileVersion,
+      ),
       expectedCommit,
       mismatched: containers
         .filter((c) => hasKnownCommit(c) && c.build?.commit !== expectedCommit)

--- a/apps/admin-server/tests/integration/deployment-versions.routes.test.ts
+++ b/apps/admin-server/tests/integration/deployment-versions.routes.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, vi } from 'vitest';
 import type { BuildInfo } from '@scribear/base-fastify-server';
 
 import type { DeploymentVersionsReport } from '#src/server/features/deployment-versions/deployment-versions.service.js';
+import { EXPECTED_COMPOSE_FILE_VERSION } from '#src/server/features/deployment-versions/deployment-versions.service.js';
 import {
   TEST_CLIENT_WEBAPP_BASE_URL,
   TEST_NODE_BASE_URL,
@@ -110,6 +111,27 @@ describe('Deployment versions route', () => {
       ]);
       expect(data.mismatched).toEqual([]);
       expect(data.expectedCommit).toBe(COMMIT);
+    });
+
+    // The compose file rides the same payload rather than a route of its own:
+    // it is the same question ("is this deployment consistent?") and it needs no
+    // probe, so a second request would be a second round trip for a comparison
+    // between one environment variable and one constant.
+    it('carries the compose file alongside the containers', async () => {
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: URL,
+        headers: { cookie },
+      });
+
+      // Assert
+      const { data } = res.json<DeploymentVersionsBody>();
+      expect(data.composeFile).toEqual({
+        expected: EXPECTED_COMPOSE_FILE_VERSION,
+        reported: EXPECTED_COMPOSE_FILE_VERSION,
+        status: 'match',
+      });
     });
   });
 

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -1,0 +1,123 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { describe, expect } from 'vitest';
+
+import { EXPECTED_COMPOSE_FILE_VERSION } from '#src/server/features/deployment-versions/deployment-versions.service.js';
+
+/**
+ * Drift guard for the compose-file version check.
+ *
+ * The check compares a literal in `deployment/compose.yml` against a constant
+ * in this image, which only works while a human keeps the two in step — and a
+ * version number nobody remembers to bump is worse than no version number at
+ * all, because it reports a match that was never verified.
+ *
+ * So this suite fails on any change to `deployment/compose.yml`, not only on a
+ * mismatch. The author then makes the one call this scheme needs and cannot
+ * make for itself: is this a change operators must redeploy for? Re-pinning the
+ * hash is a deliberate act with a message next to it, rather than something
+ * that happens silently.
+ *
+ * A regex rather than a YAML parser deliberately: neither this workspace nor
+ * the repo has one, and the literal is matched at a fixed indentation inside a
+ * block this guard also hashes, so a change that moves it fails here rather
+ * than parsing to something wrong.
+ */
+
+const COMPOSE_FILE = 'deployment/compose.yml';
+
+/**
+ * sha256 of `deployment/compose.yml`, as committed.
+ *
+ * Re-pin it whenever that file changes — see the failure message below for
+ * which of the two remedies applies.
+ */
+const COMPOSE_FILE_SHA256 =
+  '57fa3a56bc51c57d291161fd273ce01b59e789c7c8aacd37e290a7715561419a';
+
+/** Walks up from the working directory, which differs by how vitest was run. */
+function repoFile(relative: string): string {
+  let dir = process.cwd();
+  for (;;) {
+    const candidate = resolve(dir, relative);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`Could not locate ${relative} above ${process.cwd()}`);
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * Reads `COMPOSE_FILE_VERSION: "<n>"` out of the compose file.
+ *
+ * Throws rather than returning null if it is gone or has changed shape: a drift
+ * guard that can silently stop guarding is worse than no guard at all. The
+ * quotes are required by the pattern because an unquoted `1` is a YAML integer,
+ * and compose refuses to start a stack whose environment value is not a string.
+ */
+function composeFileVersion(source: string): number {
+  const match = /^\s*COMPOSE_FILE_VERSION:\s*"(\d+)"\s*$/m.exec(source);
+  if (!match?.[1]) {
+    throw new Error(
+      `Could not read \`COMPOSE_FILE_VERSION: "<n>"\` from ${COMPOSE_FILE}. ` +
+        `It must stay a quoted integer literal — never a \`\${...}\` ` +
+        `interpolation, which would let a stale .env vouch for the compose ` +
+        `file. If the declaration moved, update this guard rather than ` +
+        `deleting it.`,
+    );
+  }
+  return Number(match[1]);
+}
+
+describe('deployment/compose.yml version', (it) => {
+  const path = repoFile(COMPOSE_FILE);
+  const bytes = readFileSync(path);
+  const source = bytes.toString('utf8');
+
+  it('declares the version this admin-server image expects', () => {
+    // Act
+    const declared = composeFileVersion(source);
+
+    // Assert — these two are the whole check. If they disagree here, every
+    // deployment built from this commit reports a mismatch it does not have,
+    // and the one real mismatch it exists to catch becomes unreadable.
+    expect(
+      declared,
+      `${COMPOSE_FILE} declares COMPOSE_FILE_VERSION ${String(declared)}, but ` +
+        `admin-server's EXPECTED_COMPOSE_FILE_VERSION is ` +
+        `${String(EXPECTED_COMPOSE_FILE_VERSION)}. Both must move together: ` +
+        `bump the literal in ${COMPOSE_FILE} and the constant in ` +
+        `apps/admin-server/src/server/features/deployment-versions/` +
+        `deployment-versions.service.ts.`,
+    ).toBe(EXPECTED_COMPOSE_FILE_VERSION);
+  });
+
+  it('has not changed since the version was last considered', () => {
+    // Act
+    const actual = createHash('sha256').update(bytes).digest('hex');
+
+    // Assert — the pin is what makes the version number trustworthy: without
+    // it, a compose change that needed a bump would ship with the old number
+    // and every deployment would be told it is up to date.
+    expect(
+      actual,
+      `${COMPOSE_FILE} has changed since its hash was pinned.\n\n` +
+        `  new sha256: ${actual}\n\n` +
+        `Decide which kind of change it is, then update this test:\n\n` +
+        `  * Operators must redeploy for it — a new or removed service, a new, ` +
+        `renamed or re-defaulted environment variable, changed wiring, ports ` +
+        `or volumes. Bump COMPOSE_FILE_VERSION in ${COMPOSE_FILE} AND ` +
+        `EXPECTED_COMPOSE_FILE_VERSION in ` +
+        `apps/admin-server/src/server/features/deployment-versions/` +
+        `deployment-versions.service.ts, then re-pin the hash above. Add a ` +
+        `note to deployment/UPGRADING.md while you are there.\n\n` +
+        `  * They do not — a comment, a doc link, formatting. Re-pin the hash ` +
+        `above and leave both versions where they are.\n\n` +
+        `Bumping when in doubt is the cheap mistake: it costs an operator one ` +
+        `\`docker compose up -d\` they did not strictly need.`,
+    ).toBe(COMPOSE_FILE_SHA256);
+  });
+});

--- a/apps/admin-server/tests/unit/features/deployment-versions/deployment-versions.service.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/deployment-versions.service.test.ts
@@ -3,7 +3,11 @@ import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 import type { BuildInfo } from '@scribear/base-fastify-server';
 
 import type { DeploymentVersionsConfig } from '#src/server/features/deployment-versions/deployment-versions.service.js';
-import { DeploymentVersionsService } from '#src/server/features/deployment-versions/deployment-versions.service.js';
+import {
+  DeploymentVersionsService,
+  EXPECTED_COMPOSE_FILE_VERSION,
+  resolveComposeFileVersion,
+} from '#src/server/features/deployment-versions/deployment-versions.service.js';
 
 const COMMIT = 'def6e68f0b3c4a1d9e2f5a7b8c0d1e2f3a4b5c6d';
 const OLDER = '17db8150a2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7';
@@ -34,6 +38,10 @@ function config(
       { name: 'node-server', url: 'http://node-server:80/build-info' },
     ],
     nonReporting: [{ name: 'scribear-db', detail: 'no HTTP surface' }],
+    // A compose file in step with this image unless a test says otherwise,
+    // derived from the constant so that bumping the version does not silently
+    // turn every other test's deployment into a stale one.
+    reportedComposeFileVersion: String(EXPECTED_COMPOSE_FILE_VERSION),
     ...overrides,
   };
 }
@@ -314,5 +322,98 @@ describe('DeploymentVersionsService', (it) => {
     for (const call of fetchMock.mock.calls) {
       expect((call[1] as RequestInit).signal).toBeInstanceOf(AbortSignal);
     }
+  });
+
+  // The compose file is the one part of a deployment that is not an image, so
+  // nothing above can see it: every container can be on the newest commit while
+  // the file wiring them together is a release old.
+  it('reports the compose file even when no container answers', async () => {
+    // Arrange
+    vi.stubGlobal('fetch', () => Promise.reject(new Error('ECONNREFUSED')));
+
+    // Act
+    const report = await new DeploymentVersionsService(
+      config({ reportedComposeFileVersion: '' }),
+    ).report();
+
+    // Assert
+    expect(report.composeFile.status).toBe('unknown');
+    expect(report.composeFile.expected).toBe(EXPECTED_COMPOSE_FILE_VERSION);
+  });
+});
+
+describe('resolveComposeFileVersion', (it) => {
+  it('matches a compose file built for this image', () => {
+    // Act
+    const result = resolveComposeFileVersion(
+      String(EXPECTED_COMPOSE_FILE_VERSION),
+    );
+
+    // Assert
+    expect(result).toEqual({
+      expected: EXPECTED_COMPOSE_FILE_VERSION,
+      reported: EXPECTED_COMPOSE_FILE_VERSION,
+      status: 'match',
+    });
+  });
+
+  // The failure this whole mechanism exists for: images pulled, file not
+  // copied, so services and variables the new images expect are simply absent.
+  it('calls a compose file older than the images stale', () => {
+    // Act
+    const result = resolveComposeFileVersion(
+      String(EXPECTED_COMPOSE_FILE_VERSION - 1),
+    );
+
+    // Assert
+    expect(result.status).toBe('stale');
+    expect(result.reported).toBe(EXPECTED_COMPOSE_FILE_VERSION - 1);
+  });
+
+  // The mirror image, and just as much a partial upgrade: the file was copied
+  // and the images were not pulled. Reported separately because the remedy is
+  // the opposite one.
+  it('calls a compose file newer than the images ahead', () => {
+    // Act
+    const result = resolveComposeFileVersion(
+      String(EXPECTED_COMPOSE_FILE_VERSION + 1),
+    );
+
+    // Assert
+    expect(result.status).toBe('ahead');
+  });
+
+  // Absent is not a mismatch and not an all-clear: it means the running file
+  // predates this variable, so it is at least that old and nothing more can be
+  // said about it.
+  it('reports an absent variable as unknown rather than a mismatch', () => {
+    // Act
+    const result = resolveComposeFileVersion('');
+
+    // Assert
+    expect(result).toEqual({
+      expected: EXPECTED_COMPOSE_FILE_VERSION,
+      reported: null,
+      status: 'unknown',
+    });
+  });
+
+  // A hand-edited compose file can say anything. None of it is worth throwing
+  // over on a page an operator opened *because* the deployment is suspect.
+  it('reports a value that is not a version number as unknown', () => {
+    // Act & Assert
+    for (const raw of ['v2', '1.0', 'latest', '-1']) {
+      expect(resolveComposeFileVersion(raw).status).toBe('unknown');
+    }
+  });
+
+  // Compose passes the literal through verbatim, and a stray space in a
+  // hand-edited file should not read as a compose file that never reported.
+  it('tolerates surrounding whitespace', () => {
+    // Act & Assert
+    expect(
+      resolveComposeFileVersion(` ${String(EXPECTED_COMPOSE_FILE_VERSION)} `)
+        .status,
+    ).toBe('match');
   });
 });

--- a/apps/admin-server/tests/utils/use-server.ts
+++ b/apps/admin-server/tests/utils/use-server.ts
@@ -4,6 +4,7 @@ import { LogLevel } from '@scribear/base-fastify-server';
 
 import type { AppConfig } from '#src/app-config/app-config.js';
 import createServer from '#src/server/create-server.js';
+import { EXPECTED_COMPOSE_FILE_VERSION } from '#src/server/features/deployment-versions/deployment-versions.service.js';
 
 export const TEST_ADMIN_KEY = 'test-admin-key';
 export const TEST_USERNAME = 'engrit';
@@ -106,6 +107,11 @@ export function buildTestAppConfig(
     // document without listing all eleven of the real stack's containers.
     deploymentVersionsConfig: {
       timeoutMs: 500,
+      // A compose file in step with this image, so a test that cares about the
+      // compose-file row states the mismatch it is testing. Derived from the
+      // constant rather than written as a number, or bumping the version would
+      // silently turn the default deployment into a stale one.
+      reportedComposeFileVersion: String(EXPECTED_COMPOSE_FILE_VERSION),
       targets: [
         { name: 'session-manager', url: `${TEST_SM_BASE_URL}/build-info` },
         { name: 'node-server', url: `${TEST_NODE_BASE_URL}/build-info` },

--- a/apps/admin-webapp/src/features/config-check/deployment-versions-table.tsx
+++ b/apps/admin-webapp/src/features/config-check/deployment-versions-table.tsx
@@ -20,6 +20,8 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
 import type {
+  ComposeFileStatus,
+  ComposeFileVersion,
   ContainerVersion,
   DeploymentVersionsReport,
   VersionProbeStatus,
@@ -42,6 +44,65 @@ const STATUS_META: Record<
   unsupported: { label: 'old image', color: 'warning' },
   unreachable: { label: 'no answer', color: 'error' },
   'not-reported': { label: 'n/a', color: 'default' },
+};
+
+/**
+ * The compose file's four outcomes, as a row and as a banner.
+ *
+ * Every one of them is an icon *and* a word: colour alone would leave `stale`
+ * and `ahead` — the two an operator has to tell apart to know whether to copy a
+ * file or pull images — indistinguishable to anyone reading this in greyscale
+ * or with a colour vision deficiency.
+ */
+const COMPOSE_STATUS_META: Record<
+  ComposeFileStatus,
+  {
+    label: string;
+    color: 'success' | 'warning' | 'default';
+    severity: 'success' | 'warning' | 'info';
+    icon: React.ReactElement;
+    /** Headline of the banner. States the finding, not the status name. */
+    title: string;
+    /** What it means and what to do about it. */
+    detail: string;
+  }
+> = {
+  match: {
+    label: 'in step',
+    color: 'success',
+    severity: 'success',
+    icon: <CheckCircleIcon fontSize="small" />,
+    title: 'The compose file matches these images',
+    detail:
+      'deployment/compose.yml is the version these images were built for.',
+  },
+  stale: {
+    label: 'old file',
+    color: 'warning',
+    severity: 'warning',
+    icon: <WarningIcon fontSize="small" />,
+    title: 'This stack is running an old compose file',
+    detail:
+      'The images were pulled but deployment/compose.yml was not updated, so services, environment variables or wiring these images expect may simply be absent. Copy the current deployment/compose.yml from the repo and run `docker compose up -d`.',
+  },
+  ahead: {
+    label: 'old images',
+    color: 'warning',
+    severity: 'warning',
+    icon: <WarningIcon fontSize="small" />,
+    title: 'The compose file is newer than these images',
+    detail:
+      'deployment/compose.yml was updated but the images were not all pulled, so this stack is half upgraded. Run `docker compose pull && docker compose up -d` in deployment/.',
+  },
+  unknown: {
+    label: 'not reported',
+    color: 'default',
+    severity: 'info',
+    icon: <HelpOutlinedIcon fontSize="small" />,
+    title: 'The compose file did not report a version',
+    detail:
+      'It predates this check, so it is at least that old — which is not the same as being wrong, only unverifiable. Copy the current deployment/compose.yml from the repo and run `docker compose up -d` to start reporting it.',
+  },
 };
 
 function shortCommit(commit: string): string {
@@ -180,6 +241,71 @@ const ContainerRow = ({
 };
 
 /**
+ * The compose file, as a row in the same table.
+ *
+ * It is not a container and does not pretend to be one — it has no commit,
+ * branch or build time, and says so with the same em dash a container that did
+ * not supply a field uses. It belongs here anyway: an operator reading this
+ * table is asking "is this deployment consistent?", and the file wiring the
+ * containers together is the one piece of it that no image carries and no
+ * `docker compose pull` updates.
+ */
+const ComposeFileRow = ({
+  composeFile,
+}: {
+  composeFile: ComposeFileVersion;
+}) => {
+  const meta = COMPOSE_STATUS_META[composeFile.status];
+
+  return (
+    <TableRow hover>
+      <TableCell sx={{ fontWeight: 500 }}>compose.yml</TableCell>
+      <TableCell>
+        {composeFile.reported === null
+          ? '—'
+          : `v${String(composeFile.reported)}`}
+      </TableCell>
+      <TableCell>—</TableCell>
+      <TableCell>—</TableCell>
+      <TableCell>—</TableCell>
+      <TableCell>
+        <Tooltip
+          title={`These images were built for compose file v${String(composeFile.expected)}.`}
+        >
+          <Chip
+            size="small"
+            variant="outlined"
+            label={`expects v${String(composeFile.expected)}`}
+          />
+        </Tooltip>
+      </TableCell>
+      <TableCell>
+        <Stack
+          direction="row"
+          spacing={0.5}
+          useFlexGap
+          sx={{
+            alignItems: 'center',
+            flexWrap: 'wrap',
+          }}
+        >
+          <Chip
+            size="small"
+            color={meta.color}
+            variant="outlined"
+            icon={meta.icon}
+            label={meta.label}
+          />
+          <Tooltip title={meta.detail}>
+            <HelpOutlinedIcon fontSize="small" color="disabled" />
+          </Tooltip>
+        </Stack>
+      </TableCell>
+    </TableRow>
+  );
+};
+
+/**
  * What each container in this deployment was built from.
  *
  * This is the only place in the console that can answer the question, and the
@@ -215,6 +341,7 @@ export const DeploymentVersionsTable = ({
 
   const mismatched = new Set(report.mismatched);
   const stale = report.containers.filter((c) => c.status === 'unsupported');
+  const composeMeta = COMPOSE_STATUS_META[report.composeFile.status];
 
   return (
     <Box>
@@ -261,6 +388,20 @@ export const DeploymentVersionsTable = ({
           not recreated by the last upgrade.
         </Alert>
       )}
+      {/* Only when there is something to say. A green "the compose file
+          matches" banner on top of the green commit banner would double the
+          reassurance and halve the chance either is read; the row in the table
+          below carries the match case. */}
+      {report.composeFile.status !== 'match' && (
+        <Alert
+          severity={composeMeta.severity}
+          icon={composeMeta.icon}
+          sx={{ mb: 2 }}
+        >
+          <AlertTitle>{composeMeta.title}</AlertTitle>
+          {composeMeta.detail}
+        </Alert>
+      )}
       {report.locallyBuilt.length > 0 && !report.unstamped && (
         <Alert severity="info" sx={{ mb: 2 }}>
           <AlertTitle>Locally built images are running here</AlertTitle>
@@ -299,6 +440,9 @@ export const DeploymentVersionsTable = ({
                 isMismatched={mismatched.has(container.service)}
               />
             ))}
+            {/* Last, below every container: it is part of the deployment but
+                not part of the fleet of images above it. */}
+            <ComposeFileRow composeFile={report.composeFile} />
           </TableBody>
         </Table>
       </TableContainer>
@@ -313,10 +457,12 @@ export const DeploymentVersionsTable = ({
         }}
       >
         <RemoveCircleOutlinedIcon fontSize="inherit" />
-        Every value is baked into the image at build time, so it describes the
-        artifact rather than the source tree it sits next to. An em dash means
-        the build did not supply that field. Read{' '}
-        {new Date(report.checkedAt).toLocaleString()}.
+        Every container value is baked into the image at build time, so it
+        describes the artifact rather than the source tree it sits next to. An
+        em dash means the build did not supply that field. The{' '}
+        <code>compose.yml</code> row is the exception: it is not an image, and
+        its version is the literal the running compose file passes to
+        admin-server. Read {new Date(report.checkedAt).toLocaleString()}.
       </Typography>
     </Box>
   );

--- a/apps/admin-webapp/src/features/dashboard/audio-meter-bar.tsx
+++ b/apps/admin-webapp/src/features/dashboard/audio-meter-bar.tsx
@@ -202,6 +202,16 @@ export const AudioMeterBar = ({
           fontFamily: 'monospace',
           fontVariantNumeric: 'tabular-nums',
           whiteSpace: 'nowrap',
+          // `minWidth` alone was not a floor: setting it overrides a flex
+          // item's default `min-width: auto`, which is the thing that stops an
+          // item shrinking below its content. The bar beside this asks for
+          // `width: 100%`, so the readout lost the negotiation and "-23.4 dBFS"
+          // rendered clipped mid-word on a session card at every viewport width
+          // — measured in a real browser; jsdom has no layout, so no unit test
+          // could have seen it. The figure is the accessible value this
+          // component exists to show (SC 1.4.1), so it never shrinks; the bar
+          // is the part that gives way, down to its own 60px floor.
+          flexShrink: 0,
           minWidth: '4.5em',
           textAlign: 'right',
         }}

--- a/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
+++ b/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
@@ -270,7 +270,17 @@ const SessionCard = ({
   };
 
   return (
-    <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+    // `sm: 6` used to give two 12-wide columns at the sm breakpoint, but
+    // `AppLayout`'s sidebar is a fixed ~232px at every viewport width (it does
+    // not collapse below `md`), so a 600px viewport leaves ~320px of grid
+    // content — two columns there means ~150px cards, well under the ~180px
+    // the audio strip (bar `minWidth: 60` + gap + the dBFS readout's `4.5em`
+    // + CardContent padding) needs. `md`/`lg` already give a wide enough card
+    // (measured ~196px+ in a real browser) and are left alone. Staying single
+    // column through the whole `sm` range (320-620px of content) trades grid
+    // density for a card that never has to fit two things into one column's
+    // width.
+    <Grid size={{ xs: 12, sm: 12, md: 4, lg: 3 }}>
       <Card variant="outlined" sx={{ position: 'relative' }}>
         <IconButton
           size="small"
@@ -295,9 +305,25 @@ const SessionCard = ({
             <Stack
               direction="row"
               spacing={1}
+              useFlexGap
               sx={{
                 justifyContent: 'space-between',
                 alignItems: 'flex-start',
+                // A real (UUID) session UID and the status/audio chips are
+                // both rigid content competing for one line: the chips carry
+                // `flexShrink: 0` (their labels must stay whole, D1 below),
+                // so on a card too narrow for both, flexbox had nowhere to
+                // take the space from except the UID — squeezing it down
+                // past its longest unbreakable hyphen segment and forcing a
+                // real horizontal overflow past the card edge (visible as
+                // the audio chip's tail sitting under the neighbouring
+                // grid cell / icon button). `flexWrap: 'wrap'` lets the chip
+                // group drop to its own line instead, so the UID always gets
+                // either the full row (chips wrapped below) or a row with
+                // real spare width (chips fit beside it) — never a width
+                // narrower than its own content demands.
+                flexWrap: 'wrap',
+                rowGap: 0.5,
                 // Clearance for the absolutely-positioned "Open live captions"
                 // button above, which has an opaque background and a higher
                 // z-index: without it the button paints over the last ~18px of
@@ -310,7 +336,22 @@ const SessionCard = ({
             >
               <Typography
                 variant="body2"
-                sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}
+                sx={{
+                  fontFamily: 'monospace',
+                  // `break-all` allows a break between *any* two characters,
+                  // which the flex-item min-content calculation takes
+                  // literally: the browser sizes this item's floor as one
+                  // glyph wide, so a narrow card (or, before the Grid change
+                  // above, every card at `sm`) rendered the UID one character
+                  // per line. `overflow-wrap: break-word` breaks only when a
+                  // run genuinely does not fit, and — unlike `break-all` — it
+                  // does not enter the min-content calculation, so it does
+                  // not force the item to shrink pre-emptively. Session UIDs
+                  // are UUIDs, so the hyphens already give the browser a
+                  // normal break opportunity every 4-12 characters; nothing
+                  // here hides a character, it only ever adds a line break.
+                  overflowWrap: 'break-word',
+                }}
               >
                 {session.sessionUid}
               </Typography>

--- a/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
+++ b/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
@@ -298,6 +298,14 @@ const SessionCard = ({
               sx={{
                 justifyContent: 'space-between',
                 alignItems: 'flex-start',
+                // Clearance for the absolutely-positioned "Open live captions"
+                // button above, which has an opaque background and a higher
+                // z-index: without it the button paints over the last ~18px of
+                // this row, and since the audio chip is the rightmost thing in
+                // it, "audio: good" rendered as "audio: goo". Measured in a
+                // browser at every breakpoint — the chip is the text half of
+                // "never colour alone" (D1), so it has to be readable whole.
+                pr: 2.5,
               }}
             >
               <Typography

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -242,8 +242,24 @@ export interface ContainerVersion {
   detail?: string;
 }
 
+/** 'match' | 'stale' (the compose file is older than the images) | 'ahead' (the
+ *  images are older than the compose file) | 'unknown' (the file reported
+ *  nothing, so it predates this check and is at least that old). */
+export type ComposeFileStatus = 'match' | 'stale' | 'ahead' | 'unknown';
+
+/** How `deployment/compose.yml` compares to the file admin-server's image was
+ *  built for. The compose file is the one part of a deployment that is not an
+ *  image, so pulling images cannot update it and no container can read it. */
+export interface ComposeFileVersion {
+  expected: number;
+  /** Null when the compose file reported nothing, or nothing numeric. */
+  reported: number | null;
+  status: ComposeFileStatus;
+}
+
 export interface DeploymentVersionsReport {
   containers: ContainerVersion[];
+  composeFile: ComposeFileVersion;
   /** The commit the deployment is taken to be — whichever the most containers
    *  report. Null when nothing reported one. */
   expectedCommit: string | null;

--- a/apps/admin-webapp/tests/features/config-check/deployment-versions-table.test.tsx
+++ b/apps/admin-webapp/tests/features/config-check/deployment-versions-table.test.tsx
@@ -1,0 +1,195 @@
+import { screen, within } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect } from 'vitest';
+
+import { DeploymentVersionsTable } from '#src/features/config-check/deployment-versions-table';
+import type {
+  ComposeFileStatus,
+  DeploymentVersionsReport,
+} from '#src/lib/admin-api';
+
+import { renderWithProviders } from '../../utils/render-with-providers';
+
+const COMMIT = 'def6e68f0b3c4a1d9e2f5a7b8c0d1e2f3a4b5c6d';
+
+/** A healthy deployment: one commit everywhere, compose file in step. */
+function report(
+  overrides: Partial<DeploymentVersionsReport> = {},
+): DeploymentVersionsReport {
+  return {
+    containers: [
+      {
+        service: 'admin-server',
+        status: 'ok',
+        build: {
+          service: 'admin-server',
+          version: '1.4.2',
+          commit: COMMIT,
+          ref: 'staging',
+          builtAt: '2026-07-24T12:03:11Z',
+          imageTags: ['staging'],
+          pullRequest: null,
+          origin: 'ci',
+          dirty: false,
+        },
+      },
+    ],
+    composeFile: { expected: 3, reported: 3, status: 'match' },
+    expectedCommit: COMMIT,
+    mismatched: [],
+    locallyBuilt: [],
+    dirty: [],
+    unstamped: false,
+    checkedAt: '2026-07-25T09:00:00Z',
+    ...overrides,
+  };
+}
+
+function composeFile(
+  status: ComposeFileStatus,
+  reported: number | null,
+): Partial<DeploymentVersionsReport> {
+  return { composeFile: { expected: 3, reported, status } };
+}
+
+/** The compose file's own row, found by the label in its first cell. */
+function composeRow(): HTMLElement {
+  return screen.getByRole('row', { name: /compose\.yml/ });
+}
+
+describe('DeploymentVersionsTable compose file row', (it) => {
+  it('has no a11y violations', async () => {
+    const { container } = renderWithProviders(
+      <DeploymentVersionsTable report={report()} loading={false} />,
+    );
+
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
+  });
+
+  // The two findings that are not a match both render a banner, and a banner is
+  // where the axe risk is: it is the only part of this component whose colour
+  // changes with the status.
+  it('has no a11y violations when the compose file is out of step', async () => {
+    const { container } = renderWithProviders(
+      <DeploymentVersionsTable
+        report={report(composeFile('stale', 2))}
+        loading={false}
+      />,
+    );
+
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
+  });
+
+  it('shows the reported version and the one the images expect', () => {
+    // Act
+    renderWithProviders(
+      <DeploymentVersionsTable report={report()} loading={false} />,
+    );
+
+    // Assert — both halves of the comparison, so an operator can see which of
+    // the two moved without reading the banner.
+    const row = composeRow();
+    expect(within(row).getByText('v3')).toBeInTheDocument();
+    expect(within(row).getByText('expects v3')).toBeInTheDocument();
+  });
+
+  // Never colour alone: `stale` and `ahead` are the two an operator has to tell
+  // apart to know whether to copy a file or pull images, and they share a
+  // colour. The word in the chip is what distinguishes them.
+  it('names each status in text, not only in colour', () => {
+    // Arrange
+    const cases: [ComposeFileStatus, number | null, string][] = [
+      ['match', 3, 'in step'],
+      ['stale', 2, 'old file'],
+      ['ahead', 4, 'old images'],
+      ['unknown', null, 'not reported'],
+    ];
+
+    for (const [status, reported, label] of cases) {
+      // Act
+      const { unmount } = renderWithProviders(
+        <DeploymentVersionsTable
+          report={report(composeFile(status, reported))}
+          loading={false}
+        />,
+      );
+
+      // Assert
+      expect(within(composeRow()).getByText(label)).toBeInTheDocument();
+
+      unmount();
+    }
+  });
+
+  // A compose file older than the images is the failure this row exists for,
+  // and the remedy is specific: copy the file, do not pull images again.
+  it('tells the operator to copy the compose file when it is stale', () => {
+    // Act
+    renderWithProviders(
+      <DeploymentVersionsTable
+        report={report(composeFile('stale', 2))}
+        loading={false}
+      />,
+    );
+
+    // Assert
+    expect(
+      screen.getByText(/This stack is running an old compose file/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Copy the current deployment\/compose\.yml/),
+    ).toBeInTheDocument();
+  });
+
+  // The mirror image, and deliberately not folded into "out of step": pulling
+  // images is the fix here, and copying the file again would do nothing.
+  it('tells the operator to pull images when the file is ahead', () => {
+    // Act
+    renderWithProviders(
+      <DeploymentVersionsTable
+        report={report(composeFile('ahead', 4))}
+        loading={false}
+      />,
+    );
+
+    // Assert
+    expect(
+      screen.getByText(/The compose file is newer than these images/),
+    ).toBeInTheDocument();
+  });
+
+  // Absent is not a mismatch. It is reported as an absence of evidence, with an
+  // em dash rather than a version, so nobody reads it as a measured value.
+  it('reports an unversioned compose file without asserting a mismatch', () => {
+    // Act
+    renderWithProviders(
+      <DeploymentVersionsTable
+        report={report(composeFile('unknown', null))}
+        loading={false}
+      />,
+    );
+
+    // Assert
+    expect(screen.getByText(/did not report a version/)).toBeInTheDocument();
+    expect(within(composeRow()).getByText('not reported')).toBeInTheDocument();
+  });
+
+  // A match is carried by the row alone: a second green banner beside the
+  // "every container is on one commit" one would halve the chance either is
+  // read.
+  it('raises no banner when the compose file matches', () => {
+    // Act
+    renderWithProviders(
+      <DeploymentVersionsTable report={report()} loading={false} />,
+    );
+
+    // Assert
+    expect(
+      screen.queryByText(/The compose file matches these images/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin-webapp/tests/features/dashboard/audio-meter-bar.test.tsx
+++ b/apps/admin-webapp/tests/features/dashboard/audio-meter-bar.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { describe, expect } from 'vitest';
 
@@ -42,6 +42,31 @@ describe('AudioMeterBar', (it) => {
     );
 
     expect(document.body).toHaveTextContent('-23.4 dBFS');
+  });
+
+  it('keeps the dBFS readout from shrinking beside the bar', () => {
+    // The bar asks for `width: 100%`, so in the flex row both children compete
+    // for space. `minWidth` reads like a floor but is not one on its own: it
+    // replaces a flex item's default `min-width: auto`, which is exactly the
+    // rule that stops an item shrinking below its own content — so the readout
+    // rendered clipped mid-word ("-23.4 dB…") on every session card until
+    // `flexShrink: 0` was added.
+    //
+    // jsdom does no layout, so this asserts the declaration rather than the
+    // result; the clipping itself was only visible in a real browser.
+    render(
+      <AudioMeterBar
+        rmsDbfs={-23.4}
+        peakDbfs={-12.1}
+        status="good"
+        label="Audio level for session test"
+      />,
+    );
+
+    const readout = screen.getByText('-23.4 dBFS');
+
+    expect(getComputedStyle(readout).flexShrink).toBe('0');
+    expect(getComputedStyle(readout).whiteSpace).toBe('nowrap');
   });
 
   it('renders an em-dash when there is no signal', () => {

--- a/apps/admin-webapp/tests/features/dashboard/fleet-panel.test.tsx
+++ b/apps/admin-webapp/tests/features/dashboard/fleet-panel.test.tsx
@@ -228,6 +228,76 @@ describe('SessionCard audio strip', (it) => {
   });
 });
 
+describe('SessionCard layout', (it) => {
+  beforeEach(() => {
+    vi.mocked(useFleet).mockReset();
+  });
+
+  it('stays a full-width column through the whole `sm` range, not two-up', () => {
+    // AppLayout's sidebar is a fixed ~232px at every viewport width, so a
+    // `sm: 6` card (the old value) got ~150px at a 600px viewport — too
+    // narrow for the audio strip (bar + dBFS readout) to fit without
+    // clipping, measured in a real browser. jsdom does no layout, so this
+    // can't see the resulting pixel widths; it only pins the breakpoint prop
+    // Grid actually receives, as a proxy for "don't go back to two columns
+    // before the sidebar's fixed cost stops mattering".
+    const container = mountFleet(
+      [visibleSession({ sessionUid: 'session-1' })],
+      [buildAudio({}, { sessionUid: 'session-1' })],
+    );
+
+    const sessionGrid = [...container.querySelectorAll('.MuiGrid-root')].find(
+      (el) => el.className.includes('MuiGrid-grid-xs-12'),
+    );
+
+    expect(sessionGrid?.className).toContain('MuiGrid-grid-sm-12');
+    expect(sessionGrid?.className).not.toContain('MuiGrid-grid-sm-6');
+  });
+
+  it('lets the header row wrap the status/audio chips below the session UID', () => {
+    // A full UUID and the two rigid (flexShrink: 0) chips are both fixed-size
+    // content competing for one line; on a card too narrow for both, the only
+    // place flexbox could take space from used to be the UID itself — down
+    // past its longest unbreakable hyphen segment, which overflowed the card
+    // (measured in a real browser: the audio chip's tail landed under the
+    // neighbouring grid cell). `flexWrap: 'wrap'` lets the chip group drop to
+    // its own line instead. jsdom does no layout, so it can't see the
+    // overflow or the wrap actually happen — this only asserts the
+    // declaration is present.
+    const container = mountFleet(
+      [visibleSession({ sessionUid: 'session-1' })],
+      [buildAudio({}, { sessionUid: 'session-1' })],
+    );
+
+    const header = container.querySelector(
+      '.MuiCardContent-root .MuiStack-root',
+    );
+
+    expect(header).not.toBeNull();
+    expect(getComputedStyle(header!).flexWrap).toBe('wrap');
+  });
+
+  it('wraps the session UID at natural break points instead of one character per line', () => {
+    // `word-break: break-all` allows a break between *any* two characters,
+    // which the browser's min-content calculation takes literally: the
+    // flex item's floor becomes one glyph wide, so — squeezed against the
+    // fixed-size chips — the UID rendered one character per line (measured in
+    // a real browser). `overflow-wrap: break-word` only breaks a run that
+    // truly doesn't fit, and unlike `break-all` it doesn't enter the
+    // min-content calculation, so it doesn't pre-emptively shrink. This only
+    // pins the declaration change; jsdom can't see how a UUID actually wraps.
+    mountFleet(
+      [visibleSession({ sessionUid: 'session-1' })],
+      [buildAudio({}, { sessionUid: 'session-1' })],
+    );
+
+    const uid = screen.getByText('session-1');
+
+    expect(getComputedStyle(uid).overflowWrap).toBe('break-word');
+    expect(getComputedStyle(uid).wordBreak).not.toBe('break-all');
+  });
+});
+
 describe('SessionCard with a throughput-only snapshot', (it) => {
   beforeEach(() => {
     vi.mocked(useFleet).mockReset();

--- a/apps/monitoring-sidecar/tests/unit/audio-meter-csp.test.ts
+++ b/apps/monitoring-sidecar/tests/unit/audio-meter-csp.test.ts
@@ -1,0 +1,134 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect } from 'vitest';
+
+/**
+ * The standalone microphone meter ships as one self-contained HTML file whose
+ * DSP and UI are inline `<script>` blocks. This build copies that file into the
+ * bundle (see the `copy-audio-meter-page` plugin in `vite.config.ts`), so
+ * operators reach it at `/admin/audio-meter.html` — behind the nginx location
+ * that sets a Content-Security-Policy.
+ *
+ * The SPA's policy (`script-src 'self'`) blocks inline script, and a blocked
+ * meter fails **silently**: the page renders in full, "Start metering" does
+ * nothing, and every readout stays an em-dash. So nginx gives that one path its
+ * own policy whose `script-src` names the sha256 of each script the page ships.
+ *
+ * Those hashes live in another workspace than the file they pin, and any edit
+ * to the page invalidates them. This suite recomputes them from the shipped
+ * page and fails if the two have drifted apart — which is the only automated
+ * signal that would otherwise exist between "someone edits the meter" and "an
+ * operator opens a dead page".
+ *
+ * It lives in this workspace rather than in admin-webapp — which is the app
+ * that ships the page — because reading the two files needs `node:fs`, and
+ * admin-webapp's tsconfig pins `types: ["vite/client"]` on purpose. This is
+ * already the workspace that reads the shared page from disk (see
+ * `audio-meter-dsp.test.ts`), and it serves the same file itself.
+ */
+
+const PAGE_PATH = fileURLToPath(
+  new URL(
+    '../../../../libs/audio-meter-page/audio-meter.html',
+    import.meta.url,
+  ),
+);
+const NGINX_CONF_PATH = fileURLToPath(
+  new URL('../../../../infra/scribear-nginx/nginx.conf', import.meta.url),
+);
+
+const LOCATION = 'location = /admin/audio-meter.html {';
+
+/** Text of every `<script>` element in the page, in document order. */
+function inlineScripts(html: string): string[] {
+  return [...html.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/g)].map(
+    (match) => match[1] ?? '',
+  );
+}
+
+/** The CSP `add_header` value from a single nginx location block. */
+function cspOfLocation(conf: string, header: string): string {
+  const start = conf.indexOf(header);
+  expect(start, `${header} is missing from nginx.conf`).toBeGreaterThanOrEqual(
+    0,
+  );
+  // Locations in this file are indented four spaces inside `server`, so the
+  // block ends at the first line that closes at that indentation.
+  const end = conf.indexOf('\n        }', start);
+  const block = conf.slice(start, end);
+  const csp = /add_header Content-Security-Policy "([^"]+)"/.exec(block);
+  expect(csp, `no Content-Security-Policy in ${header}`).not.toBeNull();
+  return csp![1]!;
+}
+
+describe('audio-meter page CSP', (it) => {
+  const html = readFileSync(PAGE_PATH, 'utf8');
+  const conf = readFileSync(NGINX_CONF_PATH, 'utf8');
+
+  it('allows the sha256 of every script the page actually ships', () => {
+    // Arrange: the hashes CSP checks are of the element's exact text, so they
+    // change on any edit inside a <script> block — including whitespace.
+    const expected = inlineScripts(html).map(
+      (source) =>
+        `sha256-${createHash('sha256').update(source, 'utf8').digest('base64')}`,
+    );
+    expect(
+      expected.length,
+      'the page should still carry its DSP and UI scripts',
+    ).toBe(2);
+
+    // Act
+    const csp = cspOfLocation(conf, LOCATION);
+
+    // Assert: naming the regeneration command in the message matters — whoever
+    // trips this is editing the meter page, not thinking about nginx.
+    for (const hash of expected) {
+      expect(
+        csp,
+        `nginx.conf does not allow '${hash}'.\n` +
+          "Recompute after editing the page and paste into infra/scribear-nginx/nginx.conf's " +
+          `${LOCATION.slice(0, -2)} block:\n` +
+          '  node -e \'const f=require("fs"),c=require("crypto");' +
+          'for(const m of f.readFileSync("libs/audio-meter-page/audio-meter.html","utf8")' +
+          '.matchAll(/<script\\b[^>]*>([\\s\\S]*?)<\\/script>/g))' +
+          'console.log("sha256-"+c.createHash("sha256").update(m[1]).digest("base64"))\'',
+      ).toContain(hash);
+    }
+  });
+
+  it('pins those scripts by hash rather than reopening inline execution', () => {
+    // A future "fix" for a hash mismatch could be to add 'unsafe-inline', which
+    // would make this page's policy weaker than the SPA's beside it. The hashes
+    // are what keep the relaxation to exactly the two scripts in the repo.
+    const csp = cspOfLocation(conf, LOCATION);
+    const scriptSrc = /script-src ([^;]+)/.exec(csp)?.[1] ?? '';
+
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+    // The page assembles its AudioWorklet module from its own DSP source as a
+    // blob; without this it silently falls back to a main-thread
+    // ScriptProcessorNode. Working, but deprecated and on the UI thread.
+    expect(scriptSrc).toContain('blob:');
+  });
+
+  it('keeps the meter on its own policy without loosening the SPA', () => {
+    // The SPA policy must stay strict: it is the one with a login form, an API
+    // and a session behind it. Only the static meter page gets the exception.
+    const spaCsp = cspOfLocation(conf, 'location /admin/ {');
+
+    expect(spaCsp).toContain("script-src 'self';");
+    expect(spaCsp).not.toContain('sha256-');
+    expect(spaCsp).not.toContain('blob:');
+  });
+
+  it('serves the meter from admin-webapp, not from a second copy', () => {
+    // An exact-match location wins over the /admin/ prefix regardless of order,
+    // so nginx replaces the whole matched URI — the upstream path has to be
+    // spelled out or the request arrives at admin-webapp as "/" and the SPA
+    // answers with index.html, which looks like a working page.
+    const start = conf.indexOf(LOCATION);
+    const block = conf.slice(start, conf.indexOf('\n        }', start));
+
+    expect(block).toContain('proxy_pass http://admin-webapp/audio-meter.html;');
+  });
+});

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,40 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — the Deployment Check notices an out-of-date `compose.yml`
+
+### A new `compose.yml` row on the Deployment Check page
+
+`deployment/compose.yml` is not part of any image, so `docker compose pull`
+never updates it. Until now nothing noticed: a stack could run this month's
+images against last month's file, missing whichever services, environment
+variables and wiring the new images expect, with every container reporting
+green.
+
+`compose.yml` now carries a version number of its own, and admin-server compares
+it against the version its image was built for. The result is one more row at
+the bottom of **Deployment Check → Deployed versions**, beside the containers:
+
+| Status | What it means | What to do |
+| --- | --- | --- |
+| `in step` | The file matches these images. | Nothing. |
+| `old file` | The images are newer than `compose.yml` — you pulled without copying the file. | Copy the current [`compose.yml`](compose.yml) from the repo over `deployment/compose.yml`, keep your `.env`, and run `docker compose up -d`. |
+| `old images` | `compose.yml` is newer than the images — the file was copied but not everything was pulled. | `docker compose pull && docker compose up -d`. |
+| `not reported` | The running file predates this check, so it is at least that old. | Same as `old file`: copy the current file and `docker compose up -d`. |
+
+Expect `not reported` on the first upgrade to this release, until the new file is
+in place.
+
+**Nothing here can stop a stack from starting.** The version is a plain literal
+in `compose.yml` — it changes what the console *reports* and never what runs,
+it is not `:?`-guarded, and it is deliberately **not** an `.env` key: an `.env`
+carried over from an older release is exactly the thing that goes stale, so
+letting it supply this value would let the stale half of a deployment vouch for
+the other half. There is nothing to add to `.env` for this, and editing the
+literal by hand only makes the console report something untrue.
+
+---
+
 ## Unreleased — audio meter and audio telemetry in the admin console
 
 The admin console gains an **Audio meter** nav item and a live **audio health**

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -30,6 +30,30 @@ whoever is at the room's PC. The page needs a secure context (HTTPS or
 a LAN IP will see the mic button fail — use HTTPS or open it from the machine
 itself.
 
+### The nginx image must be upgraded with the rest, or the meter is dead
+
+`/admin/` is served with a Content-Security-Policy, and the meter page keeps its
+DSP and UI in inline `<script>` blocks (it is one self-contained file on
+purpose, so an audio engineer can copy it to a source machine). The SPA's
+`script-src 'self'` blocks those, and it fails **silently**: the page renders in
+full, the device list populates, "Start metering" does nothing, and every
+readout stays an em-dash. Nothing on screen says why.
+
+`scribear-nginx` therefore ships a policy for that one URL, naming the sha256 of
+each script the page contains. **Deploying the new admin-webapp image against an
+older nginx gives you the dead page**, and a stale nginx with a *newer* meter
+page does the same thing, because the hashes will not match its content. Pull
+both images together. To check a running deployment:
+
+```sh
+curl -sk https://<host>/admin/audio-meter.html -o /dev/null -D - | grep -i content-security
+# script-src must list two sha256-… values; if it says only 'self', nginx is stale
+```
+
+The check that catches this before a release is a browser, not a request: a
+`200` response and correct bytes prove nothing here, because the page that runs
+and the page that is inert are byte-identical.
+
 ### Clipping is now measured as runs at the rail (behaviour change)
 
 `clippingPct` on published audio telemetry changed meaning. It used to count

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -148,6 +148,29 @@ services:
     expose:
       - "80"
     environment:
+      # The identity of *this file*, so the admin console can notice that new
+      # images are running against an old compose file. Nothing else in the
+      # stack can see that: this file is not part of any image, so an operator
+      # who pulls new images without copying it gets missing services, missing
+      # variables and changed wiring, silently. admin-server compares this
+      # against the value baked into its own image and reports the result on
+      # the Deployment Check page.
+      #
+      # A literal, deliberately, and never `${COMPOSE_FILE_VERSION:-}`: a
+      # carried-over .env is exactly the thing that goes stale, so letting it
+      # supply this value would let the stale half of a deployment vouch for
+      # the other half. Nothing about it belongs in .env.
+      #
+      # Bump it when a change to this file is one an operator must redeploy
+      # for - a new service, a new or renamed variable, changed wiring - and
+      # bump `EXPECTED_COMPOSE_FILE_VERSION` in admin-server to match. A unit
+      # test fails if the two ever disagree, or if this file changes without
+      # someone deciding which of the two cases they are in.
+      #
+      # Not `:?`-guarded, like DEPLOYMENT_ENV below and unlike the secrets: it
+      # changes what is *reported*, never what runs, and must not be able to
+      # stop a stack from starting.
+      COMPOSE_FILE_VERSION: "1"
       LOG_LEVEL: ${ADMIN_LOG_LEVEL:-info}
       ADMIN_API_KEY: ${SESSION_MANAGER_API_KEY}
       SESSION_MANAGER_BASE_URL: http://session-manager:80

--- a/infra/scribear-nginx/nginx.conf
+++ b/infra/scribear-nginx/nginx.conf
@@ -163,6 +163,43 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # The standalone microphone meter (libs/audio-meter-page/audio-meter.html,
+        # copied into admin-webapp's bundle at build time) is a single
+        # self-contained file whose DSP and UI are inline <script> blocks. Under
+        # the /admin/ policy below, `script-src 'self'` blocks both: the page
+        # renders, "Start metering" does nothing, and every readout stays an
+        # em-dash — with nothing on screen saying why. Confirmed in a built
+        # container with a real browser, which is the only way this shows up.
+        #
+        # So it gets its own policy rather than a relaxation of /admin/'s. This
+        # one is tighter than the SPA's in every direction except inline script:
+        # the page fetches nothing, talks to nothing (`connect-src 'none'`) and
+        # only ever reaches the local microphone, so the two hashes below are
+        # the complete set of code allowed to run on it. `blob:` is for the
+        # AudioWorklet module the page assembles from its own DSP source; the
+        # page falls back to a main-thread ScriptProcessorNode without it, which
+        # works but is deprecated and does the DSP on the UI thread.
+        #
+        # Each hash is the sha256 of one <script> element's exact text. Editing
+        # audio-meter.html changes them and silently kills the page again, so
+        # apps/monitoring-sidecar/tests/unit/audio-meter-csp.test.ts recomputes
+        # them from the shipped file and fails if they drift.
+        #
+        # Exact match, so it wins over the /admin/ prefix block regardless of
+        # order; proxy_pass therefore has to name the upstream path in full,
+        # since nginx replaces the whole matched URI with the one given here.
+        location = /admin/audio-meter.html {
+            proxy_pass http://admin-webapp/audio-meter.html;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            add_header Content-Security-Policy "default-src 'none'; script-src 'sha256-RWNlfOyAl35IBnodBIF4L/PTN52DEr4n99OXyrXEas4=' 'sha256-8tT+VI7MV9h248c3XwAAU9tXmFKbMwPQp2Vlt/MwXrY=' blob:; style-src 'unsafe-inline'; img-src data:; connect-src 'none'; base-uri 'none'; form-action 'none'" always;
+            # Re-declare HSTS for the same reason the block below does.
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        }
+
         location /admin/ {
             proxy_pass http://admin-webapp/;
             proxy_set_header Host              $host;


### PR DESCRIPTION
Follow-up to #165. Three defects, all found by running the built containers in a real browser rather than by reading code — which is exactly what `NEXTSTEPS-AUDIOVIZ.md` had listed as still needing a human.

## 1. `/admin/audio-meter.html` was dead in the deployed stack

nginx serves `/admin/` with `script-src 'self'`, and the standalone meter keeps its DSP and UI in inline `<script>` blocks (it is one self-contained file on purpose, so an audio engineer can copy it to a source machine). Both scripts were blocked.

The page still renders in full — all of its chrome is static HTML — so it fails **silently**: "Start metering" does nothing and every readout stays an em-dash, with nothing on screen saying why. The response is a `200` whose bytes are identical to `libs/audio-meter-page/audio-meter.html`, which is what the plan's checklist asked for, so no request-level check could ever have caught this. The inert page and the working page differ only once you press the button.

The fix is a dedicated `location = /admin/audio-meter.html` with its own policy rather than a relaxation of the SPA's. It is *tighter* than the SPA's in every direction except inline script:

```
default-src 'none'; script-src 'sha256-…' 'sha256-…' blob:;
style-src 'unsafe-inline'; img-src data:; connect-src 'none';
base-uri 'none'; form-action 'none'
```

- The page fetches nothing and talks to nothing, so `connect-src 'none'` holds — even in the worst case, microphone audio has nowhere to go.
- The two hashes are the complete set of code allowed to run, so this is a bounded relaxation, not `'unsafe-inline'`. It also gives mild tamper-evidence: modified page bytes stop executing rather than executing modified.
- `blob:` is for the AudioWorklet module the page assembles from its own DSP source. Without it the page silently falls back to a main-thread `ScriptProcessorNode` — verified by instrumenting `addModule`: worklet with it, fallback without, and **no console output either way**. Dropping `blob:` for a stricter policy is a one-word change if reviewers prefer it.

Because the hashes pin bytes that live in another workspace, `apps/monitoring-sidecar/tests/unit/audio-meter-csp.test.ts` recomputes them from the shipped page and fails on drift, naming the command to regenerate. Mutation-tested both ways: an edit inside a `<script>` block, and dropping `blob:` from the policy.

> ⚠️ **Operators must upgrade the nginx image with the rest.** A new admin-webapp behind an older nginx reproduces the dead page, and a stale nginx with a newer meter page does the same, because the hashes will not match. Recorded in `deployment/UPGRADING.md` with a `curl` one-liner to check a running deployment.

## 2 & 3. The session card was hiding its own audio numbers

Both defects hide the *text* half of "never colour alone" (SC 1.4.1) — the requirement this panel exists to meet.

- **The dBFS readout was clipped mid-word at every viewport width**: 76.3px of text in a 55.5px box, so ~3 characters of `-23.4 dBFS` were cut. `minWidth: '4.5em'` reads like a floor but is not one — setting `min-width` replaces a flex item's default `min-width: auto`, which is exactly the rule that stops an item shrinking below its content. The bar beside it asks for `width: 100%` and won. `flexShrink: 0` makes the bar give way instead, down to its own 60px floor.
- **The "Open live captions" button painted over the audio chip.** It is absolutely positioned at the card's top-right with an opaque background and a higher `z-index`, and the audio chip is the rightmost item in the header row, so `audio: good` rendered as `audio: goo`. The row now reserves clearance.

Neither is visible to the existing gates: jsdom does no layout, so `toHaveTextContent('-23.4 dBFS')` passes on visually truncated text, and overlap is a paint-order fact axe cannot see. Both were measured in a real browser (Range width vs box width; `elementFromPoint` at the last glyph). The regression guard that *is* possible under jsdom asserts the flex declaration, and the test says plainly that it is a proxy for the thing that actually broke.

## How this was verified

Real `admin-webapp` and `scribear-nginx` images, a self-signed cert, and a stub `admin-server` whose `/fleet` audio numbers advance on every read:

- meter page: bytes identical to source, runs with no console errors on Chrome's fake audio device, AudioWorklet path loads, `/admin/audit` hard-refresh still returns the SPA, `/admin/` still carries the strict SPA policy;
- dashboard: `aria-valuetext` and `aria-valuenow` both changed between polls, `/fleet` polled at 4969/5000 ms gaps, **0** requests over 12 s while hidden, one immediate refresh on becoming visible, and the "no audio reaching ASR" card and roll-up counts rendered as specified.

Two caveats stated for the record: `document.hidden` was overridden and `visibilitychange` dispatched, because headless Chrome cannot background a page (CDP's lifecycle states are `active`/`frozen` only); and the stub is not a real Redis-fed admin-server.

## Gates

`npm run format`, `lint`, `tsc --noEmit` and `test:unit` clean in `apps/admin-webapp` (273 tests) and `apps/monitoring-sidecar`. No `package.json` changed, so no lockfile churn.

## Still to come on this branch

- the session card at ≤600px viewport, where the card is ~150px wide because the sidebar is a fixed ~230px at every width and the grid is still `sm: 6` — the UID renders one character per line and the audio strip overflows again. Pre-existing and not audio-specific, but the audio row is the widest content in the card, so it breaks first.
- a compose-file version check: `deployment/compose.yml` is not part of any image, so a deployment can run an old file against new images with nothing to detect it. A literal version in the file, echoed to admin-server and compared against the value baked into its image, reported on the Deployment Check page — with a repo-side guard that fails CI when the file changes without the number moving.
