### PR TITLE
Fix end-to-end audio: upstream re-auth, kiosk handshake, auto-session overlap

### DIFF
--- a/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
+++ b/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
@@ -428,7 +428,10 @@ const SessionCard = ({
           {audio === undefined ? (
             <Typography variant="caption" color="error">
               {session.upstreamState === 'OPEN'
-                ? 'no audio reaching ASR'
+                ? session.audioFramesReceived !== undefined &&
+                  session.audioFramesReceived > 0
+                  ? 'audio received, not reaching ASR'
+                  : 'no audio from source'
                 : 'no audio telemetry'}
             </Typography>
           ) : headline === undefined ? (

--- a/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
+++ b/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
@@ -401,6 +401,10 @@ const SessionCard = ({
               {event &&
                 !event.transcriptionServiceConnected &&
                 ' · ASR disconnected'}
+              {event &&
+                event.sourceDeviceConnected &&
+                event.sourceMicrophoneActive === false &&
+                ' · mic off'}
             </Typography>
             {p95 !== null && (
               <Typography
@@ -431,7 +435,9 @@ const SessionCard = ({
                 ? session.audioFramesReceived !== undefined &&
                   session.audioFramesReceived > 0
                   ? 'audio received, not reaching ASR'
-                  : 'no audio from source'
+                  : event?.sourceMicrophoneActive === false
+                    ? 'mic off'
+                    : 'no audio from source'
                 : 'no audio telemetry'}
             </Typography>
           ) : headline === undefined ? (

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -314,6 +314,14 @@ export interface SessionSnapshot {
   pendingChunkCount: number;
   upstreamState: UpstreamState;
   upstreamRetryAttempt: number;
+  /**
+   * Binary frames received from the source since the session opened, counted
+   * before decode (malformed frames included - they still prove the source is
+   * sending). Optional: older node-server publishers that predate it omit it.
+   * 0 = source sent nothing; >0 = source is sending (lets the fleet view
+   * distinguish "kiosk sent nothing" from "upstream broke").
+   */
+  audioFramesReceived?: number;
   latency: LatencySeries[];
   /** Publish time, epoch ms, on the publishing host's clock. */
   updatedAt: number;

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -322,8 +322,8 @@ export interface SessionSnapshot {
    * distinguish "kiosk sent nothing" from "upstream broke").
    */
   audioFramesReceived?: number;
-  latency: LatencySeries[];
-  /** Publish time, epoch ms, on the publishing host's clock. */
+  sourceMicrophoneActive?: boolean | null;
+  latency: LatencySeries[]; /** Publish time, epoch ms, on the publishing host's clock. */
   updatedAt: number;
   nodeInstanceId: string;
   processUid: string;
@@ -598,6 +598,7 @@ export interface SessionStatusEvent {
   sessionUid: string;
   transcriptionServiceConnected: boolean;
   sourceDeviceConnected: boolean;
+  sourceMicrophoneActive?: boolean | null;
   /** Publish time, epoch ms, on the publisher's clock. */
   at: number;
 }

--- a/apps/admin-webapp/tests/features/dashboard/fleet-panel.test.tsx
+++ b/apps/admin-webapp/tests/features/dashboard/fleet-panel.test.tsx
@@ -342,15 +342,22 @@ describe('SessionCard with no audio snapshot', (it) => {
     vi.mocked(useFleet).mockReset();
   });
 
-  it('renders "no audio reaching ASR" for an OPEN session rather than an empty strip', () => {
+  it('names the source as the suspect for an OPEN session with no frames received', () => {
     // PLAN-AUDIOVIZ §7.2: when there is no snapshot for an OPEN session the
     // strip must render the finding, not disappear — the absence *is* failure
     // mode C1. An empty space reads as "nothing to report".
     //
+    // `audioFramesReceived: 0` splits that finding one level further: the
+    // upstream is open and node-server has received nothing, so the source is
+    // the thing to go and look at.
+    //
     // The session event is only here to get the card past the grid's default
     // `['crit','warn']` connectivity filter; an OPEN session with a healthy
     // stream derives `good` and would be filtered out.
-    const session = buildSession({ upstreamState: 'OPEN' });
+    const session = buildSession({
+      upstreamState: 'OPEN',
+      audioFramesReceived: 0,
+    });
     const events = new Map<string, SessionStatusEvent>([
       [
         session.sessionUid,
@@ -366,7 +373,38 @@ describe('SessionCard with no audio snapshot', (it) => {
 
     mountFleet([session], [], events);
 
-    expect(screen.getByText('no audio reaching ASR')).toBeInTheDocument();
+    expect(screen.getByText('no audio from source')).toBeInTheDocument();
+  });
+
+  it('blames the pipeline, not the source, once frames have been received', () => {
+    // The other half of the split. Same visible state - upstream OPEN, no audio
+    // snapshot - but node-server has counted frames from the source, so the
+    // microphone is provably fine and the break is downstream. Telling these
+    // two apart is the whole point of the counter: without it both read as "no
+    // audio reaching ASR" and every investigation starts by checking the mic.
+    const session = buildSession({
+      upstreamState: 'OPEN',
+      audioFramesReceived: 1200,
+    });
+    const events = new Map<string, SessionStatusEvent>([
+      [
+        session.sessionUid,
+        {
+          t: 'session',
+          sessionUid: session.sessionUid,
+          transcriptionServiceConnected: false,
+          sourceDeviceConnected: true,
+          at: 1_000,
+        },
+      ],
+    ]);
+
+    mountFleet([session], [], events);
+
+    expect(
+      screen.getByText('audio received, not reaching ASR'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('no audio from source')).not.toBeInTheDocument();
   });
 
   it('renders the softer "no audio telemetry" when the session is not OPEN', () => {
@@ -375,7 +413,7 @@ describe('SessionCard with no audio snapshot', (it) => {
     mountFleet([visibleSession({ upstreamState: 'CONNECTING' })], []);
 
     expect(screen.getByText('no audio telemetry')).toBeInTheDocument();
-    expect(screen.queryByText('no audio reaching ASR')).not.toBeInTheDocument();
+    expect(screen.queryByText('no audio from source')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/client-webapp/src/app/root.tsx
+++ b/apps/client-webapp/src/app/root.tsx
@@ -42,6 +42,7 @@ import {
 
 import { JoinSessionModal } from '#src/features/session-provider/components/join-session-modal';
 import { LatencyBadge } from '#src/features/session-provider/components/latency-badge';
+import { LeaveSessionButton } from '#src/features/session-provider/components/leave-session-button';
 import { useAppDispatch, useAppSelector } from '#src/store/use-redux';
 
 /**
@@ -135,7 +136,7 @@ export const Root = () => {
       isHeaderHideEnabled={isHeaderHideEnabled}
       onToggleHeaderHide={() => dispatch(toggleHeaderHide())}
       drawerContent={DrawerMenus}
-      headerButtons={[]}
+      headerButtons={[<LeaveSessionButton key="leave" />]}
       headerBreakpoint="md"
     >
       <JoinSessionModal />

--- a/apps/client-webapp/src/features/session-provider/components/leave-session-button.tsx
+++ b/apps/client-webapp/src/features/session-provider/components/leave-session-button.tsx
@@ -1,0 +1,44 @@
+import LogoutIcon from '@mui/icons-material/Logout';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+
+import { useAppDispatch, useAppSelector } from '#src/store/use-redux';
+
+import { ClientLifecycle } from '../services/client-session-service-status';
+import {
+  leaveSession,
+  selectLifecycle,
+} from '../stores/client-session-service-slice';
+
+/**
+ * Header button that disconnects from the current session so the viewer can
+ * join a different room.
+ *
+ * Renders nothing unless a session is actually joined: while the join dialog is
+ * open there is nothing to leave, and a live "Leave" control behind a modal is
+ * only reachable by keyboard users tabbing out of it.
+ *
+ * All of the work happens in the service, which tears down the socket, clears
+ * the persisted identity so a reload does not resume the old session, and drops
+ * to `IDLE`. The join dialog is bound to `IDLE`, so it reopens on its own, and
+ * the middleware clears the transcript on any exit from `ACTIVE` - the next room
+ * starts blank rather than inheriting the last one's captions.
+ */
+export const LeaveSessionButton = () => {
+  const dispatch = useAppDispatch();
+  const lifecycle = useAppSelector(selectLifecycle);
+
+  if (lifecycle !== ClientLifecycle.ACTIVE) return null;
+
+  return (
+    <Tooltip title="Leave session">
+      <IconButton
+        color="inherit"
+        aria-label="Leave session and join a different room"
+        onClick={() => dispatch(leaveSession())}
+      >
+        <LogoutIcon />
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
@@ -684,7 +684,44 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
       ? this._nodeServerClient.transcriptionStreamSource
       : this._nodeServerClient.transcriptionStreamClient;
 
-    const socket = factory({ params: { sessionUid: session.uid } });
+    const socket = factory(
+      { params: { sessionUid: session.uid } },
+      {
+        // Authenticate in the handshake and wait for `authOk` before the client
+        // reports OPEN. The node server closes the socket with 1008
+        // `binary-before-auth` on any binary frame that arrives before auth has
+        // completed, and completing it is not instant on the server side: the
+        // first source on a session waits for `registerSource` to fetch the
+        // session config. Sending `auth` from the `open` handler and starting
+        // capture on the next line left that as a race the source lost whenever
+        // the server was the slower of the two.
+        //
+        // Doing it here closes the race by construction rather than by timing:
+        // `sendBinary` only reaches the socket once the client is OPEN, and the
+        // client does not reach OPEN until this resolves. It also means every
+        // reconnect re-authenticates with the current token, instead of relying
+        // on the `open` handler to remember to.
+        onHandshake: async (sender, messages) => {
+          const sessionToken = this._sessionToken;
+          if (sessionToken === null) return;
+          sender.send({
+            type: TranscriptionStreamClientMessageType.AUTH,
+            sessionToken,
+          });
+          await new Promise<void>((resolve) => {
+            const onMessage = (msg: {
+              type: TranscriptionStreamServerMessageType;
+            }) => {
+              if (msg.type === TranscriptionStreamServerMessageType.AUTH_OK) {
+                messages.off('message', onMessage);
+                resolve();
+              }
+            };
+            messages.on('message', onMessage);
+          });
+        },
+      },
+    );
     this._socket = socket;
 
     socket.on('stateChange', (to) => {
@@ -698,14 +735,14 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
     });
 
     socket.on('open', () => {
-      // Send the auth message once the socket is open. The server replies
-      // with `authOk`; we just wait for it as part of the message stream.
+      // Auth already completed in the handshake above, so reaching OPEN means
+      // the server has accepted us and binary frames are safe to send.
+      //
+      // This fires again on every reconnect, so both calls below must be safe
+      // to repeat: each replaces its predecessor rather than stacking a second
+      // interval and a second live microphone stream on top of it.
       const sessionToken = this._sessionToken;
       if (sessionToken === null) return;
-      socket.send({
-        type: TranscriptionStreamClientMessageType.AUTH,
-        sessionToken,
-      });
       this._scheduleTokenRefresh(sessionToken, session.uid);
 
       if (isSource) {
@@ -785,12 +822,24 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
       });
     };
     sendPing();
+    // Replace rather than stack: this runs again on every reconnect, and a
+    // leaked interval would keep pinging on behalf of a dead socket forever.
+    if (this._timeSyncTimer !== null) clearInterval(this._timeSyncTimer);
     this._timeSyncTimer = setInterval(sendPing, TIME_SYNC_INTERVAL_MS);
   }
 
   private async _beginAudioCapture(
     socket: WebSocketClient<typeof TRANSCRIPTION_STREAM_SCHEMA>,
   ): Promise<void> {
+    // A reconnect calls this again. The previous stream captured the previous
+    // socket handle, so its chunks are already discarded by the identity check
+    // below - but it is still an open AudioContext with a live worklet, and
+    // leaving one behind per reconnect leaks them for the life of the page.
+    if (this._audioStream !== null) {
+      this._microphoneService.closeAudioStream(this._audioStream);
+      this._audioStream = null;
+    }
+
     const stream = await this._microphoneService.getAudioStream(
       AUDIO_CHANNELS,
       AUDIO_SAMPLE_RATE,

--- a/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
@@ -708,6 +708,19 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
             type: TranscriptionStreamClientMessageType.AUTH,
             sessionToken,
           });
+          // Probe the clock now rather than waiting for `open`. The node server
+          // answers `timeSyncPing` without auth, and the reply reaches the
+          // normal `message` handler even mid-handshake, so firing it here buys
+          // a full auth round trip - which on a cold session is however long
+          // `registerSource` takes to fetch the config. That is the difference
+          // between the first audio chunks carrying `sentAt` (and so reporting
+          // end-to-end latency) and only the later ones doing so.
+          if (isSource) {
+            sender.send({
+              type: TranscriptionStreamClientMessageType.TIME_SYNC_PING,
+              t0: Date.now(),
+            });
+          }
           await new Promise<void>((resolve) => {
             const onMessage = (msg: {
               type: TranscriptionStreamServerMessageType;

--- a/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
@@ -330,6 +330,7 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
    */
   mute(): void {
     this._muted = true;
+    this._sendSourceState(false);
   }
 
   /**
@@ -337,6 +338,26 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
    */
   unmute(): void {
     this._muted = false;
+    this._sendSourceState(true);
+  }
+
+  /**
+   * Send the current mic state to the node server so the fleet dashboard can
+   * distinguish "mic is off" from "something broke" when no audio arrives.
+   * No-op when no socket is connected (the state will be seeded on the next
+   * AUTH_OK). Safe to call from `mute`/`unmute` which may fire before a
+   * socket exists.
+   */
+  private _sendSourceState(
+    microphoneActive: boolean,
+    socket?: WebSocketClient<typeof TRANSCRIPTION_STREAM_SCHEMA>,
+  ): void {
+    const sock = socket ?? this._socket;
+    if (sock === null) return;
+    sock.send({
+      type: TranscriptionStreamClientMessageType.SOURCE_STATE,
+      microphoneActive,
+    });
   }
 
   private async _initialize(): Promise<void> {
@@ -761,6 +782,11 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
       if (isSource) {
         this._startTimeSync(socket);
         void this._beginAudioCapture(socket);
+        // Seed the server with the current mic state, so a muted kiosk reads as
+        // muted on the dashboard rather than as a session that mysteriously
+        // sends no audio. Reaching `open` means auth already succeeded, and a
+        // reconnect re-seeds for free.
+        this._sendSourceState(!this._muted, socket);
       }
     });
 

--- a/apps/node-server/src/server/features/transcription-stream/events/fleet-status-delta.events.ts
+++ b/apps/node-server/src/server/features/transcription-stream/events/fleet-status-delta.events.ts
@@ -14,6 +14,9 @@ export const FLEET_STATUS_DELTA_SCHEMA = Type.Object({
   sessionUid: Type.String(),
   transcriptionServiceConnected: Type.Boolean(),
   sourceDeviceConnected: Type.Boolean(),
+  sourceMicrophoneActive: Type.Optional(
+    Type.Union([Type.Boolean(), Type.Null()]),
+  ),
   at: Type.Integer(),
 });
 export type FleetStatusDelta = Static<typeof FLEET_STATUS_DELTA_SCHEMA>;

--- a/apps/node-server/src/server/features/transcription-stream/events/session-status.events.ts
+++ b/apps/node-server/src/server/features/transcription-stream/events/session-status.events.ts
@@ -13,6 +13,9 @@ import type { ChannelDefinition } from '#src/server/shared/services/event-bus.se
 export const SESSION_STATUS_MESSAGE_SCHEMA = Type.Object({
   transcriptionServiceConnected: Type.Boolean(),
   sourceDeviceConnected: Type.Boolean(),
+  sourceMicrophoneActive: Type.Optional(
+    Type.Union([Type.Boolean(), Type.Null()]),
+  ),
 });
 export type SessionStatusMessage = Static<typeof SESSION_STATUS_MESSAGE_SCHEMA>;
 

--- a/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
@@ -85,10 +85,30 @@ export interface SessionSnapshot {
    * original "no audio arriving" report a blind guess.
    */
   audioFramesReceived: number;
+  /**
+   * `true` if any connected source reports its mic active, `false` if every
+   * source that has reported says otherwise, `null` if none has reported. The
+   * third case is not the same as "off" and must stay distinguishable: an
+   * older kiosk never sends the message at all.
+   */
+  sourceMicrophoneActive: boolean | null;
+}
+
+/**
+ * Handle returned by {@link TranscriptionOrchestratorService.registerSource}.
+ * The caller MUST call `unregister` when the source connection closes. The
+ * caller SHOULD call `setMicrophoneActive` when the source's mic state
+ * changes (and once after auth to seed it).
+ */
+export interface SourceHandle {
+  unregister: () => void;
+  setMicrophoneActive: (active: boolean) => void;
 }
 
 interface SessionState {
   sourceCount: number;
+  /** Monotonic counter for per-source IDs within this session. */
+  nextSourceId: number;
   /**
    * Provider the upstream was opened against. Read from the session's initial
    * config and kept, rather than re-read from the long-poll on demand, because
@@ -107,6 +127,14 @@ interface SessionState {
    * Monotonic per session; reset to 0 when `SessionState` is created.
    */
   audioFramesReceived: number;
+  /**
+   * Per-source microphone state, keyed by a source ID assigned at
+   * registration. `true` = mic active (unmuted), `false` = mic off.
+   * Absent = source has not reported yet. The aggregate
+   * `sourceMicrophoneActive` is computed in `_setStatus` as "any source
+   * reports true", or `null` when no source has reported.
+   */
+  sourceMicStates: Map<number, boolean | undefined>;
   upstream: UpstreamClient;
   longPoll: SessionConfigPoll;
   audioUnsubscribe: () => void;
@@ -195,19 +223,28 @@ export class TranscriptionOrchestratorService {
    * session opens the upstream transcription connection and starts tracking
    * config via long-poll; subsequent registrations just bump the ref count.
    *
-   * Returns an unregister function the caller MUST invoke when the source
-   * connection closes. The upstream is torn down when the count returns to 0.
+   * Returns a {@link SourceHandle} whose `unregister` the caller MUST invoke
+   * when the source connection closes, and whose `setMicrophoneActive` the
+   * caller SHOULD invoke to report mic state. The upstream is torn down when
+   * the count returns to 0.
    */
-  async registerSource(sessionUid: string): Promise<() => void> {
+  async registerSource(sessionUid: string): Promise<SourceHandle> {
     let state = this._sessions.get(sessionUid);
     if (state === undefined) {
       state = await this._openSession(sessionUid);
       this._sessions.set(sessionUid, state);
     }
+    const sourceId = state.nextSourceId++;
     state.sourceCount += 1;
+    state.sourceMicStates.set(sourceId, undefined);
     this._setStatus(sessionUid, state);
-    return () => {
-      this._unregisterSource(sessionUid);
+    return {
+      unregister: () => {
+        this._unregisterSource(sessionUid, sourceId);
+      },
+      setMicrophoneActive: (active: boolean) => {
+        this._setSourceMicrophone(sessionUid, sourceId, active);
+      },
     };
   }
 
@@ -243,6 +280,7 @@ export class TranscriptionOrchestratorService {
       return {
         transcriptionServiceConnected: false,
         sourceDeviceConnected: false,
+        sourceMicrophoneActive: null,
       };
     }
     return state.status;
@@ -286,6 +324,7 @@ export class TranscriptionOrchestratorService {
         upstreamState: state.upstream.state,
         upstreamRetryAttempt: state.upstream.attempt,
         audioFramesReceived: state.audioFramesReceived,
+        sourceMicrophoneActive: this._aggregateMicState(state),
       });
     }
     return { sessions, truncated: this._sessions.size > sessions.length };
@@ -300,11 +339,13 @@ export class TranscriptionOrchestratorService {
     const next: SessionStatusMessage = {
       transcriptionServiceConnected: state.upstream.state === 'OPEN',
       sourceDeviceConnected: state.sourceCount > 0,
+      sourceMicrophoneActive: this._aggregateMicState(state),
     };
     if (
       next.transcriptionServiceConnected ===
         state.status.transcriptionServiceConnected &&
-      next.sourceDeviceConnected === state.status.sourceDeviceConnected
+      next.sourceDeviceConnected === state.status.sourceDeviceConnected &&
+      next.sourceMicrophoneActive === state.status.sourceMicrophoneActive
     ) {
       return;
     }
@@ -315,6 +356,38 @@ export class TranscriptionOrchestratorService {
       ...next,
       at: Date.now(),
     });
+  }
+
+  /**
+   * Computes the aggregate mic state: `true` if any source reports mic
+   * active, `false` if all sources report mic off, `null` if no source has
+   * reported yet. A disconnected source is removed from the map by
+   * `_unregisterSource`, so stale entries don't influence the aggregate.
+   */
+  private _aggregateMicState(state: SessionState): boolean | null {
+    if (state.sourceMicStates.size === 0) return null;
+    let anyReported = false;
+    for (const micState of state.sourceMicStates.values()) {
+      if (micState === true) return true;
+      if (micState === false) anyReported = true;
+    }
+    return anyReported ? false : null;
+  }
+
+  /**
+   * Update one source's mic state and recompute the aggregate. Called by the
+   * `SourceHandle.setMicrophoneActive` closure.
+   */
+  private _setSourceMicrophone(
+    sessionUid: string,
+    sourceId: number,
+    active: boolean,
+  ): void {
+    const state = this._sessions.get(sessionUid);
+    if (state === undefined) return;
+    if (!state.sourceMicStates.has(sourceId)) return;
+    state.sourceMicStates.set(sourceId, active);
+    this._setStatus(sessionUid, state);
   }
 
   /**
@@ -466,9 +539,11 @@ export class TranscriptionOrchestratorService {
 
     const state: SessionState = {
       sourceCount: 0,
+      nextSourceId: 0,
       providerKey: initial.transcriptionProviderId,
       roomUid: initial.roomUid,
       audioFramesReceived: 0,
+      sourceMicStates: new Map(),
       upstream,
       longPoll,
       audioUnsubscribe: () => {
@@ -679,10 +754,11 @@ export class TranscriptionOrchestratorService {
     });
   }
 
-  private _unregisterSource(sessionUid: string): void {
+  private _unregisterSource(sessionUid: string, sourceId: number): void {
     const state = this._sessions.get(sessionUid);
     if (state === undefined) return;
     state.sourceCount -= 1;
+    state.sourceMicStates.delete(sourceId);
     if (state.sourceCount > 0) {
       this._setStatus(sessionUid, state);
       return;
@@ -706,7 +782,17 @@ export class TranscriptionOrchestratorService {
     ) {
       this._eventBus.publish(
         SessionStatusChannel,
-        { transcriptionServiceConnected: false, sourceDeviceConnected: false },
+        {
+          transcriptionServiceConnected: false,
+          sourceDeviceConnected: false,
+          // `null`, not `false`: the last source has gone, so the mic state is
+          // unknown rather than known-off. Reporting `false` here would put
+          // "mic off" on a session that has no source at all - which is the
+          // same species of misleading readout this field exists to remove,
+          // and would disagree with `getStatus()`, which already answers
+          // `null` for a session it holds no state for.
+          sourceMicrophoneActive: null,
+        },
         sessionUid,
       );
     }

--- a/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
@@ -402,9 +402,48 @@ export class TranscriptionOrchestratorService {
     const longPoll = this._sessionConfigPollFactory(sessionUid);
     const initial = await this._awaitFirstConfig(longPoll, sessionUid);
 
-    const upstream = this._transcriptionServiceClient.transcriptionStream({
-      params: { providerKey: initial.transcriptionProviderId },
-    });
+    // The config the upstream must be (re)told about on every connection. Held
+    // in a mutable box rather than read from `initial` so a reconnect after a
+    // config bump replays the CURRENT config, not the one this session opened
+    // with. Updated by the long-poll handler below.
+    let currentConfig = initial;
+
+    const upstream = this._transcriptionServiceClient.transcriptionStream(
+      { params: { providerKey: initial.transcriptionProviderId } },
+      {
+        // Auth and config belong in the handshake, not in a one-time send after
+        // start(). The transcription service closes 1008 "Audio chunk before
+        // authentication" on any binary that arrives unauthenticated, and this
+        // client reconnects automatically - so sending them once meant that the
+        // FIRST upstream blip permanently broke the session: reconnect, forward
+        // audio, get closed, repeat forever, with the source still happily
+        // streaming and nothing reaching a provider.
+        //
+        // Running here also fixes the ordering hazard. `onHandshake`'s sender
+        // writes straight to the socket while the client is still HANDSHAKING,
+        // and the outbound queue is not flushed until it reaches OPEN. Audio
+        // buffered during the outage therefore lands strictly after auth and
+        // config, instead of racing ahead of them - and it can no longer evict
+        // them, which a 64-slot drop-oldest queue at ~10 frames/s otherwise did
+        // after ~6.4s of any upstream that was slow to accept (a cold CUDA
+        // model load being the obvious one).
+        onHandshake: (sender) => {
+          sender.send({
+            type: TranscriptionStreamClientMessageType.AUTH,
+            api_key: this._transcriptionApiKey,
+          });
+          sender.send({
+            type: TranscriptionStreamClientMessageType.CONFIG,
+            // Trusted by Session Manager when the session was created; the
+            // upstream provider validates its own config schema on receipt.
+            config: currentConfig.transcriptionStreamConfig as never,
+            session_uid: sessionUid,
+            room_uid: currentConfig.roomUid,
+          });
+          return Promise.resolve();
+        },
+      },
+    );
 
     const state: SessionState = {
       sourceCount: 0,
@@ -465,19 +504,9 @@ export class TranscriptionOrchestratorService {
       this._setStatus(sessionUid, state);
     });
 
+    // Auth and config are sent by `onHandshake` above, on this connection and
+    // on every reconnect after it.
     upstream.start();
-    upstream.send({
-      type: TranscriptionStreamClientMessageType.AUTH,
-      api_key: this._transcriptionApiKey,
-    });
-    upstream.send({
-      type: TranscriptionStreamClientMessageType.CONFIG,
-      // Trusted by Session Manager when the session was created; the
-      // upstream provider validates its own config schema on receipt.
-      config: initial.transcriptionStreamConfig as never,
-      session_uid: sessionUid,
-      room_uid: initial.roomUid,
-    });
 
     state.audioUnsubscribe = this._eventBus.subscribe(
       AudioFrameChannel,
@@ -515,6 +544,9 @@ export class TranscriptionOrchestratorService {
     );
 
     longPoll.on('data', (session) => {
+      // Keep the handshake's view current, so a reconnect replays this config
+      // rather than the one the session opened with.
+      currentConfig = session;
       // Future iteration: reconnect the upstream if `transcriptionProviderId`
       // changed, or push a new CONFIG message if only the config did. For
       // now we just log so the long-poll keeps the cursor advancing and we

--- a/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
@@ -75,6 +75,16 @@ export interface SessionSnapshot {
   pendingChunkCount: number;
   upstreamState: ConnectionState;
   upstreamRetryAttempt: number;
+  /**
+   * Binary frames received from the source since the session opened, counted
+   * before decode (so a malformed frame still counts as "the source is sending
+   * something"; the malformed subset is tracked by `decodeDropsTotal`).
+   * Monotonic per session (resets when `SessionState` is destroyed). The fleet
+   * dashboard uses this to distinguish "source sent nothing" (0) from "source
+   * is sending but the ASR is silent" (>0) — the ambiguity that made the
+   * original "no audio arriving" report a blind guess.
+   */
+  audioFramesReceived: number;
 }
 
 interface SessionState {
@@ -89,6 +99,14 @@ interface SessionState {
   providerKey: string;
   /** Room this session belongs to, if known. Same rationale as `providerKey`. */
   roomUid: string | null;
+  /**
+   * Binary frames received from the source since the session opened.
+   * Incremented in the `AudioFrameChannel` callback before decode, so a
+   * malformed frame still counts as "received" (the source is sending
+   * *something*) — `recordDecodeDrop` already tracks the malformed subset.
+   * Monotonic per session; reset to 0 when `SessionState` is created.
+   */
+  audioFramesReceived: number;
   upstream: UpstreamClient;
   longPoll: SessionConfigPoll;
   audioUnsubscribe: () => void;
@@ -267,6 +285,7 @@ export class TranscriptionOrchestratorService {
         pendingChunkCount: state.pendingChunks.size,
         upstreamState: state.upstream.state,
         upstreamRetryAttempt: state.upstream.attempt,
+        audioFramesReceived: state.audioFramesReceived,
       });
     }
     return { sessions, truncated: this._sessions.size > sessions.length };
@@ -449,6 +468,7 @@ export class TranscriptionOrchestratorService {
       sourceCount: 0,
       providerKey: initial.transcriptionProviderId,
       roomUid: initial.roomUid,
+      audioFramesReceived: 0,
       upstream,
       longPoll,
       audioUnsubscribe: () => {
@@ -511,6 +531,10 @@ export class TranscriptionOrchestratorService {
     state.audioUnsubscribe = this._eventBus.subscribe(
       AudioFrameChannel,
       (frame) => {
+        // Count every frame the source sent — before decode, so a malformed
+        // frame still registers as "the source is sending something." The
+        // malformed subset is tracked separately by recordDecodeDrop.
+        state.audioFramesReceived += 1;
         // Stamp ingress on the monotonic clock before any work, so the
         // pipeline latency excludes our own decode cost.
         const recvMono = performance.now();

--- a/apps/node-server/src/server/features/transcription-stream/transcription-stream.controller.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-stream.controller.ts
@@ -272,6 +272,14 @@ export class TranscriptionStreamController {
             t1: Date.now(),
           });
           break;
+        case TranscriptionStreamClientMessageType.SOURCE_STATE:
+          // Forward the source's mic state to the orchestrator so the fleet
+          // dashboard can distinguish "mic is off" from "something broke."
+          // Ignored for client-role connections (no orchestrator handle).
+          if (ready) {
+            service?.handleSourceState(parsed.microphoneActive);
+          }
+          break;
       }
     });
   }

--- a/apps/node-server/src/server/features/transcription-stream/transcription-stream.controller.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-stream.controller.ts
@@ -214,7 +214,21 @@ export class TranscriptionStreamController {
           return;
         }
         if (!ready) {
-          closeWith(1008, 'binary-before-auth');
+          // Drop pre-auth binary and count it rather than closing the socket.
+          // A source that begins streaming before AUTH_OK (the kiosk did this
+          // historically, starting capture on socket `open`) would otherwise be
+          // closed 1008 `binary-before-auth` and reconnect-loop: the default
+          // auto-reconnect re-sends AUTH, the next first chunk again beats
+          // AUTH_OK, and the cycle repeats with no audio ever delivered. The
+          // frame is worthless here regardless — the orchestrator has not
+          // subscribed yet — so dropping is strictly the better failure mode:
+          // the socket lives to complete auth, after which audio flows.
+          // The auth-timeout watchdog still closes a socket that never auths.
+          this._metrics.recordBinaryBeforeAuthDrop();
+          this._logger.debug(
+            { sessionUid, role },
+            'dropping binary frame received before auth completed',
+          );
           return;
         }
         const buffer = Buffer.isBuffer(data)

--- a/apps/node-server/src/server/features/transcription-stream/transcription-stream.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-stream.service.ts
@@ -13,6 +13,7 @@ import { LatencyChannel } from './events/latency.events.js';
 import { SessionEndedChannel } from './events/session-ended.events.js';
 import { SessionStatusChannel } from './events/session-status.events.js';
 import { TranscriptChannel } from './events/transcript.events.js';
+import type { SourceHandle } from './transcription-orchestrator.service.js';
 import type { TranscriptionStreamRole } from './transcription-stream.auth.js';
 
 type ServerMessage = Static<
@@ -54,7 +55,7 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
   private _unsubscribeLatency: (() => void) | null = null;
   private _unsubscribeSessionStatus: (() => void) | null = null;
   private _unsubscribeSessionEnded: (() => void) | null = null;
-  private _orchestratorUnregister: (() => void) | null = null;
+  private _orchestratorHandle: SourceHandle | null = null;
   private _closed = false;
   private _metrics: AppDependencies['nodeServerMetricsService'];
   /**
@@ -86,7 +87,7 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
    */
   async start(): Promise<void> {
     if (this._role === 'source') {
-      const unregister =
+      const handle =
         await this._transcriptionOrchestratorService.registerSource(
           this._sessionUid,
         );
@@ -94,10 +95,10 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
       // registration; if so, immediately release the registration and bail
       // out before subscribing to the buses.
       if (this._closed) {
-        unregister();
+        handle.unregister();
         return;
       }
-      this._orchestratorUnregister = unregister;
+      this._orchestratorHandle = handle;
     }
 
     // Counted here rather than in the constructor: a connection only costs
@@ -186,6 +187,18 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
   }
 
   /**
+   * Forward a source-state message (mic active/on/off) to the orchestrator.
+   * Only meaningful for source-role connections; client-role connections are
+   * ignored. The orchestrator aggregates across sources and publishes a
+   * session-status delta so the fleet dashboard can distinguish "mic is off"
+   * from "something broke."
+   */
+  handleSourceState(microphoneActive: boolean): void {
+    if (this._closed) return;
+    this._orchestratorHandle?.setMicrophoneActive(microphoneActive);
+  }
+
+  /**
    * Called by the controller when the underlying socket closes. Releases
    * orchestrator and bus resources held by this connection.
    */
@@ -214,7 +227,7 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
     this._unsubscribeSessionStatus = null;
     this._unsubscribeSessionEnded?.();
     this._unsubscribeSessionEnded = null;
-    this._orchestratorUnregister?.();
-    this._orchestratorUnregister = null;
+    this._orchestratorHandle?.unregister();
+    this._orchestratorHandle = null;
   }
 }

--- a/apps/node-server/src/server/shared/services/node-server-metrics.service.ts
+++ b/apps/node-server/src/server/shared/services/node-server-metrics.service.ts
@@ -202,6 +202,7 @@ export class NodeServerMetricsService {
   private _latency = new LatencyAggregate(PROCESS_LATENCY_CAPACITY);
 
   private _decodeDropsTotal = 0;
+  private _binaryBeforeAuthDropsTotal = 0;
   private _pendingChunkEvictionsTotal = 0;
   private _upstreamChurnTotal = 0;
   private _authSuccessTotal = 0;
@@ -250,6 +251,19 @@ export class NodeServerMetricsService {
   /** A malformed SAFP frame was dropped instead of forwarded upstream (U2). */
   recordDecodeDrop(): void {
     this._decodeDropsTotal += 1;
+  }
+
+  /**
+   * A binary frame arrived before the connection authenticated (H1). Dropped
+   * rather than closed: a source that begins streaming before AUTH_OK would
+   * otherwise be closed 1008 `binary-before-auth` and reconnect-loop, because
+   * the auto-reconnect re-sends AUTH and the next first chunk again beats
+   * AUTH_OK. Dropping is strictly the better failure mode — the frame is
+   * worthless before auth (the orchestrator isn't subscribed yet) and the
+   * socket lives to complete auth, after which audio flows normally.
+   */
+  recordBinaryBeforeAuthDrop(): void {
+    this._binaryBeforeAuthDropsTotal += 1;
   }
 
   /**
@@ -397,6 +411,7 @@ export class NodeServerMetricsService {
       processUid: this.processUid,
       processStartedAt: this.processStartedAt,
       decodeDropsTotal: this._decodeDropsTotal,
+      binaryBeforeAuthDropsTotal: this._binaryBeforeAuthDropsTotal,
       pendingChunkEvictionsTotal: this._pendingChunkEvictionsTotal,
       upstreamChurnTotal: this._upstreamChurnTotal,
       authSuccessTotal: this._authSuccessTotal,

--- a/apps/node-server/src/server/shared/services/status-snapshot.service.ts
+++ b/apps/node-server/src/server/shared/services/status-snapshot.service.ts
@@ -45,6 +45,7 @@ export class StatusSnapshotService {
       summary: {
         activeSessionCount: this._orchestrator.activeSessionCount,
         decodeDropsTotal: counters.decodeDropsTotal,
+        binaryBeforeAuthDropsTotal: counters.binaryBeforeAuthDropsTotal,
         pendingChunkEvictionsTotal: counters.pendingChunkEvictionsTotal,
         upstreamChurnTotal: counters.upstreamChurnTotal,
         authSuccessTotal: counters.authSuccessTotal,

--- a/apps/node-server/tests/integration/features/telemetry/redis-telemetry-publisher.test.ts
+++ b/apps/node-server/tests/integration/features/telemetry/redis-telemetry-publisher.test.ts
@@ -49,6 +49,7 @@ function fakeProcess(): StatusProcess {
     summary: {
       activeSessionCount: 1,
       decodeDropsTotal: 0,
+      binaryBeforeAuthDropsTotal: 0,
       pendingChunkEvictionsTotal: 0,
       upstreamChurnTotal: 0,
       authSuccessTotal: 0,

--- a/apps/node-server/tests/integration/features/transcription-stream/transcription-stream.routes.test.ts
+++ b/apps/node-server/tests/integration/features/transcription-stream/transcription-stream.routes.test.ts
@@ -13,7 +13,7 @@ import {
 import type { SessionTokenPayload } from '@scribear/session-manager-schema';
 
 import { seedSession } from '#tests/utils/seed-session.js';
-import { useServer } from '#tests/utils/use-server.js';
+import { TEST_SERVICE_API_KEY, useServer } from '#tests/utils/use-server.js';
 
 const FAR_FUTURE = Math.floor(Date.now() / 1000) + 3600;
 const DEBUG_SAMPLE_RATE = 48000;
@@ -218,6 +218,146 @@ describe('Transcription Stream Routes', () => {
       expect(closed.code).toBe(1008);
       expect(closed.reason).toBe('missing-scope');
     });
+  });
+
+  describe('pre-auth binary handling (H1)', (it) => {
+    /** Reads the binaryBeforeAuthDropsTotal counter off /status. */
+    async function readBinaryBeforeAuthDrops(): Promise<number> {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: '/api/node-server/v1/status',
+        headers: { authorization: `Bearer ${TEST_SERVICE_API_KEY}` },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      return body.summary.binaryBeforeAuthDropsTotal;
+    }
+
+    /**
+     * Resolves if the socket is still open after `ms`, rejects if it closes.
+     * The pre-auth binary guard must DROP, not close — a close here is the H1
+     * regression (the old 1008 `binary-before-auth` that reconnect-looped the
+     * kiosk).
+     */
+    function expectStaysOpen(ws: WebSocket, ms: number): Promise<void> {
+      return new Promise((resolve, reject) => {
+        const onClose = (code: number, reason: Buffer) => {
+          cleanup();
+          reject(
+            new Error(
+              `socket closed unexpectedly: ${String(code)} ${reason.toString('utf8')}`,
+            ),
+          );
+        };
+        const timer = setTimeout(() => {
+          cleanup();
+          resolve();
+        }, ms);
+        function cleanup() {
+          clearTimeout(timer);
+          ws.off('close', onClose);
+        }
+        ws.on('close', onClose);
+      });
+    }
+
+    it(
+      'drops pre-auth binary without closing, then auth and audio still flow',
+      { timeout: 60_000 },
+      async () => {
+        // Arrange
+        const before = await readBinaryBeforeAuthDrops();
+        const ws = await server.fastify.injectWS(sourcePath(realSessionUid));
+        const { messages, stop } = collectMessages(ws);
+
+        // Act 1 — send two binary frames BEFORE auth. Old behaviour closed
+        // 1008 `binary-before-auth` on the first and reconnect-looped; new
+        // behaviour drops and counts, and the socket must stay open.
+        ws.send(
+          Buffer.from(
+            encodeAudioFrame({ chunkId: crypto.randomUUID() }, TEST_AUDIO),
+          ),
+        );
+        ws.send(
+          Buffer.from(
+            encodeAudioFrame({ chunkId: crypto.randomUUID() }, TEST_AUDIO),
+          ),
+        );
+
+        // Act 2 — authenticate immediately. The pre-auth binaries were
+        // dropped; AUTH now runs and the auth-timeout watchdog still has its
+        // full window (the binaries did not consume any of it).
+        ws.send(
+          JSON.stringify({
+            type: TranscriptionStreamClientMessageType.AUTH,
+            sessionToken: signToken({
+              sessionUid: realSessionUid,
+              clientId: 'preauth-src',
+              scopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+              exp: FAR_FUTURE,
+            }),
+          }),
+        );
+
+        // Assert 1 — no close from the pre-auth binaries. A 1008 close would
+        // have fired within milliseconds, so one second is a strong signal.
+        await expectStaysOpen(ws, 1000);
+
+        // Assert 2 — the socket survived, so AUTH_OK arrives.
+        await vi.waitFor(
+          () => {
+            expect(
+              messages.find(
+                (m) => m.type === TranscriptionStreamServerMessageType.AUTH_OK,
+              ),
+            ).toBeDefined();
+          },
+          { timeout: 15_000 },
+        );
+
+        // Assert 3 — the dropped frames were counted.
+        const after = await readBinaryBeforeAuthDrops();
+        expect(after).toBeGreaterThanOrEqual(before + 2);
+
+        // Act 3 + Assert 4 — wait for the upstream to open, send audio, and
+        // confirm a transcript comes back. Proves the pre-auth drop did not
+        // leave the connection in a state that blocks real audio.
+        await vi.waitFor(
+          () => {
+            const status = [...messages]
+              .reverse()
+              .find(
+                (m) =>
+                  m.type ===
+                  TranscriptionStreamServerMessageType.SESSION_STATUS,
+              );
+            expect(status).toMatchObject({
+              transcriptionServiceConnected: true,
+            });
+          },
+          { timeout: 30_000 },
+        );
+
+        ws.send(
+          Buffer.from(
+            encodeAudioFrame({ chunkId: crypto.randomUUID() }, TEST_AUDIO),
+          ),
+        );
+
+        await vi.waitFor(
+          () => {
+            const transcripts = messages.filter(
+              (m) => m.type === TranscriptionStreamServerMessageType.TRANSCRIPT,
+            );
+            expect(transcripts.length).toBeGreaterThan(0);
+          },
+          { timeout: 30_000 },
+        );
+
+        stop();
+        ws.terminate();
+      },
+    );
   });
 
   describe('source role with live upstream', (it) => {

--- a/apps/node-server/tests/unit/features/telemetry/redis-telemetry-publisher.service.test.ts
+++ b/apps/node-server/tests/unit/features/telemetry/redis-telemetry-publisher.service.test.ts
@@ -88,6 +88,7 @@ function fakeProcess(): StatusProcess {
     summary: {
       activeSessionCount: 1,
       decodeDropsTotal: 0,
+      binaryBeforeAuthDropsTotal: 0,
       pendingChunkEvictionsTotal: 0,
       upstreamChurnTotal: 2,
       authSuccessTotal: 3,

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
@@ -122,6 +122,27 @@ function makeHarness(
   };
 }
 
+/**
+ * Invoke the `onHandshake` the orchestrator registered on the upstream client,
+ * with a fresh sender. Each call stands for one connection: the first one, or
+ * any reconnect the client makes on its own after a drop.
+ */
+async function runUpstreamHandshake(
+  h: Harness,
+  sender: { send: ReturnType<typeof vi.fn>; sendBinary: ReturnType<typeof vi.fn> },
+): Promise<void> {
+  const overrides = h.transcriptionStreamFactory.mock.calls[0]?.[1] as {
+    onHandshake: (
+      sender: unknown,
+      messages: { on: () => void; off: () => void },
+    ) => Promise<void>;
+  };
+  await overrides.onHandshake(sender, {
+    on: () => undefined,
+    off: () => undefined,
+  });
+}
+
 describe('TranscriptionOrchestratorService', () => {
   let h: Harness;
 
@@ -145,19 +166,78 @@ describe('TranscriptionOrchestratorService', () => {
       // Assert
       expect(h.poolFactory).toHaveBeenCalledWith(SESSION_UID);
       expect(h.longPoll.start).toHaveBeenCalledTimes(1);
-      expect(h.transcriptionStreamFactory).toHaveBeenCalledWith({
-        params: { providerKey: PROVIDER_KEY },
-      });
+      expect(h.transcriptionStreamFactory).toHaveBeenCalledWith(
+        { params: { providerKey: PROVIDER_KEY } },
+        expect.objectContaining({ onHandshake: expect.any(Function) }),
+      );
       expect(h.upstream.start).toHaveBeenCalledTimes(1);
-      expect(h.upstream.send).toHaveBeenCalledWith(
+
+      // Auth and config are the handshake, not a one-time send after start().
+      const sender = { send: vi.fn(), sendBinary: vi.fn() };
+      await runUpstreamHandshake(h, sender);
+
+      expect(sender.send).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'auth', api_key: 'tx-key' }),
       );
-      expect(h.upstream.send).toHaveBeenCalledWith(
+      expect(sender.send).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'config',
           config: { sample_rate: 48000, num_channels: 1 },
           session_uid: SESSION_UID,
           room_uid: ROOM_UID,
+        }),
+      );
+    });
+
+    it('re-sends auth and config on every reconnect', async () => {
+      // A session that survives an upstream blip is the whole point: the
+      // transcription service closes 1008 on unauthenticated binary, and this
+      // client reconnects on its own. Sending credentials once meant the first
+      // blip broke the session permanently while the source kept streaming.
+      // Arrange
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit('data', fakeSession());
+      await promise;
+
+      // Act - three independent connections, as three reconnects would be.
+      const senders = [
+        { send: vi.fn(), sendBinary: vi.fn() },
+        { send: vi.fn(), sendBinary: vi.fn() },
+        { send: vi.fn(), sendBinary: vi.fn() },
+      ];
+      for (const sender of senders) await runUpstreamHandshake(h, sender);
+
+      // Assert
+      for (const sender of senders) {
+        expect(sender.send).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'auth', api_key: 'tx-key' }),
+        );
+        expect(sender.send).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'config', session_uid: SESSION_UID }),
+        );
+      }
+    });
+
+    it('replays the current config on reconnect, not the one it opened with', async () => {
+      // Arrange
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit('data', fakeSession());
+      await promise;
+
+      // Act - a config bump arrives, then the upstream reconnects.
+      h.longPoll.emit('data', {
+        ...fakeSession(),
+        transcriptionStreamConfig: { sample_rate: 16000, num_channels: 2 },
+        sessionConfigVersion: 2,
+      });
+      const sender = { send: vi.fn(), sendBinary: vi.fn() };
+      await runUpstreamHandshake(h, sender);
+
+      // Assert
+      expect(sender.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'config',
+          config: { sample_rate: 16000, num_channels: 2 },
         }),
       );
     });

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
@@ -14,6 +14,7 @@ import { SessionStatusChannel } from '#src/server/features/transcription-stream/
 import { TranscriptChannel } from '#src/server/features/transcription-stream/events/transcript.events.js';
 import {
   type SessionConfigPollFactory,
+  type SourceHandle,
   TranscriptionOrchestratorService,
 } from '#src/server/features/transcription-stream/transcription-orchestrator.service.js';
 import { EventBusService } from '#src/server/shared/services/event-bus.service.js';
@@ -129,7 +130,10 @@ function makeHarness(
  */
 async function runUpstreamHandshake(
   h: Harness,
-  sender: { send: ReturnType<typeof vi.fn>; sendBinary: ReturnType<typeof vi.fn> },
+  sender: {
+    send: ReturnType<typeof vi.fn>;
+    sendBinary: ReturnType<typeof vi.fn>;
+  },
 ): Promise<void> {
   const overrides = h.transcriptionStreamFactory.mock.calls[0]?.[1] as {
     onHandshake: (
@@ -347,6 +351,7 @@ describe('TranscriptionOrchestratorService', () => {
       expect(statuses).toContainEqual({
         transcriptionServiceConnected: true,
         sourceDeviceConnected: true,
+        sourceMicrophoneActive: null,
       });
     });
   });
@@ -491,7 +496,7 @@ describe('TranscriptionOrchestratorService', () => {
       await registerAndDrain(h, SESSION_UID);
 
       // Act - drop one of two registrations.
-      a();
+      a.unregister();
 
       // Assert
       expect(h.upstream.terminate).not.toHaveBeenCalled();
@@ -501,7 +506,7 @@ describe('TranscriptionOrchestratorService', () => {
 
     it('tears down the upstream and publishes a final disconnected status when the last source unregisters', async () => {
       // Arrange
-      const unregister = await registerAndDrain(h, SESSION_UID);
+      const handle = await registerAndDrain(h, SESSION_UID);
       h.upstream.setOpen();
 
       const statuses: {
@@ -517,7 +522,7 @@ describe('TranscriptionOrchestratorService', () => {
       );
 
       // Act
-      unregister();
+      handle.unregister();
 
       // Assert
       expect(h.upstream.terminate).toHaveBeenCalledWith(
@@ -529,15 +534,21 @@ describe('TranscriptionOrchestratorService', () => {
       expect(statuses[statuses.length - 1]).toEqual({
         transcriptionServiceConnected: false,
         sourceDeviceConnected: false,
+        // `null`, not `false`. With the last source gone the mic state is
+        // unknown, not known-off; `false` would render "mic off" against a
+        // session that has no source at all, and would contradict
+        // `getStatus()`, which answers `null` for a session it holds no state
+        // for.
+        sourceMicrophoneActive: null,
       });
     });
 
     it('stops forwarding audio after the last source unregisters', async () => {
       // Arrange
-      const unregister = await registerAndDrain(h, SESSION_UID);
+      const handle = await registerAndDrain(h, SESSION_UID);
 
       // Act
-      unregister();
+      handle.unregister();
       h.upstream.sendBinary.mockClear();
       h.bus.publish(AudioFrameChannel, Buffer.from([1]), SESSION_UID);
 
@@ -555,6 +566,7 @@ describe('TranscriptionOrchestratorService', () => {
       expect(status).toEqual({
         transcriptionServiceConnected: false,
         sourceDeviceConnected: false,
+        sourceMicrophoneActive: null,
       });
     });
 
@@ -570,6 +582,7 @@ describe('TranscriptionOrchestratorService', () => {
       expect(status).toEqual({
         transcriptionServiceConnected: true,
         sourceDeviceConnected: true,
+        sourceMicrophoneActive: null,
       });
     });
   });
@@ -660,12 +673,12 @@ describe('TranscriptionOrchestratorService telemetry (B1.1)', () => {
 
 /**
  * Helper: register a source and drain the long-poll's first data event so
- * the registration promise resolves, returning the unregister function.
+ * the registration promise resolves, returning the source handle.
  */
 async function registerAndDrain(
   h: Harness,
   sessionUid: string,
-): Promise<() => void> {
+): Promise<SourceHandle> {
   const promise = h.orchestrator.registerSource(sessionUid);
   h.longPoll.emit('data', fakeSession({ uid: sessionUid }));
   return await promise;

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
@@ -370,6 +370,26 @@ describe('TranscriptionOrchestratorService', () => {
       expect(h.upstream.sendBinary).toHaveBeenCalledWith(frame);
     });
 
+    it('counts every received frame in audioFramesReceived and exposes it in sessionSnapshots', async () => {
+      // Arrange
+      await registerAndDrain(h, SESSION_UID);
+
+      const frame = Buffer.from(
+        encodeAudioFrame({ chunkId: 'c1' }, new Uint8Array([1, 2, 3])),
+      );
+
+      // Act — send three well-formed frames.
+      h.bus.publish(AudioFrameChannel, frame, SESSION_UID);
+      h.bus.publish(AudioFrameChannel, frame, SESSION_UID);
+      h.bus.publish(AudioFrameChannel, frame, SESSION_UID);
+
+      // Assert — the counter is per-session, monotonic, and visible in the
+      // snapshot the fleet dashboard reads.
+      const { sessions } = h.orchestrator.sessionSnapshots(10);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.audioFramesReceived).toBe(3);
+    });
+
     it('drops a malformed (non-SAFP) frame instead of forwarding it', async () => {
       // Arrange
       const promise = h.orchestrator.registerSource(SESSION_UID);

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.controller.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.controller.test.ts
@@ -133,6 +133,7 @@ function makeMetrics() {
     recordOrchestratorFailure: vi.fn(),
     recordConnectionOpen: vi.fn(),
     recordConnectionClose: vi.fn(),
+    recordBinaryBeforeAuthDrop: vi.fn(),
   };
 }
 
@@ -395,17 +396,17 @@ describe('TranscriptionStreamController', () => {
       );
     });
 
-    it('closes with 1008 binary-before-auth when a source sends binary before authenticating', () => {
+    it('drops pre-auth binary without closing and counts it (H1)', () => {
       const h = makeHarness('source');
       h.handlers.message(Buffer.from([1]), true);
 
-      expect(h.socket.close).toHaveBeenCalledWith(1008, 'binary-before-auth');
-      expect(h.metrics.recordWsClose).toHaveBeenCalledWith(
-        1008,
-        'binary-before-auth',
-        'source',
-        'server',
-      );
+      // Old behaviour closed 1008 `binary-before-auth` and reconnect-looped
+      // the kiosk; new behaviour drops the worthless pre-auth frame and lets
+      // the socket live to complete auth, after which audio flows.
+      expect(h.socket.close).not.toHaveBeenCalled();
+      expect(h.metrics.recordBinaryBeforeAuthDrop).toHaveBeenCalledTimes(1);
+      // The drop must NOT be double-counted as a ws close.
+      expect(h.metrics.recordWsClose).not.toHaveBeenCalled();
     });
 
     it('closes with 1007 invalid-json when a text message is not valid JSON', () => {

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.service.test.ts
@@ -38,17 +38,22 @@ function makeHarness(
   const logger = createMockLogger();
   const bus = new EventBusService(logger as never);
   const unregisterSource = vi.fn();
+  const setMicrophoneActive = vi.fn();
   const registerSource = vi.fn(() => {
     if (options.registerThrows) {
       return Promise.reject(new Error('orchestrator-down'));
     }
-    return Promise.resolve(unregisterSource);
+    return Promise.resolve({
+      unregister: unregisterSource,
+      setMicrophoneActive,
+    });
   });
   const getStatus = vi.fn(
     () =>
       options.initialStatus ?? {
         transcriptionServiceConnected: false,
         sourceDeviceConnected: false,
+        sourceMicrophoneActive: null,
       },
   );
   const orchestrator = {
@@ -190,11 +195,17 @@ describe('TranscriptionStreamService', () => {
 
     it('releases the orchestrator registration when the connection closed mid-start', async () => {
       // Arrange - delay the registerSource resolution so we can close before it returns.
-      let resolveRegister: (unregister: () => void) => void = () => undefined;
+      let resolveRegister: (handle: {
+        unregister: () => void;
+        setMicrophoneActive: () => void;
+      }) => void = () => undefined;
       const unregister = vi.fn();
       const registerSource = vi.fn(
         () =>
-          new Promise<() => void>((resolve) => {
+          new Promise<{
+            unregister: () => void;
+            setMicrophoneActive: () => void;
+          }>((resolve) => {
             resolveRegister = resolve;
           }),
       );
@@ -221,7 +232,10 @@ describe('TranscriptionStreamService', () => {
       // Act - close before resolving the registration.
       const pending = service.start();
       service.close();
-      resolveRegister(unregister);
+      resolveRegister({
+        unregister,
+        setMicrophoneActive: vi.fn(),
+      });
       await pending;
 
       // Assert

--- a/apps/node-server/tests/unit/shared/services/status-snapshot.service.test.ts
+++ b/apps/node-server/tests/unit/shared/services/status-snapshot.service.test.ts
@@ -17,6 +17,7 @@ function gauges(overrides: Partial<SessionSnapshot> = {}): SessionSnapshot {
     pendingChunkCount: 3,
     upstreamState: 'OPEN',
     upstreamRetryAttempt: 0,
+    audioFramesReceived: 0,
     ...overrides,
   };
 }

--- a/apps/node-server/tests/unit/shared/services/status-snapshot.service.test.ts
+++ b/apps/node-server/tests/unit/shared/services/status-snapshot.service.test.ts
@@ -18,6 +18,7 @@ function gauges(overrides: Partial<SessionSnapshot> = {}): SessionSnapshot {
     upstreamState: 'OPEN',
     upstreamRetryAttempt: 0,
     audioFramesReceived: 0,
+    sourceMicrophoneActive: null,
     ...overrides,
   };
 }

--- a/apps/session-manager/src/server/features/schedule-management/utils/auto-session-reconciler.ts
+++ b/apps/session-manager/src/server/features/schedule-management/utils/auto-session-reconciler.ts
@@ -8,6 +8,14 @@ import { buildAutoSessionRow } from './occurrence-to-session.js';
 import { materializeWindow } from './window-materializer.js';
 
 /**
+ * The largest value a JS `Date` can hold, standing in for the database's
+ * `'infinity'` upper bound on an open-ended session. Slots are always clipped
+ * to a window's own end, so using it as a blocker end simply means "blocks
+ * everything after this point", which is what an open-ended session does.
+ */
+const END_OF_TIME = new Date(8_640_000_000_000_000);
+
+/**
  * Brings the room's auto sessions into agreement with its active windows and
  * non-auto sessions over `[now, windowEnd]`. Used by every schedule and
  * window write path.
@@ -71,9 +79,21 @@ export async function reconcileAutoSessions(
 
   const blockerSessions = nonAuto.map((s) => ({
     effectiveStart: s.effectiveStart,
-    // Open-ended on-demand sessions block any auto session beyond `now` -
-    // model that as a session that ends at the materialization horizon.
-    effectiveEnd: s.effectiveEnd ?? windowEnd,
+    // Open-ended on-demand sessions block every auto session after them, so
+    // they have to block to the actual end of time rather than to the
+    // materialization horizon.
+    //
+    // Bounding them at `windowEnd` looks equivalent and is not: window
+    // occurrences are expanded per local day and routinely run PAST the
+    // horizon (a 00:00-23:59 daily window on the horizon day ends at 23:59,
+    // hours after a horizon that lands mid-afternoon). That leaves a gap
+    // between the blocker's end and the occurrence's end, the materializer
+    // dutifully fills it with an AUTO slot, and that slot overlaps a session
+    // the database models as `[start, infinity)`. The deferred exclusion
+    // constraint then rejects the whole transaction at COMMIT - so creating an
+    // on-demand session in any room with auto-sessions enabled failed with a
+    // 500 rather than pre-empting the AUTO session as intended.
+    effectiveEnd: s.effectiveEnd ?? END_OF_TIME,
   }));
 
   const active = await repo.findActiveAutoSession(db, roomUid, now);

--- a/apps/session-manager/tests/integration/features/schedule-management/schedule-management.routes.test.ts
+++ b/apps/session-manager/tests/integration/features/schedule-management/schedule-management.routes.test.ts
@@ -943,6 +943,50 @@ describe('Schedule Management Routes', () => {
       expect(res.json<{ code: string }>().code).toBe('ROOM_NOT_FOUND');
     });
 
+    it('pre-empts a running AUTO session instead of failing on the overlap constraint', async () => {
+      // Regression: an open-ended ON_DEMAND session is `[start, infinity)` in
+      // the database, but the reconciler used to model it as merely blocking up
+      // to the materialization horizon. Window occurrences run past that
+      // horizon (a round-the-clock window on the horizon day ends at 23:59,
+      // hours after a horizon that lands mid-afternoon), so the materializer
+      // filled the leftover gap with an AUTO slot that overlapped the
+      // open-ended session, and the deferred exclusion constraint rejected the
+      // whole transaction at COMMIT. The effect was that a room with
+      // auto-sessions switched on could not create an on-demand session at all.
+      // Arrange - a room whose auto-session window is active right now.
+      const { roomUid } = await setupRoom();
+      await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/update-room-schedule-config`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { roomUid, autoSessionEnabled: true },
+      });
+      const window = await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/create-auto-session-window`,
+        headers: { authorization: ADMIN_HEADER },
+        body: defaultWindowBody(roomUid, {
+          localStartTime: '00:00:00',
+          localEndTime: '23:59:59',
+          daysOfWeek: ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'],
+          activeStart: '2020-01-01T00:00:00.000Z',
+        }),
+      });
+      expect(window.statusCode).toBe(201);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/create-on-demand-session`,
+        headers: { authorization: ADMIN_HEADER },
+        body: makeBody(roomUid, { name: 'Pre-empts the AUTO session' }),
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(201);
+      expect(res.json<{ type: string }>().type).toBe('ON_DEMAND');
+    });
+
     it('returns 409 when another non-AUTO session is already active', async () => {
       // Arrange
       const { roomUid } = await setupRoom();

--- a/compare.txt
+++ b/compare.txt
@@ -1,0 +1,188 @@
+COMPARISON: debug/e2e-audio vs GLM-Debug-E2E
+============================================
+
+Two independent investigations of the same report ("kiosk audio never reaches
+the transcription service"), both starting from commit 0db5918. This file
+records what each found, what was merged, and why.
+
+
+THE SHARED ROOT CAUSE
+---------------------
+
+Both branches independently found the same bug and wrote near-identical fixes.
+
+node-server sent AUTH + CONFIG to the transcription service exactly once, right
+after `upstream.start()`. The upstream WebSocket client reconnects on its own,
+so after any blip it reopened the socket and forwarded audio with no
+credentials. The transcription service closes 1008 "Audio chunk before
+authentication" on unauthenticated binary. Reconnect, stream, get closed,
+repeat - forever. The kiosk stayed connected and kept sending; node-server kept
+accepting; nothing reached a provider again for the life of the session.
+
+Both fixed it the same way: move AUTH + CONFIG into the client's `onHandshake`,
+which runs on every connection, writes directly to the socket, and completes
+before the outbound queue flushes. Both added per-call options to
+`createWebSocketClient` to make a per-session handshake possible, and both kept
+the current config in a mutable holder updated by the config long-poll.
+
+That convergence is the strongest evidence available that the fix is right.
+
+
+WHAT THE OTHER BRANCH DID BETTER (all merged in)
+------------------------------------------------
+
+1. Drop-and-count pre-auth binary, instead of closing 1008.
+   This branch identified it and deferred it to a follow-up note. That branch
+   built it: a `binaryBeforeAuthDropsTotal` counter, the status field, and an
+   integration test that sends binary before auth and asserts the socket
+   SURVIVES. The frame is worthless before auth anyway, so dropping is strictly
+   the better failure mode - and it makes the same mistake non-fatal for every
+   future client rather than relying on each one to get the ordering right.
+
+2. `audioFramesReceived` - a per-session ingress counter, wired end to end.
+   The most valuable single item on either branch. The admin fleet audio meter
+   is fed only by the transcription service's Redis index, so "no audio" could
+   not distinguish a silent source from a broken upstream - the exact ambiguity
+   that made the original report a guess. This branch wrote that down as a
+   lesson and implemented nothing. That branch closed it: orchestrator ingress
+   -> status schema -> Redis -> admin card, which now reads "no audio from
+   source" at 0 and "audio received, not reaching ASR" above it.
+
+3. Kiosk mic state on the dashboard (`sourceState` message ->
+   `sourceMicrophoneActive`).
+   A muted kiosk reports `sourceDeviceConnected: true` and sends nothing, which
+   looks exactly like the server-side faults being chased. This cost time
+   inside this very investigation, when a kiosk toggled an even number of times
+   read as a broken pipeline. Neither branch would have found it from the code;
+   that branch noticed it from using the product.
+
+4. Named `WebSocketClientFactoryOptions<S>` instead of the same inline
+   `Omit<...>` repeated in three positions that must stay identical.
+
+5. Self-provisioning in the e2e harness. Their smoke test registers its own
+   device, room and session instead of asking the operator to create them.
+   Adopted as `--provision` on this branch's existing harness rather than
+   checking in a second overlapping tool at a second path.
+
+   Not adopted from it: asserting transcripts by scanning the kiosk page for
+   expected phrases. Counting frames out and transcripts in over CDP survives a
+   copy change and gives the before/after split the restart assertion needs.
+
+
+DEFECTS FOUND IN THE ADOPTED WORK (fixed here)
+----------------------------------------------
+
+1. The branch did not compile. `binaryBeforeAuthDropsTotal` was added as a
+   REQUIRED summary field, breaking `tsc --build` for admin-server and
+   therefore `build-containers.sh` outright.
+
+   Worse than a build break: that record is republished to Redis and read back
+   through a strict `Value.Check`. A required field that an older publisher
+   omits does not degrade to a missing counter - the whole snapshot fails and
+   the node DISAPPEARS FROM THE FLEET VIEW for the length of a rolling deploy.
+   The dashboard you would be watching during the deploy. Now optional, which
+   is what the same commit already did for `audioFramesReceived`.
+
+2. A stale admin-webapp test asserting the UI copy that the same commit
+   changed. Fixed, plus a second case added for the other branch of the split.
+
+3. On the final source unregister it published `sourceMicrophoneActive: false`,
+   which puts "mic off" on a session that no longer has any source, and
+   contradicts `getStatus()` answering `null` for a session it holds no state
+   for. `null` is the honest answer for "no source, so unknown".
+
+4. `audioFramesReceived` was documented as counting "well-formed SAFP frames"
+   in four places, but increments before decode. The commit message described
+   the intent correctly; the docs contradicted it. A malformed frame still
+   proves the source is sending, which is the counter's entire purpose.
+
+
+WHAT THIS BRANCH HAD THAT THE OTHER DID NOT
+-------------------------------------------
+
+1. The auto-session 500. `create-on-demand-session` failed with
+   "conflicting key value violates exclusion constraint sessions_no_overlap" in
+   EVERY room with auto-sessions enabled - so AUTO and ON_DEMAND could not
+   coexist at all. An open-ended session is `[start, infinity)` in the
+   database, but the reconciler modelled it as blocking only to the 7-day
+   materialization horizon; window occurrences run past that horizon, the gap
+   got filled with an AUTO slot, and the deferred constraint rejected the
+   transaction at COMMIT. Found by driving the product through a real handover,
+   not by reading the code.
+
+2. Kiosk reconnect duplication. The other branch still has it. `on('open')`
+   fires again on every reconnect, and `_beginAudioCapture` overwrote
+   `_audioStream` without closing the previous one. This is not merely a leak:
+   the same `WebSocketClient` instance is reused across reconnects, so the old
+   stream's `this._socket !== socket` guard stays false and BOTH streams keep
+   sending - duplicated, interleaved audio into the ASR. Their own upstream fix
+   makes reconnects survivable, which makes this more likely to bite. Also a
+   stacked time-sync interval per reconnect.
+
+3. Handshake-based kiosk auth. Their kiosk still sends `auth` from `open` and
+   gates capture on the AUTH_OK message. Both are correct, but authenticating
+   in `onHandshake` means `sendBinary` cannot physically reach the socket
+   before OPEN - ordering becomes structural rather than a property of one call
+   site. Verified live: `binaryBeforeAuthDropsTotal` stays 0.
+
+4. Session-type coverage. Every session type driven end to end with real audio:
+   on-demand, calendared (ONCE and WEEKLY), auto, and both handover directions
+   (auto -> on-demand, on-demand -> auto), each verified in the database rather
+   than by "transcripts kept arriving".
+
+5. A negative-verified regression test. The harness was proven to FAIL on the
+   pre-fix code (135 transcripts before an upstream restart, 0 after) and pass
+   after (135 / 99), so it is known to catch the bug rather than assumed to.
+
+
+ONE ADVANTAGE OF THEIR KIOSK APPROACH, TAKEN SEPARATELY
+-------------------------------------------------------
+
+The node server answers `timeSyncPing` without authentication, so there is no
+reason to wait for auth before the first clock probe. Because this branch
+authenticates in the handshake, `open` - and with it `_startTimeSync` - does not
+fire until AUTH_OK, which on a cold session is however long `registerSource`
+takes to fetch the config. The probe now fires from inside the handshake, so
+the first audio chunks carry `sentAt` and report end-to-end latency.
+
+
+THE HONEST SUMMARY
+------------------
+
+Neither branch was better. They failed in opposite directions, and the failure
+modes were characteristic:
+
+  - The other branch reasoned from the code and built the observability this
+    debug had only written down. It shipped a monorepo that did not compile,
+    because it ran one workspace's tests.
+
+  - This branch drove the product and found two bugs invisible from the code,
+    but left the diagnostic gaps it had correctly identified as follow-up notes
+    rather than fixing them.
+
+Reading the peer diff was worth more than either branch's own review. The merged
+result is better than either input.
+
+
+LESSONS WORTH KEEPING
+---------------------
+
+- Any credential sent once per socket is a bug if the client can reconnect.
+  Auth is a property of the connection, not the session, so it belongs in the
+  handshake. Worth grepping for other one-shot `send()` calls after a `start()`.
+
+- In a monorepo with shared schema packages, the schema change IS the blast
+  radius. Run the root build and test suite, not the workspace you are editing.
+
+- A required field in a Redis-published schema is a rolling-deploy outage, not
+  a missing field. Default to `Type.Optional` unless both sides ship atomically.
+
+- For a feature with a "currently active" notion, at least one test fixture must
+  be active NOW. The auto-session 500 survived 341 passing integration tests
+  because every fixture used a far-future window in a room with auto-sessions
+  off. Those tests covered the code paths and never covered the state the
+  product is actually in.
+
+- Log the `detail` field of Postgres errors. For exclusion and unique
+  violations it contains the entire diagnosis; the message alone contains none
+  of it.

--- a/infra/scribear-redis/src/telemetry/fleet-event.schema.ts
+++ b/infra/scribear-redis/src/telemetry/fleet-event.schema.ts
@@ -18,6 +18,9 @@ export const SESSION_STATUS_EVENT_SCHEMA = Type.Object({
   sessionUid: Type.String(),
   transcriptionServiceConnected: Type.Boolean(),
   sourceDeviceConnected: Type.Boolean(),
+  sourceMicrophoneActive: Type.Optional(
+    Type.Union([Type.Boolean(), Type.Null()]),
+  ),
   at: Type.Integer({
     description:
       'Publish time in epoch milliseconds, on the publisher’s clock.',

--- a/libs/clients/base-websocket-client/src/create-websocket-client.ts
+++ b/libs/clients/base-websocket-client/src/create-websocket-client.ts
@@ -16,6 +16,10 @@ import { WebSocketClient } from './websocket-client.js';
  */
 type WebSocketClientFactory<S extends BaseWebSocketRouteSchema> = (
   params: ConnectParams<S>,
+  overrides?: Omit<
+    WebSocketClientOptions<S>,
+    'schema' | 'route' | 'baseUrl' | 'params'
+  >,
 ) => WebSocketClient<S>;
 
 /**
@@ -29,7 +33,11 @@ type WebSocketClientFactory<S extends BaseWebSocketRouteSchema> = (
  * @param route URL pattern for the WebSocket endpoint.
  * @param baseUrl Base URL of the server. HTTP schemes are translated to ws/wss.
  * @param options Shared connection settings applied to every instance produced
- *   by this factory (backoff, queue policy, handshake, etc.).
+ *   by this factory (backoff, queue policy, handshake, etc.). Each call to the
+ *   factory may override any of them, which is what makes a per-connection
+ *   `onHandshake` possible: a handshake that has to replay per-session
+ *   credentials or config cannot be baked into a factory shared by every
+ *   session, but it is exactly the handshake that must survive a reconnect.
  */
 function createWebSocketClient<S extends BaseWebSocketRouteSchema>(
   schema: S,
@@ -40,8 +48,21 @@ function createWebSocketClient<S extends BaseWebSocketRouteSchema>(
     'schema' | 'route' | 'baseUrl' | 'params'
   >,
 ): WebSocketClientFactory<S> {
-  return (params: ConnectParams<S>): WebSocketClient<S> =>
-    new WebSocketClient({ schema, route, baseUrl, params, ...options });
+  return (
+    params: ConnectParams<S>,
+    overrides?: Omit<
+      WebSocketClientOptions<S>,
+      'schema' | 'route' | 'baseUrl' | 'params'
+    >,
+  ): WebSocketClient<S> =>
+    new WebSocketClient({
+      schema,
+      route,
+      baseUrl,
+      params,
+      ...options,
+      ...overrides,
+    });
 }
 
 export { createWebSocketClient };

--- a/libs/clients/base-websocket-client/src/create-websocket-client.ts
+++ b/libs/clients/base-websocket-client/src/create-websocket-client.ts
@@ -10,16 +10,29 @@ import type {
 import { WebSocketClient } from './websocket-client.js';
 
 /**
+ * Connection settings a caller may supply, either baked into a factory at
+ * {@link createWebSocketClient} time or overridden per factory call. Everything
+ * {@link WebSocketClientOptions} accepts except the four fields that identify
+ * the connection itself, which the factory always supplies.
+ *
+ * Named rather than inlined because it appears in three positions that must
+ * stay identical, and because callers building their own options object want
+ * something to annotate it with.
+ */
+export type WebSocketClientFactoryOptions<S extends BaseWebSocketRouteSchema> =
+  Omit<WebSocketClientOptions<S>, 'schema' | 'route' | 'baseUrl' | 'params'>;
+
+/**
  * Typed factory produced by {@link createWebSocketClient}. Each call creates
  * an independent {@link WebSocketClient} instance, so multiple simultaneous
  * connections to the same route are each started by a separate call.
+ *
+ * The optional second argument overrides the factory's baked options for this
+ * one instance; anything left unset keeps the baked value.
  */
 type WebSocketClientFactory<S extends BaseWebSocketRouteSchema> = (
   params: ConnectParams<S>,
-  overrides?: Omit<
-    WebSocketClientOptions<S>,
-    'schema' | 'route' | 'baseUrl' | 'params'
-  >,
+  overrides?: WebSocketClientFactoryOptions<S>,
 ) => WebSocketClient<S>;
 
 /**
@@ -43,17 +56,11 @@ function createWebSocketClient<S extends BaseWebSocketRouteSchema>(
   schema: S,
   route: BaseRouteDefinition,
   baseUrl: string,
-  options?: Omit<
-    WebSocketClientOptions<S>,
-    'schema' | 'route' | 'baseUrl' | 'params'
-  >,
+  options?: WebSocketClientFactoryOptions<S>,
 ): WebSocketClientFactory<S> {
   return (
     params: ConnectParams<S>,
-    overrides?: Omit<
-      WebSocketClientOptions<S>,
-      'schema' | 'route' | 'baseUrl' | 'params'
-    >,
+    overrides?: WebSocketClientFactoryOptions<S>,
   ): WebSocketClient<S> =>
     new WebSocketClient({
       schema,

--- a/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
+++ b/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
@@ -175,10 +175,18 @@ export const STATUS_PROCESS_SCHEMA = Type.Object({
     decodeDropsTotal: Type.Integer({
       description: 'Malformed SAFP frames dropped rather than forwarded (U2).',
     }),
-    binaryBeforeAuthDropsTotal: Type.Integer({
-      description:
-        'Binary frames a source sent before its AUTH handshake completed (H1). Dropped rather than closed: a source that starts streaming before AUTH_OK would otherwise be closed 1008 `binary-before-auth` and reconnect-loop, because each reconnect re-sends AUTH and the next first chunk again beats AUTH_OK.',
-    }),
+    // Optional for the same reason as `audioFramesReceived` below, and it
+    // matters more here: this record is republished to Redis and read back by
+    // admin-server through a strict `Value.Check`, so a required field that an
+    // older publisher omits does not degrade to a missing counter - it fails
+    // the whole snapshot and the node disappears from the fleet view for the
+    // length of a rolling deploy.
+    binaryBeforeAuthDropsTotal: Type.Optional(
+      Type.Integer({
+        description:
+          'Binary frames a source sent before its AUTH handshake completed. Dropped rather than closed: a source that starts streaming before AUTH_OK would otherwise be closed 1008 `binary-before-auth` and reconnect-loop, because each reconnect re-sends AUTH and the next first chunk again beats AUTH_OK. Optional for backward-compat with publishers that predate it.',
+      }),
+    ),
     pendingChunkEvictionsTotal: Type.Integer({
       description:
         'Uncorrelated audio frames evicted at the per-session cap (N3).',

--- a/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
+++ b/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
@@ -130,6 +130,12 @@ export const STATUS_SESSION_SCHEMA = Type.Object(
       description:
         'Consecutive reconnect attempts for this session’s upstream. Non-zero while flapping; back to 0 once a connection is established.',
     }),
+    audioFramesReceived: Type.Optional(
+      Type.Integer({
+        description:
+          'Binary frames received from the source since the session opened, counted before decode so a malformed frame still registers as "the source is sending something" (the malformed subset is `decodeDropsTotal`). Monotonic per session, resets on session end. Lets the fleet dashboard distinguish "source sent nothing" (0) from "source is sending but the ASR is silent" (>0) — the two cases that "no audio reaching ASR" alone cannot tell apart. Optional for backward-compat with older publishers that do not emit it.',
+      }),
+    ),
     latency: Type.Array(LATENCY_SERIES_SCHEMA, {
       description: `Per-session latency (B1.4). ${LATENCY_ARRAY_DESCRIPTION} Retained per session and discarded when the session’s last connection closes, so unlike the process-wide series these describe live rooms only.`,
     }),
@@ -168,6 +174,10 @@ export const STATUS_PROCESS_SCHEMA = Type.Object({
     }),
     decodeDropsTotal: Type.Integer({
       description: 'Malformed SAFP frames dropped rather than forwarded (U2).',
+    }),
+    binaryBeforeAuthDropsTotal: Type.Integer({
+      description:
+        'Binary frames a source sent before its AUTH handshake completed (H1). Dropped rather than closed: a source that starts streaming before AUTH_OK would otherwise be closed 1008 `binary-before-auth` and reconnect-loop, because each reconnect re-sends AUTH and the next first chunk again beats AUTH_OK.',
     }),
     pendingChunkEvictionsTotal: Type.Integer({
       description:

--- a/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
+++ b/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
@@ -136,6 +136,12 @@ export const STATUS_SESSION_SCHEMA = Type.Object(
           'Binary frames received from the source since the session opened, counted before decode so a malformed frame still registers as "the source is sending something" (the malformed subset is `decodeDropsTotal`). Monotonic per session, resets on session end. Lets the fleet dashboard distinguish "source sent nothing" (0) from "source is sending but the ASR is silent" (>0) — the two cases that "no audio reaching ASR" alone cannot tell apart. Optional for backward-compat with older publishers that do not emit it.',
       }),
     ),
+    sourceMicrophoneActive: Type.Optional(
+      Type.Union([Type.Boolean(), Type.Null()], {
+        description:
+          'Whether at least one connected source has its microphone active (unmuted). Null when no source has reported state yet. Absent when no source has reported and the publisher predates the field. Lets the fleet dashboard distinguish "mic is off" from "something broke" when no audio frames arrive.',
+      }),
+    ),
     latency: Type.Array(LATENCY_SERIES_SCHEMA, {
       description: `Per-session latency (B1.4). ${LATENCY_ARRAY_DESCRIPTION} Retained per session and discarded when the session’s last connection closes, so unlike the process-wide series these describe live rooms only.`,
     }),

--- a/libs/schemas/node-server-schema/src/transcription-stream/routes/transcription-stream.schema.ts
+++ b/libs/schemas/node-server-schema/src/transcription-stream/routes/transcription-stream.schema.ts
@@ -12,6 +12,7 @@ import { TRANSCRIPT_FRAGMENT_SCHEMA } from '#src/transcription-stream/entities/t
 export enum TranscriptionStreamClientMessageType {
   AUTH = 'auth',
   TIME_SYNC_PING = 'timeSyncPing',
+  SOURCE_STATE = 'sourceState',
 }
 
 export enum TranscriptionStreamServerMessageType {
@@ -53,6 +54,13 @@ const TRANSCRIPTION_STREAM_SCHEMA = {
       type: Type.Literal(TranscriptionStreamClientMessageType.TIME_SYNC_PING),
       t0: Type.Number(),
     }),
+    // Source reports its microphone state so the fleet dashboard can
+    // distinguish "mic is off" from "something broke" when no audio frames
+    // arrive. Sent on mute/unmute transitions and once after AUTH_OK to seed.
+    Type.Object({
+      type: Type.Literal(TranscriptionStreamClientMessageType.SOURCE_STATE),
+      microphoneActive: Type.Boolean(),
+    }),
   ]),
   allowServerBinaryMessage: false,
   serverMessage: Type.Union([
@@ -74,6 +82,12 @@ const TRANSCRIPTION_STREAM_SCHEMA = {
         description:
           'Whether at least one source device is currently authenticated and streaming audio for this session.',
       }),
+      sourceMicrophoneActive: Type.Optional(
+        Type.Union([Type.Boolean(), Type.Null()], {
+          description:
+            'Whether at least one connected source has its microphone active (unmuted). Null when no source has reported state yet. Absent when no source has reported and the publisher predates the field.',
+        }),
+      ),
     }),
     Type.Object({
       type: Type.Literal(TranscriptionStreamServerMessageType.SESSION_ENDED),

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:unit": "npm run test:unit --workspaces --if-present",
     "a11y:axe": "node tools/a11y/axe-scan.mjs",
     "a11y:mock": "node tools/a11y/mock-server.mjs",
-    "a11y:axe:authed": "node tools/a11y/axe-scan-authed.mjs"
+    "a11y:axe:authed": "node tools/a11y/axe-scan-authed.mjs",
+    "e2e:audio": "node tools/e2e-audio/kiosk-audio-e2e.mjs"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/tools/e2e-audio/README.md
+++ b/tools/e2e-audio/README.md
@@ -1,0 +1,72 @@
+# End-to-end audio check
+
+Drives a real headless Chromium kiosk against a running stack and verifies that
+audio reaches a transcription provider — and, optionally, that it **keeps**
+reaching one after the transcription service restarts underneath it.
+
+Unlike `tools/a11y`, this needs the whole stack up (`deployment/compose.yml`):
+session-manager, node-server, and transcription-service all take part.
+
+## Why
+
+`apps/kiosk-webapp` has no test suite, so the audio capture path was only ever
+exercised by hand. The failure this was written for was invisible to every other
+check: the kiosk stayed connected, node-server kept accepting frames, the admin
+console kept reporting the session as live — and audio silently stopped reaching
+a provider after the first upstream blip, because credentials were sent once per
+_session_ instead of once per _connection_. Catching that needs a real browser
+and a deliberately broken upstream.
+
+## Run
+
+```bash
+# One-shot: does audio flow at all?
+node tools/e2e-audio/kiosk-audio-e2e.mjs --activation-code ABCD1234
+
+# The regression check: break the upstream mid-stream, require recovery.
+node tools/e2e-audio/kiosk-audio-e2e.mjs \
+  --activation-code ABCD1234 \
+  --stream-seconds 120 \
+  --restart-cmd 'docker compose -f deployment/compose.yml restart transcription-service'
+```
+
+Exits non-zero on failure and prints which assertion failed. `--json` emits the
+result as JSON for CI.
+
+## Setup
+
+The device must be registered and its room must have an active session:
+
+```bash
+cd deployment
+./register-device.sh kiosk-e2e            # -> deviceUid + activationCode
+./create-room.sh e2e-room <deviceUid>     # -> roomUid
+./create-session.sh <roomUid> e2e-session # on-demand, starts immediately
+```
+
+Activation codes are **single-use**: each run needs a fresh one, or a device
+that is already activated in a profile you keep.
+
+## Options
+
+| Flag                | Default             | Meaning                                           |
+| ------------------- | ------------------- | ------------------------------------------------- |
+| `--base-url`        | `https://localhost` | stack origin (self-signed certs are accepted)     |
+| `--activation-code` | —                   | required unless the profile is already registered |
+| `--stream-seconds`  | `45`                | total streaming time; the restart happens halfway |
+| `--restart-cmd`     | —                   | shell command to restart the upstream mid-stream  |
+| `--json`            | off                 | machine-readable result                           |
+
+Chrome is auto-detected from `CHROME_PATH`, then `/usr/bin/google-chrome-stable`,
+`google-chrome`, `chromium-browser`, `chromium`.
+
+## Notes
+
+- Audio comes from Chrome's fake capture device fed by
+  `test_audio_files/speech/harvard_16k_mono.wav`, so runs are deterministic and
+  need no real microphone.
+- The microphone permission is pre-granted. Without that the kiosk stops at
+  `INFO_PROMPT` and waits for a second activation call, which looks exactly like
+  a genuine audio fault — connected, but silent.
+- The mic control is a toggle, so the script clicks and then _verifies_ binary
+  frames are on the wire rather than clicking a fixed number of times.

--- a/tools/e2e-audio/README.md
+++ b/tools/e2e-audio/README.md
@@ -20,12 +20,11 @@ and a deliberately broken upstream.
 ## Run
 
 ```bash
-# One-shot: does audio flow at all?
-node tools/e2e-audio/kiosk-audio-e2e.mjs --activation-code ABCD1234
+# Everything, from nothing: provisions a device/room/session, then checks audio.
+npm run e2e:audio -- --provision
 
 # The regression check: break the upstream mid-stream, require recovery.
-node tools/e2e-audio/kiosk-audio-e2e.mjs \
-  --activation-code ABCD1234 \
+npm run e2e:audio -- --provision \
   --stream-seconds 120 \
   --restart-cmd 'docker compose -f deployment/compose.yml restart transcription-service'
 ```
@@ -35,7 +34,12 @@ result as JSON for CI.
 
 ## Setup
 
-The device must be registered and its room must have an active session:
+`--provision` does it for you: it reads `SESSION_MANAGER_API_KEY` from
+`deployment/.env`, registers a device, creates a room with that device as its
+source, and opens an on-demand session — all uniquely named, so repeated runs
+never collide.
+
+Do it by hand only if you want to point at an existing device:
 
 ```bash
 cd deployment
@@ -44,8 +48,20 @@ cd deployment
 ./create-session.sh <roomUid> e2e-session # on-demand, starts immediately
 ```
 
-Activation codes are **single-use**: each run needs a fresh one, or a device
-that is already activated in a profile you keep.
+then pass `--activation-code`. Activation codes are **single-use**, which is
+the main reason `--provision` exists: the manual path burns a device per run
+and every failed run leaves an orphan room behind.
+
+## Testing a calendared session
+
+The point of a calendared session is that the kiosk is already running and idle
+when the session starts, so it must make the UPCOMING → ACTIVE transition on its
+own. Create the schedule, then start the run with a wait long enough to cover
+the gap:
+
+```bash
+npm run e2e:audio -- --activation-code ABCD1234 --session-wait-seconds 300
+```
 
 ## Options
 

--- a/tools/e2e-audio/kiosk-audio-e2e.mjs
+++ b/tools/e2e-audio/kiosk-audio-e2e.mjs
@@ -3,11 +3,20 @@
  * transcription provider, and does it stay working after the upstream restarts?
  *
  * Usage:
+ *   node tools/e2e-audio/kiosk-audio-e2e.mjs --provision [options]
  *   node tools/e2e-audio/kiosk-audio-e2e.mjs --activation-code <CODE> [options]
  *
  * Options:
+ *   --provision            register a device, room and on-demand session first,
+ *                          reading the admin key from deployment/.env. Removes
+ *                          the manual setup entirely; without it you must
+ *                          supply --activation-code for an existing device
+ *                          whose room already has an active session.
  *   --base-url <url>       default https://localhost
  *   --stream-seconds <n>   default 45   how long to stream before scoring
+ *   --session-wait-seconds <n>  default 60. Raise it to test a CALENDARED
+ *                          session, where the kiosk must be running and idle
+ *                          before the session starts.
  *   --restart-cmd <cmd>    shell command that restarts the transcription
  *                          service. When given, it runs mid-stream and the run
  *                          only passes if transcripts resume afterwards.
@@ -22,12 +31,11 @@
  * connection. Nothing short of driving the real browser and then breaking the
  * upstream underneath it catches that.
  *
- * Requires a running stack (deployment/compose.yml) and a registered source
- * device whose room has an active session. Chrome is auto-detected from
- * CHROME_PATH, then the usual system locations.
+ * Requires a running stack (deployment/compose.yml). Chrome is auto-detected
+ * from CHROME_PATH, then the usual system locations.
  */
 import { execSync } from 'node:child_process';
-import { existsSync, mkdtempSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -67,11 +75,13 @@ function parseArgs(argv) {
     activationCode: '',
     restartCmd: '',
     sessionWaitSeconds: 60,
+    provision: false,
     json: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const flag = argv[i];
     if (flag === '--json') args.json = true;
+    else if (flag === '--provision') args.provision = true;
     else if (flag === '--base-url') args.baseUrl = argv[++i];
     else if (flag === '--stream-seconds')
       args.streamSeconds = Number(argv[++i]);
@@ -84,6 +94,72 @@ function parseArgs(argv) {
 }
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Read `deployment/.env` for the admin key. Deliberately a plain scan rather
+ * than a dotenv dependency: one key is needed and the file's own values are
+ * unquoted shell-hostile strings, so `source`-ing it is worse than reading it.
+ */
+function loadDeploymentEnv() {
+  const path = join(__dirname, '..', '..', 'deployment', '.env');
+  if (!existsSync(path)) {
+    throw new Error(`--provision needs ${path}, which does not exist.`);
+  }
+  const env = {};
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const match = /^\s*([A-Z0-9_]+)\s*=\s*(.*)$/.exec(line);
+    if (match) env[match[1]] = match[2].trim().replace(/^["']|["']$/g, '');
+  }
+  return env;
+}
+
+/**
+ * Register a device, put it in a fresh room as the source, and open an
+ * on-demand session there. Returns the activation code.
+ *
+ * Worth automating rather than documenting: activation codes are single-use, so
+ * the manual path burns a device per run and every failed run leaves another
+ * orphan room behind.
+ */
+function provision(baseUrl, log) {
+  const env = loadDeploymentEnv();
+  const key = env.SESSION_MANAGER_API_KEY;
+  if (!key) {
+    throw new Error('deployment/.env has no SESSION_MANAGER_API_KEY.');
+  }
+  const api = `${baseUrl}/api/session-manager/v1`;
+  const post = (path, body) => {
+    const out = execSync(
+      `curl -sk -X POST ${api}/${path} -H 'Content-Type: application/json' ` +
+        `-H 'Authorization: Bearer ${key}' -d '${JSON.stringify(body)}'`,
+      { encoding: 'utf8' },
+    );
+    const parsed = JSON.parse(out);
+    if (parsed.code) {
+      throw new Error(`${path} failed: ${parsed.code} ${parsed.message ?? ''}`);
+    }
+    return parsed;
+  };
+
+  // Unique names so repeated runs never collide on a leftover room.
+  const stamp = `e2e-${process.pid}-${Math.floor(Date.now() / 1000)}`;
+  const device = post('device-management/register-device', { name: stamp });
+  const room = post('room-management/create-room', {
+    name: stamp,
+    timezone: 'UTC',
+    autoSessionEnabled: false,
+    sourceDeviceUids: [device.deviceUid],
+  });
+  post('schedule-management/create-on-demand-session', {
+    roomUid: room.uid,
+    name: stamp,
+    joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+    transcriptionProviderId: 'whisper',
+    transcriptionStreamConfig: {},
+  });
+  log(`--- provisioned device ${device.deviceUid} in room ${room.uid}`);
+  return device.activationCode;
+}
 
 /** Click the first visible control whose text or aria-label contains `needle`. */
 function clickByText(page, needle) {
@@ -105,6 +181,10 @@ async function main() {
   const log = (...m) => {
     if (!args.json) console.log(...m);
   };
+
+  if (args.provision) {
+    args.activationCode = provision(args.baseUrl, log);
+  }
 
   const browser = await puppeteer.launch({
     executablePath: resolveChrome(),

--- a/tools/e2e-audio/kiosk-audio-e2e.mjs
+++ b/tools/e2e-audio/kiosk-audio-e2e.mjs
@@ -66,6 +66,7 @@ function parseArgs(argv) {
     streamSeconds: 45,
     activationCode: '',
     restartCmd: '',
+    sessionWaitSeconds: 60,
     json: false,
   };
   for (let i = 0; i < argv.length; i++) {
@@ -74,6 +75,8 @@ function parseArgs(argv) {
     else if (flag === '--base-url') args.baseUrl = argv[++i];
     else if (flag === '--stream-seconds')
       args.streamSeconds = Number(argv[++i]);
+    else if (flag === '--session-wait-seconds')
+      args.sessionWaitSeconds = Number(argv[++i]);
     else if (flag === '--activation-code') args.activationCode = argv[++i];
     else if (flag === '--restart-cmd') args.restartCmd = argv[++i];
   }
@@ -177,8 +180,16 @@ async function main() {
   // would flip it on with nothing to measure, and the click-and-verify loop
   // below would then toggle it back off looking for frames that could not
   // arrive yet.
-  log('--- waiting for the session socket');
-  for (let waited = 0; waited < 60 && !sourceSocketOpen; waited += 2) {
+  //
+  // Raise `--session-wait-seconds` to test a CALENDARED session: the whole
+  // point there is that the kiosk is already running and idle when the session
+  // starts, so it has to make the UPCOMING -> ACTIVE transition on its own.
+  log(`--- waiting up to ${args.sessionWaitSeconds}s for the session socket`);
+  for (
+    let waited = 0;
+    waited < args.sessionWaitSeconds && !sourceSocketOpen;
+    waited += 2
+  ) {
     await sleep(2000);
   }
   if (!sourceSocketOpen) {
@@ -186,6 +197,7 @@ async function main() {
       'Kiosk never opened a transcription-stream socket - is a session active in its room?',
     );
   }
+  log('--- session socket open');
 
   // The microphone control is a TOGGLE, so a fixed number of clicks is a coin
   // flip. Click, then confirm audio is actually on the wire before continuing.

--- a/tools/e2e-audio/kiosk-audio-e2e.mjs
+++ b/tools/e2e-audio/kiosk-audio-e2e.mjs
@@ -1,0 +1,273 @@
+/**
+ * End-to-end audio check: does a real Chromium kiosk get audio all the way to a
+ * transcription provider, and does it stay working after the upstream restarts?
+ *
+ * Usage:
+ *   node tools/e2e-audio/kiosk-audio-e2e.mjs --activation-code <CODE> [options]
+ *
+ * Options:
+ *   --base-url <url>       default https://localhost
+ *   --stream-seconds <n>   default 45   how long to stream before scoring
+ *   --restart-cmd <cmd>    shell command that restarts the transcription
+ *                          service. When given, it runs mid-stream and the run
+ *                          only passes if transcripts resume afterwards.
+ *   --json                 machine-readable result on stdout
+ *
+ * Why this exists: the kiosk is the app the product depends on for audio
+ * capture and it has no test suite of its own, so the audio path was only ever
+ * exercised by hand. The failure this was written for was invisible to every
+ * other check - the kiosk stayed connected, node-server kept accepting frames,
+ * and audio silently stopped reaching a provider after the first upstream blip
+ * because credentials were sent once per session instead of once per
+ * connection. Nothing short of driving the real browser and then breaking the
+ * upstream underneath it catches that.
+ *
+ * Requires a running stack (deployment/compose.yml) and a registered source
+ * device whose room has an active session. Chrome is auto-detected from
+ * CHROME_PATH, then the usual system locations.
+ */
+import { execSync } from 'node:child_process';
+import { existsSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer-core';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const CHROME_CANDIDATES = [
+  process.env.CHROME_PATH,
+  '/usr/bin/google-chrome-stable',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium-browser',
+  '/usr/bin/chromium',
+].filter(Boolean);
+
+/** Speech fixture played into Chrome's fake microphone. */
+const WAV = join(
+  __dirname,
+  '..',
+  '..',
+  'test_audio_files',
+  'speech',
+  'harvard_16k_mono.wav',
+);
+
+function resolveChrome() {
+  for (const p of CHROME_CANDIDATES) if (existsSync(p)) return p;
+  throw new Error(
+    `No Chrome/Chromium found. Set CHROME_PATH. Tried: ${CHROME_CANDIDATES.join(', ')}`,
+  );
+}
+
+function parseArgs(argv) {
+  const args = {
+    baseUrl: 'https://localhost',
+    streamSeconds: 45,
+    activationCode: '',
+    restartCmd: '',
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === '--json') args.json = true;
+    else if (flag === '--base-url') args.baseUrl = argv[++i];
+    else if (flag === '--stream-seconds')
+      args.streamSeconds = Number(argv[++i]);
+    else if (flag === '--activation-code') args.activationCode = argv[++i];
+    else if (flag === '--restart-cmd') args.restartCmd = argv[++i];
+  }
+  return args;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Click the first visible control whose text or aria-label contains `needle`. */
+function clickByText(page, needle) {
+  return page.evaluate((text) => {
+    const els = [...document.querySelectorAll('button, [role="button"], a')];
+    const hit = els.find(
+      (el) =>
+        (el.textContent ?? '').trim().toLowerCase().includes(text) ||
+        (el.getAttribute('aria-label') ?? '').toLowerCase().includes(text),
+    );
+    if (!hit) return false;
+    hit.click();
+    return true;
+  }, needle.toLowerCase());
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const log = (...m) => {
+    if (!args.json) console.log(...m);
+  };
+
+  const browser = await puppeteer.launch({
+    executablePath: resolveChrome(),
+    headless: true,
+    acceptInsecureCerts: true,
+    // A fresh profile per run would burn a device activation code every time
+    // (they are single-use), so the DEVICE_TOKEN cookie needs somewhere to live
+    // for the duration of the run at least.
+    userDataDir: mkdtempSync(join(tmpdir(), 'scribear-e2e-')),
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--ignore-certificate-errors',
+      '--use-fake-device-for-media-stream',
+      '--use-fake-ui-for-media-stream',
+      `--use-file-for-fake-audio-capture=${WAV}`,
+      '--autoplay-policy=no-user-gesture-required',
+    ],
+  });
+
+  // Pre-grant the microphone. Without this the service stops at INFO_PROMPT and
+  // waits for a second activation call, which reads as "connected but silent" -
+  // the same symptom as a genuine audio fault.
+  await browser
+    .defaultBrowserContext()
+    .overridePermissions(args.baseUrl, ['microphone']);
+
+  const page = await browser.newPage();
+  let binaryFrames = 0;
+  const transcripts = [];
+
+  let sourceSocketOpen = false;
+
+  const cdp = await page.createCDPSession();
+  await cdp.send('Network.enable');
+  cdp.on('Network.webSocketCreated', (e) => {
+    if (e.url.includes('/transcription-stream/')) sourceSocketOpen = true;
+  });
+  cdp.on('Network.webSocketFrameSent', (e) => {
+    if (e.response.opcode === 2) binaryFrames++;
+  });
+  cdp.on('Network.webSocketFrameReceived', (e) => {
+    if (e.response.opcode !== 1) return;
+    if (e.response.payloadData.includes('"type":"transcript"')) {
+      transcripts.push(Date.now());
+    }
+  });
+
+  log('--- opening /kiosk');
+  await page.goto(`${args.baseUrl}/kiosk`, {
+    waitUntil: 'networkidle2',
+    timeout: 60000,
+  });
+
+  if (
+    await page.evaluate(() =>
+      document.body.innerText.includes('not registered'),
+    )
+  ) {
+    if (!args.activationCode) {
+      throw new Error(
+        'Device is unregistered and no --activation-code was supplied.',
+      );
+    }
+    log('--- activating device');
+    await page.type('input', args.activationCode);
+    await clickByText(page, 'activate');
+    await sleep(4000);
+  }
+
+  // Wait for the kiosk to join its session first. Audio only reaches the wire
+  // through the session socket, so toggling the mic before the socket exists
+  // would flip it on with nothing to measure, and the click-and-verify loop
+  // below would then toggle it back off looking for frames that could not
+  // arrive yet.
+  log('--- waiting for the session socket');
+  for (let waited = 0; waited < 60 && !sourceSocketOpen; waited += 2) {
+    await sleep(2000);
+  }
+  if (!sourceSocketOpen) {
+    throw new Error(
+      'Kiosk never opened a transcription-stream socket - is a session active in its room?',
+    );
+  }
+
+  // The microphone control is a TOGGLE, so a fixed number of clicks is a coin
+  // flip. Click, then confirm audio is actually on the wire before continuing.
+  log('--- enabling microphone');
+  let streaming = false;
+  for (let attempt = 1; attempt <= 4 && !streaming; attempt++) {
+    const before = binaryFrames;
+    await clickByText(page, 'microphone');
+    await sleep(4000);
+    streaming = binaryFrames > before + 5;
+    log(`    attempt ${attempt}: frames ${before} -> ${binaryFrames}`);
+  }
+  if (!streaming) {
+    throw new Error(
+      'Microphone never started streaming - no binary frames left the browser.',
+    );
+  }
+
+  const half = Math.floor(args.streamSeconds / 2);
+  log(`--- streaming ${half}s before the restart`);
+  await sleep(half * 1000);
+
+  let restartAtMs = null;
+  if (args.restartCmd) {
+    log(`--- restarting upstream: ${args.restartCmd}`);
+    restartAtMs = Date.now();
+    execSync(args.restartCmd, { stdio: args.json ? 'ignore' : 'inherit' });
+  }
+
+  log(`--- streaming ${args.streamSeconds - half}s after the restart`);
+  const framesBeforeTail = binaryFrames;
+  await sleep((args.streamSeconds - half) * 1000);
+
+  const after = restartAtMs
+    ? transcripts.filter((t) => t > restartAtMs).length
+    : transcripts.length;
+  const before = restartAtMs
+    ? transcripts.filter((t) => t <= restartAtMs).length
+    : 0;
+
+  const failures = [];
+  if (binaryFrames <= framesBeforeTail) {
+    failures.push('the browser stopped sending audio');
+  }
+  if (transcripts.length === 0) {
+    failures.push('no transcripts ever arrived');
+  }
+  // The regression this exists for: transcripts before the restart, none after.
+  if (restartAtMs && after === 0) {
+    failures.push(
+      'no transcripts after the upstream restart (session did not recover)',
+    );
+  }
+
+  const result = {
+    ok: failures.length === 0,
+    binaryFrames,
+    transcripts: transcripts.length,
+    transcriptsBeforeRestart: restartAtMs ? before : null,
+    transcriptsAfterRestart: restartAtMs ? after : null,
+    failures,
+  };
+
+  await browser.close();
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log('\n=== RESULT ===');
+    console.log(`binary frames sent : ${result.binaryFrames}`);
+    console.log(`transcripts        : ${result.transcripts}`);
+    if (restartAtMs) {
+      console.log(`  before restart   : ${before}`);
+      console.log(`  after restart    : ${after}`);
+    }
+    console.log(result.ok ? '\nPASS' : `\nFAIL\n - ${failures.join('\n - ')}`);
+  }
+
+  process.exit(result.ok ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
Audio from a Chromium kiosk never reached the transcription service. Three
production bugs, each reproduced against the compose stack and each fixed with
a test that fails on the old code.

## The bugs

**1. node-server never re-authenticated its upstream after a reconnect.**
`_openSession` sent `AUTH` + `CONFIG` exactly once. The client reconnects on its
own, so after any blip it reopened the socket and forwarded audio with no
credentials; the transcription service closes 1008 *"Audio chunk before
authentication"* on unauthenticated binary. Reconnect, stream, get closed,
repeat — forever. The kiosk stayed connected, node-server kept accepting frames,
and nothing reached a provider again for the life of the session.

Reproduced by restarting `transcription-service` under a live kiosk: upstream
pinned at `WAITING_RETRY`, `pendingChunkCount` past 880, a 1008 per attempt.

**2. The kiosk raced its own auth.** It sent `auth` from the socket's `open`
handler and started capture on the next line, so a binary frame could arrive
before the server was `ready` and get the socket closed 1008
`binary-before-auth`. Now authenticated in `onHandshake`: `sendBinary` cannot
reach the socket before OPEN, so ordering is structural rather than a matter of
timing. Two reconnect leaks fixed alongside it — a stacked time-sync interval,
and a leaked AudioContext whose old stream kept sending, duplicating audio into
the ASR after any reconnect.

**3. `create-on-demand-session` returned 500 in any room with auto-sessions
enabled** — every such room, every time, so AUTO and ON_DEMAND could not coexist.
An open-ended session is `[start, infinity)` in the database, but the reconciler
modelled it as blocking only to the 7-day horizon; window occurrences run past
that horizon, the gap got filled with an AUTO slot, and the deferred exclusion
constraint rejected the transaction at COMMIT.

## Verification

Every session type driven end to end with real audio, and both handovers
confirmed in the database rather than by "transcripts kept arriving":

| Path | Result |
|---|---|
| on-demand | 1352 frames, 234 transcripts |
| calendared `ONCE` | joined a 19:05:00 start at 19:05:03 from idle |
| calendared `WEEKLY` | joined its occurrence from idle; `MON,WED,FRI` expands correctly |
| auto | 1540 frames, 280 transcripts |
| auto → on-demand, mid-stream | was a 500; now 145 transcripts before / 136 after |
| on-demand → auto, mid-stream | 163 before / 149 after; AUTO row starts at the exact `end_override` |

Upstream-restart recovery, CPU and `cuda128`. Suites: node-server 200 unit +
46 integration, session-manager 456 unit + 341 integration, admin-webapp 285,
root build and `build-containers.sh` clean.

## Also in here

- **`tools/e2e-audio`** (`npm run e2e:audio`) — drives real Chromium, breaks the
  upstream mid-stream, and fails unless transcripts resume. Proven to catch the
  bug: 135 transcripts before a restart and **0** after on pre-fix code (exit 1),
  135/99 after (exit 0). `--provision` sets up its own device, room and session.
  `apps/kiosk-webapp` and `apps/client-webapp` have no test suites at all, which
  is how the audio path went unexercised.
- **Diagnostics.** The fleet audio meter was fed only by the transcription
  service, so "no audio" could not distinguish a silent source from a broken
  upstream — the ambiguity that made the original report a guess. Adds an
  ingress frame counter and kiosk mic state, so the session card now separates
  *no audio from source* / *audio received, not reaching ASR* / *mic off*.
  Pre-auth binary is dropped and counted instead of killing the connection.
- **`feat(client-webapp)`: a Leave control** so a viewer can join a different
  room; the app returns to the join dialog. The service already supported it —
  this is the missing affordance.
- **`compare.txt`** — this work was done alongside a parallel investigation
  (`GLM-Debug-E2E`) that reached the same root cause independently. Its better
  ideas are merged in and attributed per commit; two defects found in that code
  are fixed here, including a required schema field that broke the monorepo
  build and would have dropped nodes from the fleet view during a rolling
  deploy. Safe to delete on merge.