### PR TITLE
feat(deployment): cache transcription model downloads on a bind mount

### DIFF
--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
@@ -50,7 +50,7 @@ export interface ContainerVersion {
  * version.test.ts` fails if the two ever disagree, or if that file changes
  * without someone having made that call.
  */
-export const EXPECTED_COMPOSE_FILE_VERSION = 2;
+export const EXPECTED_COMPOSE_FILE_VERSION = 3;
 
 /**
  * How the running `compose.yml` compares to the one this image was built for.

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  'b69d5a508b709c1454d9c93191769f726e2366f83fbaa5a4e798773b1bec4229';
+  'bc603d06b3f20b2de8f5a7e2d371a90e065442e8a1605ae5d52f0e647aef763f';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  'bc603d06b3f20b2de8f5a7e2d371a90e065442e8a1605ae5d52f0e647aef763f';
+  '2037ff27a3828420825f038698898363cee4e5fd137af536b31b9a579efcb8d1';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -142,9 +142,9 @@ TRANSCRIPTION_REDIS_URL=
 PROVIDER_CONFIG_PATH=./provider_config.json
 # Host directory bind-mounted at /models inside transcription-service, where
 # faster-whisper and silero-vad cache downloaded weights (via HF_HOME). Defaults
-# to ./models relative to compose.yml; create it before first `up -d` so Docker
-# does not create it as root-owned. A deployment with models already downloaded
-# can point this at that directory to avoid a re-download.
+# to ./models relative to compose.yml; created automatically on first download.
+# A deployment with models already downloaded can point this at that directory
+# to avoid a re-download.
 MODEL_DOWNLOAD_PATH=./models
 # Upstream secret for remote/OpenAI-like transcription providers. Forwarded into
 # the transcription-service container; a provider references it by name via the

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -140,6 +140,12 @@ TRANSCRIPTION_AUDIO_SILENCE_THRESHOLD=0.01
 #   TRANSCRIPTION_REDIS_URL=redis://:CHANGEME@redis:6379
 TRANSCRIPTION_REDIS_URL=
 PROVIDER_CONFIG_PATH=./provider_config.json
+# Host directory bind-mounted at /models inside transcription-service, where
+# faster-whisper and silero-vad cache downloaded weights (via HF_HOME). Defaults
+# to ./models relative to compose.yml; create it before first `up -d` so Docker
+# does not create it as root-owned. A deployment with models already downloaded
+# can point this at that directory to avoid a re-download.
+MODEL_DOWNLOAD_PATH=./models
 # Upstream secret for remote/OpenAI-like transcription providers. Forwarded into
 # the transcription-service container; a provider references it by name via the
 # "api_key_env" field in provider_config.json. Leave empty unless a configured

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -28,15 +28,9 @@ directory there, so weights are fetched once and reused. Both `huggingface_hub`
 and `torch.hub` (silero-vad) honour `HF_HOME`, so the one variable covers both.
 
 The host path is `MODEL_DOWNLOAD_PATH`, defaulting to `./models` relative to
-`compose.yml`. **Create it before the next `up -d`** so Docker does not create
-it as root-owned:
-
-```bash
-mkdir -p models
-```
-
-A deployment that already has weights downloaded can point `MODEL_DOWNLOAD_PATH`
-at that directory to skip the initial download.
+`compose.yml`; it is created automatically on first download. A deployment that
+already has weights downloaded can point `MODEL_DOWNLOAD_PATH` at that directory
+to skip the initial download.
 
 ### `COMPOSE_FILE_VERSION` bumped to 3
 

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,40 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — transcription-service model downloads are now cached on a bind mount (`compose.yml` v3)
+
+**Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. Deployment
+Check will report `old file` until you do. Nothing breaks if you delay: the
+service still runs, it just re-downloads model weights on every container
+recreation as before.
+
+### What changed
+
+`transcription-service` downloads faster-whisper and silero-vad weights at
+runtime into `/root/.cache` inside the container, which a `docker compose up -d`
+discards. The service now sets `HF_HOME: /models/hf` and bind-mounts a host
+directory there, so weights are fetched once and reused. Both `huggingface_hub`
+and `torch.hub` (silero-vad) honour `HF_HOME`, so the one variable covers both.
+
+The host path is `MODEL_DOWNLOAD_PATH`, defaulting to `./models` relative to
+`compose.yml`. **Create it before the next `up -d`** so Docker does not create
+it as root-owned:
+
+```bash
+mkdir -p models
+```
+
+A deployment that already has weights downloaded can point `MODEL_DOWNLOAD_PATH`
+at that directory to skip the initial download.
+
+### `COMPOSE_FILE_VERSION` bumped to 3
+
+This change adds a volume and an environment variable, so the file version
+moves from 2 to 3. `EXPECTED_COMPOSE_FILE_VERSION` in admin-server moves with
+it; Deployment Check reports `old file` until the new `compose.yml` is copied.
+
+---
+
 ## Unreleased — **breaking:** a CUDA deployment now needs `-f compose.gpu.yml`
 
 **If you run `TRANSCRIPTION_DEVICE=cuda` or `cuda128`, your start command changes:**

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -380,8 +380,9 @@ services:
       # and silero-vad via torch.hub; both honour HF_HOME (torch.hub falls back
       # to it when TORCH_HOME is unset), so one variable redirects both. The
       # path is inside the bind mount below, so weights survive container
-      # recreation instead of re-downloading on every `up -d`. The directory is
-      # created on first download; the host dir only needs to exist.
+      # recreation instead of re-downloading on every `up -d`. The container
+      # runs as root, so Docker auto-creating the host dir on first `up -d` is
+      # fine - no manual mkdir needed.
       HF_HOME: /models/hf
     volumes:
       - ${PROVIDER_CONFIG_PATH:-./provider_config.json}:/app/provider_config.json:ro

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -170,7 +170,7 @@ services:
       # Not `:?`-guarded, like DEPLOYMENT_ENV below and unlike the secrets: it
       # changes what is *reported*, never what runs, and must not be able to
       # stop a stack from starting.
-      COMPOSE_FILE_VERSION: "2"
+      COMPOSE_FILE_VERSION: "3"
       LOG_LEVEL: ${ADMIN_LOG_LEVEL:-info}
       ADMIN_API_KEY: ${SESSION_MANAGER_API_KEY}
       SESSION_MANAGER_BASE_URL: http://session-manager:80
@@ -376,8 +376,16 @@ services:
       # hostname, which compose sets to the container name, so scaling this
       # service gives each replica a distinct identity with no configuration.
       REDIS_URL: ${TRANSCRIPTION_REDIS_URL:-}
+      # Model download cache. faster-whisper pulls weights via huggingface_hub
+      # and silero-vad via torch.hub; both honour HF_HOME (torch.hub falls back
+      # to it when TORCH_HOME is unset), so one variable redirects both. The
+      # path is inside the bind mount below, so weights survive container
+      # recreation instead of re-downloading on every `up -d`. The directory is
+      # created on first download; the host dir only needs to exist.
+      HF_HOME: /models/hf
     volumes:
       - ${PROVIDER_CONFIG_PATH:-./provider_config.json}:/app/provider_config.json:ro
+      - ${MODEL_DOWNLOAD_PATH:-./models}:/models
     networks:
       - backend
     restart: unless-stopped


### PR DESCRIPTION
## What

`transcription-service` downloads faster-whisper and silero-vad weights at runtime into `/root/.cache` inside the container, which `docker compose up -d` discards — so every container recreation re-downloads multi-GB model weights. This sets `HF_HOME: /models/hf` and bind-mounts a host directory (`MODEL_DOWNLOAD_PATH`, default `./models`) at `/models`, so weights are fetched once and reused across recreations.

Both `huggingface_hub` (faster-whisper) and `torch.hub` (silero-vad) honour `HF_HOME` — torch.hub falls back to it when `TORCH_HOME` is unset — so the one variable redirects both. The `/models/hf` directory is created on first download; the host dir only needs to exist.

## Changes

- `deployment/compose.yml`: add `HF_HOME: /models/hf` env var and `${MODEL_DOWNLOAD_PATH:-./models}:/models` volume to `transcription-service`.
- `deployment/.env.example`: document `MODEL_DOWNLOAD_PATH`.
- `deployment/UPGRADING.md`: new `Unreleased` section with the operator steps (`mkdir -p models` before next `up -d`).
- `COMPOSE_FILE_VERSION` `2` → `3` and `EXPECTED_COMPOSE_FILE_VERSION` to match; re-pinned the drift-guard sha256.

## Operator action

Copy the new `compose.yml`, create the cache dir, and `up -d`:

```bash
mkdir -p models
docker compose up -d
```

Nothing breaks if delayed — the service still runs, it just keeps re-downloading on recreation as before.

## Verification

- `docker compose -f deployment/compose.yml config --quiet` parses clean.
- `npm run test:unit --workspace apps/admin-server` — 151 passed (incl. the compose-file-version drift guard).
- `npm run lint --workspace apps/admin-server` — clean.