### PR TITLE
feat: widen Config Check coverage of placeholder secrets and monitoring health

### DIFF
--- a/.changeset/config-check-monitoring-health.md
+++ b/.changeset/config-check-monitoring-health.md
@@ -1,0 +1,54 @@
+---
+'@scribear/admin-server': minor
+---
+
+Config Check reports two more placeholder secrets, and whether the monitoring
+profile is actually working rather than merely switched on.
+
+`TEST_AUDIO_SERVICE_KEY` and a placeholder password inside `ADMIN_REDIS_URL`
+are both in admin-server's own environment and were simply never checked.
+`TEST_AUDIO_SERVICE_KEY` is unconditional rather than gated on
+`TEST_AUDIO_BASE_URL` being set, because that variable defaults to the in-stack
+service and the generator refuses to start on an empty or `CHANGEME` key — the
+secret is live by default, unlike the off-by-default telemetry gate.
+`ADMIN_REDIS_URL` reuses the existing `redisUrlHasPassword` convention where an
+unparseable URL returns false rather than flagging, deferring that case to the
+reachability check. A placeholder Redis password therefore produces *two*
+findings — `redis-url-placeholder-password` and `telemetry-unreachable` — and
+that is correct rather than duplicated: one is a static fact about the URL
+string, the other is what the deployment actually observes.
+
+The monitoring checks close a gap the `monitoring` compose profile opened:
+turning it on and having it silently not work looked identical to having it
+work. Config Check now verifies Prometheus is reachable **and** lists the
+`scribear_sidecar` scrape target as up (a reachable Prometheus scraping nothing
+is the failure that leaves every Grafana panel empty), that Grafana is
+reachable, and that Grafana no longer accepts the `admin`/`CHANGEME` default
+login. That last one is a probe rather than a credential — it attempts exactly
+the well-known default against an authenticated route and reports whether it
+succeeded — so admin-server never needs `GRAFANA_ADMIN_PASSWORD`.
+
+Leaving monitoring off is itself reported (`monitoring-not-configured`, warning
+in staging/production, advisory in development) rather than staying silent: a
+fleet-health dashboard is worth nudging toward once a deployment is more than a
+throwaway container. New env: `ADMIN_GRAFANA_BASE_URL`,
+`ADMIN_PROMETHEUS_BASE_URL`, both empty by default and deliberately not
+`:?`-guarded in `compose.yml` — an unset value must never block the stack from
+starting. `COMPOSE_FILE_VERSION` bumped 5→6 for them, which is this repo's
+established trigger for new env vars on an existing always-running service; the
+prior monitoring-dashboard release's `UPGRADING.md` entry was titled
+"(compose.yml v6)" without ever bumping the constant, and that header is
+corrected here so it does not collide.
+
+All findings use a new `'monitoring'` `CheckCategory`, so the subsystem groups
+under one chip rather than splitting across `'monitoring'` and `'secrets'`.
+
+**Removed before shipping: a Grafana dashboard-provisioning check.** It was
+implemented and then deleted after live testing showed it fired even when the
+dashboard genuinely was provisioned. `GET /api/dashboards/uid/...` requires
+Grafana auth, and the only credential this check is permitted to try is the
+well-known default — so it could succeed only on deployments that have *not*
+secured Grafana, making it a guaranteed false positive on every properly
+secured one. Not routed around by giving admin-server a real Grafana
+credential (that trades a report for the security it reports on) or by enabling
+anonymous access. `_checkGrafana` carries a doc-comment saying so.

--- a/.changeset/config-check-sidecar-mediated-secret-audit.md
+++ b/.changeset/config-check-sidecar-mediated-secret-audit.md
@@ -1,0 +1,74 @@
+---
+'@scribear/node-server-schema': minor
+'@scribear/node-server': minor
+'@scribear/monitoring-sidecar': minor
+'@scribear/admin-server': minor
+---
+
+Config Check now reports on the four secrets admin-server deliberately never
+holds, without being given any of them.
+
+`JWT_SECRET`, `NODE_SERVER_KEY`, `NODE_SERVER_SERVICE_KEY` and
+`TRANSCRIPTION_API_KEY` are invisible to admin-server by design, so a
+deployment could sit on all four as `CHANGEME` placeholders with Config Check
+entirely green. The obvious fix — hand admin-server copies so it can check them
+— makes every deployment strictly less secure in order to report on its
+security, and was rejected by the plan's own trust-boundary table.
+
+Instead the service that already holds all four classifies its own copies.
+node-server's `AppConfig` gains a `secretPlaceholders` getter applying the same
+case-insensitive `CHANGEME` substring rule Config Check already uses, exposed
+as four booleans on its existing authenticated `GET /status`
+(`SECRET_PLACEHOLDERS_SCHEMA`). The monitoring sidecar already polls that
+endpoint with `NODE_SERVER_SERVICE_API_KEY`, so it re-exposes the
+classification on a new `GET /api/monitoring/v1/config-audit` —
+unauthenticated and backend-network-only, the same trust boundary `/metrics`
+and `/probes/readiness` already carry. admin-server reads that over the compose
+network it already uses for the sidecar's build info and translates
+node-server's env var names to the deployment `.env` names. Four booleans move;
+no secret value does, and no service gains a credential it did not already
+have. Verified live with `docker exec admin-server env`.
+
+Why node-server rather than session-manager or transcription-service, which
+also hold some of these: node-server is the only service that holds **all
+four** and already has an authenticated status endpoint an observability
+consumer polls. So this phase needed no change to either of those services, no
+new env var anywhere, and no `COMPOSE_FILE_VERSION` bump.
+
+**The new field is deliberately a sibling of `sessions`/`sessionsTruncated` on
+the route response, not part of `STATUS_PROCESS_SCHEMA`.**
+`NODE_SNAPSHOT_SCHEMA` spreads `STATUS_PROCESS_SCHEMA.properties`, so the
+obvious placement would have silently published a secret classification into
+the Redis fleet-telemetry namespace, admin-server's `FleetSnapshot` and the
+fleet dashboard — three more copies to go stale, for data with exactly one
+reader.
+
+Also deliberately **not** a Prometheus metric. Routing it through `/metrics`
+would gate these findings behind the optional `monitoring` compose profile;
+Prometheus and Grafana are opt-in, and these four secrets are live in every
+deployment. It is a classification, not a measurement.
+
+**`unavailable` is a first-class answer, never silence.** `AbsoluteStatusPoller`
+gains an `enabled` getter so `nodeServer.status` can distinguish "will never
+poll" (`disabled` — the sidecar has no service key), "has not polled yet"
+(`not-yet-polled`) and the existing `POLL_ERROR_REASONS` from a failed poll.
+Config Check turns any of them into its own
+`secret-placeholder-audit-unavailable` finding (warning; advisory in
+development, matching the four secret findings), so a broken sidecar reads as
+"cannot currently check" and never as a clean bill of health. Admin-server
+validates the whole `/config-audit` body with `Value.Check` against a TypeBox
+schema before dereferencing any field — the same thing
+`NodeStatusPollerService._parseBody` does one hop upstream, so both ends of the
+wire are validated alike. The schema stays open to unknown properties on
+purpose, so a *newer* sidecar's extra fields still validate and upgrading the
+sidecar first cannot blind Config Check.
+
+**Known limitation, named in the finding's own remediation text:** a
+placeholder `NODE_SERVER_SERVICE_KEY` can only ever surface as the generic
+`secret-placeholder-audit-unavailable`, never as its own finding. That key
+guards `/status` itself, and node-server's `ServiceAuthService` refuses to
+construct while it contains `CHANGEME` — a deliberate pre-existing fail-closed
+design — so the endpoint 500s before it can self-report on that specific key.
+The deployment still never reads as clean; the operator gets "something is
+wrong with node-server's status auth" rather than the variable's name. Not
+worked around by giving a second service a way past node-server's boot check.

--- a/apps/admin-server/src/app-config/app-config.ts
+++ b/apps/admin-server/src/app-config/app-config.ts
@@ -337,6 +337,7 @@ export class AppConfig {
       testAudioServiceKey: this._env.TEST_AUDIO_SERVICE_KEY,
       grafanaBaseUrl: this._env.ADMIN_GRAFANA_BASE_URL,
       prometheusBaseUrl: this._env.ADMIN_PROMETHEUS_BASE_URL,
+      monitoringSidecarBaseUrl: this._env.MONITORING_SIDECAR_BASE_URL,
       azureTenantId: this._env.AZURE_TENANT_ID,
       azureClientId: this._env.AZURE_CLIENT_ID,
       azureClientSecret: this._env.AZURE_CLIENT_SECRET,

--- a/apps/admin-server/src/app-config/app-config.ts
+++ b/apps/admin-server/src/app-config/app-config.ts
@@ -97,6 +97,16 @@ const CONFIG_SCHEMA = Type.Object({
   // and /fleet answers 503 rather than the BFF failing to boot.
   REDIS_URL: Type.String({ default: '' }),
 
+  // Config Check's monitoring probes (Phase 1, PLAN-ConfigCheck-Coverage).
+  // Empty (the default) means the monitoring compose profile was never
+  // turned on — reported as a warning in staging/production (advisory in
+  // development), since a fleet-health dashboard is worth having once a
+  // deployment is more than a throwaway container. Set both together when
+  // you turn the profile on; never `:?`-guarded, since an unset value must
+  // never stop the stack from starting.
+  ADMIN_GRAFANA_BASE_URL: Type.String({ default: '' }),
+  ADMIN_PROMETHEUS_BASE_URL: Type.String({ default: '' }),
+
   // Operator test-audio devices (PLAN-TestAudioDevices §3). Empty base URL is
   // the default and means the feature is off: the panel reads
   // `{ available: false, devices: [] }` at 200 and every mutation 503s, the
@@ -324,6 +334,9 @@ export class AppConfig {
       dbUser: this._env.DB_USER,
       dbPassword: this._env.DB_PASSWORD,
       redisUrl: this._env.REDIS_URL,
+      testAudioServiceKey: this._env.TEST_AUDIO_SERVICE_KEY,
+      grafanaBaseUrl: this._env.ADMIN_GRAFANA_BASE_URL,
+      prometheusBaseUrl: this._env.ADMIN_PROMETHEUS_BASE_URL,
       azureTenantId: this._env.AZURE_TENANT_ID,
       azureClientId: this._env.AZURE_CLIENT_ID,
       azureClientSecret: this._env.AZURE_CLIENT_SECRET,

--- a/apps/admin-server/src/server/features/config-check/config-check.service.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.service.ts
@@ -1,3 +1,7 @@
+import { Type } from 'typebox';
+import type { Static } from 'typebox';
+import { Value } from 'typebox/value';
+
 import {
   LATEST_MIGRATION,
   MIGRATION_TABLE,
@@ -88,23 +92,33 @@ const DOC = {
  * (unlike node-server/session-manager/transcription-service), the same
  * reasoning `_prometheusIsScrapingSidecar`'s local `TargetsResponse`
  * interface already follows for Prometheus's API.
+ *
+ * A runtime schema rather than a bare `interface` + cast, because this body
+ * crosses a version boundary: an older or newer sidecar can answer 200 with a
+ * shape this build does not know, and every field below is dereferenced
+ * unconditionally afterwards. `Value.Check` is what
+ * `NodeStatusPollerService._parseBody` already does one hop upstream for the
+ * same reason.
  */
-interface ConfigAuditResponse {
-  nodeServer:
-    | {
-        status: 'ok';
-        secretPlaceholders: {
-          sessionTokenSigningKeyIsPlaceholder: boolean;
-          sessionManagerServiceApiKeyIsPlaceholder: boolean;
-          nodeServerServiceApiKeyIsPlaceholder: boolean;
-          transcriptionServiceApiKeyIsPlaceholder: boolean;
-        };
-      }
-    | {
-        status: 'unavailable';
-        reason: string;
-      };
-}
+const CONFIG_AUDIT_RESPONSE_SCHEMA = Type.Object({
+  nodeServer: Type.Union([
+    Type.Object({
+      status: Type.Literal('ok'),
+      secretPlaceholders: Type.Object({
+        sessionTokenSigningKeyIsPlaceholder: Type.Boolean(),
+        sessionManagerServiceApiKeyIsPlaceholder: Type.Boolean(),
+        nodeServerServiceApiKeyIsPlaceholder: Type.Boolean(),
+        transcriptionServiceApiKeyIsPlaceholder: Type.Boolean(),
+      }),
+    }),
+    Type.Object({
+      status: Type.Literal('unavailable'),
+      reason: Type.String(),
+    }),
+  ]),
+});
+
+type ConfigAuditResponse = Static<typeof CONFIG_AUDIT_RESPONSE_SCHEMA>;
 
 export interface ConfigCheckReport {
   environment: DeploymentEnv;
@@ -560,6 +574,24 @@ export function evaluateStaticChecks(
   return findings;
 }
 
+/**
+ * Why a `_probe` call did not produce a usable answer, as a clause to drop
+ * into a finding's detail.
+ *
+ * Worth spelling out rather than assuming a timeout: `_probe` returns `null`
+ * for both an abort at `upstreamTimeoutMs` and an immediate connection/DNS
+ * failure — indistinguishable from its `catch`, hence the deliberately
+ * unspecific "did not answer" — but a non-`null` response that failed
+ * `.ok` is a service that answered promptly with an error status, which
+ * "did not answer within Nms" would describe simply wrongly, sending an
+ * operator looking for a network problem that isn't there.
+ */
+function probeFailure(response: Response | null, timeoutMs: number): string {
+  return response === null
+    ? `did not answer within ${String(timeoutMs)}ms`
+    : `answered HTTP ${String(response.status)}`;
+}
+
 /** True when the URL has a non-empty password component. */
 function redisUrlHasPassword(rawUrl: string): boolean {
   try {
@@ -814,7 +846,7 @@ export class ConfigCheckService {
             id: 'monitoring-prometheus-unreachable',
             category: 'monitoring',
             title: 'Prometheus is configured but unreachable',
-            detail: `ADMIN_PROMETHEUS_BASE_URL is set and /-/healthy did not answer within ${String(this._config.upstreamTimeoutMs)}ms. The monitoring compose profile may not be running.`,
+            detail: `ADMIN_PROMETHEUS_BASE_URL is set and /-/healthy ${probeFailure(health, this._config.upstreamTimeoutMs)}. The monitoring compose profile may not be running.`,
             remediation:
               'Check that COMPOSE_PROFILES includes monitoring in deployment/.env and that the prometheus container is up.',
             docUrl: DOC.monitoring,
@@ -903,7 +935,7 @@ export class ConfigCheckService {
             id: 'monitoring-grafana-unreachable',
             category: 'monitoring',
             title: 'Grafana is configured but unreachable',
-            detail: `ADMIN_GRAFANA_BASE_URL is set and /api/health did not answer within ${String(this._config.upstreamTimeoutMs)}ms. The monitoring compose profile may not be running.`,
+            detail: `ADMIN_GRAFANA_BASE_URL is set and /api/health ${probeFailure(health, this._config.upstreamTimeoutMs)}. The monitoring compose profile may not be running.`,
             remediation:
               'Check that COMPOSE_PROFILES includes monitoring in deployment/.env and that the grafana container is up.',
             docUrl: DOC.monitoring,
@@ -998,32 +1030,36 @@ export class ConfigCheckService {
 
     if (!response?.ok) {
       return unavailable(
-        `monitoring-sidecar's /api/monitoring/v1/config-audit did not answer within ${String(this._config.upstreamTimeoutMs)}ms. JWT_SECRET, NODE_SERVER_KEY, NODE_SERVER_SERVICE_KEY and TRANSCRIPTION_API_KEY could not be checked.`,
+        `monitoring-sidecar's /api/monitoring/v1/config-audit ${probeFailure(response, this._config.upstreamTimeoutMs)}. JWT_SECRET, NODE_SERVER_KEY, NODE_SERVER_SERVICE_KEY and TRANSCRIPTION_API_KEY could not be checked.`,
       );
     }
 
-    // One try/catch around parsing *and* reading the body: a malformed JSON
-    // payload and a 200 whose shape does not match `ConfigAuditResponse` (an
-    // older or newer sidecar) are the same "cannot currently vouch for this"
-    // case from a caller's point of view, and neither may throw uncaught out
-    // of a `Promise.all` member — that would 500 the whole report over one
-    // check that has its own dedicated unavailable state to report instead.
-    let body: ConfigAuditResponse;
+    // Parsing and shape-validating are both failures of the same kind from a
+    // caller's point of view — "the sidecar cannot currently vouch for this" —
+    // and neither may throw uncaught out of a `Promise.all` member, which
+    // would 500 the whole report over one check that has its own dedicated
+    // unavailable state to report instead. The shape check is `Value.Check`
+    // over the whole body rather than a `'nodeServer' in parsed` guard: the
+    // fields below are dereferenced unconditionally, so a partial match (a
+    // `nodeServer` with no `secretPlaceholders`, or a `secretPlaceholders`
+    // with no fields) would otherwise either throw here or, worse, read every
+    // flag as `undefined` and report a malformed sidecar as a clean deployment.
+    let parsed: unknown;
     try {
-      const parsed: unknown = await response.json();
-      if (
-        typeof parsed !== 'object' ||
-        parsed === null ||
-        !('nodeServer' in parsed)
-      ) {
-        throw new Error('unexpected /config-audit body shape');
-      }
-      body = parsed as ConfigAuditResponse;
+      parsed = await response.json();
     } catch {
       return unavailable(
         "monitoring-sidecar's /api/monitoring/v1/config-audit answered with a body Config Check could not parse.",
       );
     }
+
+    if (!Value.Check(CONFIG_AUDIT_RESPONSE_SCHEMA, parsed)) {
+      return unavailable(
+        "monitoring-sidecar's /api/monitoring/v1/config-audit answered with a body Config Check does not recognize — the sidecar may be a different version than admin-server. JWT_SECRET, NODE_SERVER_KEY, NODE_SERVER_SERVICE_KEY and TRANSCRIPTION_API_KEY could not be checked.",
+      );
+    }
+
+    const body: ConfigAuditResponse = parsed;
 
     if (body.nodeServer.status !== 'ok') {
       return unavailable(

--- a/apps/admin-server/src/server/features/config-check/config-check.service.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.service.ts
@@ -81,6 +81,31 @@ const DOC = {
   monitoring: `${WIKI}/Deployment#monitoring`,
 } as const;
 
+/**
+ * The shape of `GET /api/monitoring/v1/config-audit` on the monitoring
+ * sidecar (PLAN-ConfigCheck-Coverage Phase 2). Restated here rather than
+ * imported — the sidecar has no schema package other services depend on
+ * (unlike node-server/session-manager/transcription-service), the same
+ * reasoning `_prometheusIsScrapingSidecar`'s local `TargetsResponse`
+ * interface already follows for Prometheus's API.
+ */
+interface ConfigAuditResponse {
+  nodeServer:
+    | {
+        status: 'ok';
+        secretPlaceholders: {
+          sessionTokenSigningKeyIsPlaceholder: boolean;
+          sessionManagerServiceApiKeyIsPlaceholder: boolean;
+          nodeServerServiceApiKeyIsPlaceholder: boolean;
+          transcriptionServiceApiKeyIsPlaceholder: boolean;
+        };
+      }
+    | {
+        status: 'unavailable';
+        reason: string;
+      };
+}
+
 export interface ConfigCheckReport {
   environment: DeploymentEnv;
   /**
@@ -129,6 +154,18 @@ export interface ConfigCheckConfig {
   grafanaBaseUrl: string;
   /** Base URL of Prometheus, reached only over the backend network. Empty unless the `monitoring` compose profile is on. */
   prometheusBaseUrl: string;
+  /**
+   * Base URL of the monitoring sidecar, reached only over the backend
+   * network. Unlike `grafanaBaseUrl`/`prometheusBaseUrl` this is never empty
+   * in practice — the sidecar is a core service with no compose profile —
+   * used to read `/api/monitoring/v1/config-audit` (PLAN-ConfigCheck-Coverage
+   * Phase 2): node-server's self-reported classification of whether
+   * JWT_SECRET/NODE_SERVER_KEY/NODE_SERVER_SERVICE_KEY/TRANSCRIPTION_API_KEY
+   * are still placeholders, relayed through the sidecar because it already
+   * holds the key node-server's status endpoint requires and admin-server
+   * never needs to.
+   */
+  monitoringSidecarBaseUrl: string;
   azureTenantId: string;
   azureClientId: string;
   azureClientSecret: string;
@@ -586,12 +623,14 @@ export class ConfigCheckService {
     const { environment, environmentSource, declaredButInvalid } =
       resolveEnvironment(this._config);
 
-    const [telemetry, services, database, monitoring] = await Promise.all([
-      this._checkTelemetryBackplane(environment),
-      this._checkServiceReachability(environment),
-      this._checkDatabase(environment),
-      this._checkMonitoring(environment),
-    ]);
+    const [telemetry, services, database, monitoring, secretPlaceholders] =
+      await Promise.all([
+        this._checkTelemetryBackplane(environment),
+        this._checkServiceReachability(environment),
+        this._checkDatabase(environment),
+        this._checkMonitoring(environment),
+        this._checkSecretPlaceholders(environment),
+      ]);
 
     const findings = [
       ...evaluateStaticChecks(this._config, environment, declaredButInvalid),
@@ -599,6 +638,7 @@ export class ConfigCheckService {
       ...telemetry,
       ...services,
       ...monitoring,
+      ...secretPlaceholders,
     ];
 
     const summary: Record<CheckSeverity, number> = {
@@ -908,6 +948,145 @@ export class ConfigCheckService {
     }
 
     return findings;
+  }
+
+  /**
+   * Reads node-server's self-reported classification of the four secrets
+   * admin-server has no way to see directly — JWT_SECRET, NODE_SERVER_KEY,
+   * NODE_SERVER_SERVICE_KEY, TRANSCRIPTION_API_KEY (PLAN-ConfigCheck-Coverage
+   * Phase 2) — relayed through the monitoring sidecar's
+   * `/api/monitoring/v1/config-audit`, which already holds the key
+   * node-server's status endpoint requires. admin-server never receives (and
+   * does not need) any of these four secrets themselves — the same "probe,
+   * don't acquire" discipline `_checkGrafana`'s password check already
+   * follows.
+   *
+   * Unlike the Grafana/Prometheus checks above, this is never gated on an
+   * optional profile: the sidecar is a core service, and all four secrets are
+   * live in every deployment regardless of whether `monitoring` is on.
+   */
+  private async _checkSecretPlaceholders(
+    env: DeploymentEnv,
+  ): Promise<ConfigFinding[]> {
+    const response = await this._probe(
+      `${this._config.monitoringSidecarBaseUrl}/api/monitoring/v1/config-audit`,
+    );
+
+    const unavailable = (detail: string): ConfigFinding[] => [
+      finding(
+        {
+          id: 'secret-placeholder-audit-unavailable',
+          category: 'secrets',
+          title: 'Could not check node-server-held secrets for placeholders',
+          detail,
+          // Verified live: a placeholder NODE_SERVER_SERVICE_KEY produces
+          // exactly this finding, never `node-server-service-key-placeholder`
+          // — node-server's ServiceAuthService refuses to construct at all
+          // once its own inbound key contains CHANGEME (fails closed by
+          // design, so a misconfigured deployment fails loudly rather than
+          // serving telemetry to anyone), which means /status itself 500s
+          // before it can ever self-report on that specific key. Named here
+          // so an operator does not have to discover it by reading logs.
+          remediation:
+            "Check that monitoring-sidecar is running and reachable at monitoring-sidecar:80, and that its NODE_SERVER_SERVICE_API_KEY matches node-server's. If node-server is otherwise healthy, this can also mean NODE_SERVER_SERVICE_KEY itself is still the deployment/.env.example placeholder — node-server refuses to serve /status at all in that case, which this check cannot distinguish from an unrelated outage.",
+          docUrl: DOC.deployment,
+        },
+        { development: 'advisory', staging: 'warning', production: 'warning' },
+        env,
+      ),
+    ];
+
+    if (!response?.ok) {
+      return unavailable(
+        `monitoring-sidecar's /api/monitoring/v1/config-audit did not answer within ${String(this._config.upstreamTimeoutMs)}ms. JWT_SECRET, NODE_SERVER_KEY, NODE_SERVER_SERVICE_KEY and TRANSCRIPTION_API_KEY could not be checked.`,
+      );
+    }
+
+    // One try/catch around parsing *and* reading the body: a malformed JSON
+    // payload and a 200 whose shape does not match `ConfigAuditResponse` (an
+    // older or newer sidecar) are the same "cannot currently vouch for this"
+    // case from a caller's point of view, and neither may throw uncaught out
+    // of a `Promise.all` member — that would 500 the whole report over one
+    // check that has its own dedicated unavailable state to report instead.
+    let body: ConfigAuditResponse;
+    try {
+      const parsed: unknown = await response.json();
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        !('nodeServer' in parsed)
+      ) {
+        throw new Error('unexpected /config-audit body shape');
+      }
+      body = parsed as ConfigAuditResponse;
+    } catch {
+      return unavailable(
+        "monitoring-sidecar's /api/monitoring/v1/config-audit answered with a body Config Check could not parse.",
+      );
+    }
+
+    if (body.nodeServer.status !== 'ok') {
+      return unavailable(
+        `monitoring-sidecar reports node-server status "${body.nodeServer.reason}" — JWT_SECRET, NODE_SERVER_KEY, NODE_SERVER_SERVICE_KEY and TRANSCRIPTION_API_KEY could not be checked.`,
+      );
+    }
+
+    const sp = body.nodeServer.secretPlaceholders;
+    const checks: {
+      id: string;
+      flagged: boolean;
+      variable: string;
+      consequence: string;
+    }[] = [
+      {
+        id: 'jwt-secret-placeholder',
+        flagged: sp.sessionTokenSigningKeyIsPlaceholder,
+        variable: 'JWT_SECRET',
+        consequence: 'Every session token is forgeable.',
+      },
+      {
+        id: 'node-server-key-placeholder',
+        flagged: sp.sessionManagerServiceApiKeyIsPlaceholder,
+        variable: 'NODE_SERVER_KEY',
+        consequence:
+          'The shared service-to-service key between node-server and session-manager is public.',
+      },
+      {
+        id: 'node-server-service-key-placeholder',
+        flagged: sp.nodeServerServiceApiKeyIsPlaceholder,
+        variable: 'NODE_SERVER_SERVICE_KEY',
+        consequence:
+          "The key guarding node-server's own status endpoint — the one this very check reads through the sidecar — is public.",
+      },
+      {
+        id: 'transcription-api-key-placeholder',
+        flagged: sp.transcriptionServiceApiKeyIsPlaceholder,
+        variable: 'TRANSCRIPTION_API_KEY',
+        consequence:
+          'The shared key between node-server and transcription-service is public.',
+      },
+    ];
+
+    return checks
+      .filter((c) => c.flagged)
+      .map((c) =>
+        finding(
+          {
+            id: c.id,
+            category: 'secrets',
+            title: `${c.variable} is still the example placeholder`,
+            detail: `node-server reports ${c.variable} is still deployment/.env.example's CHANGEME placeholder. ${c.consequence}`,
+            remediation: `Set ${c.variable} in deployment/.env to a high-entropy secret and recreate node-server (and session-manager/transcription-service, which also hold it) — see deployment/UPGRADING.md.`,
+            docUrl: DOC.deployment,
+          },
+          {
+            development: 'advisory',
+            staging: 'critical',
+            production: 'critical',
+          },
+          env,
+        ),
+      );
   }
 
   /**

--- a/apps/admin-server/src/server/features/config-check/config-check.service.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.service.ts
@@ -25,7 +25,8 @@ export type CheckCategory =
   | 'access'
   | 'telemetry'
   | 'services'
-  | 'environment';
+  | 'environment'
+  | 'monitoring';
 
 /**
  * Severity of one finding in each environment.
@@ -77,6 +78,7 @@ const DOC = {
   postgres: `${WIKI}/Deployment#postgres`,
   migrations: `${WIKI}/Deployment#3-run-database-migrations`,
   redis: `${WIKI}/Deployment#redis`,
+  monitoring: `${WIKI}/Deployment#monitoring`,
 } as const;
 
 export interface ConfigCheckReport {
@@ -118,6 +120,15 @@ export interface ConfigCheckConfig {
   dbUser: string;
   dbPassword: string;
   redisUrl: string;
+  /** admin-server's inbound key for the test-audio generator (`TestAudioConfig.serviceKey`). */
+  testAudioServiceKey: string;
+  /**
+   * Base URL of Grafana, reached only over the backend network. Empty unless
+   * the `monitoring` compose profile is on — see `_checkMonitoring`.
+   */
+  grafanaBaseUrl: string;
+  /** Base URL of Prometheus, reached only over the backend network. Empty unless the `monitoring` compose profile is on. */
+  prometheusBaseUrl: string;
   azureTenantId: string;
   azureClientId: string;
   azureClientSecret: string;
@@ -280,6 +291,12 @@ export function evaluateStaticChecks(
       title: 'DB_PASSWORD is still the example placeholder',
       value: config.dbPassword,
       variable: 'DB_PASSWORD',
+    },
+    {
+      id: 'test-audio-service-key-placeholder',
+      title: 'TEST_AUDIO_SERVICE_KEY is still the example placeholder',
+      value: config.testAudioServiceKey,
+      variable: 'TEST_AUDIO_SERVICE_KEY',
     },
   ];
 
@@ -479,6 +496,28 @@ export function evaluateStaticChecks(
         env,
       ),
     );
+  } else if (redisUrlHasPlaceholderPassword(config.redisUrl)) {
+    findings.push(
+      finding(
+        {
+          id: 'redis-url-placeholder-password',
+          category: 'telemetry',
+          title:
+            'The telemetry Redis URL is still the example placeholder password',
+          detail:
+            "ADMIN_REDIS_URL's password is still the deployment/.env.example placeholder. Anyone who has read the repository knows this value.",
+          remediation:
+            'Set REDIS_PASSWORD in deployment/.env to a high-entropy secret, then update ADMIN_REDIS_URL (and NODE_SERVER_REDIS_URL/TRANSCRIPTION_REDIS_URL, if set) to match.',
+          docUrl: DOC.redis,
+        },
+        {
+          development: 'advisory',
+          staging: 'critical',
+          production: 'critical',
+        },
+        env,
+      ),
+    );
   }
 
   return findings;
@@ -493,6 +532,20 @@ function redisUrlHasPassword(rawUrl: string): boolean {
     // fail to connect; claiming "no password" here would be a second, worse
     // explanation of the same fact.
     return true;
+  }
+}
+
+/**
+ * True when the URL's password is still the `deployment/.env.example`
+ * placeholder — e.g. a copied `redis://:CHANGEME@redis:6379` where
+ * `REDIS_PASSWORD` was since changed but `ADMIN_REDIS_URL` was not.
+ */
+function redisUrlHasPlaceholderPassword(rawUrl: string): boolean {
+  try {
+    return isPlaceholder(new URL(rawUrl).password);
+  } catch {
+    // Unparseable. Reported separately by the reachability check.
+    return false;
   }
 }
 
@@ -533,10 +586,11 @@ export class ConfigCheckService {
     const { environment, environmentSource, declaredButInvalid } =
       resolveEnvironment(this._config);
 
-    const [telemetry, services, database] = await Promise.all([
+    const [telemetry, services, database, monitoring] = await Promise.all([
       this._checkTelemetryBackplane(environment),
       this._checkServiceReachability(environment),
       this._checkDatabase(environment),
+      this._checkMonitoring(environment),
     ]);
 
     const findings = [
@@ -544,6 +598,7 @@ export class ConfigCheckService {
       ...database,
       ...telemetry,
       ...services,
+      ...monitoring,
     ];
 
     const summary: Record<CheckSeverity, number> = {
@@ -628,6 +683,231 @@ export class ConfigCheckService {
         ),
       ];
     }
+  }
+
+  /**
+   * Is the `monitoring` compose profile (if the operator turned it on)
+   * actually working — Prometheus reachable and scraping its one target,
+   * Grafana reachable and its default password actually changed.
+   *
+   * Unlike most optional features on this page, an unset pair of base URLs is
+   * not treated as silent: a fleet-health dashboard is worth having in
+   * staging and production, so leaving it off is worth a nudge there (not in
+   * development, where a dashboard for a single throwaway container buys
+   * nothing). Reachability is gated on both `grafanaBaseUrl` and
+   * `prometheusBaseUrl` being set, since a deployment that never turns the
+   * profile on has neither container running, and probing them would report
+   * a false `unreachable` rather than the true fact.
+   *
+   * Each of Prometheus and Grafana is checked independently once configured:
+   * an operator who only wired one of the two base URLs (unusual, but not
+   * invalid) still gets a report on whichever one they configured.
+   */
+  private async _checkMonitoring(env: DeploymentEnv): Promise<ConfigFinding[]> {
+    const { grafanaBaseUrl, prometheusBaseUrl } = this._config;
+
+    if (grafanaBaseUrl === '' && prometheusBaseUrl === '') {
+      return [
+        finding(
+          {
+            id: 'monitoring-not-configured',
+            category: 'monitoring',
+            title: 'The fleet-health dashboard is not set up',
+            detail:
+              'ADMIN_GRAFANA_BASE_URL and ADMIN_PROMETHEUS_BASE_URL are both unset, so Config Check cannot see whether the monitoring compose profile is on, and there is no dashboard for evaluators or on-call staff to check.',
+            remediation:
+              'Add monitoring to COMPOSE_PROFILES in deployment/.env, then set ADMIN_GRAFANA_BASE_URL and ADMIN_PROMETHEUS_BASE_URL — see deployment/monitoring/README.md.',
+            docUrl: DOC.monitoring,
+          },
+          {
+            development: 'advisory',
+            staging: 'warning',
+            production: 'warning',
+          },
+          env,
+        ),
+      ];
+    }
+
+    const [prometheus, grafana] = await Promise.all([
+      prometheusBaseUrl === ''
+        ? Promise.resolve([])
+        : this._checkPrometheus(prometheusBaseUrl, env),
+      grafanaBaseUrl === ''
+        ? Promise.resolve([])
+        : this._checkGrafana(grafanaBaseUrl, env),
+    ]);
+
+    return [...prometheus, ...grafana];
+  }
+
+  /** `fetch` with the shared upstream timeout, `null` on any failure to answer at all. */
+  private async _probe(
+    url: string,
+    init?: RequestInit,
+  ): Promise<Response | null> {
+    try {
+      return await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(this._config.upstreamTimeoutMs),
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Reachable, and scraping the one target it is configured to scrape
+   * (`deployment/monitoring/prometheus.yml`'s `scribear_sidecar` job).
+   * Short-circuited like `_checkDatabase`: an unreachable Prometheus cannot
+   * meaningfully be asked what it is scraping.
+   */
+  private async _checkPrometheus(
+    baseUrl: string,
+    env: DeploymentEnv,
+  ): Promise<ConfigFinding[]> {
+    const health = await this._probe(`${baseUrl}/-/healthy`);
+    if (!health?.ok) {
+      return [
+        finding(
+          {
+            id: 'monitoring-prometheus-unreachable',
+            category: 'monitoring',
+            title: 'Prometheus is configured but unreachable',
+            detail: `ADMIN_PROMETHEUS_BASE_URL is set and /-/healthy did not answer within ${String(this._config.upstreamTimeoutMs)}ms. The monitoring compose profile may not be running.`,
+            remediation:
+              'Check that COMPOSE_PROFILES includes monitoring in deployment/.env and that the prometheus container is up.',
+            docUrl: DOC.monitoring,
+          },
+          {
+            development: 'advisory',
+            staging: 'warning',
+            production: 'warning',
+          },
+          env,
+        ),
+      ];
+    }
+
+    if (await this._prometheusIsScrapingSidecar(baseUrl)) return [];
+
+    return [
+      finding(
+        {
+          id: 'monitoring-prometheus-not-scraping',
+          category: 'monitoring',
+          title: 'Prometheus is up but not scraping the fleet sidecar',
+          detail:
+            "Prometheus answered /-/healthy, but its scribear_sidecar scrape target is missing or not up. The Grafana fleet dashboard's data source will be empty.",
+          remediation:
+            'Check monitoring-sidecar is running and reachable at monitoring-sidecar:80, and that deployment/monitoring/prometheus.yml was not edited to remove the target.',
+          docUrl: DOC.monitoring,
+        },
+        { development: 'advisory', staging: 'warning', production: 'warning' },
+        env,
+      ),
+    ];
+  }
+
+  private async _prometheusIsScrapingSidecar(
+    baseUrl: string,
+  ): Promise<boolean> {
+    const response = await this._probe(`${baseUrl}/api/v1/targets`);
+    if (!response?.ok) return false;
+
+    interface TargetsResponse {
+      data?: {
+        activeTargets?: { labels?: { job?: string }; health?: string }[];
+      };
+    }
+
+    try {
+      const body = (await response.json()) as TargetsResponse;
+      return (body.data?.activeTargets ?? []).some(
+        (t) => t.labels?.job === 'scribear_sidecar' && t.health === 'up',
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Reachable, and no longer answering to the well-known default admin
+   * password.
+   *
+   * No dashboard-provisioning check here, deliberately: Grafana's dashboard
+   * API (`/api/dashboards/uid/...`) requires authentication, same as every
+   * other route past `/api/health`, and admin-server holds no real Grafana
+   * credential to check it with (see the class doc — that is the whole
+   * point). The only credential this check is allowed to try is the
+   * well-known default, which by construction only succeeds on exactly the
+   * deployments that have *not* changed it — so a dashboard check built on it
+   * would read "missing" on every properly-secured deployment, a guaranteed
+   * false positive on the good case. Verified live: the earlier version of
+   * this check did exactly that.
+   *
+   * The password check needs no secret at all — it always attempts exactly
+   * `admin`/`CHANGEME` over HTTP Basic auth against an authenticated route and
+   * reports whether that succeeded, so admin-server never receives (and does
+   * not need) `GRAFANA_ADMIN_PASSWORD` itself.
+   */
+  private async _checkGrafana(
+    baseUrl: string,
+    env: DeploymentEnv,
+  ): Promise<ConfigFinding[]> {
+    const health = await this._probe(`${baseUrl}/api/health`);
+    if (!health?.ok) {
+      return [
+        finding(
+          {
+            id: 'monitoring-grafana-unreachable',
+            category: 'monitoring',
+            title: 'Grafana is configured but unreachable',
+            detail: `ADMIN_GRAFANA_BASE_URL is set and /api/health did not answer within ${String(this._config.upstreamTimeoutMs)}ms. The monitoring compose profile may not be running.`,
+            remediation:
+              'Check that COMPOSE_PROFILES includes monitoring in deployment/.env and that the grafana container is up.',
+            docUrl: DOC.monitoring,
+          },
+          {
+            development: 'advisory',
+            staging: 'warning',
+            production: 'warning',
+          },
+          env,
+        ),
+      ];
+    }
+
+    const findings: ConfigFinding[] = [];
+
+    const credentials = Buffer.from('admin:CHANGEME').toString('base64');
+    const login = await this._probe(`${baseUrl}/api/org`, {
+      headers: { Authorization: `Basic ${credentials}` },
+    });
+    if (login?.ok) {
+      findings.push(
+        finding(
+          {
+            id: 'monitoring-grafana-default-password',
+            category: 'monitoring',
+            title: 'Grafana admin password is still the example placeholder',
+            detail:
+              'Grafana accepted admin/CHANGEME, the deployment/.env.example placeholder. Anyone who has read the repository can sign in to Grafana as an administrator.',
+            remediation:
+              'Set GRAFANA_ADMIN_PASSWORD in deployment/.env to a high-entropy secret and recreate the grafana container — its admin password is set from GF_SECURITY_ADMIN_PASSWORD only on first start.',
+            docUrl: DOC.monitoring,
+          },
+          {
+            development: 'advisory',
+            staging: 'critical',
+            production: 'critical',
+          },
+          env,
+        ),
+      );
+    }
+
+    return findings;
   }
 
   /**

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
@@ -50,7 +50,7 @@ export interface ContainerVersion {
  * version.test.ts` fails if the two ever disagree, or if that file changes
  * without someone having made that call.
  */
-export const EXPECTED_COMPOSE_FILE_VERSION = 5;
+export const EXPECTED_COMPOSE_FILE_VERSION = 6;
 
 /**
  * How the running `compose.yml` compares to the one this image was built for.

--- a/apps/admin-server/tests/integration/config-check.routes.test.ts
+++ b/apps/admin-server/tests/integration/config-check.routes.test.ts
@@ -72,13 +72,14 @@ describe('Config check route', () => {
       expect(body.data.environmentSource).toBe('explicit');
     });
 
-    // Two findings, and both are properties of this fixture rather than of the
-    // configuration: telemetry is switched off above, and the test database is a
-    // plain Postgres carrying only admin-server's own audit tables — the shared
-    // schema `infra/scribear-db` owns has deliberately never been migrated here,
-    // since applying it would mean building that image (pg_cron, pg_trgm) to
-    // test a route that has nothing to do with it.
-    it('reports the telemetry advisory and the unmigrated shared schema', async () => {
+    // Three findings, and all are properties of this fixture rather than of
+    // the configuration: telemetry is switched off above, the monitoring
+    // profile's base URLs are unset by default (`buildTestAppConfig`), and the
+    // test database is a plain Postgres carrying only admin-server's own audit
+    // tables — the shared schema `infra/scribear-db` owns has deliberately
+    // never been migrated here, since applying it would mean building that
+    // image (pg_cron, pg_trgm) to test a route that has nothing to do with it.
+    it('reports the telemetry and monitoring advisories and the unmigrated shared schema', async () => {
       const res = await server.fastify.inject({
         method: 'GET',
         url: URL,
@@ -87,7 +88,11 @@ describe('Config check route', () => {
 
       expect(
         res.json<ConfigCheckBody>().data.findings.map((f) => f.id),
-      ).toEqual(['fleet-telemetry-disabled', 'schema-never-migrated']);
+      ).toEqual([
+        'fleet-telemetry-disabled',
+        'schema-never-migrated',
+        'monitoring-not-configured',
+      ]);
     });
 
     it('states the schema finding with a fix and a wiki link', async () => {

--- a/apps/admin-server/tests/integration/config-check.routes.test.ts
+++ b/apps/admin-server/tests/integration/config-check.routes.test.ts
@@ -2,12 +2,28 @@ import { afterEach, beforeAll, beforeEach, describe, expect, vi } from 'vitest';
 
 import type { ConfigCheckReport } from '#src/server/features/config-check/config-check.service.js';
 import {
+  TEST_MONITORING_SIDECAR_BASE_URL,
   TEST_NODE_BASE_URL,
   TEST_SM_BASE_URL,
   TEST_TS_BASE_URL,
   login,
   useServer,
 } from '#tests/utils/use-server.js';
+
+const CONFIG_AUDIT_URL = `${TEST_MONITORING_SIDECAR_BASE_URL}/api/monitoring/v1/config-audit`;
+
+/** node-server reports every secret fine - the default unless a test spoils it. */
+const CONFIG_AUDIT_CLEAN = {
+  nodeServer: {
+    status: 'ok',
+    secretPlaceholders: {
+      sessionTokenSigningKeyIsPlaceholder: false,
+      sessionManagerServiceApiKeyIsPlaceholder: false,
+      nodeServerServiceApiKeyIsPlaceholder: false,
+      transcriptionServiceApiKeyIsPlaceholder: false,
+    },
+  },
+};
 
 const URL = '/api/admin/v1/config-check';
 
@@ -30,8 +46,19 @@ describe('Config check route', () => {
 
   beforeEach(() => {
     // Every probed service answers healthy, so `services-unreachable` stays
-    // quiet unless a test wants it.
+    // quiet unless a test wants it. The sidecar's `/config-audit` gets its
+    // own body - `_checkSecretPlaceholders` is unconditional (the sidecar has
+    // no compose profile to be "off" behind), so every test in this file
+    // needs an answer for it, not just the ones that care about Phase 2.
     vi.stubGlobal('fetch', (url: string) => {
+      if (url.startsWith(CONFIG_AUDIT_URL)) {
+        return Promise.resolve(
+          new Response(JSON.stringify(CONFIG_AUDIT_CLEAN), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
       const known = [TEST_SM_BASE_URL, TEST_NODE_BASE_URL, TEST_TS_BASE_URL];
       if (!known.some((base) => url.startsWith(base))) {
         return Promise.reject(new Error('connect ECONNREFUSED'));
@@ -162,6 +189,74 @@ describe('Config check route', () => {
       });
 
       expect(res.body).not.toContain('test-db-password');
+    });
+  });
+
+  describe('a secret only node-server can see (PLAN-ConfigCheck-Coverage Phase 2)', (it) => {
+    it('is reported as critical when node-server flags it via the sidecar', async () => {
+      vi.stubGlobal('fetch', (url: string) => {
+        if (url.startsWith(CONFIG_AUDIT_URL)) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                nodeServer: {
+                  status: 'ok',
+                  secretPlaceholders: {
+                    sessionTokenSigningKeyIsPlaceholder: true,
+                    sessionManagerServiceApiKeyIsPlaceholder: false,
+                    nodeServerServiceApiKeyIsPlaceholder: false,
+                    transcriptionServiceApiKeyIsPlaceholder: false,
+                  },
+                },
+              }),
+              { status: 200, headers: { 'content-type': 'application/json' } },
+            ),
+          );
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ status: 'ok' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      });
+
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: URL,
+        headers: { cookie },
+      });
+
+      const { data } = res.json<ConfigCheckBody>();
+      const found = data.findings.find(
+        (f) => f.id === 'jwt-secret-placeholder',
+      );
+      expect(found?.severity).toBe('critical');
+      expect(data.blockingForProduction).toBeGreaterThanOrEqual(1);
+    });
+
+    it('reports unavailable rather than silence when the sidecar cannot answer', async () => {
+      vi.stubGlobal('fetch', (url: string) => {
+        if (url.startsWith(CONFIG_AUDIT_URL)) {
+          return Promise.reject(new Error('connect ECONNREFUSED'));
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ status: 'ok' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      });
+
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: URL,
+        headers: { cookie },
+      });
+
+      expect(
+        res.json<ConfigCheckBody>().data.findings.map((f) => f.id),
+      ).toContain('secret-placeholder-audit-unavailable');
     });
   });
 });

--- a/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
+++ b/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, vi } from 'vitest';
+import { afterEach, describe, expect, vi } from 'vitest';
 
 import {
   LATEST_MIGRATION,
@@ -25,6 +25,11 @@ const CLEAN: ConfigCheckConfig = {
   dbUser: 'scribear',
   dbPassword: 'e2b7d94a1c60f38b',
   redisUrl: 'redis://:5c9e1a7f3d824b60@redis:6379',
+  testAudioServiceKey: 'c3f8a2e91d5b7064af0e9d3c7b1a5e82',
+  // Off by default, like a deployment that never turns on the monitoring
+  // profile. `monitoringService` below turns it on with its own overrides.
+  grafanaBaseUrl: '',
+  prometheusBaseUrl: '',
   azureTenantId: 'tenant-1',
   azureClientId: 'client-1',
   azureClientSecret: '0b4e8d2a7f16c395',
@@ -155,6 +160,83 @@ async function healthIds(components: HealthComponentLike[]): Promise<string[]> {
   return report.findings.map((f) => f.id);
 }
 
+const PROMETHEUS_TEST_URL = 'http://prometheus.test';
+const GRAFANA_TEST_URL = 'http://grafana.test';
+
+/** One stubbed HTTP answer, or a network failure, keyed by URL prefix. */
+type ProbeAnswers = Record<
+  string,
+  { status: number; body?: unknown } | 'network-error'
+>;
+
+/**
+ * Everything reachable and healthy: both healthy endpoints answer, the
+ * sidecar scrape target is up, and the default password is rejected. Each
+ * monitoring test overrides exactly the one answer it cares about.
+ */
+const MONITORING_HEALTHY: ProbeAnswers = {
+  [`${PROMETHEUS_TEST_URL}/-/healthy`]: { status: 200 },
+  [`${PROMETHEUS_TEST_URL}/api/v1/targets`]: {
+    status: 200,
+    body: {
+      data: {
+        activeTargets: [{ labels: { job: 'scribear_sidecar' }, health: 'up' }],
+      },
+    },
+  },
+  [`${GRAFANA_TEST_URL}/api/health`]: { status: 200 },
+  // The real check: a probe that always tries admin/CHANGEME and nothing
+  // else. Rejected here, since the "healthy" baseline models a deployment
+  // that already changed the default password.
+  [`${GRAFANA_TEST_URL}/api/org`]: { status: 401 },
+};
+
+function stubProbes(answers: ProbeAnswers) {
+  vi.stubGlobal('fetch', (url: string) => {
+    const match = Object.keys(answers).find((base) => url.startsWith(base));
+    const answer = match === undefined ? undefined : answers[match];
+    if (answer === undefined || answer === 'network-error') {
+      return Promise.reject(new Error('connect ECONNREFUSED'));
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(answer.body ?? {}), {
+        status: answer.status,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+  });
+}
+
+/**
+ * A `ConfigCheckService` with both monitoring base URLs wired to the stubbed
+ * `fetch` above, and every other dependency healthy, so `check()`'s findings
+ * are exactly what `_checkMonitoring` produced.
+ */
+function monitoringService(
+  overrides: Partial<ConfigCheckConfig> = {},
+): ConfigCheckService {
+  type Args = ConstructorParameters<typeof ConfigCheckService>;
+  return new ConfigCheckService(
+    {
+      ...CLEAN,
+      grafanaBaseUrl: GRAFANA_TEST_URL,
+      prometheusBaseUrl: PROMETHEUS_TEST_URL,
+      ...overrides,
+    },
+    { enabled: false } as unknown as Args[1],
+    { check: () => Promise.resolve([]) } as unknown as Args[2],
+    REACHABLE_DB as unknown as Args[3],
+    gateway(LATEST_MIGRATION) as unknown as Args[4],
+  );
+}
+
+async function monitoringIds(
+  overrides: Partial<ConfigCheckConfig> = {},
+): Promise<string[]> {
+  const report = await monitoringService(overrides).check();
+  return report.findings.map((f) => f.id);
+}
+
 describe('resolveEnvironment', () => {
   describe('an explicit value', (it) => {
     it.each(['development', 'staging', 'production'] as const)(
@@ -233,6 +315,7 @@ describe('evaluateStaticChecks', () => {
       ['adminApiKey', 'admin-api-key-placeholder'],
       ['adminSessionSecret', 'admin-session-secret-placeholder'],
       ['dbPassword', 'db-password-placeholder'],
+      ['testAudioServiceKey', 'test-audio-service-key-placeholder'],
     ] as const)('are caught for %s', (field, expectedId) => {
       expect(ids({ [field]: 'CHANGEME' })).toContain(expectedId);
     });
@@ -362,6 +445,24 @@ describe('evaluateStaticChecks', () => {
         'redis-url-no-password',
       );
     });
+
+    // The realistic mistake: REDIS_PASSWORD was changed but the copied
+    // `redis://:CHANGEME@redis:6379` example from .env.example was not.
+    it('flags a Redis URL whose password is still the placeholder', () => {
+      expect(ids({ redisUrl: 'redis://:CHANGEME@redis:6379' })).toContain(
+        'redis-url-placeholder-password',
+      );
+    });
+
+    it('does not flag a real password as a placeholder', () => {
+      expect(ids()).not.toContain('redis-url-placeholder-password');
+    });
+
+    it('does not also claim an unparseable URL has a placeholder password', () => {
+      expect(ids({ redisUrl: 'not-a-url' })).not.toContain(
+        'redis-url-placeholder-password',
+      );
+    });
   });
 
   describe('the --dev flag', (it) => {
@@ -395,6 +496,7 @@ describe('evaluateStaticChecks', () => {
         adminLocalCredentials: 'engrit CHANGEME',
         dbPassword: 'CHANGEME',
         redisUrl: 'redis://:sup3rs3cr3tp4ss@redis:6379',
+        testAudioServiceKey: 'CHANGEME',
         allowedGroup: '',
       };
       const { environment, declaredButInvalid } = resolveEnvironment(spoiled);
@@ -406,6 +508,7 @@ describe('evaluateStaticChecks', () => {
         CLEAN.adminApiKey,
         CLEAN.adminSessionSecret,
         CLEAN.dbPassword,
+        CLEAN.testAudioServiceKey,
         'sup3rs3cr3tp4ss',
         '4f9a2c7e1b83d05a',
       ]) {
@@ -761,5 +864,212 @@ describe('the service health rollup', (it) => {
     expect(found).not.toContain('services-unreachable');
     expect(found).not.toContain('services-failing');
     expect(found).not.toContain('services-degraded');
+  });
+});
+
+describe('the monitoring probes', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('neither base URL configured', (it) => {
+    it('reports the dashboard as not set up, not silence', async () => {
+      stubProbes(MONITORING_HEALTHY);
+      const report = await monitoringService({
+        grafanaBaseUrl: '',
+        prometheusBaseUrl: '',
+      }).check();
+
+      const found = report.findings.find(
+        (f) => f.id === 'monitoring-not-configured',
+      );
+      expect(found).toBeTruthy();
+      // Not development: a dashboard for a single throwaway container buys
+      // nothing there, but staging/production is a warning, not silence.
+      expect(found?.severity).toBe('warning');
+    });
+
+    it('is only advisory in development', async () => {
+      const report = await monitoringService({
+        grafanaBaseUrl: '',
+        prometheusBaseUrl: '',
+        declaredEnv: 'development',
+      }).check();
+
+      const found = report.findings.find(
+        (f) => f.id === 'monitoring-not-configured',
+      );
+      expect(found?.severity).toBe('advisory');
+    });
+
+    it('probes nothing over the network', async () => {
+      vi.stubGlobal('fetch', () => {
+        throw new Error('unexpected fetch when monitoring is unconfigured');
+      });
+
+      await expect(
+        monitoringService({
+          grafanaBaseUrl: '',
+          prometheusBaseUrl: '',
+        }).check(),
+      ).resolves.toBeTruthy();
+    });
+  });
+
+  describe('both base URLs configured and healthy', (it) => {
+    it('reports nothing', async () => {
+      stubProbes(MONITORING_HEALTHY);
+      const found = await monitoringIds();
+      expect(found.filter((id) => id.startsWith('monitoring-'))).toEqual([]);
+    });
+  });
+
+  describe('Prometheus', (it) => {
+    it('reports unreachable when /-/healthy does not answer', async () => {
+      stubProbes({
+        ...MONITORING_HEALTHY,
+        [`${PROMETHEUS_TEST_URL}/-/healthy`]: 'network-error',
+      });
+      expect(await monitoringIds()).toContain(
+        'monitoring-prometheus-unreachable',
+      );
+    });
+
+    it('reports not-scraping when the sidecar target is missing', async () => {
+      stubProbes({
+        ...MONITORING_HEALTHY,
+        [`${PROMETHEUS_TEST_URL}/api/v1/targets`]: {
+          status: 200,
+          body: { data: { activeTargets: [] } },
+        },
+      });
+      const found = await monitoringIds();
+      expect(found).toContain('monitoring-prometheus-not-scraping');
+      expect(found).not.toContain('monitoring-prometheus-unreachable');
+    });
+
+    it('reports not-scraping when the target is down rather than up', async () => {
+      stubProbes({
+        ...MONITORING_HEALTHY,
+        [`${PROMETHEUS_TEST_URL}/api/v1/targets`]: {
+          status: 200,
+          body: {
+            data: {
+              activeTargets: [
+                { labels: { job: 'scribear_sidecar' }, health: 'down' },
+              ],
+            },
+          },
+        },
+      });
+      expect(await monitoringIds()).toContain(
+        'monitoring-prometheus-not-scraping',
+      );
+    });
+
+    it('does not also ask about targets when unreachable', async () => {
+      // Short-circuited like `_checkDatabase`: an unreachable Prometheus
+      // cannot meaningfully be asked what it is scraping.
+      stubProbes({
+        [`${PROMETHEUS_TEST_URL}/-/healthy`]: 'network-error',
+        [`${GRAFANA_TEST_URL}/api/health`]: { status: 200 },
+        [`${GRAFANA_TEST_URL}/api/org`]: { status: 401 },
+      });
+      const found = await monitoringIds();
+      expect(found).toContain('monitoring-prometheus-unreachable');
+      expect(found).not.toContain('monitoring-prometheus-not-scraping');
+    });
+  });
+
+  describe('Grafana', (it) => {
+    it('reports unreachable when /api/health does not answer', async () => {
+      stubProbes({
+        ...MONITORING_HEALTHY,
+        [`${GRAFANA_TEST_URL}/api/health`]: 'network-error',
+      });
+      expect(await monitoringIds()).toContain('monitoring-grafana-unreachable');
+    });
+
+    it('does not also probe the password when unreachable', async () => {
+      stubProbes({
+        [`${PROMETHEUS_TEST_URL}/-/healthy`]: { status: 200 },
+        [`${PROMETHEUS_TEST_URL}/api/v1/targets`]: MONITORING_HEALTHY[
+          `${PROMETHEUS_TEST_URL}/api/v1/targets`
+        ] as { status: number; body?: unknown },
+        [`${GRAFANA_TEST_URL}/api/health`]: 'network-error',
+      });
+      const found = await monitoringIds();
+      expect(found).toContain('monitoring-grafana-unreachable');
+      expect(found).not.toContain('monitoring-grafana-default-password');
+    });
+
+    describe('the default-password probe', (it) => {
+      it('fires critical in staging/production when admin/CHANGEME is accepted', async () => {
+        stubProbes({
+          ...MONITORING_HEALTHY,
+          [`${GRAFANA_TEST_URL}/api/org`]: { status: 200 },
+        });
+        const report = await monitoringService().check();
+        const found = report.findings.find(
+          (f) => f.id === 'monitoring-grafana-default-password',
+        );
+        expect(found).toBeTruthy();
+        expect(found?.severity).toBe('critical');
+      });
+
+      it('does not fire when the credentials are rejected', async () => {
+        // MONITORING_HEALTHY already answers 401 to admin/CHANGEME, modelling
+        // a deployment that changed the default password.
+        stubProbes(MONITORING_HEALTHY);
+        expect(await monitoringIds()).not.toContain(
+          'monitoring-grafana-default-password',
+        );
+      });
+
+      it('sends exactly admin/CHANGEME over HTTP Basic auth, and nothing else', async () => {
+        let sawAuthHeader: string | null = null;
+        vi.stubGlobal('fetch', (url: string, init?: RequestInit) => {
+          if (url.startsWith(`${GRAFANA_TEST_URL}/api/org`)) {
+            const headers = new Headers(init?.headers);
+            sawAuthHeader = headers.get('authorization');
+            return Promise.resolve(new Response(null, { status: 401 }));
+          }
+          const match = Object.keys(MONITORING_HEALTHY).find((base) =>
+            url.startsWith(base),
+          );
+          const answer =
+            match === undefined ? undefined : MONITORING_HEALTHY[match];
+          if (answer === undefined || answer === 'network-error') {
+            return Promise.reject(new Error('connect ECONNREFUSED'));
+          }
+          return Promise.resolve(
+            new Response(JSON.stringify(answer.body ?? {}), {
+              status: answer.status,
+            }),
+          );
+        });
+
+        await monitoringService().check();
+
+        expect(sawAuthHeader).toBe(
+          `Basic ${Buffer.from('admin:CHANGEME').toString('base64')}`,
+        );
+      });
+    });
+  });
+
+  describe('a deployment that only wires one of the two base URLs', (it) => {
+    it('still reports on the one it configured', async () => {
+      stubProbes({
+        [`${GRAFANA_TEST_URL}/api/health`]: 'network-error',
+      });
+      const found = await monitoringIds({ prometheusBaseUrl: '' });
+
+      expect(found).toContain('monitoring-grafana-unreachable');
+      expect(found).not.toContain('monitoring-not-configured');
+      expect(found.some((id) => id.startsWith('monitoring-prometheus-'))).toBe(
+        false,
+      );
+    });
   });
 });

--- a/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
+++ b/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 
 import {
   LATEST_MIGRATION,
@@ -12,6 +12,16 @@ import {
   evaluateStaticChecks,
   resolveEnvironment,
 } from '#src/server/features/config-check/config-check.service.js';
+
+/**
+ * The sidecar is a core service with no compose profile, unlike Grafana/
+ * Prometheus, so — unlike `grafanaBaseUrl`/`prometheusBaseUrl` below — `CLEAN`
+ * gives it a real (test) URL rather than leaving it unset. The top-level
+ * `beforeEach` near the bottom of this file stubs every test's `fetch` to
+ * answer it cleanly by default, so `_checkSecretPlaceholders` fires no
+ * findings for a test that does not care about it.
+ */
+const SIDECAR_TEST_URL = 'http://monitoring-sidecar.test';
 
 /** A deployment with nothing wrong with it. Each test spoils one thing. */
 const CLEAN: ConfigCheckConfig = {
@@ -30,6 +40,7 @@ const CLEAN: ConfigCheckConfig = {
   // profile. `monitoringService` below turns it on with its own overrides.
   grafanaBaseUrl: '',
   prometheusBaseUrl: '',
+  monitoringSidecarBaseUrl: SIDECAR_TEST_URL,
   azureTenantId: 'tenant-1',
   azureClientId: 'client-1',
   azureClientSecret: '0b4e8d2a7f16c395',
@@ -162,6 +173,7 @@ async function healthIds(components: HealthComponentLike[]): Promise<string[]> {
 
 const PROMETHEUS_TEST_URL = 'http://prometheus.test';
 const GRAFANA_TEST_URL = 'http://grafana.test';
+const CONFIG_AUDIT_URL = `${SIDECAR_TEST_URL}/api/monitoring/v1/config-audit`;
 
 /** One stubbed HTTP answer, or a network failure, keyed by URL prefix. */
 type ProbeAnswers = Record<
@@ -170,9 +182,30 @@ type ProbeAnswers = Record<
 >;
 
 /**
- * Everything reachable and healthy: both healthy endpoints answer, the
- * sidecar scrape target is up, and the default password is rejected. Each
- * monitoring test overrides exactly the one answer it cares about.
+ * node-server reports every secret fine — the default `/config-audit` answer
+ * everywhere except the `secret placeholders` describe below, which overrides
+ * it to explore every other shape.
+ */
+const CONFIG_AUDIT_HEALTHY: { status: number; body: unknown } = {
+  status: 200,
+  body: {
+    nodeServer: {
+      status: 'ok',
+      secretPlaceholders: {
+        sessionTokenSigningKeyIsPlaceholder: false,
+        sessionManagerServiceApiKeyIsPlaceholder: false,
+        nodeServerServiceApiKeyIsPlaceholder: false,
+        transcriptionServiceApiKeyIsPlaceholder: false,
+      },
+    },
+  },
+};
+
+/**
+ * Everything reachable and healthy: both monitoring endpoints answer, the
+ * sidecar scrape target is up, the default Grafana password is rejected, and
+ * node-server's secret audit comes back clean. Each monitoring test overrides
+ * exactly the one answer it cares about.
  */
 const MONITORING_HEALTHY: ProbeAnswers = {
   [`${PROMETHEUS_TEST_URL}/-/healthy`]: { status: 200 },
@@ -189,6 +222,7 @@ const MONITORING_HEALTHY: ProbeAnswers = {
   // else. Rejected here, since the "healthy" baseline models a deployment
   // that already changed the default password.
   [`${GRAFANA_TEST_URL}/api/org`]: { status: 401 },
+  [CONFIG_AUDIT_URL]: CONFIG_AUDIT_HEALTHY,
 };
 
 function stubProbes(answers: ProbeAnswers) {
@@ -206,6 +240,24 @@ function stubProbes(answers: ProbeAnswers) {
     );
   });
 }
+
+/**
+ * Every `.check()`-calling test needs a `/config-audit` answer regardless of
+ * whether it cares about Phase 2 secrets — `_checkSecretPlaceholders` is
+ * unconditional, unlike the Grafana/Prometheus probes above, since the
+ * sidecar is a core service rather than behind the optional `monitoring`
+ * profile. This keeps `dbService`/`healthService`-based tests hermetic
+ * without every one of them having to know that. Tests that care about this
+ * check (or about Grafana/Prometheus) call `stubProbes` themselves, which
+ * replaces this default outright.
+ */
+beforeEach(() => {
+  stubProbes({ [CONFIG_AUDIT_URL]: CONFIG_AUDIT_HEALTHY });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 /**
  * A `ConfigCheckService` with both monitoring base URLs wired to the stubbed
@@ -1071,5 +1123,146 @@ describe('the monitoring probes', () => {
         false,
       );
     });
+  });
+});
+
+describe('secret placeholders (PLAN-ConfigCheck-Coverage Phase 2)', (it) => {
+  it('reports nothing when node-server says every secret is fine', async () => {
+    // Arrange - the top-level `beforeEach` already stubs this cleanly;
+    // asserted explicitly here as the baseline the rest of this block spoils.
+    const found = await monitoringIds();
+
+    expect(found.some((id) => id.endsWith('-placeholder'))).toBe(false);
+  });
+
+  it.each([
+    [
+      'sessionTokenSigningKeyIsPlaceholder',
+      'jwt-secret-placeholder',
+      'JWT_SECRET',
+    ],
+    [
+      'sessionManagerServiceApiKeyIsPlaceholder',
+      'node-server-key-placeholder',
+      'NODE_SERVER_KEY',
+    ],
+    [
+      'nodeServerServiceApiKeyIsPlaceholder',
+      'node-server-service-key-placeholder',
+      'NODE_SERVER_SERVICE_KEY',
+    ],
+    [
+      'transcriptionServiceApiKeyIsPlaceholder',
+      'transcription-api-key-placeholder',
+      'TRANSCRIPTION_API_KEY',
+    ],
+  ] as const)(
+    'flags %s as %s, critical in production',
+    async (field, expectedId, variable) => {
+      stubProbes({
+        [CONFIG_AUDIT_URL]: {
+          status: 200,
+          body: {
+            nodeServer: {
+              status: 'ok',
+              secretPlaceholders: {
+                sessionTokenSigningKeyIsPlaceholder: false,
+                sessionManagerServiceApiKeyIsPlaceholder: false,
+                nodeServerServiceApiKeyIsPlaceholder: false,
+                transcriptionServiceApiKeyIsPlaceholder: false,
+                [field]: true,
+              },
+            },
+          },
+        },
+      });
+
+      const report = await monitoringService().check();
+      const found = report.findings.find((f) => f.id === expectedId);
+
+      expect(found).toBeTruthy();
+      expect(found?.severity).toBe('critical');
+      expect(found?.title).toContain(variable);
+      // Never a value, only ever the variable name and a classification.
+      expect(found?.detail).not.toMatch(/[A-Za-z0-9+/]{16,}/);
+    },
+  );
+
+  it('is only advisory in development, unlike a real deployment secret', async () => {
+    stubProbes({
+      [CONFIG_AUDIT_URL]: {
+        status: 200,
+        body: {
+          nodeServer: {
+            status: 'ok',
+            secretPlaceholders: {
+              sessionTokenSigningKeyIsPlaceholder: true,
+              sessionManagerServiceApiKeyIsPlaceholder: false,
+              nodeServerServiceApiKeyIsPlaceholder: false,
+              transcriptionServiceApiKeyIsPlaceholder: false,
+            },
+          },
+        },
+      },
+    });
+
+    const report = await monitoringService({
+      declaredEnv: 'development',
+    }).check();
+    const found = report.findings.find(
+      (f) => f.id === 'jwt-secret-placeholder',
+    );
+
+    expect(found?.severity).toBe('advisory');
+    expect(found?.productionSeverity).toBe('critical');
+  });
+
+  it('reports unavailable, not silence, when the sidecar cannot be reached', async () => {
+    stubProbes({ [CONFIG_AUDIT_URL]: 'network-error' });
+
+    const found = await monitoringIds();
+
+    expect(found).toContain('secret-placeholder-audit-unavailable');
+  });
+
+  it('reports unavailable when the sidecar answers with a body Config Check cannot parse', async () => {
+    vi.stubGlobal('fetch', () =>
+      Promise.resolve(new Response('not json at all', { status: 200 })),
+    );
+
+    const found = await monitoringIds();
+
+    expect(found).toContain('secret-placeholder-audit-unavailable');
+  });
+
+  it.each(['disabled', 'unauthorized', 'not-yet-polled'] as const)(
+    'reports unavailable, not a clean bill of health, when node-server status is %s',
+    async (reason) => {
+      stubProbes({
+        [CONFIG_AUDIT_URL]: {
+          status: 200,
+          body: { nodeServer: { status: 'unavailable', reason } },
+        },
+      });
+
+      const found = await monitoringIds();
+
+      expect(found).toContain('secret-placeholder-audit-unavailable');
+      expect(found.some((id) => id.endsWith('-placeholder'))).toBe(false);
+    },
+  );
+
+  it('is only a warning, never critical, when the audit itself is unavailable', async () => {
+    // A missing report is a sidecar/network problem, not proof of a bad
+    // secret - it must not read as worse than "cannot currently check".
+    stubProbes({ [CONFIG_AUDIT_URL]: 'network-error' });
+
+    const report = await monitoringService().check();
+    const found = report.findings.find(
+      (f) => f.id === 'secret-placeholder-audit-unavailable',
+    );
+
+    expect(found?.severity).toBe('warning');
+    expect(found?.productionSeverity).toBe('warning');
   });
 });

--- a/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
+++ b/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
@@ -1235,6 +1235,106 @@ describe('secret placeholders (PLAN-ConfigCheck-Coverage Phase 2)', (it) => {
     expect(found).toContain('secret-placeholder-audit-unavailable');
   });
 
+  // Valid JSON of the wrong shape is the version-skew case - an older or
+  // newer sidecar answering 200 - and is the failure mode that matters most,
+  // because both bad outcomes are silent: a missing `secretPlaceholders`
+  // throws inside `check()`'s `Promise.all` and 500s the whole report, and a
+  // present-but-empty one reads every flag as `undefined` and reports a
+  // malformed sidecar as a clean deployment. Neither is invalid JSON, so the
+  // test above never covered them.
+  it.each([
+    ['`nodeServer` is missing entirely', {}],
+    ['`nodeServer` is not an object', { nodeServer: 'ok' }],
+    [
+      '`status` is ok but `secretPlaceholders` is missing',
+      { nodeServer: { status: 'ok' } },
+    ],
+    [
+      '`secretPlaceholders` is present but empty',
+      { nodeServer: { status: 'ok', secretPlaceholders: {} } },
+    ],
+    [
+      '`secretPlaceholders` is missing one field',
+      {
+        nodeServer: {
+          status: 'ok',
+          secretPlaceholders: {
+            sessionTokenSigningKeyIsPlaceholder: false,
+            sessionManagerServiceApiKeyIsPlaceholder: false,
+            nodeServerServiceApiKeyIsPlaceholder: false,
+          },
+        },
+      },
+    ],
+    [
+      '`status` is unavailable but `reason` is missing',
+      { nodeServer: { status: 'unavailable' } },
+    ],
+  ])(
+    'reports unavailable, and never crashes the report, when %s',
+    async (_label, body) => {
+      stubProbes({ [CONFIG_AUDIT_URL]: { status: 200, body } });
+
+      const report = await monitoringService().check();
+      const found = report.findings.map((f) => f.id);
+
+      expect(found).toContain('secret-placeholder-audit-unavailable');
+      expect(found.some((id) => id.endsWith('-placeholder'))).toBe(false);
+    },
+  );
+
+  it('accepts a body carrying fields this build does not know about', async () => {
+    // The other half of version skew: a *newer* sidecar adding a field must
+    // not read as unavailable, or upgrading the sidecar first would blind
+    // Config Check until admin-server caught up.
+    stubProbes({
+      [CONFIG_AUDIT_URL]: {
+        status: 200,
+        body: {
+          nodeServer: {
+            status: 'ok',
+            somethingNew: 42,
+            secretPlaceholders: {
+              sessionTokenSigningKeyIsPlaceholder: true,
+              sessionManagerServiceApiKeyIsPlaceholder: false,
+              nodeServerServiceApiKeyIsPlaceholder: false,
+              transcriptionServiceApiKeyIsPlaceholder: false,
+              someFutureKeyIsPlaceholder: false,
+            },
+          },
+        },
+      },
+    });
+
+    const found = await monitoringIds();
+
+    expect(found).toContain('jwt-secret-placeholder');
+    expect(found).not.toContain('secret-placeholder-audit-unavailable');
+  });
+
+  it('says the sidecar answered with an error, not that it timed out, on a non-2xx', async () => {
+    stubProbes({ [CONFIG_AUDIT_URL]: { status: 503 } });
+
+    const report = await monitoringService().check();
+    const found = report.findings.find(
+      (f) => f.id === 'secret-placeholder-audit-unavailable',
+    );
+
+    expect(found?.detail).toContain('answered HTTP 503');
+    expect(found?.detail).not.toContain('did not answer');
+  });
+
+  it('says it timed out when the sidecar does not answer at all', async () => {
+    stubProbes({ [CONFIG_AUDIT_URL]: 'network-error' });
+
+    const report = await monitoringService().check();
+    const found = report.findings.find(
+      (f) => f.id === 'secret-placeholder-audit-unavailable',
+    );
+
+    expect(found?.detail).toContain('did not answer within');
+  });
+
   it.each(['disabled', 'unauthorized', 'not-yet-polled'] as const)(
     'reports unavailable, not a clean bill of health, when node-server status is %s',
     async (reason) => {

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  '1e011890bdd532302c5bdced68cca50de5799fe2218d51bf664a2007f570bd6f';
+  '5f136376db564fb24aa75dca5729bd49e7b5c01e79b8e391b4abb5fae7b6b73d';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/apps/admin-server/tests/utils/use-server.ts
+++ b/apps/admin-server/tests/utils/use-server.ts
@@ -13,6 +13,8 @@ export const TEST_LOCAL_CREDENTIALS = `${TEST_USERNAME} ${TEST_PASSWORD}`;
 export const TEST_SM_BASE_URL = 'http://session-manager.test';
 export const TEST_NODE_BASE_URL = 'http://node-server.test';
 export const TEST_TS_BASE_URL = 'http://transcription-service.test';
+export const TEST_MONITORING_SIDECAR_BASE_URL =
+  'http://monitoring-sidecar.test';
 export const TEST_CLIENT_WEBAPP_BASE_URL = 'http://client-webapp.test';
 export const TEST_AUDIO_BASE_URL = 'http://test-audio-generator.test';
 export const TEST_AUDIO_SERVICE_KEY = 'test-audio-service-key';
@@ -167,10 +169,25 @@ export function buildTestAppConfig(
       // probes pass both base URLs explicitly.
       grafanaBaseUrl: '',
       prometheusBaseUrl: '',
+      // Unlike the two above, this is never empty in a real deployment - the
+      // sidecar is a core service with no compose profile. Tests that care
+      // about `_checkSecretPlaceholders` stub this URL's `/config-audit`
+      // response explicitly; the shared `beforeEach` in
+      // config-check.routes.test.ts answers it cleanly by default.
+      monitoringSidecarBaseUrl: TEST_MONITORING_SIDECAR_BASE_URL,
       azureTenantId: 'test-tenant',
       azureClientId: 'test-client',
       azureClientSecret: 'test-client-secret',
       allowedGroup: 'test-admins',
+      // Was missing entirely until Phase 2: every prior caller of `_probe`
+      // (`_checkMonitoring`) was gated behind `grafanaBaseUrl`/
+      // `prometheusBaseUrl`, both empty by default here, so `_probe` was
+      // never actually exercised by this fixture until
+      // `_checkSecretPlaceholders` (unconditional) started calling it. Short,
+      // matching the other stubbed timeouts above - these targets are
+      // stubbed, so a real timeout would only ever be hit by a test that
+      // meant to hit it.
+      upstreamTimeoutMs: 500,
       ...overrides.configCheckConfig,
     },
     cookieSecret: overrides.cookieSecret ?? TEST_COOKIE_SECRET,

--- a/apps/admin-server/tests/utils/use-server.ts
+++ b/apps/admin-server/tests/utils/use-server.ts
@@ -161,6 +161,12 @@ export function buildTestAppConfig(
       dbUser: dbConfig.dbUser,
       dbPassword: 'test-db-password',
       redisUrl: 'redis://:test-redis-password@redis.test:6379',
+      testAudioServiceKey: TEST_AUDIO_SERVICE_KEY,
+      // Disabled by default, like a deployment that never turns on the
+      // monitoring profile — which is most of them. Tests that exercise the
+      // probes pass both base URLs explicitly.
+      grafanaBaseUrl: '',
+      prometheusBaseUrl: '',
       azureTenantId: 'test-tenant',
       azureClientId: 'test-client',
       azureClientSecret: 'test-client-secret',

--- a/apps/monitoring-sidecar/src/server/create-server.ts
+++ b/apps/monitoring-sidecar/src/server/create-server.ts
@@ -7,6 +7,7 @@ import type { AppConfig } from '#src/app-config/app-config.js';
 import type { AppDependencies } from './dependency-injection/app-dependencies.js';
 import registerDependencies from './dependency-injection/register-dependencies.js';
 import { audioMeterRouter } from './features/audio-meter/audio-meter.router.js';
+import { configAuditRouter } from './features/config-audit/config-audit.router.js';
 import { metricsRouter } from './features/metrics/metrics.router.js';
 import { probesRouter } from './features/probes/probes.router.js';
 
@@ -72,6 +73,7 @@ async function createServer(
 
   fastify.register(probesRouter);
   fastify.register(metricsRouter);
+  fastify.register(configAuditRouter);
   if (audioMeterPage) fastify.register(audioMeterRouter);
 
   if (startCollectors) {

--- a/apps/monitoring-sidecar/src/server/dependency-injection/app-dependencies.ts
+++ b/apps/monitoring-sidecar/src/server/dependency-injection/app-dependencies.ts
@@ -9,6 +9,7 @@ import type {
 
 import type { AppConfig, BaseConfig } from '#src/app-config/app-config.js';
 import type { AudioMeterController } from '#src/server/features/audio-meter/audio-meter.controller.js';
+import type { ConfigAuditController } from '#src/server/features/config-audit/config-audit.controller.js';
 import type { MetricsController } from '#src/server/features/metrics/metrics.controller.js';
 import type { LivenessController } from '#src/server/features/probes/liveness.controller.js';
 import type { ReadinessController } from '#src/server/features/probes/readiness.controller.js';
@@ -64,6 +65,9 @@ interface AppDependencies extends BaseDependencies {
 
   // Metrics
   metricsController: MetricsController;
+
+  // Config audit (PLAN-ConfigCheck-Coverage Phase 2)
+  configAuditController: ConfigAuditController;
 
   // Standalone audio meter (A4)
   audioMeterController: AudioMeterController;

--- a/apps/monitoring-sidecar/src/server/dependency-injection/register-dependencies.ts
+++ b/apps/monitoring-sidecar/src/server/dependency-injection/register-dependencies.ts
@@ -3,6 +3,7 @@ import { type AwilixContainer, Lifetime, asClass, asValue } from 'awilix';
 import { DeviceAuthClient } from '@scribear/test-audio-source';
 
 import { AudioMeterController } from '#src/server/features/audio-meter/audio-meter.controller.js';
+import { ConfigAuditController } from '#src/server/features/config-audit/config-audit.controller.js';
 import { MetricsController } from '#src/server/features/metrics/metrics.controller.js';
 import { LivenessController } from '#src/server/features/probes/liveness.controller.js';
 import { ReadinessController } from '#src/server/features/probes/readiness.controller.js';
@@ -82,6 +83,9 @@ function registerDependencies(
       lifetime: Lifetime.SCOPED,
     }),
     metricsController: asClass(MetricsController, {
+      lifetime: Lifetime.SCOPED,
+    }),
+    configAuditController: asClass(ConfigAuditController, {
       lifetime: Lifetime.SCOPED,
     }),
     // The one controller registered as an instance: it holds a single

--- a/apps/monitoring-sidecar/src/server/features/config-audit/config-audit.controller.ts
+++ b/apps/monitoring-sidecar/src/server/features/config-audit/config-audit.controller.ts
@@ -1,0 +1,69 @@
+import type {
+  BaseFastifyReply,
+  BaseFastifyRequest,
+} from '@scribear/base-fastify-server';
+
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+
+import type { CONFIG_AUDIT_SCHEMA } from './config-audit.schema.js';
+
+/**
+ * Serves node-server's self-reported secret-placeholder classification
+ * (PLAN-ConfigCheck-Coverage Phase 2), read straight off
+ * `NodeStatusPollerService` rather than recomputed here — the classification
+ * itself is entirely node-server's to make, this controller only relays it.
+ *
+ * `status` reflects the *most recent poll's* health, not merely whether a
+ * classification has ever been seen: a consumer must be able to tell "node
+ * server reports X" from "cannot currently ask node-server", and a stale
+ * reading from before an outage started would blur exactly that
+ * distinction.
+ */
+export class ConfigAuditController {
+  private _nodeStatusPoller: AppDependencies['nodeStatusPollerService'];
+
+  constructor(
+    nodeStatusPollerService: AppDependencies['nodeStatusPollerService'],
+  ) {
+    this._nodeStatusPoller = nodeStatusPollerService;
+  }
+
+  configAudit(
+    _req: BaseFastifyRequest<typeof CONFIG_AUDIT_SCHEMA>,
+    res: BaseFastifyReply<typeof CONFIG_AUDIT_SCHEMA>,
+  ) {
+    const { enabled, lastResult, secretPlaceholders } = this._nodeStatusPoller;
+
+    if (!enabled) {
+      res
+        .code(200)
+        .send({ nodeServer: { status: 'unavailable', reason: 'disabled' } });
+      return;
+    }
+
+    if (lastResult === null || !lastResult.ok || secretPlaceholders === null) {
+      // The middle case (`!lastResult.ok`) is the common one in production —
+      // an outage or a wrong key. The others narrow the same "not currently
+      // safe to call this current" state: no poll has completed yet, or (this
+      // should be unreachable, since `_apply` sets both together) a report
+      // that claims success without a classification to go with it.
+      res.code(200).send({
+        nodeServer: {
+          status: 'unavailable',
+          // The `?? 'not-yet-polled'` only matters for the unreachable
+          // ok-but-no-classification case above, where `lastResult.reason`
+          // is null.
+          reason:
+            lastResult === null
+              ? 'not-yet-polled'
+              : (lastResult.reason ?? 'not-yet-polled'),
+        },
+      });
+      return;
+    }
+
+    res.code(200).send({
+      nodeServer: { status: 'ok', secretPlaceholders },
+    });
+  }
+}

--- a/apps/monitoring-sidecar/src/server/features/config-audit/config-audit.router.ts
+++ b/apps/monitoring-sidecar/src/server/features/config-audit/config-audit.router.ts
@@ -1,0 +1,16 @@
+import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
+
+import resolveHandler from '#src/server/dependency-injection/resolve-handler.js';
+
+import {
+  CONFIG_AUDIT_ROUTE,
+  CONFIG_AUDIT_SCHEMA,
+} from './config-audit.schema.js';
+
+export function configAuditRouter(fastify: BaseFastifyInstance) {
+  fastify.route({
+    ...CONFIG_AUDIT_ROUTE,
+    schema: CONFIG_AUDIT_SCHEMA,
+    handler: resolveHandler('configAuditController', 'configAudit'),
+  });
+}

--- a/apps/monitoring-sidecar/src/server/features/config-audit/config-audit.schema.ts
+++ b/apps/monitoring-sidecar/src/server/features/config-audit/config-audit.schema.ts
@@ -1,0 +1,48 @@
+import { Type } from 'typebox';
+
+import { SECRET_PLACEHOLDERS_SCHEMA } from '@scribear/node-server-schema';
+
+import { MONITORING_BASE_PATH } from '#src/server/base-path.js';
+
+/**
+ * Re-exposes node-server's self-reported secret-placeholder classification
+ * (PLAN-ConfigCheck-Coverage Phase 2), read off `GET /status` — which the
+ * sidecar already polls with a key it already holds
+ * (`NODE_SERVER_SERVICE_API_KEY`) — and relayed here for Admin Server's
+ * Config Check to read without ever being handed that key itself.
+ *
+ * Unauthenticated and backend-network-only, the same trust boundary
+ * `/metrics` and `/probes/readiness` already carry: the sidecar sits on the
+ * `backend` compose network only and is not exposed through nginx.
+ *
+ * `reason` is `Type.String()` rather than a closed literal union, matching
+ * `StatusPollResult.reason` on `AbsoluteStatusPoller` — it is one of
+ * `POLL_ERROR_REASONS` plus `disabled`/`not-yet-polled`, but pinning that set
+ * here too would be the third restatement of it.
+ */
+export const CONFIG_AUDIT_SCHEMA = {
+  description:
+    'Secret-placeholder classification self-reported by node-server, relayed unchanged. `nodeServer.status` is `unavailable` whenever the sidecar cannot currently vouch for the classification - no service key configured, no poll completed yet, or the most recent poll failed - so a consumer never mistakes a stale or absent reading for a clean bill of health.',
+  response: {
+    200: Type.Object({
+      nodeServer: Type.Union([
+        Type.Object({
+          status: Type.Literal('ok'),
+          secretPlaceholders: SECRET_PLACEHOLDERS_SCHEMA,
+        }),
+        Type.Object({
+          status: Type.Literal('unavailable'),
+          reason: Type.String({
+            description:
+              "'disabled' (no NODE_SERVER_SERVICE_API_KEY configured on the sidecar), 'not-yet-polled' (enabled, but the first poll has not completed), or one of AbsoluteStatusPoller's POLL_ERROR_REASONS from the most recent poll.",
+          }),
+        }),
+      ]),
+    }),
+  },
+};
+
+export const CONFIG_AUDIT_ROUTE = {
+  method: 'GET' as const,
+  url: `${MONITORING_BASE_PATH}/config-audit`,
+};

--- a/apps/monitoring-sidecar/src/server/shared/node-status/node-status-poller.service.ts
+++ b/apps/monitoring-sidecar/src/server/shared/node-status/node-status-poller.service.ts
@@ -2,7 +2,10 @@ import type { Static } from 'typebox';
 import { Value } from 'typebox/value';
 
 import type { BaseLogger } from '@scribear/base-fastify-server';
-import { STATUS_SCHEMA } from '@scribear/node-server-schema';
+import {
+  STATUS_SCHEMA,
+  type SecretPlaceholders,
+} from '@scribear/node-server-schema';
 
 import type { MetricsRegistry } from '#src/server/shared/metrics/metrics-registry.service.js';
 import {
@@ -41,6 +44,16 @@ export class NodeStatusPollerService extends AbsoluteStatusPoller<NodeStatusBody
   /** Sessions present in the previous poll, so vanished ones can be removed. */
   private _knownSessions = new Set<string>();
 
+  /**
+   * The most recently polled secret-placeholder classification
+   * (PLAN-ConfigCheck-Coverage Phase 2), or null before the first successful
+   * poll. Not a metric — folding it into `MetricsRegistry` would wrongly gate
+   * Config Check's findings behind the optional `monitoring`/Prometheus
+   * profile — so it is stashed here instead, the same way `lastResult` is,
+   * and re-exposed directly by `ConfigAuditController`.
+   */
+  private _secretPlaceholders: SecretPlaceholders | null = null;
+
   // Own constructor solely so Awilix (CLASSIC mode, resolves by parameter name)
   // sees a first parameter named `nodeStatusPollerConfig`, matching the
   // registration key. Without it the class inherits the base constructor whose
@@ -67,10 +80,16 @@ export class NodeStatusPollerService extends AbsoluteStatusPoller<NodeStatusBody
   /** Kinds seen in the previous poll, so a kind that stopped can be removed. */
   private _knownLatencyKinds = new Set<string>();
 
+  /** @see {@link _secretPlaceholders} */
+  get secretPlaceholders(): SecretPlaceholders | null {
+    return this._secretPlaceholders;
+  }
+
   protected _apply(body: NodeStatusBody): void {
     this._applyCounters(body);
     this._applySessionGauges(body);
     this._applyLatencyQuantiles(body);
+    this._secretPlaceholders = body.secretPlaceholders;
   }
 
   private _applyCounters(body: NodeStatusBody): void {

--- a/apps/monitoring-sidecar/src/server/shared/status-poll/absolute-status-poller.ts
+++ b/apps/monitoring-sidecar/src/server/shared/status-poll/absolute-status-poller.ts
@@ -152,6 +152,16 @@ export abstract class AbsoluteStatusPoller<
     return this._lastResult;
   }
 
+  /**
+   * False when this poller was constructed with no API key, and so will never
+   * poll at all — distinct from `lastResult === null`, which a consumer could
+   * otherwise not tell apart from "enabled, but the first poll has not
+   * completed yet".
+   */
+  get enabled(): boolean {
+    return this._config.enabled;
+  }
+
   /** Runs one poll. Exposed so tests can drive it deterministically. */
   async pollOnce(): Promise<StatusPollResult> {
     const body = await this._fetchStatus();

--- a/apps/monitoring-sidecar/tests/fixtures/fake-node-status.ts
+++ b/apps/monitoring-sidecar/tests/fixtures/fake-node-status.ts
@@ -71,6 +71,14 @@ export function latencySeries(
   };
 }
 
+/** Mirrors `SecretPlaceholders` (PLAN-ConfigCheck-Coverage Phase 2). */
+export interface FakeSecretPlaceholders {
+  sessionTokenSigningKeyIsPlaceholder: boolean;
+  sessionManagerServiceApiKeyIsPlaceholder: boolean;
+  nodeServerServiceApiKeyIsPlaceholder: boolean;
+  transcriptionServiceApiKeyIsPlaceholder: boolean;
+}
+
 export interface FakeStatusBody {
   processUid: string;
   processStartedAt: string;
@@ -88,7 +96,15 @@ export interface FakeStatusBody {
   latency: FakeLatencySeries[];
   sessions: FakeSession[];
   sessionsTruncated: boolean;
+  secretPlaceholders: FakeSecretPlaceholders;
 }
+
+const NO_PLACEHOLDERS: FakeSecretPlaceholders = {
+  sessionTokenSigningKeyIsPlaceholder: false,
+  sessionManagerServiceApiKeyIsPlaceholder: false,
+  nodeServerServiceApiKeyIsPlaceholder: false,
+  transcriptionServiceApiKeyIsPlaceholder: false,
+};
 
 const ZERO_SUMMARY = {
   activeSessionCount: 0,
@@ -112,12 +128,15 @@ export const FAKE_PROCESS_UID = '11111111-1111-4111-8111-111111111111';
  * without restating the other ten.
  */
 export function statusBody(
-  overrides: Partial<Omit<FakeStatusBody, 'summary' | 'sessions'>> & {
+  overrides: Partial<
+    Omit<FakeStatusBody, 'summary' | 'sessions' | 'secretPlaceholders'>
+  > & {
     summary?: Partial<typeof ZERO_SUMMARY>;
     sessions?: FakeSessionInput[];
+    secretPlaceholders?: Partial<FakeSecretPlaceholders>;
   } = {},
 ): FakeStatusBody {
-  const { summary, sessions, ...rest } = overrides;
+  const { summary, sessions, secretPlaceholders, ...rest } = overrides;
   return {
     processUid: FAKE_PROCESS_UID,
     processStartedAt: '2026-07-20T00:00:00.000Z',
@@ -134,6 +153,7 @@ export function statusBody(
       ...session,
     })),
     summary: { ...ZERO_SUMMARY, ...summary },
+    secretPlaceholders: { ...NO_PLACEHOLDERS, ...secretPlaceholders },
   };
 }
 

--- a/apps/monitoring-sidecar/tests/integration/config-audit.test.ts
+++ b/apps/monitoring-sidecar/tests/integration/config-audit.test.ts
@@ -1,0 +1,177 @@
+import { asValue } from 'awilix';
+import { afterEach, beforeEach, describe, expect } from 'vitest';
+
+import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
+
+import { AppConfig } from '#src/app-config/app-config.js';
+import createServer from '#src/server/create-server.js';
+import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+import type { StatusPollResult } from '#src/server/shared/status-poll/absolute-status-poller.js';
+
+const ROUTE = '/api/monitoring/v1/config-audit';
+
+/**
+ * Boots the real server with collectors disabled — the poller's own polling
+ * behaviour is covered by `node-status-poller.test.ts`; this suite is about
+ * the HTTP surface `ConfigAuditController` builds from whatever state the
+ * poller reports, so tests swap in a minimal fake rather than driving a real
+ * poll.
+ */
+async function boot() {
+  process.env['LOG_LEVEL'] = 'silent';
+  process.env['PORT'] = '0';
+  process.env['HOST'] = '127.0.0.1';
+
+  const config = new AppConfig();
+  const { fastify } = await createServer(config, { startCollectors: false });
+  await fastify.ready();
+  return fastify;
+}
+
+/** A stand-in for `NodeStatusPollerService`, narrowed to what the controller reads. */
+interface FakePoller {
+  enabled: boolean;
+  lastResult: StatusPollResult | null;
+  secretPlaceholders: AppDependencies['nodeStatusPollerService']['secretPlaceholders'];
+}
+
+function stubPoller(fastify: BaseFastifyInstance, fake: FakePoller) {
+  fastify.diContainer.register({
+    nodeStatusPollerService: asValue(
+      fake as unknown as AppDependencies['nodeStatusPollerService'],
+    ),
+  });
+}
+
+describe('config audit (PLAN-ConfigCheck-Coverage Phase 2)', () => {
+  let fastify: BaseFastifyInstance;
+
+  beforeEach(async () => {
+    fastify = await boot();
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+  });
+
+  describe('GET /config-audit', (it) => {
+    it('reports disabled when this sidecar holds no service key', async () => {
+      // Arrange - the default test boot sets no NODE_SERVER_SERVICE_API_KEY,
+      // so the real poller registered by DI is already disabled; nothing to
+      // stub.
+
+      // Act
+      const res = await fastify.inject({ method: 'GET', url: ROUTE });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toStrictEqual({
+        nodeServer: { status: 'unavailable', reason: 'disabled' },
+      });
+    });
+
+    it('reports not-yet-polled when enabled but no poll has completed', async () => {
+      // Arrange
+      stubPoller(fastify, {
+        enabled: true,
+        lastResult: null,
+        secretPlaceholders: null,
+      });
+
+      // Act
+      const res = await fastify.inject({ method: 'GET', url: ROUTE });
+
+      // Assert
+      expect(res.json()).toStrictEqual({
+        nodeServer: { status: 'unavailable', reason: 'not-yet-polled' },
+      });
+    });
+
+    it("relays the most recent poll's failure reason", async () => {
+      // Arrange - node-server rejecting the sidecar's key must not read as a
+      // clean bill of health for secrets it can no longer be asked about.
+      stubPoller(fastify, {
+        enabled: true,
+        lastResult: {
+          ok: false,
+          reason: 'unauthorized',
+          processUid: null,
+          restarted: false,
+        },
+        secretPlaceholders: null,
+      });
+
+      // Act
+      const res = await fastify.inject({ method: 'GET', url: ROUTE });
+
+      // Assert
+      expect(res.json()).toStrictEqual({
+        nodeServer: { status: 'unavailable', reason: 'unauthorized' },
+      });
+    });
+
+    it('reports the classification unchanged once the last poll succeeded', async () => {
+      // Arrange
+      stubPoller(fastify, {
+        enabled: true,
+        lastResult: {
+          ok: true,
+          reason: null,
+          processUid: '11111111-1111-4111-8111-111111111111',
+          restarted: false,
+        },
+        secretPlaceholders: {
+          sessionTokenSigningKeyIsPlaceholder: false,
+          sessionManagerServiceApiKeyIsPlaceholder: false,
+          nodeServerServiceApiKeyIsPlaceholder: false,
+          transcriptionServiceApiKeyIsPlaceholder: true,
+        },
+      });
+
+      // Act
+      const res = await fastify.inject({ method: 'GET', url: ROUTE });
+
+      // Assert
+      expect(res.json()).toStrictEqual({
+        nodeServer: {
+          status: 'ok',
+          secretPlaceholders: {
+            sessionTokenSigningKeyIsPlaceholder: false,
+            sessionManagerServiceApiKeyIsPlaceholder: false,
+            nodeServerServiceApiKeyIsPlaceholder: false,
+            transcriptionServiceApiKeyIsPlaceholder: true,
+          },
+        },
+      });
+    });
+
+    it('stays unavailable if the last poll failed even with a stale classification cached', async () => {
+      // Arrange - a consumer must be able to tell "node-server says X" from
+      // "cannot currently ask node-server"; a stale-but-present classification
+      // must not read as current.
+      stubPoller(fastify, {
+        enabled: true,
+        lastResult: {
+          ok: false,
+          reason: 'unreachable',
+          processUid: null,
+          restarted: false,
+        },
+        secretPlaceholders: {
+          sessionTokenSigningKeyIsPlaceholder: false,
+          sessionManagerServiceApiKeyIsPlaceholder: false,
+          nodeServerServiceApiKeyIsPlaceholder: false,
+          transcriptionServiceApiKeyIsPlaceholder: false,
+        },
+      });
+
+      // Act
+      const res = await fastify.inject({ method: 'GET', url: ROUTE });
+
+      // Assert
+      expect(res.json()).toStrictEqual({
+        nodeServer: { status: 'unavailable', reason: 'unreachable' },
+      });
+    });
+  });
+});

--- a/apps/monitoring-sidecar/tests/integration/node-status-poller.test.ts
+++ b/apps/monitoring-sidecar/tests/integration/node-status-poller.test.ts
@@ -553,6 +553,85 @@ describe('node-server status poller (B1.1 PR 4)', () => {
     });
   });
 
+  describe('secret placeholders (PLAN-ConfigCheck-Coverage Phase 2)', (it) => {
+    it('is null before any successful poll', async () => {
+      // Arrange - an unauthorized poll never reaches `_apply`, so there is
+      // nothing to classify yet.
+      const { poller } = await createPoller('wrong-key');
+
+      // Act
+      await poller.pollOnce();
+
+      // Assert
+      expect(poller.secretPlaceholders).toBeNull();
+    });
+
+    it('relays the classification node-server reports, unmodified', async () => {
+      // Arrange - the poller must not recompute this from anything of its
+      // own; node-server is the only side that ever sees the real secrets.
+      const { poller } = await createPoller();
+      node.setBody(
+        statusBody({
+          secretPlaceholders: {
+            transcriptionServiceApiKeyIsPlaceholder: true,
+          },
+        }),
+      );
+
+      // Act
+      await poller.pollOnce();
+
+      // Assert
+      expect(poller.secretPlaceholders).toStrictEqual({
+        sessionTokenSigningKeyIsPlaceholder: false,
+        sessionManagerServiceApiKeyIsPlaceholder: false,
+        nodeServerServiceApiKeyIsPlaceholder: false,
+        transcriptionServiceApiKeyIsPlaceholder: true,
+      });
+    });
+
+    it('keeps the last known classification when a later poll fails', async () => {
+      // Arrange - a gauge left behind is the existing convention for a
+      // transient outage (see "reports a server error without losing prior
+      // counter values" above); the endpoint controller, not the poller, is
+      // what decides whether to still call this current.
+      const { poller } = await createPoller();
+      node.setBody(
+        statusBody({
+          secretPlaceholders: { nodeServerServiceApiKeyIsPlaceholder: true },
+        }),
+      );
+      await poller.pollOnce();
+
+      // Act
+      node.setFailure(500);
+      await poller.pollOnce();
+
+      // Assert
+      expect(
+        poller.secretPlaceholders?.nodeServerServiceApiKeyIsPlaceholder,
+      ).toBe(true);
+    });
+  });
+
+  describe('enabled', (it) => {
+    it('is true when constructed with an API key', async () => {
+      // Act
+      const { poller } = await createPoller();
+
+      // Assert
+      expect(poller.enabled).toBe(true);
+    });
+
+    it('is false when constructed with no API key', async () => {
+      // Act
+      const { poller } = await createPoller('');
+
+      // Assert
+      expect(poller.enabled).toBe(false);
+    });
+  });
+
   describe('disabled', (it) => {
     it('never polls when no service API key is configured', async () => {
       // Arrange - failing closed keeps a default deployment from 401-ing

--- a/apps/node-server/src/app-config/app-config.ts
+++ b/apps/node-server/src/app-config/app-config.ts
@@ -4,6 +4,7 @@ import { Type } from 'typebox';
 import type { Static } from 'typebox';
 
 import { LogLevel } from '@scribear/base-fastify-server';
+import type { SecretPlaceholders } from '@scribear/node-server-schema';
 
 import { DEFAULT_DEMO_SESSION_UID } from '#src/server/features/demo-room/demo-room.constants.js';
 import type { ServiceAuthConfig } from '#src/server/shared/services/service-auth.service.js';
@@ -59,6 +60,19 @@ export interface DemoRoomConfig {
   enabled: boolean;
   /** Session UID captions are published for; matches the seeded session. */
   sessionUid: string;
+}
+
+/**
+ * Matches the `deployment/.env.example` stub marker as a substring — the same
+ * check `config-check.service.ts` on the Admin Server makes of its own
+ * secrets. Duplicated rather than shared: this codebase restates rather than
+ * shares this kind of check across services (see e.g. transcription-service's
+ * Python side restating the status schema rather than importing it), and it
+ * is three lines.
+ */
+const PLACEHOLDER_MARKER = 'CHANGEME';
+function isPlaceholder(value: string): boolean {
+  return value.toUpperCase().includes(PLACEHOLDER_MARKER);
 }
 
 export interface TelemetryPublisherConfig {
@@ -121,6 +135,29 @@ export class AppConfig {
     return {
       baseUrl: this._env.TRANSCRIPTION_SERVICE_BASE_URL,
       apiKey: this._env.TRANSCRIPTION_SERVICE_API_KEY,
+    };
+  }
+
+  /**
+   * Classifies each secret this process holds without ever exposing its
+   * value (PLAN-ConfigCheck-Coverage Phase 2) — reported on `GET /status`,
+   * the endpoint the monitoring sidecar already polls, and from there relayed
+   * to Config Check on the Admin Server.
+   */
+  get secretPlaceholders(): SecretPlaceholders {
+    return {
+      sessionTokenSigningKeyIsPlaceholder: isPlaceholder(
+        this._env.SESSION_TOKEN_SIGNING_KEY,
+      ),
+      sessionManagerServiceApiKeyIsPlaceholder: isPlaceholder(
+        this._env.SESSION_MANAGER_SERVICE_API_KEY,
+      ),
+      nodeServerServiceApiKeyIsPlaceholder: isPlaceholder(
+        this._env.NODE_SERVER_SERVICE_API_KEY,
+      ),
+      transcriptionServiceApiKeyIsPlaceholder: isPlaceholder(
+        this._env.TRANSCRIPTION_SERVICE_API_KEY,
+      ),
     };
   }
 

--- a/apps/node-server/src/server/dependency-injection/app-dependencies.ts
+++ b/apps/node-server/src/server/dependency-injection/app-dependencies.ts
@@ -2,6 +2,7 @@
 import '@fastify/awilix';
 
 import type { BaseDependencies } from '@scribear/base-fastify-server';
+import type { SecretPlaceholders } from '@scribear/node-server-schema';
 import type { TelemetryRedisClient } from '@scribear/scribear-redis';
 import type { SessionManagerClient } from '@scribear/session-manager-client';
 import type { TranscriptionServiceClient } from '@scribear/transcription-service-client';
@@ -48,6 +49,7 @@ interface AppDependencies extends BaseDependencies {
   transcriptionServiceClientConfig: TranscriptionServiceClientConfig;
   telemetryPublisherConfig: TelemetryPublisherConfig;
   demoRoomConfig: DemoRoomConfig;
+  secretPlaceholders: SecretPlaceholders;
 
   // Shared services
   serviceAuthService: ServiceAuthService;

--- a/apps/node-server/src/server/dependency-injection/register-dependencies.ts
+++ b/apps/node-server/src/server/dependency-injection/register-dependencies.ts
@@ -53,6 +53,7 @@ function registerDependencies(
     ),
     telemetryPublisherConfig: asValue(config.telemetryPublisherConfig),
     demoRoomConfig: asValue(config.demoRoomConfig),
+    secretPlaceholders: asValue(config.secretPlaceholders),
 
     // Shared services
     serviceAuthService: asClass(ServiceAuthService, {

--- a/apps/node-server/src/server/features/status/status.controller.ts
+++ b/apps/node-server/src/server/features/status/status.controller.ts
@@ -19,9 +19,14 @@ import type { AppDependencies } from '#src/server/dependency-injection/app-depen
  */
 export class StatusController {
   private _snapshots: AppDependencies['statusSnapshotService'];
+  private _secretPlaceholders: AppDependencies['secretPlaceholders'];
 
-  constructor(statusSnapshotService: AppDependencies['statusSnapshotService']) {
+  constructor(
+    statusSnapshotService: AppDependencies['statusSnapshotService'],
+    secretPlaceholders: AppDependencies['secretPlaceholders'],
+  ) {
     this._snapshots = statusSnapshotService;
+    this._secretPlaceholders = secretPlaceholders;
   }
 
   status(
@@ -35,6 +40,7 @@ export class StatusController {
       ...this._snapshots.process(),
       sessions,
       sessionsTruncated: truncated,
+      secretPlaceholders: this._secretPlaceholders,
     });
   }
 }

--- a/apps/node-server/tests/integration/features/status/status.routes.test.ts
+++ b/apps/node-server/tests/integration/features/status/status.routes.test.ts
@@ -65,6 +65,12 @@ interface StatusBody {
     latency: LatencySeriesBody[];
   }[];
   sessionsTruncated: boolean;
+  secretPlaceholders: {
+    sessionTokenSigningKeyIsPlaceholder: boolean;
+    sessionManagerServiceApiKeyIsPlaceholder: boolean;
+    nodeServerServiceApiKeyIsPlaceholder: boolean;
+    transcriptionServiceApiKeyIsPlaceholder: boolean;
+  };
 }
 
 function signToken(payload: SessionTokenPayload): string {
@@ -238,6 +244,24 @@ describe('Status Routes', () => {
       expect(Date.parse(second.generatedAt)).toBeGreaterThanOrEqual(
         Date.parse(first.processStartedAt),
       );
+    });
+  });
+
+  describe('secret placeholders (PLAN-ConfigCheck-Coverage Phase 2)', (it) => {
+    it('reports classifications sourced from AppConfig, not recomputed here', async () => {
+      // Act - the test fixture's own secrets (use-server.ts) contain no
+      // CHANGEME marker, so every classification should read false; this
+      // guards the wiring from AppConfig through StatusController, not the
+      // classification logic itself, which app-config.test.ts covers.
+      const body = await statusBody();
+
+      // Assert
+      expect(body.secretPlaceholders).toStrictEqual({
+        sessionTokenSigningKeyIsPlaceholder: false,
+        sessionManagerServiceApiKeyIsPlaceholder: false,
+        nodeServerServiceApiKeyIsPlaceholder: false,
+        transcriptionServiceApiKeyIsPlaceholder: false,
+      });
     });
   });
 

--- a/apps/node-server/tests/unit/app-config/app-config.test.ts
+++ b/apps/node-server/tests/unit/app-config/app-config.test.ts
@@ -234,6 +234,52 @@ describe('AppConfig', () => {
     });
   });
 
+  describe('secret placeholders (PLAN-ConfigCheck-Coverage Phase 2)', (it) => {
+    it('reports every secret as not-a-placeholder for a fully-populated environment', () => {
+      // Act
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert
+      expect(config.secretPlaceholders).toStrictEqual({
+        sessionTokenSigningKeyIsPlaceholder: false,
+        sessionManagerServiceApiKeyIsPlaceholder: false,
+        nodeServerServiceApiKeyIsPlaceholder: false,
+        transcriptionServiceApiKeyIsPlaceholder: false,
+      });
+    });
+
+    it('flags only the secret that is still CHANGEME, matching case-insensitively', () => {
+      // Arrange - the deployment/.env.example marker embedded in an otherwise
+      // real-looking value, same as config-check.service.ts's own tests on
+      // the Admin Server exercise for its own secrets.
+      process.env['TRANSCRIPTION_SERVICE_API_KEY'] = 'changeme';
+
+      // Act
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert - never the value itself, only the classification.
+      expect(config.secretPlaceholders).toStrictEqual({
+        sessionTokenSigningKeyIsPlaceholder: false,
+        sessionManagerServiceApiKeyIsPlaceholder: false,
+        nodeServerServiceApiKeyIsPlaceholder: false,
+        transcriptionServiceApiKeyIsPlaceholder: true,
+      });
+    });
+
+    it('flags a secret whose value only contains the marker as a substring', () => {
+      // Arrange
+      process.env['SESSION_TOKEN_SIGNING_KEY'] = 'prefix-CHANGEME-suffix';
+
+      // Act
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert
+      expect(
+        config.secretPlaceholders.sessionTokenSigningKeyIsPlaceholder,
+      ).toBe(true);
+    });
+  });
+
   describe('schema validation', (it) => {
     it('throws when a required variable is missing', () => {
       // Arrange

--- a/apps/node-server/tests/utils/use-server.ts
+++ b/apps/node-server/tests/utils/use-server.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, inject } from 'vitest';
 
 import { LogLevel } from '@scribear/base-fastify-server';
+import type { SecretPlaceholders } from '@scribear/node-server-schema';
 
 import type {
   AppConfig,
@@ -38,6 +39,7 @@ export interface TestAppConfigOverrides {
   transcriptionServiceClientConfig?: Partial<TranscriptionServiceClientConfig>;
   telemetryPublisherConfig?: Partial<TelemetryPublisherConfig>;
   demoRoomConfig?: Partial<DemoRoomConfig>;
+  secretPlaceholders?: Partial<SecretPlaceholders>;
 }
 
 /**
@@ -99,6 +101,16 @@ export function buildTestAppConfig(
       enabled: false,
       sessionUid: DEFAULT_DEMO_SESSION_UID,
       ...overrides.demoRoomConfig,
+    },
+    // None of the fixture's own secrets contain the CHANGEME marker, so the
+    // default here is "nothing is a placeholder" - tests that want to assert
+    // the opposite override individual fields.
+    secretPlaceholders: {
+      sessionTokenSigningKeyIsPlaceholder: false,
+      sessionManagerServiceApiKeyIsPlaceholder: false,
+      nodeServerServiceApiKeyIsPlaceholder: false,
+      transcriptionServiceApiKeyIsPlaceholder: false,
+      ...overrides.secretPlaceholders,
     },
   } as unknown as AppConfig;
 }

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -46,6 +46,17 @@ GRAFANA_ADMIN_PASSWORD=CHANGEME
 # How long Prometheus keeps scraped samples before dropping them. Untested
 # against real staging disk sizing - lower it on a small disk.
 PROMETHEUS_RETENTION=15d
+# admin-server's Config Check (Admin -> Config Check) probes these two
+# in-cluster URLs directly to report whether this profile, once turned on, is
+# actually working - Prometheus reachable and scraping, Grafana reachable and
+# its default password actually changed. Empty (the default) is itself reported: a
+# warning in staging/production nudging you to turn monitoring on (advisory
+# in development, where a fleet dashboard for one throwaway container buys
+# nothing). Set both together when you do:
+#   ADMIN_GRAFANA_BASE_URL=http://grafana:3000
+#   ADMIN_PROMETHEUS_BASE_URL=http://prometheus:9090
+ADMIN_GRAFANA_BASE_URL=
+ADMIN_PROMETHEUS_BASE_URL=
 
 # -- Image Registry ---------
 # Registry/namespace to pull images from.

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,7 +12,35 @@ lists every key the current `compose.yml` understands.
 
 ---
 
-## Unreleased — opt-in Prometheus + Grafana dashboard (`compose.yml` v6)
+## Unreleased — Config Check probes the monitoring profile (`compose.yml` v6)
+
+**Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d` to
+pick up two new admin-server environment variables:
+`ADMIN_GRAFANA_BASE_URL` and `ADMIN_PROMETHEUS_BASE_URL`. Both are empty by
+default, so nothing breaks if you delay.
+
+### What it adds
+
+Admin → Config Check now reports whether the `monitoring` profile (see the
+entry below), once turned on, is actually working — Prometheus reachable and
+scraping the fleet sidecar, and Grafana reachable with its admin password no
+longer the `CHANGEME` default. Leaving `monitoring` off is itself reported: a
+warning in staging/production nudging you to turn it on (advisory in
+development).
+
+To wire it up once you have the `monitoring` profile on, add to `.env` (see
+`.env.example`):
+
+```dotenv
+ADMIN_GRAFANA_BASE_URL=http://grafana:3000
+ADMIN_PROMETHEUS_BASE_URL=http://prometheus:9090
+```
+
+## Unreleased — opt-in Prometheus + Grafana dashboard
+
+No `compose.yml` version bump: two new services gated entirely behind the
+`monitoring` profile, so a stack that never sets `COMPOSE_PROFILES=monitoring`
+recreates no existing container.
 
 **No action needed unless you want it.** Purely additive: a new `monitoring`
 compose profile, off by default, same mechanism `autoupdate` already uses.

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -205,7 +205,7 @@ services:
       # Not `:?`-guarded, like DEPLOYMENT_ENV below and unlike the secrets: it
       # changes what is *reported*, never what runs, and must not be able to
       # stop a stack from starting.
-      COMPOSE_FILE_VERSION: "5"
+      COMPOSE_FILE_VERSION: "6"
       LOG_LEVEL: ${ADMIN_LOG_LEVEL:-info}
       ADMIN_API_KEY: ${SESSION_MANAGER_API_KEY}
       SESSION_MANAGER_BASE_URL: http://session-manager:80
@@ -239,6 +239,16 @@ services:
       # start, and this console reports the devices as unreachable.
       TEST_AUDIO_BASE_URL: ${TEST_AUDIO_BASE_URL:-http://test-audio-generator:80}
       TEST_AUDIO_SERVICE_KEY: ${TEST_AUDIO_SERVICE_KEY:-}
+      # Config Check's monitoring probes (PLAN-ConfigCheck-Coverage Phase 1).
+      # Empty by default and NOT defaulted to the in-stack services, unlike
+      # the URLs above — grafana/prometheus only exist when the `monitoring`
+      # profile (below) is on, so defaulting these would make Config Check
+      # probe containers that do not exist on every deployment that never
+      # turns that profile on. Left unset, Config Check reports a warning in
+      # staging/production nudging the operator to turn monitoring on, rather
+      # than staying silent. Set both in .env when you do.
+      ADMIN_GRAFANA_BASE_URL: ${ADMIN_GRAFANA_BASE_URL:-}
+      ADMIN_PROMETHEUS_BASE_URL: ${ADMIN_PROMETHEUS_BASE_URL:-}
       ADMIN_SESSION_SECRET: ${ADMIN_SESSION_SECRET}
       ADMIN_LOCAL_CREDENTIALS: ${ADMIN_LOCAL_CREDENTIALS}
       # Defaulted to the bundled container. Point them at a managed Postgres

--- a/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
+++ b/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
@@ -267,6 +267,45 @@ export const STATUS_PROCESS_SCHEMA = Type.Object({
 /** This process's own telemetry. @see {@link STATUS_PROCESS_SCHEMA} */
 export type StatusProcess = Static<typeof STATUS_PROCESS_SCHEMA>;
 
+/**
+ * Whether each secret this process holds is still the
+ * `deployment/.env.example` `CHANGEME` placeholder — never the value itself,
+ * matching the discipline `describeSecret()` already applies on the Admin
+ * Server (PLAN-ConfigCheck-Coverage Phase 2).
+ *
+ * A sibling of `sessions`/`sessionsTruncated` on the route response rather
+ * than a member of {@link STATUS_PROCESS_SCHEMA}: that schema's properties
+ * are spread into the Redis fleet-snapshot schema
+ * (`infra/scribear-redis/src/telemetry/node-snapshot.schema.ts`), and this
+ * classification has exactly one consumer (Config Check, via the monitoring
+ * sidecar) that has no business fanning out to the fleet-telemetry path.
+ *
+ * Named after this process's own env vars, not the deployment `.env` names
+ * that alias them — the Admin Server side of Phase 2 does that translation,
+ * since it is the one that already speaks in `.env.example` terms.
+ */
+export const SECRET_PLACEHOLDERS_SCHEMA = Type.Object({
+  sessionTokenSigningKeyIsPlaceholder: Type.Boolean({
+    description:
+      'True if SESSION_TOKEN_SIGNING_KEY (deployment JWT_SECRET) is still the deployment/.env.example placeholder. Every session token would be forgeable.',
+  }),
+  sessionManagerServiceApiKeyIsPlaceholder: Type.Boolean({
+    description:
+      'True if SESSION_MANAGER_SERVICE_API_KEY (deployment NODE_SERVER_KEY) is still the deployment/.env.example placeholder. The outbound key this process presents to Session Manager would be public.',
+  }),
+  nodeServerServiceApiKeyIsPlaceholder: Type.Boolean({
+    description:
+      'True if NODE_SERVER_SERVICE_API_KEY (deployment NODE_SERVER_SERVICE_KEY, the key that guards this very endpoint) is still the deployment/.env.example placeholder.',
+  }),
+  transcriptionServiceApiKeyIsPlaceholder: Type.Boolean({
+    description:
+      'True if TRANSCRIPTION_SERVICE_API_KEY (deployment TRANSCRIPTION_API_KEY) is still the deployment/.env.example placeholder. The shared key this process and Transcription Service present to each other would be public.',
+  }),
+});
+
+/** @see {@link SECRET_PLACEHOLDERS_SCHEMA} */
+export type SecretPlaceholders = Static<typeof SECRET_PLACEHOLDERS_SCHEMA>;
+
 const STATUS_SCHEMA = {
   description:
     'Operational telemetry for this Node Server process: connection, session and upstream counters that are otherwise only inferable from log text. Counters are monotonic since process start and are never reset - consumers difference successive reads to obtain rates, and must compare `processUid` first, because a restart returns every counter to zero and would otherwise read as a large negative rate. Intended for internal observability consumers (Monitoring Sidecar, Admin Server) on the cluster-internal network; it must not be exposed through the public reverse proxy.',
@@ -295,6 +334,7 @@ const STATUS_SCHEMA = {
         sessionsTruncated: Type.Boolean({
           description: `True when more than ${String(STATUS_MAX_SESSIONS)} sessions were active and \`sessions\` lists only the first ${String(STATUS_MAX_SESSIONS)}. \`summary.activeSessionCount\` is always the real total.`,
         }),
+        secretPlaceholders: SECRET_PLACEHOLDERS_SCHEMA,
       },
       { description: 'Telemetry snapshot for this process.' },
     ),


### PR DESCRIPTION
## Summary

Widens **Admin → Config Check** in three phases. Phases 0 and 1 use data admin-server already holds or can probe unauthenticated; Phase 2 reaches the four secrets admin-server deliberately does *not* hold, by relaying node-server's own self-report through the monitoring sidecar.

### Phase 0 — placeholder secrets already in reach
- Flags `TEST_AUDIO_SERVICE_KEY` and `ADMIN_REDIS_URL` left at their `CHANGEME` placeholders — data admin-server already holds, just wasn't checked.

### Phase 1 — monitoring reachability
- Config Check now reports whether the opt-in `monitoring` profile, once turned on, is actually working — Prometheus reachable and scraping the fleet sidecar, Grafana reachable with its default `admin`/`CHANGEME` login disabled. Leaving `monitoring` off is itself reported (warning in staging/production, advisory in development) rather than staying silent.
- Adds `ADMIN_GRAFANA_BASE_URL`/`ADMIN_PROMETHEUS_BASE_URL` (empty by default, never `:?`-guarded — an unset value must never block the stack from starting) and a new `'monitoring'` `CheckCategory`.
- Bumps `compose.yml` `COMPOSE_FILE_VERSION` 5→6 for the two new admin-server env vars, and fixes a stale "(compose.yml v6)" `UPGRADING.md` header left over from the prior monitoring-dashboard PR that never actually bumped the constant.
- A Grafana dashboard-provisioning probe was implemented and live-verified during this work, then removed: that endpoint requires Grafana auth admin-server doesn't have once a deployment rotates the password away from the `admin`/`CHANGEME` probe pair, so it could only ever succeed on deployments that haven't secured Grafana yet.

### Phase 2 — the four secrets admin-server never holds
`JWT_SECRET`, `NODE_SERVER_KEY`, `NODE_SERVER_SERVICE_KEY` and `TRANSCRIPTION_API_KEY` are invisible to admin-server by design, and handing it copies to check them would be a strictly worse deployment. Instead, the service that already holds all four classifies them itself and the classification — never a value — is relayed:

- **node-server** computes the four booleans with the same substring `CHANGEME` rule Config Check already uses, exposed on its existing authenticated `GET /status` as a new `secretPlaceholders` field. Deliberately a sibling of `sessions` rather than part of `STATUS_PROCESS_SCHEMA`, so it does **not** leak into the Redis fleet-snapshot schema and out to the fleet dashboard — this data has exactly one consumer.
- **monitoring-sidecar** already polls that endpoint with a key it already holds, so it re-exposes the classification on a new unauthenticated, backend-network-only `GET /api/monitoring/v1/config-audit` — the same trust boundary `/metrics` and `/probes/readiness` already carry. Its `nodeServer.status` is `unavailable` (with a reason) whenever the sidecar cannot currently vouch for the reading: no key configured, no poll completed yet, or the last poll failed. A stale or absent reading can never be mistaken for a clean bill of health.
- **admin-server** reads that endpoint over the compose network it already uses for the sidecar's build info, translates node-server's field names to the deployment `.env` names, and reports each flagged secret as its own finding (critical in staging/production, advisory in development), plus one `secret-placeholder-audit-unavailable` finding when the audit itself can't be performed.

No new env var, no new service-to-service key, and no `compose.yml` change for this phase — admin-server still never receives any of the four secrets. Verified live with `docker exec admin-server env`.

**Known limitation, documented in the finding's own remediation text:** a placeholder `NODE_SERVER_SERVICE_KEY` can only ever surface as the generic `secret-placeholder-audit-unavailable`, never as its own named finding. That key guards `/status` itself, and node-server's `ServiceAuthService` refuses to construct at all when it contains `CHANGEME` — a deliberate pre-existing fail-closed design, so the endpoint 500s before it can self-report on that specific key. The deployment still never reads as clean; it just gets "something is wrong with node-server's status auth" rather than the exact variable name.

### Follow-up fixes in this PR
- **Restores four sidecar files that were committed by reference only.** The Phase 2 commit registered `ConfigAuditController` in the sidecar's DI container and imported `config-audit.router.js` from `create-server.ts`, but the feature folder and its integration test were never `git add`ed — that tree did not build from a clean checkout.
- **Validates the `/config-audit` body before reading it.** The first malformed-200 hardening only guarded the top-level `nodeServer` key. `{nodeServer:{status:'ok'}}` threw a `TypeError` outside the `try` and inside `check()`'s `Promise.all`, 500-ing the whole Config Check route; `{nodeServer:{status:'ok',secretPlaceholders:{}}}` read every flag as `undefined` and reported a malformed sidecar as a **clean** deployment. Now validated with `Value.Check` against a TypeBox schema before any field is dereferenced — the same thing the sidecar's own poller does one hop upstream, so both ends of the wire are validated alike. `Type.Object` stays open, so a *newer* sidecar's extra fields still validate and upgrading the sidecar first can't blind Config Check.
- **Stops reporting HTTP errors as timeouts.** `!response?.ok` is true both for a probe that never answered and for one that answered 503; the detail text claimed a timeout either way, sending an operator after a network problem that isn't there. Applied to all three probe callers this branch adds.

## Test plan
- [x] admin-server — `npx vitest run --project unit` (191/191), `--project integration` (96/96)
- [x] monitoring-sidecar — 139 unit / 89 integration
- [x] node-server — 210 unit / 48 integration
- [x] `npx tsc --build --force`, `npx eslint src tests`, `npx prettier --check src tests` in each of the three apps and `libs/schemas/node-server-schema` — all clean
- [x] **Phase 0+1 live** against an isolated `docker compose` project (distinct project name, scratch admin-server image, the live stack's `:dev` images for every other service): `TEST_AUDIO_SERVICE_KEY`/`ADMIN_REDIS_URL` placeholders, monitoring off, monitoring on with the default Grafana password, and monitoring on after rotating that password — each produced the expected findings and only those.
- [x] **Phase 2 live** in the same isolated-project style with node-server, monitoring-sidecar and admin-server all rebuilt from the working tree: all four secrets real → `/config-audit` reports all false and Config Check shows nothing; `JWT_SECRET=CHANGEME...` → the field flips, `jwt-secret-placeholder` fires critical in staging, and no secret value appears anywhere in the response; reverting clears it on the next poll. Same for `NODE_SERVER_KEY`. `docker exec admin-server-1 env` confirmed admin-server never held any of the four at any point.
- [x] `TRANSCRIPTION_API_KEY=CHANGEME` could not be exercised end-to-end live — transcription-service's own pre-existing boot guard refuses to start with it, so node-server (which waits on it) never starts either. Covered by unit tests identically to the other three.
