### PR TITLE
feat(admin): surface active and live sessions, and make timezones explicit

### DIFF
--- a/.changeset/admin-active-and-live-sessions.md
+++ b/.changeset/admin-active-and-live-sessions.md
@@ -35,3 +35,12 @@ demo room's permanently-active fixture session), and the scheduling page gains
 a Sessions table that polls every 15s while the tab is visible. Its range
 widened to the last 7 days so a session that started before page-load still
 appears.
+
+Every admin page that prints a timestamp now says which timezone it is
+printing in, in the same place and the same words, via a shared
+`TimezoneNote`. Room-scoped pages (room detail, scheduling, session detail)
+render times in the room's zone rather than the browser's, and when the two
+differ the note escalates to a red warning triangle naming both — the case
+where misreading a schedule has consequences. Pages showing deployment-wide
+times (audit, devices, dashboard, deployment check) state the browser's zone,
+which is the only one in play there.

--- a/.changeset/admin-active-and-live-sessions.md
+++ b/.changeset/admin-active-and-live-sessions.md
@@ -1,0 +1,37 @@
+---
+'@scribear/session-manager-schema': minor
+'@scribear/session-manager-client': minor
+'@scribear/session-manager': minor
+'@scribear/admin-server': minor
+'@scribear/admin-webapp': minor
+---
+
+Surface active and live sessions in the admin console.
+
+Sessions have no status column — "active" is derived from
+`COALESCE(end_override, scheduled_end_time)` — and no admin route read that
+derivation, so the console could not show a room's running session, listed no
+ON_DEMAND/AUTO rows on the scheduling page, and refused a second on-demand
+session with `ANOTHER_SESSION_ACTIVE` while showing nothing that explained the
+conflict.
+
+Two read routes now expose the repository queries that already existed:
+
+- `GET /schedule-management/list-sessions?roomUid=&from=&to=` — sessions whose
+  effective interval overlaps the range, including the ON_DEMAND and AUTO rows
+  that have no parent schedule and so were invisible to list-schedules.
+- `GET /schedule-management/get-active-session/:roomUid` — the room's active
+  session, or a `null` 200 body so "nothing is running" stays distinct from
+  "room not found" (404).
+
+Both are mirrored through the session-manager client and the admin BFF
+(`/sessions/list`, `/rooms/:roomUid/active-session`). `listSessionsForRoomInRange`
+and `findActiveSession` now return `ROOM_NOT_FOUND`, matching
+`listSchedulesForRoom`.
+
+In the console, the room detail page gains an "Active session" card (name,
+type, effective start/end, View and End-early actions, the last hidden for the
+demo room's permanently-active fixture session), and the scheduling page gains
+a Sessions table that polls every 15s while the tab is visible. Its range
+widened to the last 7 days so a session that started before page-load still
+appears.

--- a/apps/admin-server/src/server/features/scheduling/scheduling.controller.ts
+++ b/apps/admin-server/src/server/features/scheduling/scheduling.controller.ts
@@ -13,12 +13,14 @@ import type {
   DELETE_AUTO_SESSION_WINDOW_INPUT,
   DELETE_SCHEDULE_INPUT,
   END_SESSION_EARLY_INPUT,
+  GET_ACTIVE_SESSION_INPUT,
   GET_AUTO_SESSION_WINDOW_INPUT,
   GET_SCHEDULE_INPUT,
   GET_SESSION_INPUT,
   GET_SESSION_JOIN_CODE_INPUT,
   LIST_AUTO_SESSION_WINDOWS_INPUT,
   LIST_SCHEDULES_INPUT,
+  LIST_SESSIONS_INPUT,
   START_SESSION_EARLY_INPUT,
   UPDATE_AUTO_SESSION_WINDOW_INPUT,
   UPDATE_ROOM_SCHEDULE_CONFIG_INPUT,
@@ -88,6 +90,28 @@ export class SchedulingController {
     res: BaseFastifyReply,
   ) {
     this._gateway.respond(req, res, await this._gateway.getSession(req.params));
+  }
+
+  async listSessions(
+    req: BaseFastifyRequest<typeof LIST_SESSIONS_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    this._gateway.respond(
+      req,
+      res,
+      await this._gateway.listSessions(req.query),
+    );
+  }
+
+  async getActiveSession(
+    req: BaseFastifyRequest<typeof GET_ACTIVE_SESSION_INPUT>,
+    res: BaseFastifyReply,
+  ) {
+    this._gateway.respond(
+      req,
+      res,
+      await this._gateway.getActiveSession(req.params),
+    );
   }
 
   async getSessionJoinCode(

--- a/apps/admin-server/src/server/features/scheduling/scheduling.router.ts
+++ b/apps/admin-server/src/server/features/scheduling/scheduling.router.ts
@@ -19,6 +19,8 @@ import {
   DELETE_SCHEDULE_ROUTE,
   END_SESSION_EARLY_INPUT,
   END_SESSION_EARLY_ROUTE,
+  GET_ACTIVE_SESSION_INPUT,
+  GET_ACTIVE_SESSION_ROUTE,
   GET_AUTO_SESSION_WINDOW_INPUT,
   GET_AUTO_SESSION_WINDOW_ROUTE,
   GET_SCHEDULE_INPUT,
@@ -31,6 +33,8 @@ import {
   LIST_AUTO_SESSION_WINDOWS_ROUTE,
   LIST_SCHEDULES_INPUT,
   LIST_SCHEDULES_ROUTE,
+  LIST_SESSIONS_INPUT,
+  LIST_SESSIONS_ROUTE,
   START_SESSION_EARLY_INPUT,
   START_SESSION_EARLY_ROUTE,
   UPDATE_AUTO_SESSION_WINDOW_INPUT,
@@ -84,6 +88,20 @@ export function schedulingRouter(fastify: BaseFastifyInstance) {
     schema: GET_SESSION_INPUT,
     preHandler: readGuards,
     handler: resolveHandler('schedulingController', 'getSession'),
+  });
+
+  fastify.route({
+    ...LIST_SESSIONS_ROUTE,
+    schema: LIST_SESSIONS_INPUT,
+    preHandler: readGuards,
+    handler: resolveHandler('schedulingController', 'listSessions'),
+  });
+
+  fastify.route({
+    ...GET_ACTIVE_SESSION_ROUTE,
+    schema: GET_ACTIVE_SESSION_INPUT,
+    preHandler: readGuards,
+    handler: resolveHandler('schedulingController', 'getActiveSession'),
   });
 
   fastify.route({

--- a/apps/admin-server/src/server/features/scheduling/scheduling.schema.ts
+++ b/apps/admin-server/src/server/features/scheduling/scheduling.schema.ts
@@ -23,7 +23,6 @@ import { ADMIN_BASE_PATH } from '#src/server/base-path.js';
 const P_SCHEDULES = `${ADMIN_BASE_PATH}/schedules`;
 const P_AUTO_WINDOWS = `${ADMIN_BASE_PATH}/auto-windows`;
 const P_SESSIONS = `${ADMIN_BASE_PATH}/sessions`;
-const P_ROOMS = `${ADMIN_BASE_PATH}/rooms`;
 
 // Input validation reuses the exact Session Manager request shapes (body /
 // querystring / params) — NEVER the `authorization` header, which the BFF
@@ -123,12 +122,16 @@ export const LIST_SESSIONS_ROUTE = {
   url: `${P_SESSIONS}/list`,
 };
 
+// Keyed by room, but it reads a session, so it belongs under the sessions
+// prefix alongside `get/:sessionUid` — routing it under `/rooms` would make
+// the scheduling feature own a second copy of the rooms feature's own path
+// prefix, and would be the only REST-shaped URL among verb-noun siblings.
 export const GET_ACTIVE_SESSION_INPUT = {
   params: GET_ACTIVE_SESSION_SCHEMA.params,
 };
 export const GET_ACTIVE_SESSION_ROUTE = {
   method: 'GET' as const,
-  url: `${P_ROOMS}/:roomUid/active-session`,
+  url: `${P_SESSIONS}/active/:roomUid`,
 };
 
 export const CREATE_ON_DEMAND_SESSION_INPUT = {

--- a/apps/admin-server/src/server/features/scheduling/scheduling.schema.ts
+++ b/apps/admin-server/src/server/features/scheduling/scheduling.schema.ts
@@ -5,11 +5,13 @@ import {
   DELETE_AUTO_SESSION_WINDOW_SCHEMA,
   DELETE_SCHEDULE_SCHEMA,
   END_SESSION_EARLY_SCHEMA,
+  GET_ACTIVE_SESSION_SCHEMA,
   GET_AUTO_SESSION_WINDOW_SCHEMA,
   GET_SCHEDULE_SCHEMA,
   GET_SESSION_SCHEMA,
   LIST_AUTO_SESSION_WINDOWS_SCHEMA,
   LIST_SCHEDULES_SCHEMA,
+  LIST_SESSIONS_SCHEMA,
   START_SESSION_EARLY_SCHEMA,
   UPDATE_AUTO_SESSION_WINDOW_SCHEMA,
   UPDATE_ROOM_SCHEDULE_CONFIG_SCHEMA,
@@ -21,6 +23,7 @@ import { ADMIN_BASE_PATH } from '#src/server/base-path.js';
 const P_SCHEDULES = `${ADMIN_BASE_PATH}/schedules`;
 const P_AUTO_WINDOWS = `${ADMIN_BASE_PATH}/auto-windows`;
 const P_SESSIONS = `${ADMIN_BASE_PATH}/sessions`;
+const P_ROOMS = `${ADMIN_BASE_PATH}/rooms`;
 
 // Input validation reuses the exact Session Manager request shapes (body /
 // querystring / params) — NEVER the `authorization` header, which the BFF
@@ -110,6 +113,22 @@ export const GET_SESSION_INPUT = { params: GET_SESSION_SCHEMA.params };
 export const GET_SESSION_ROUTE = {
   method: 'GET' as const,
   url: `${P_SESSIONS}/get/:sessionUid`,
+};
+
+export const LIST_SESSIONS_INPUT = {
+  querystring: LIST_SESSIONS_SCHEMA.querystring,
+};
+export const LIST_SESSIONS_ROUTE = {
+  method: 'GET' as const,
+  url: `${P_SESSIONS}/list`,
+};
+
+export const GET_ACTIVE_SESSION_INPUT = {
+  params: GET_ACTIVE_SESSION_SCHEMA.params,
+};
+export const GET_ACTIVE_SESSION_ROUTE = {
+  method: 'GET' as const,
+  url: `${P_ROOMS}/:roomUid/active-session`,
 };
 
 export const CREATE_ON_DEMAND_SESSION_INPUT = {

--- a/apps/admin-server/src/server/shared/services/session-manager-gateway.service.ts
+++ b/apps/admin-server/src/server/shared/services/session-manager-gateway.service.ts
@@ -16,6 +16,7 @@ import {
   DELETE_ROOM_SCHEMA,
   DELETE_SCHEDULE_SCHEMA,
   END_SESSION_EARLY_SCHEMA,
+  GET_ACTIVE_SESSION_SCHEMA,
   GET_AUTO_SESSION_WINDOW_SCHEMA,
   GET_DEVICE_SCHEMA,
   GET_ROOM_SCHEMA,
@@ -25,6 +26,7 @@ import {
   LIST_DEVICES_SCHEMA,
   LIST_ROOMS_SCHEMA,
   LIST_SCHEDULES_SCHEMA,
+  LIST_SESSIONS_SCHEMA,
   REGISTER_DEVICE_SCHEMA,
   REMOVE_DEVICE_FROM_ROOM_SCHEMA,
   REREGISTER_DEVICE_SCHEMA,
@@ -277,6 +279,24 @@ export class SessionManagerGatewayService {
 
   getSession(params: Static<(typeof GET_SESSION_SCHEMA)['params']>) {
     return this._client.scheduleManagement.getSession({
+      headers: this._authHeaders(),
+      params,
+    });
+  }
+
+  listSessions(
+    querystring: Static<(typeof LIST_SESSIONS_SCHEMA)['querystring']>,
+  ) {
+    return this._client.scheduleManagement.listSessions({
+      headers: this._authHeaders(),
+      querystring,
+    });
+  }
+
+  getActiveSession(
+    params: Static<(typeof GET_ACTIVE_SESSION_SCHEMA)['params']>,
+  ) {
+    return this._client.scheduleManagement.getActiveSession({
       headers: this._authHeaders(),
       params,
     });

--- a/apps/admin-server/tests/integration/scheduling.routes.test.ts
+++ b/apps/admin-server/tests/integration/scheduling.routes.test.ts
@@ -40,6 +40,25 @@ const SAMPLE_AUTO_WINDOW = {
   createdAt: '2026-01-01T00:00:00.000Z',
 };
 
+const SAMPLE_SESSION = {
+  uid: '55555555-5555-5555-5555-555555555555',
+  roomUid: ROOM_UID,
+  name: 'On-demand session',
+  type: 'ON_DEMAND',
+  scheduledSessionUid: null,
+  scheduledStartTime: '2026-08-01T09:00:00.000Z',
+  scheduledEndTime: '2026-08-01T10:00:00.000Z',
+  startOverride: null,
+  endOverride: null,
+  effectiveStart: '2026-08-01T09:00:00.000Z',
+  effectiveEnd: '2026-08-01T10:00:00.000Z',
+  joinCodeScopes: ['SEND_AUDIO'],
+  transcriptionProviderId: 'provider-1',
+  transcriptionStreamConfig: null,
+  sessionConfigVersion: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
 const SAMPLE_ROOM = {
   uid: ROOM_UID,
   name: 'Room 101',
@@ -420,6 +439,135 @@ describe('Scheduling routes', () => {
       expect(res.json<{ error: { code: string } }>().error.code).toBe(
         'BACKEND_MISCONFIGURATION',
       );
+    });
+  });
+
+  describe('sessions/list', (it) => {
+    it('forwards the room and range upstream and injects the admin key', async () => {
+      // Arrange
+      sm.respondWith({ status: 200, body: { items: [SAMPLE_SESSION] } });
+      const { cookie } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/sessions/list`,
+        query: {
+          roomUid: ROOM_UID,
+          from: '2026-08-01T00:00:00.000Z',
+          to: '2026-11-01T00:00:00.000Z',
+        },
+        headers: { cookie },
+      });
+
+      // Assert — envelope
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({
+        ok: true,
+        data: { items: [SAMPLE_SESSION] },
+      });
+      // Assert — upstream request
+      const upstream = sm.requests.find((r) =>
+        r.url.includes('/list-sessions'),
+      );
+      expect(upstream).toBeDefined();
+      expect(upstream?.headers['authorization']).toBe(
+        `Bearer ${TEST_ADMIN_KEY}`,
+      );
+      expect(upstream?.url).toContain(`roomUid=${ROOM_UID}`);
+    });
+
+    it('rejects an unauthenticated list with 401 and makes NO upstream call', async () => {
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/sessions/list`,
+        query: { roomUid: ROOM_UID },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(401);
+      expect(sm.requests).toHaveLength(0);
+    });
+  });
+
+  describe('rooms/:roomUid/active-session', (it) => {
+    it('passes a null body through as "no active session", not as an error', async () => {
+      // Arrange — the upstream route answers 200 with a literal `null` body to
+      // keep "no session is active" distinct from "room not found" (404). A
+      // gateway that treated an empty payload as a failure would turn an idle
+      // room into an error banner.
+      sm.respondWith({ status: 200, body: null });
+      const { cookie } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/rooms/${ROOM_UID}/active-session`,
+        headers: { cookie },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ ok: true, data: null });
+    });
+
+    it('returns the active session and injects the admin key upstream', async () => {
+      // Arrange
+      sm.respondWith({ status: 200, body: SAMPLE_SESSION });
+      const { cookie } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/rooms/${ROOM_UID}/active-session`,
+        headers: { cookie },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ ok: true, data: SAMPLE_SESSION });
+      const upstream = sm.requests.find((r) =>
+        r.url.includes('/get-active-session/'),
+      );
+      expect(upstream).toBeDefined();
+      expect(upstream?.headers['authorization']).toBe(
+        `Bearer ${TEST_ADMIN_KEY}`,
+      );
+    });
+
+    it('passes an upstream ROOM_NOT_FOUND through as a 404 envelope', async () => {
+      // Arrange — distinct from the null body above: the room itself is gone.
+      sm.respondWith({
+        status: 404,
+        body: { code: 'ROOM_NOT_FOUND', message: 'nope' },
+      });
+      const { cookie } = await login(server.fastify);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/rooms/${ROOM_UID}/active-session`,
+        headers: { cookie },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(404);
+      const body = res.json<{ ok: boolean; error: { code: string } }>();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe('ROOM_NOT_FOUND');
+    });
+
+    it('rejects an unauthenticated read with 401 and makes NO upstream call', async () => {
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/rooms/${ROOM_UID}/active-session`,
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(401);
+      expect(sm.requests).toHaveLength(0);
     });
   });
 });

--- a/apps/admin-server/tests/integration/scheduling.routes.test.ts
+++ b/apps/admin-server/tests/integration/scheduling.routes.test.ts
@@ -491,7 +491,7 @@ describe('Scheduling routes', () => {
     });
   });
 
-  describe('rooms/:roomUid/active-session', (it) => {
+  describe('sessions/active/:roomUid', (it) => {
     it('passes a null body through as "no active session", not as an error', async () => {
       // Arrange — the upstream route answers 200 with a literal `null` body to
       // keep "no session is active" distinct from "room not found" (404). A
@@ -503,7 +503,7 @@ describe('Scheduling routes', () => {
       // Act
       const res = await server.fastify.inject({
         method: 'GET',
-        url: `${BASE}/rooms/${ROOM_UID}/active-session`,
+        url: `${BASE}/sessions/active/${ROOM_UID}`,
         headers: { cookie },
       });
 
@@ -520,7 +520,7 @@ describe('Scheduling routes', () => {
       // Act
       const res = await server.fastify.inject({
         method: 'GET',
-        url: `${BASE}/rooms/${ROOM_UID}/active-session`,
+        url: `${BASE}/sessions/active/${ROOM_UID}`,
         headers: { cookie },
       });
 
@@ -547,7 +547,7 @@ describe('Scheduling routes', () => {
       // Act
       const res = await server.fastify.inject({
         method: 'GET',
-        url: `${BASE}/rooms/${ROOM_UID}/active-session`,
+        url: `${BASE}/sessions/active/${ROOM_UID}`,
         headers: { cookie },
       });
 
@@ -562,7 +562,7 @@ describe('Scheduling routes', () => {
       // Act
       const res = await server.fastify.inject({
         method: 'GET',
-        url: `${BASE}/rooms/${ROOM_UID}/active-session`,
+        url: `${BASE}/sessions/active/${ROOM_UID}`,
       });
 
       // Assert

--- a/apps/admin-webapp/src/components/timezone-note.tsx
+++ b/apps/admin-webapp/src/components/timezone-note.tsx
@@ -1,0 +1,75 @@
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+import { browserTimeZone } from '#src/lib/timezone';
+
+interface TimezoneNoteProps {
+  /**
+   * The zone the page's timestamps are rendered in. Omit on pages that show
+   * deployment-wide times (audit entries, health checks, device last-seen),
+   * which have no room to belong to and are shown in the browser's zone.
+   */
+  timezone?: string | undefined;
+  /** What the zone belongs to, used in the copy. Defaults to "room". */
+  ownerLabel?: string | undefined;
+}
+
+/**
+ * States which timezone the timestamps on this page are printed in.
+ *
+ * Read-only admin pages are easy to misread: a schedule that says 09:00 means
+ * nothing until you know whether that is the room's 09:00 or yours. Any page
+ * showing a time renders this note, so the answer is always in the same place
+ * and the same words.
+ *
+ * When a room's zone differs from the operator's own, the two readings of
+ * every timestamp on the page diverge — someone in Chicago administering a
+ * London room would otherwise silently plan a session six hours off. That
+ * case is called out with a red warning triangle rather than folded into the
+ * quiet caption, because it is the case where a misread has consequences.
+ */
+export const TimezoneNote = ({
+  timezone,
+  ownerLabel = 'room',
+}: TimezoneNoteProps) => {
+  const browser = browserTimeZone();
+  const zone = timezone ?? browser;
+  const differs = timezone !== undefined && timezone !== browser;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.75,
+        mb: 2,
+        color: differs ? 'error.main' : 'text.secondary',
+      }}
+    >
+      {differs ? (
+        <WarningAmberIcon fontSize="small" color="error" aria-hidden />
+      ) : (
+        <AccessTimeIcon fontSize="small" aria-hidden />
+      )}
+      <Typography variant="body2" component="p">
+        {differs ? (
+          <>
+            Times shown in the {ownerLabel}&apos;s timezone,{' '}
+            <strong>{zone}</strong> — not your own (<strong>{browser}</strong>).
+          </>
+        ) : timezone === undefined ? (
+          <>
+            Times shown in your timezone, <strong>{zone}</strong>.
+          </>
+        ) : (
+          <>
+            Times shown in the {ownerLabel}&apos;s timezone,{' '}
+            <strong>{zone}</strong>, which matches your own.
+          </>
+        )}
+      </Typography>
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/features/audit/audit-page.tsx
+++ b/apps/admin-webapp/src/features/audit/audit-page.tsx
@@ -18,6 +18,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 
+import { TimezoneNote } from '#src/components/timezone-note';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
@@ -85,6 +86,7 @@ export const AuditPage = () => {
           server&apos;s ADMIN_API_KEY.
         </Alert>
       )}
+      <TimezoneNote />
       <TableContainer component={Paper}>
         <Table size="small">
           <TableHead>

--- a/apps/admin-webapp/src/features/config-check/config-check-page.tsx
+++ b/apps/admin-webapp/src/features/config-check/config-check-page.tsx
@@ -18,6 +18,7 @@ import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
+import { TimezoneNote } from '#src/components/timezone-note';
 import type {
   CheckSeverity,
   ConfigCheckReport,
@@ -256,6 +257,7 @@ export const ConfigCheckPage = () => {
           Re-run
         </Button>
       </Box>
+      <TimezoneNote />
       <Typography
         variant="body2"
         sx={{

--- a/apps/admin-webapp/src/features/dashboard/dashboard-page.tsx
+++ b/apps/admin-webapp/src/features/dashboard/dashboard-page.tsx
@@ -16,6 +16,7 @@ import Typography from '@mui/material/Typography';
 
 import { useNavigate } from 'react-router-dom';
 
+import { TimezoneNote } from '#src/components/timezone-note';
 import type { HealthReport } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
@@ -141,6 +142,7 @@ export const DashboardPage = () => {
       <Typography variant="h5" component="h1" sx={{ mb: 2 }}>
         Dashboard
       </Typography>
+      <TimezoneNote />
       {misconfigured && (
         <Alert severity="error" sx={{ mb: 2 }}>
           Admin backend misconfiguration — an operator must check the

--- a/apps/admin-webapp/src/features/devices/device-detail-page.tsx
+++ b/apps/admin-webapp/src/features/devices/device-detail-page.tsx
@@ -24,6 +24,7 @@ import { ActivationCodeDisplay } from '#src/components/activation-code-display';
 import { ConfirmDialog } from '#src/components/confirm-dialog';
 import { KioskUrlInstructions } from '#src/components/kiosk-url-instructions';
 import { NameWithUid } from '#src/components/name-with-uid';
+import { TimezoneNote } from '#src/components/timezone-note';
 import type { ReregisterDeviceResult } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
@@ -265,6 +266,7 @@ export const DeviceDetailPage = () => {
       <Typography variant="h5" component="h1" gutterBottom>
         <NameWithUid name={device.name} uid={device.uid} showUid={showUuids} />
       </Typography>
+      <TimezoneNote />
       <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
         <Stack spacing={2}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/apps/admin-webapp/src/features/devices/devices-list-page.tsx
+++ b/apps/admin-webapp/src/features/devices/devices-list-page.tsx
@@ -33,6 +33,7 @@ import type { Device } from '@scribear/session-manager-schema';
 import { ActivationCodeDisplay } from '#src/components/activation-code-display';
 import { KioskUrlInstructions } from '#src/components/kiosk-url-instructions';
 import { NameWithUid } from '#src/components/name-with-uid';
+import { TimezoneNote } from '#src/components/timezone-note';
 import type { RegisterDeviceResult } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
@@ -233,6 +234,7 @@ export const DevicesListPage = () => {
         >
           Register device
         </Button>
+        <TimezoneNote />
       </Box>
       {misconfigured && (
         <Alert severity="error" sx={{ mb: 2 }}>

--- a/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
+++ b/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
@@ -299,9 +299,18 @@ export const RoomDetailPage = () => {
 
   // The room's currently-active session, if any. Fetched independently of the
   // room detail so a failure here never blocks the page, and reloaded after
-  // mutations that may start/stop a session.
+  // ending the session early.
+  //
+  // `loading` and `error` are both consumed below: `data` is null before the
+  // first success AND after a failure, so rendering "no session is currently
+  // active" off `data === null` alone would state a falsehood while the fetch
+  // is still in flight, and would keep stating it if the fetch failed. This
+  // card exists to explain an ANOTHER_SESSION_ACTIVE conflict, so a silent
+  // wrong "nothing is running" is the one answer it must never give.
   const {
     data: activeSession,
+    loading: activeSessionLoading,
+    error: activeSessionError,
     reload: reloadActiveSession,
   } = useAsyncData<Session | null>(
     () =>
@@ -310,6 +319,11 @@ export const RoomDetailPage = () => {
         : adminApi.getActiveSession(roomUid),
     [roomUid],
   );
+  // Only the first load is unknown-state; a failed poll/reload keeps showing
+  // the last known session rather than flipping the card to a spinner.
+  const activeSessionUnknown =
+    (activeSessionLoading || activeSessionError !== null) &&
+    activeSession === null;
 
   // Derived from the load error rather than stored as separate state.
   const misconfigured = isApiErrorCode(error, 'BACKEND_MISCONFIGURATION');
@@ -564,7 +578,25 @@ export const RoomDetailPage = () => {
               />
             )}
           </Box>
-          {activeSession === null ? (
+          {activeSessionUnknown ? (
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{ alignItems: 'center', color: 'text.secondary' }}
+            >
+              {activeSessionError === null && (
+                <CircularProgress
+                  size={16}
+                  aria-label="Loading active session"
+                />
+              )}
+              <Typography variant="body2">
+                {activeSessionError === null
+                  ? 'Checking for an active session…'
+                  : 'Could not check for an active session. A session may still be running.'}
+              </Typography>
+            </Stack>
+          ) : activeSession === null ? (
             <Typography
               variant="body2"
               sx={{

--- a/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
+++ b/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
@@ -37,10 +37,12 @@ import type { Device, Room, Session } from '@scribear/session-manager-schema';
 
 import { ConfirmDialog } from '#src/components/confirm-dialog';
 import { NameWithUid } from '#src/components/name-with-uid';
+import { TimezoneNote } from '#src/components/timezone-note';
 import type { RoomDetail } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
 import { useSettings } from '#src/lib/settings-context';
+import { formatInTimeZone } from '#src/lib/timezone';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 
@@ -510,6 +512,7 @@ export const RoomDetailPage = () => {
           </Button>
         </Box>
       </Box>
+      <TimezoneNote timezone={room.timezone} />
       <Card sx={{ mb: 3 }}>
         <CardContent>
           <Grid container spacing={2}>
@@ -550,7 +553,7 @@ export const RoomDetailPage = () => {
                 Created
               </Typography>
               <Typography variant="body1">
-                {new Date(room.createdAt).toLocaleString()}
+                {formatInTimeZone(room.createdAt, room.timezone)}
               </Typography>
             </Grid>
           </Grid>
@@ -615,10 +618,10 @@ export const RoomDetailPage = () => {
                 }}
               >
                 Started{' '}
-                {new Date(activeSession.effectiveStart).toLocaleString()}
+                {formatInTimeZone(activeSession.effectiveStart, room.timezone)}
                 {activeSession.effectiveEnd === null
                   ? ' · open-ended (no scheduled end)'
-                  : ` · ends ${new Date(activeSession.effectiveEnd).toLocaleString()}`}
+                  : ` · ends ${formatInTimeZone(activeSession.effectiveEnd, room.timezone)}`}
               </Typography>
               <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
                 <Button

--- a/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
+++ b/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
@@ -20,6 +20,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import Select from '@mui/material/Select';
 import type { SelectChangeEvent } from '@mui/material/Select';
+import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -32,7 +33,7 @@ import Typography from '@mui/material/Typography';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { DEMO_ROOM_UID } from '@scribear/session-manager-schema';
-import type { Device, Room } from '@scribear/session-manager-schema';
+import type { Device, Room, Session } from '@scribear/session-manager-schema';
 
 import { ConfirmDialog } from '#src/components/confirm-dialog';
 import { NameWithUid } from '#src/components/name-with-uid';
@@ -296,6 +297,20 @@ export const RoomDetailPage = () => {
     [roomUid],
   );
 
+  // The room's currently-active session, if any. Fetched independently of the
+  // room detail so a failure here never blocks the page, and reloaded after
+  // mutations that may start/stop a session.
+  const {
+    data: activeSession,
+    reload: reloadActiveSession,
+  } = useAsyncData<Session | null>(
+    () =>
+      roomUid === undefined
+        ? Promise.resolve(null)
+        : adminApi.getActiveSession(roomUid),
+    [roomUid],
+  );
+
   // Derived from the load error rather than stored as separate state.
   const misconfigured = isApiErrorCode(error, 'BACKEND_MISCONFIGURATION');
 
@@ -304,6 +319,8 @@ export const RoomDetailPage = () => {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [rowActionUid, setRowActionUid] = useState<string | null>(null);
+  const [endActiveSessionOpen, setEndActiveSessionOpen] = useState(false);
+  const [endingActiveSession, setEndingActiveSession] = useState(false);
 
   // Non-misconfiguration load failures are surfaced as a toast, once per error.
   useEffect(() => {
@@ -371,6 +388,28 @@ export const RoomDetailPage = () => {
       .finally(() => {
         setDeleting(false);
         setDeleteOpen(false);
+      });
+  };
+
+  const handleEndActiveSession = () => {
+    if (activeSession === null) return;
+    setEndingActiveSession(true);
+    adminApi
+      .endSessionEarly(activeSession.uid)
+      .then(() => {
+        showSuccess('Active session ended.');
+        reloadActiveSession();
+      })
+      .catch((err: unknown) => {
+        showError(
+          err instanceof ApiError
+            ? err.message
+            : 'Failed to end active session.',
+        );
+      })
+      .finally(() => {
+        setEndingActiveSession(false);
+        setEndActiveSessionOpen(false);
       });
   };
 
@@ -501,6 +540,82 @@ export const RoomDetailPage = () => {
               </Typography>
             </Grid>
           </Grid>
+        </CardContent>
+      </Card>
+      <Card sx={{ mb: 3 }}>
+        <CardContent>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              mb: 1,
+            }}
+          >
+            <Typography variant="h6" component="h2">
+              Active session
+            </Typography>
+            {activeSession !== null && (
+              <Chip
+                size="small"
+                label={activeSession.type}
+                color="success"
+                variant="outlined"
+              />
+            )}
+          </Box>
+          {activeSession === null ? (
+            <Typography
+              variant="body2"
+              sx={{
+                color: 'text.secondary',
+              }}
+            >
+              No session is currently active in this room.
+            </Typography>
+          ) : (
+            <Stack spacing={1}>
+              <Typography variant="body1">{activeSession.name}</Typography>
+              <Typography
+                variant="body2"
+                sx={{
+                  color: 'text.secondary',
+                }}
+              >
+                Started{' '}
+                {new Date(activeSession.effectiveStart).toLocaleString()}
+                {activeSession.effectiveEnd === null
+                  ? ' · open-ended (no scheduled end)'
+                  : ` · ends ${new Date(activeSession.effectiveEnd).toLocaleString()}`}
+              </Typography>
+              <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={() => {
+                    void navigate(`/sessions/${activeSession.uid}`);
+                  }}
+                >
+                  View session
+                </Button>
+                {/* The demo room's permanently-active fixture session is not a
+                    real transcription session and must not be ended from here. */}
+                {!isDemoRoom && (
+                  <Button
+                    size="small"
+                    color="error"
+                    variant="outlined"
+                    disabled={endingActiveSession}
+                    onClick={() => {
+                      setEndActiveSessionOpen(true);
+                    }}
+                  >
+                    End early
+                  </Button>
+                )}
+              </Stack>
+            </Stack>
+          )}
         </CardContent>
       </Card>
       <Box
@@ -657,6 +772,18 @@ export const RoomDetailPage = () => {
         onConfirm={handleDelete}
         onClose={() => {
           setDeleteOpen(false);
+        }}
+      />
+      <ConfirmDialog
+        open={endActiveSessionOpen}
+        title="End active session"
+        message="This ends the currently-active session now, ahead of its scheduled end time."
+        confirmLabel="End early"
+        confirmColor="error"
+        loading={endingActiveSession}
+        onConfirm={handleEndActiveSession}
+        onClose={() => {
+          setEndActiveSessionOpen(false);
         }}
       />
     </Box>

--- a/apps/admin-webapp/src/features/rooms/rooms-list-page.tsx
+++ b/apps/admin-webapp/src/features/rooms/rooms-list-page.tsx
@@ -31,6 +31,7 @@ import { DEMO_SOURCE_DEVICE_UID } from '@scribear/session-manager-schema';
 import type { Device, Room } from '@scribear/session-manager-schema';
 
 import { NameWithUid } from '#src/components/name-with-uid';
+import { TimezoneNote } from '#src/components/timezone-note';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
 import { useSettings } from '#src/lib/settings-context';
@@ -277,6 +278,7 @@ export const RoomsListPage = () => {
           New room
         </Button>
       </Box>
+      <TimezoneNote />
       {misconfigured && (
         <Alert severity="error" sx={{ mb: 2 }}>
           Admin backend misconfiguration — an operator must check the

--- a/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
+++ b/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
@@ -1,4 +1,10 @@
-import { type SyntheticEvent, useEffect, useMemo, useState } from 'react';
+import {
+  type SyntheticEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import AddIcon from '@mui/icons-material/Add';
 import Alert from '@mui/material/Alert';
@@ -980,9 +986,7 @@ export const RoomSchedulingPage = () => {
   const [rangeFrom, rangeTo] = useMemo(() => {
     const to = new Date();
     const from = new Date(to.getTime() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
-    const forward = new Date(
-      to.getTime() + RANGE_DAYS * 24 * 60 * 60 * 1000,
-    );
+    const forward = new Date(to.getTime() + RANGE_DAYS * 24 * 60 * 60 * 1000);
     return [from.toISOString(), forward.toISOString()];
   }, []);
 
@@ -1054,6 +1058,11 @@ export const RoomSchedulingPage = () => {
     [roomUid],
   );
   const sessions = sessionsData ?? [];
+  // `useAsyncData` raises `loading` on every re-fetch, including the 15s poll
+  // below. Gating the table body on it directly would blank the rows to a
+  // spinner once per poll forever; only the first load has nothing to show.
+  // Same idiom as the page-level `loading && room === null` guard.
+  const sessionsInitialLoading = sessionsLoading && sessionsData === null;
 
   // Poll the session list so a session created or started elsewhere (by the
   // auto-session reconciler, or by another operator) appears without a manual
@@ -1109,13 +1118,22 @@ export const RoomSchedulingPage = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [windowsError]);
+  // Unlike the schedule/window loads, this one repeats every SESSION_POLL_MS,
+  // so a backend that stays down would raise a fresh error object — and a
+  // fresh toast — four times a minute for as long as the page is open. Toast
+  // only when the failure is new, and reset once a poll succeeds so a later
+  // outage is still reported.
+  const lastSessionsErrorRef = useRef<string | null>(null);
   useEffect(() => {
-    if (
-      sessionsError !== null &&
-      !isApiErrorCode(sessionsError, 'BACKEND_MISCONFIGURATION')
-    ) {
-      showError(errorMessage(sessionsError, 'Failed to load sessions.'));
+    if (sessionsError === null) {
+      lastSessionsErrorRef.current = null;
+      return;
     }
+    if (isApiErrorCode(sessionsError, 'BACKEND_MISCONFIGURATION')) return;
+    const message = errorMessage(sessionsError, 'Failed to load sessions.');
+    if (lastSessionsErrorRef.current === message) return;
+    lastSessionsErrorRef.current = message;
+    showError(message);
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [sessionsError]);
 
@@ -1276,7 +1294,8 @@ export const RoomSchedulingPage = () => {
           >
             Showing occurrences between{' '}
             {formatInRoomTz(rangeFrom, room.timezone)} and{' '}
-            {formatInRoomTz(rangeTo, room.timezone)} (next {RANGE_DAYS} days).
+            {formatInRoomTz(rangeTo, room.timezone)} (last {LOOKBACK_DAYS} days
+            and next {RANGE_DAYS} days).
           </Typography>
         </Box>
         <Button
@@ -1395,7 +1414,8 @@ export const RoomSchedulingPage = () => {
           >
             Showing occurrences between{' '}
             {formatInRoomTz(rangeFrom, room.timezone)} and{' '}
-            {formatInRoomTz(rangeTo, room.timezone)} (next {RANGE_DAYS} days).
+            {formatInRoomTz(rangeTo, room.timezone)} (last {LOOKBACK_DAYS} days
+            and next {RANGE_DAYS} days).
           </Typography>
         </Box>
         <Button
@@ -1526,13 +1546,10 @@ export const RoomSchedulingPage = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {sessionsLoading ? (
+            {sessionsInitialLoading ? (
               <TableRow>
                 <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
-                  <CircularProgress
-                    size={28}
-                    aria-label="Loading sessions"
-                  />
+                  <CircularProgress size={28} aria-label="Loading sessions" />
                 </TableCell>
               </TableRow>
             ) : sessions.length === 0 ? (
@@ -1557,14 +1574,14 @@ export const RoomSchedulingPage = () => {
                   <TableRow key={s.uid}>
                     <TableCell>{s.name}</TableCell>
                     <TableCell>
-                      <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                      <Stack
+                        direction="row"
+                        spacing={1}
+                        sx={{ alignItems: 'center' }}
+                      >
                         <Chip size="small" label={s.type} variant="outlined" />
                         {isActive && (
-                          <Chip
-                            size="small"
-                            label="active"
-                            color="success"
-                          />
+                          <Chip size="small" label="active" color="success" />
                         )}
                       </Stack>
                     </TableCell>

--- a/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
+++ b/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
@@ -7,6 +7,7 @@ import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Checkbox from '@mui/material/Checkbox';
+import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -38,6 +39,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import type {
   AutoSessionWindow,
   Room,
+  Session,
   SessionSchedule,
 } from '@scribear/session-manager-schema';
 
@@ -81,6 +83,16 @@ const FREQUENCIES: readonly ScheduleFrequency[] = [
   'BIWEEKLY',
 ];
 const RANGE_DAYS = 90;
+// How far back the scheduling page looks. The session listing uses an overlap
+// predicate, so a session that started before page-load (e.g. an active
+// on-demand session) still appears. The schedule/window listing filters on
+// `active_start <= to`, so this primarily governs sessions.
+const LOOKBACK_DAYS = 7;
+// The scheduling page has no server-push; poll the session list so a session
+// created or started elsewhere (e.g. by the auto-session reconciler, or by
+// another operator) appears without a manual reload. Gated on tab visibility
+// in the effect below.
+const SESSION_POLL_MS = 15_000;
 
 function errorMessage(err: unknown, fallback: string): string {
   return err instanceof ApiError ? err.message : fallback;
@@ -966,10 +978,18 @@ export const RoomSchedulingPage = () => {
   // the range drift on every re-render (impure render, flagged by
   // react-hooks/purity and @eslint-react/purity).
   const [rangeFrom, rangeTo] = useMemo(() => {
-    const from = new Date();
-    const to = new Date(from.getTime() + RANGE_DAYS * 24 * 60 * 60 * 1000);
-    return [from.toISOString(), to.toISOString()];
+    const to = new Date();
+    const from = new Date(to.getTime() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+    const forward = new Date(
+      to.getTime() + RANGE_DAYS * 24 * 60 * 60 * 1000,
+    );
+    return [from.toISOString(), forward.toISOString()];
   }, []);
+
+  // "now" for the active-session classification in the sessions table. Updated
+  // on the same cadence as the session poll below so the "active" chip stays
+  // current without an impure `Date.now()` during render.
+  const [now, setNow] = useState(() => Date.now());
 
   const {
     data: room,
@@ -1016,6 +1036,44 @@ export const RoomSchedulingPage = () => {
   );
   const windows = windowsData ?? [];
 
+  // Live session rows (SCHEDULED/ON_DEMAND/AUTO) overlapping the range. Unlike
+  // schedules and windows, these include on-demand and AUTO sessions, which
+  // have no parent schedule and were previously invisible on this page.
+  const {
+    data: sessionsData,
+    loading: sessionsLoading,
+    error: sessionsError,
+    reload: reloadSessions,
+  } = useAsyncData<Session[]>(
+    () =>
+      roomUid === undefined
+        ? Promise.resolve([])
+        : adminApi
+            .listSessions({ roomUid, from: rangeFrom, to: rangeTo })
+            .then((res) => res.items),
+    [roomUid],
+  );
+  const sessions = sessionsData ?? [];
+
+  // Poll the session list so a session created or started elsewhere (by the
+  // auto-session reconciler, or by another operator) appears without a manual
+  // reload. Paused when the tab is hidden to avoid hammering a backgrounded
+  // page. The schedule/window lists are slower-moving and reload on mutation.
+  useEffect(() => {
+    const poll = () => {
+      if (document.visibilityState === 'visible') {
+        reloadSessions();
+        setNow(Date.now());
+      }
+    };
+    const id = window.setInterval(poll, SESSION_POLL_MS);
+    document.addEventListener('visibilitychange', poll);
+    return () => {
+      window.clearInterval(id);
+      document.removeEventListener('visibilitychange', poll);
+    };
+  }, [reloadSessions]);
+
   // Banner is derived from the room load; a misconfiguration raised by the
   // auto-session toggle surfaces as a toast instead (see handleToggleAuto).
   const misconfigured = isApiErrorCode(roomError, 'BACKEND_MISCONFIGURATION');
@@ -1051,6 +1109,15 @@ export const RoomSchedulingPage = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [windowsError]);
+  useEffect(() => {
+    if (
+      sessionsError !== null &&
+      !isApiErrorCode(sessionsError, 'BACKEND_MISCONFIGURATION')
+    ) {
+      showError(errorMessage(sessionsError, 'Failed to load sessions.'));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
+  }, [sessionsError]);
 
   const handleToggleAuto = (_e: SyntheticEvent, checked: boolean) => {
     if (roomUid === undefined || room === null) return;
@@ -1424,6 +1491,108 @@ export const RoomSchedulingPage = () => {
           </TableBody>
         </Table>
       </TableContainer>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 1,
+        }}
+      >
+        <Box>
+          <Typography variant="h6" component="h2">
+            Sessions
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{
+              color: 'text.secondary',
+            }}
+          >
+            Live session rows (scheduled, on-demand, and auto) overlapping the
+            last {LOOKBACK_DAYS} days and next {RANGE_DAYS} days.
+          </Typography>
+        </Box>
+      </Box>
+      <TableContainer component={Paper} sx={{ mb: 3 }}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Type</TableCell>
+              <TableCell>Effective start</TableCell>
+              <TableCell>Effective end</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {sessionsLoading ? (
+              <TableRow>
+                <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+                  <CircularProgress
+                    size={28}
+                    aria-label="Loading sessions"
+                  />
+                </TableCell>
+              </TableRow>
+            ) : sessions.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+                  <Typography
+                    sx={{
+                      color: 'text.secondary',
+                    }}
+                  >
+                    No sessions in this range.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              sessions.map((s) => {
+                const isActive =
+                  new Date(s.effectiveStart).getTime() <= now &&
+                  (s.effectiveEnd === null ||
+                    new Date(s.effectiveEnd).getTime() > now);
+                return (
+                  <TableRow key={s.uid}>
+                    <TableCell>{s.name}</TableCell>
+                    <TableCell>
+                      <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                        <Chip size="small" label={s.type} variant="outlined" />
+                        {isActive && (
+                          <Chip
+                            size="small"
+                            label="active"
+                            color="success"
+                          />
+                        )}
+                      </Stack>
+                    </TableCell>
+                    <TableCell>
+                      {formatInRoomTz(s.effectiveStart, room.timezone)}
+                    </TableCell>
+                    <TableCell>
+                      {s.effectiveEnd === null
+                        ? 'Open-ended'
+                        : formatInRoomTz(s.effectiveEnd, room.timezone)}
+                    </TableCell>
+                    <TableCell align="right">
+                      <Button
+                        size="small"
+                        onClick={() => {
+                          void navigate(`/sessions/${s.uid}`);
+                        }}
+                      >
+                        View
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
       <Box sx={{ mb: 3 }}>
         <Typography variant="h6" component="h2" gutterBottom>
           On-demand session
@@ -1471,6 +1640,7 @@ export const RoomSchedulingPage = () => {
           }}
           onCreated={(sessionUid) => {
             setOnDemandOpen(false);
+            reloadSessions();
             void navigate(`/sessions/${sessionUid}`);
           }}
         />

--- a/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
+++ b/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
@@ -50,6 +50,7 @@ import type {
 } from '@scribear/session-manager-schema';
 
 import { ConfirmDialog } from '#src/components/confirm-dialog';
+import { TimezoneNote } from '#src/components/timezone-note';
 import type {
   CreateAutoWindowBody,
   CreateOnDemandSessionBody,
@@ -62,6 +63,7 @@ import type {
 } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { formatInTimeZone } from '#src/lib/timezone';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 
@@ -102,18 +104,6 @@ const SESSION_POLL_MS = 15_000;
 
 function errorMessage(err: unknown, fallback: string): string {
   return err instanceof ApiError ? err.message : fallback;
-}
-
-function formatInRoomTz(iso: string, timezone: string): string {
-  try {
-    return new Intl.DateTimeFormat('en-US', {
-      timeZone: timezone,
-      dateStyle: 'medium',
-      timeStyle: 'short',
-    }).format(new Date(iso));
-  } catch {
-    return new Date(iso).toLocaleString();
-  }
 }
 
 /** Converts a `datetime-local` input value to an ISO instant, or null if empty. */
@@ -1228,16 +1218,7 @@ export const RoomSchedulingPage = () => {
       <Typography variant="h5" component="h1" gutterBottom>
         Scheduling — {room.name}
       </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          color: 'text.secondary',
-          mb: 2,
-        }}
-      >
-        All times below are shown in this room&apos;s timezone ({room.timezone}
-        ).
-      </Typography>
+      <TimezoneNote timezone={room.timezone} />
       <Card sx={{ mb: 3 }}>
         <CardContent>
           <Grid
@@ -1293,9 +1274,9 @@ export const RoomSchedulingPage = () => {
             }}
           >
             Showing occurrences between{' '}
-            {formatInRoomTz(rangeFrom, room.timezone)} and{' '}
-            {formatInRoomTz(rangeTo, room.timezone)} (last {LOOKBACK_DAYS} days
-            and next {RANGE_DAYS} days).
+            {formatInTimeZone(rangeFrom, room.timezone)} and{' '}
+            {formatInTimeZone(rangeTo, room.timezone)} (last {LOOKBACK_DAYS}{' '}
+            days and next {RANGE_DAYS} days).
           </Typography>
         </Box>
         <Button
@@ -1353,12 +1334,12 @@ export const RoomSchedulingPage = () => {
                     {s.localStartTime.slice(0, 5)}–{s.localEndTime.slice(0, 5)}
                   </TableCell>
                   <TableCell>
-                    {formatInRoomTz(s.activeStart, room.timezone)}
+                    {formatInTimeZone(s.activeStart, room.timezone)}
                   </TableCell>
                   <TableCell>
                     {s.activeEnd === null
                       ? 'Indefinite'
-                      : formatInRoomTz(s.activeEnd, room.timezone)}
+                      : formatInTimeZone(s.activeEnd, room.timezone)}
                   </TableCell>
                   <TableCell align="right">
                     <Stack
@@ -1413,9 +1394,9 @@ export const RoomSchedulingPage = () => {
             }}
           >
             Showing occurrences between{' '}
-            {formatInRoomTz(rangeFrom, room.timezone)} and{' '}
-            {formatInRoomTz(rangeTo, room.timezone)} (last {LOOKBACK_DAYS} days
-            and next {RANGE_DAYS} days).
+            {formatInTimeZone(rangeFrom, room.timezone)} and{' '}
+            {formatInTimeZone(rangeTo, room.timezone)} (last {LOOKBACK_DAYS}{' '}
+            days and next {RANGE_DAYS} days).
           </Typography>
         </Box>
         <Button
@@ -1470,12 +1451,12 @@ export const RoomSchedulingPage = () => {
                     {w.localStartTime.slice(0, 5)}–{w.localEndTime.slice(0, 5)}
                   </TableCell>
                   <TableCell>
-                    {formatInRoomTz(w.activeStart, room.timezone)}
+                    {formatInTimeZone(w.activeStart, room.timezone)}
                   </TableCell>
                   <TableCell>
                     {w.activeEnd === null
                       ? 'Indefinite'
-                      : formatInRoomTz(w.activeEnd, room.timezone)}
+                      : formatInTimeZone(w.activeEnd, room.timezone)}
                   </TableCell>
                   <TableCell align="right">
                     <Stack
@@ -1586,12 +1567,12 @@ export const RoomSchedulingPage = () => {
                       </Stack>
                     </TableCell>
                     <TableCell>
-                      {formatInRoomTz(s.effectiveStart, room.timezone)}
+                      {formatInTimeZone(s.effectiveStart, room.timezone)}
                     </TableCell>
                     <TableCell>
                       {s.effectiveEnd === null
                         ? 'Open-ended'
-                        : formatInRoomTz(s.effectiveEnd, room.timezone)}
+                        : formatInTimeZone(s.effectiveEnd, room.timezone)}
                     </TableCell>
                     <TableCell align="right">
                       <Button

--- a/apps/admin-webapp/src/features/sessions/session-detail-page.tsx
+++ b/apps/admin-webapp/src/features/sessions/session-detail-page.tsx
@@ -25,11 +25,12 @@ import Typography from '@mui/material/Typography';
 
 import { Link as RouterLink, useParams } from 'react-router-dom';
 
-import type { Session } from '@scribear/session-manager-schema';
+import type { Room, Session } from '@scribear/session-manager-schema';
 
 import { ConfirmDialog } from '#src/components/confirm-dialog';
 import { CopyIconButton } from '#src/components/copy-icon-button';
 import { OpensInNewTab } from '#src/components/opens-in-new-tab';
+import { TimezoneNote } from '#src/components/timezone-note';
 import {
   AudioMeterBar,
   PEAK_CONVENTION,
@@ -62,6 +63,7 @@ import {
 } from '#src/lib/audio-meter-url';
 import { buildJoinUrl } from '#src/lib/join-url';
 import { sessionWindowState } from '#src/lib/session-rules';
+import { formatInTimeZone } from '#src/lib/timezone';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 
@@ -74,8 +76,14 @@ function errorMessage(err: unknown, fallback: string): string {
   return err instanceof ApiError ? err.message : fallback;
 }
 
-function formatDateTime(iso: string | null): string {
-  return iso === null ? '—' : new Date(iso).toLocaleString();
+function formatDateTime(
+  iso: string | null,
+  timeZone: string | undefined,
+): string {
+  if (iso === null) return '—';
+  return timeZone === undefined
+    ? new Date(iso).toLocaleString()
+    : formatInTimeZone(iso, timeZone);
 }
 
 interface FieldRowProps {
@@ -887,6 +895,19 @@ export const SessionDetailPage = () => {
   const misconfigured = isApiErrorCode(error, 'BACKEND_MISCONFIGURATION');
   const notFound = error instanceof ApiError && error.status === 404;
 
+  // A session's times belong to its room's timezone, but the session payload
+  // carries only a roomUid — so the room is fetched for its zone alone. A
+  // failure falls back to the browser's zone, which the note then declares,
+  // rather than blanking the page.
+  const { data: room } = useAsyncData<Room | null>(
+    () =>
+      session === null
+        ? Promise.resolve(null)
+        : adminApi.getRoom(session.roomUid),
+    [session?.roomUid],
+  );
+  const timezone = room?.timezone;
+
   // Loaded independently of `session`: a failure here (or the session having
   // no join code yet) must not block the rest of the page, which already
   // renders fine from the primary load above.
@@ -1011,6 +1032,7 @@ export const SessionDetailPage = () => {
           variant="outlined"
         />
       </Box>
+      <TimezoneNote timezone={timezone} />
       <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
         <Stack spacing={2}>
           <FieldRow label="Room">
@@ -1021,20 +1043,26 @@ export const SessionDetailPage = () => {
           <Divider />
           <FieldRow label="Scheduled start">
             <Typography>
-              {formatDateTime(session.scheduledStartTime)}
+              {formatDateTime(session.scheduledStartTime, timezone)}
             </Typography>
           </FieldRow>
           <Divider />
           <FieldRow label="Scheduled end">
-            <Typography>{formatDateTime(session.scheduledEndTime)}</Typography>
+            <Typography>
+              {formatDateTime(session.scheduledEndTime, timezone)}
+            </Typography>
           </FieldRow>
           <Divider />
           <FieldRow label="Effective start">
-            <Typography>{formatDateTime(session.effectiveStart)}</Typography>
+            <Typography>
+              {formatDateTime(session.effectiveStart, timezone)}
+            </Typography>
           </FieldRow>
           <Divider />
           <FieldRow label="Effective end">
-            <Typography>{formatDateTime(session.effectiveEnd)}</Typography>
+            <Typography>
+              {formatDateTime(session.effectiveEnd, timezone)}
+            </Typography>
           </FieldRow>
           <Divider />
           <FieldRow label="Join code scopes">
@@ -1050,7 +1078,9 @@ export const SessionDetailPage = () => {
           </FieldRow>
           <Divider />
           <FieldRow label="Created">
-            <Typography>{formatDateTime(session.createdAt)}</Typography>
+            <Typography>
+              {formatDateTime(session.createdAt, timezone)}
+            </Typography>
           </FieldRow>
         </Stack>
       </Paper>

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -1066,9 +1066,7 @@ export class AdminApiClient {
       `/sessions/get/${encodeURIComponent(sessionUid)}`,
     );
   }
-  listSessions(
-    query: TimeRangeQuery,
-  ): Promise<{ items: Session[] }> {
+  listSessions(query: TimeRangeQuery): Promise<{ items: Session[] }> {
     return this._request(
       'GET',
       `/sessions/list${toQueryString(query as unknown as Record<string, QueryValue>)}`,

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -1066,6 +1066,20 @@ export class AdminApiClient {
       `/sessions/get/${encodeURIComponent(sessionUid)}`,
     );
   }
+  listSessions(
+    query: TimeRangeQuery,
+  ): Promise<{ items: Session[] }> {
+    return this._request(
+      'GET',
+      `/sessions/list${toQueryString(query as unknown as Record<string, QueryValue>)}`,
+    );
+  }
+  getActiveSession(roomUid: string): Promise<Session | null> {
+    return this._request(
+      'GET',
+      `/rooms/${encodeURIComponent(roomUid)}/active-session`,
+    );
+  }
   getSessionJoinCode(sessionUid: string): Promise<SessionJoinCodeStatus> {
     return this._request(
       'GET',

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -1075,7 +1075,7 @@ export class AdminApiClient {
   getActiveSession(roomUid: string): Promise<Session | null> {
     return this._request(
       'GET',
-      `/rooms/${encodeURIComponent(roomUid)}/active-session`,
+      `/sessions/active/${encodeURIComponent(roomUid)}`,
     );
   }
   getSessionJoinCode(sessionUid: string): Promise<SessionJoinCodeStatus> {

--- a/apps/admin-webapp/src/lib/timezone.ts
+++ b/apps/admin-webapp/src/lib/timezone.ts
@@ -1,0 +1,28 @@
+/**
+ * The timezone the browser is running in, e.g. `America/Chicago`. Falls back
+ * to `UTC` on the rare engine that reports no zone.
+ */
+export function browserTimeZone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+}
+
+/**
+ * Formats an ISO instant in an explicit timezone.
+ *
+ * Every admin page that prints a timestamp goes through this, so a page can
+ * state which zone it is using (see `TimezoneNote`) and be telling the truth.
+ * Falls back to the browser's own formatting if the zone is one `Intl` will
+ * not accept — a bad `rooms.timezone` should degrade to a readable time, not
+ * throw and blank the table that called it.
+ */
+export function formatInTimeZone(iso: string, timeZone: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(new Date(iso));
+  } catch {
+    return new Date(iso).toLocaleString();
+  }
+}

--- a/apps/admin-webapp/tests/components/timezone-note.test.tsx
+++ b/apps/admin-webapp/tests/components/timezone-note.test.tsx
@@ -1,0 +1,85 @@
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, vi } from 'vitest';
+
+import { TimezoneNote } from '#src/components/timezone-note';
+import { browserTimeZone } from '#src/lib/timezone';
+
+import { renderWithProviders } from '../utils/render-with-providers';
+
+// The note's whole job is comparing the room's zone against the operator's, so
+// the operator's zone is stubbed rather than inherited from whatever machine
+// runs the suite.
+vi.mock('#src/lib/timezone', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('#src/lib/timezone')>();
+  return { ...actual, browserTimeZone: vi.fn() };
+});
+
+describe('TimezoneNote', () => {
+  beforeEach(() => {
+    vi.mocked(browserTimeZone).mockReturnValue('America/Chicago');
+  });
+
+  describe('room zone differs from the browser zone', (it) => {
+    it('names both zones and says which one the page is using', () => {
+      // Act
+      renderWithProviders(<TimezoneNote timezone="Europe/London" />);
+
+      // Assert - the operator must be able to see, without arithmetic, that
+      // the times on the page are not their own.
+      expect(screen.getByText(/Europe\/London/)).toBeInTheDocument();
+      expect(screen.getByText(/America\/Chicago/)).toBeInTheDocument();
+      expect(screen.getByText(/not your own/i)).toBeInTheDocument();
+    });
+
+    it('escalates to an error-coloured warning icon, not a quiet caption', () => {
+      // Act
+      const { container } = renderWithProviders(
+        <TimezoneNote timezone="Europe/London" />,
+      );
+
+      // Assert - MUI stamps its error palette class onto the svg.
+      expect(
+        container.querySelector('svg.MuiSvgIcon-colorError'),
+      ).not.toBeNull();
+    });
+  });
+
+  describe('room zone matches the browser zone', (it) => {
+    it('states the zone without warning', () => {
+      // Act
+      const { container } = renderWithProviders(
+        <TimezoneNote timezone="America/Chicago" />,
+      );
+
+      // Assert
+      expect(screen.getByText(/matches your own/i)).toBeInTheDocument();
+      expect(screen.queryByText(/not your own/i)).not.toBeInTheDocument();
+      expect(container.querySelector('svg.MuiSvgIcon-colorError')).toBeNull();
+    });
+  });
+
+  describe('no room zone (deployment-wide times)', (it) => {
+    it('states the browser zone and never warns', () => {
+      // Act
+      const { container } = renderWithProviders(<TimezoneNote />);
+
+      // Assert - only one zone is in play, so there is nothing to warn about;
+      // the page still says which one it is.
+      expect(screen.getByText(/your timezone/i)).toBeInTheDocument();
+      expect(screen.getByText(/America\/Chicago/)).toBeInTheDocument();
+      expect(container.querySelector('svg.MuiSvgIcon-colorError')).toBeNull();
+    });
+  });
+
+  describe('ownerLabel', (it) => {
+    it('names what the zone belongs to', () => {
+      // Act
+      renderWithProviders(
+        <TimezoneNote timezone="Europe/London" ownerLabel="session" />,
+      );
+
+      // Assert
+      expect(screen.getByText(/session's timezone/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/admin-webapp/tests/features/rooms/fixtures.ts
+++ b/apps/admin-webapp/tests/features/rooms/fixtures.ts
@@ -1,6 +1,28 @@
-import type { Device, Room } from '@scribear/session-manager-schema';
+import type { Device, Room, Session } from '@scribear/session-manager-schema';
 
 import type { RoomDetail } from '#src/lib/admin-api';
+
+export function buildSession(overrides: Partial<Session> = {}): Session {
+  return {
+    uid: 'session-1',
+    roomUid: 'room-1',
+    name: 'Morning lecture',
+    type: 'ON_DEMAND',
+    scheduledSessionUid: null,
+    scheduledStartTime: '2026-01-01T10:00:00.000Z',
+    scheduledEndTime: '2026-01-01T11:00:00.000Z',
+    startOverride: null,
+    endOverride: null,
+    effectiveStart: '2026-01-01T10:00:00.000Z',
+    effectiveEnd: '2026-01-01T11:00:00.000Z',
+    joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+    transcriptionProviderId: 'whisper',
+    transcriptionStreamConfig: {},
+    sessionConfigVersion: 1,
+    createdAt: '2026-01-01T09:00:00.000Z',
+    ...overrides,
+  };
+}
 
 export function buildRoom(overrides: Partial<Room> = {}): Room {
   return {

--- a/apps/admin-webapp/tests/features/rooms/room-detail-page.test.tsx
+++ b/apps/admin-webapp/tests/features/rooms/room-detail-page.test.tsx
@@ -9,6 +9,7 @@ import { DEMO_ROOM_UID } from '@scribear/session-manager-schema';
 import { RoomDetailPage } from '#src/features/rooms/room-detail-page';
 import { adminApi } from '#src/lib/admin-api';
 import { ApiError } from '#src/lib/api-error';
+import { browserTimeZone, formatInTimeZone } from '#src/lib/timezone';
 
 import { renderWithProviders } from '../../utils/render-with-providers';
 import { buildDevice, buildRoomDetail, buildSession } from './fixtures';
@@ -149,6 +150,38 @@ describe('RoomDetailPage', () => {
       expect(
         screen.queryByText(/no session is currently active/i),
       ).not.toBeInTheDocument();
+    });
+
+    it("prints session times in the room's timezone, not the browser's", async () => {
+      // Arrange - the page declares the room's zone in its TimezoneNote, so
+      // every timestamp under it has to agree; printing the browser's reading
+      // of the same instant would make the note a lie and mislead anyone
+      // administering a room from elsewhere. The room zone is chosen against
+      // whatever zone this runner is in, so the assertion means the same
+      // thing on a developer's machine and in CI.
+      const browserZone = browserTimeZone();
+      const roomZone =
+        browserZone === 'Asia/Tokyo' ? 'Pacific/Honolulu' : 'Asia/Tokyo';
+      const start = '2026-07-01T15:30:00.000Z';
+      vi.mocked(adminApi.roomDetail).mockResolvedValue(
+        buildRoomDetail({ room: { timezone: roomZone } }),
+      );
+      vi.mocked(adminApi.getActiveSession).mockResolvedValue(
+        buildSession({ effectiveStart: start, effectiveEnd: null }),
+      );
+
+      // Act
+      const { container } = renderPage();
+      await waitForLoad();
+      await screen.findByText(/open-ended/i);
+
+      // Assert - the room's reading is printed, and the browser's is not.
+      expect(container.textContent).toContain(
+        formatInTimeZone(start, roomZone),
+      );
+      expect(container.textContent).not.toContain(
+        formatInTimeZone(start, browserZone),
+      );
     });
 
     it('hides End early for the demo room, whose fixture session is permanent', async () => {

--- a/apps/admin-webapp/tests/features/rooms/room-detail-page.test.tsx
+++ b/apps/admin-webapp/tests/features/rooms/room-detail-page.test.tsx
@@ -16,6 +16,8 @@ import { buildDevice, buildRoomDetail } from './fixtures';
 vi.mock('#src/lib/admin-api', () => ({
   adminApi: {
     roomDetail: vi.fn(),
+    getActiveSession: vi.fn(),
+    endSessionEarly: vi.fn(),
   },
 }));
 
@@ -42,6 +44,9 @@ async function waitForLoad() {
 describe('RoomDetailPage', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    // Default: no active session. Individual tests override as needed.
+    vi.mocked(adminApi.getActiveSession).mockResolvedValue(null);
+    vi.mocked(adminApi.endSessionEarly).mockResolvedValue(null);
   });
 
   describe('loading', (it) => {

--- a/apps/admin-webapp/tests/features/rooms/room-detail-page.test.tsx
+++ b/apps/admin-webapp/tests/features/rooms/room-detail-page.test.tsx
@@ -11,7 +11,7 @@ import { adminApi } from '#src/lib/admin-api';
 import { ApiError } from '#src/lib/api-error';
 
 import { renderWithProviders } from '../../utils/render-with-providers';
-import { buildDevice, buildRoomDetail } from './fixtures';
+import { buildDevice, buildRoomDetail, buildSession } from './fixtures';
 
 vi.mock('#src/lib/admin-api', () => ({
   adminApi: {
@@ -63,6 +63,114 @@ describe('RoomDetailPage', () => {
 
       // Assert
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+  });
+
+  describe('active session card', (it) => {
+    // The card exists to explain an ANOTHER_SESSION_ACTIVE conflict, so the
+    // one answer it must never give is a confident "nothing is running" when
+    // it does not actually know. `useAsyncData` reports `data: null` both
+    // before the first success and after a failure, so "no active session"
+    // has to be distinguished from "not yet known".
+    it('does not claim the room is idle while the lookup is still in flight', async () => {
+      // Arrange
+      vi.mocked(adminApi.roomDetail).mockResolvedValue(buildRoomDetail());
+      vi.mocked(adminApi.getActiveSession).mockReturnValue(
+        new Promise(() => {
+          /* never resolves */
+        }),
+      );
+
+      // Act
+      renderPage();
+      await screen.findByText('Active session');
+
+      // Assert
+      expect(
+        screen.queryByText(/no session is currently active/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/checking for an active session/i),
+      ).toBeInTheDocument();
+    });
+
+    it('does not claim the room is idle when the lookup failed', async () => {
+      // Arrange
+      vi.mocked(adminApi.roomDetail).mockResolvedValue(buildRoomDetail());
+      vi.mocked(adminApi.getActiveSession).mockRejectedValue(
+        new ApiError('NETWORK', 'Could not reach the admin server.', 0),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        screen.queryByText(/no session is currently active/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/could not check for an active session/i),
+      ).toBeInTheDocument();
+    });
+
+    it('reports an idle room only once the lookup succeeded with no session', async () => {
+      // Arrange
+      vi.mocked(adminApi.roomDetail).mockResolvedValue(buildRoomDetail());
+      vi.mocked(adminApi.getActiveSession).mockResolvedValue(null);
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText(/no session is currently active/i),
+      ).toBeInTheDocument();
+    });
+
+    it('renders the active session with an End early action', async () => {
+      // Arrange
+      vi.mocked(adminApi.roomDetail).mockResolvedValue(buildRoomDetail());
+      vi.mocked(adminApi.getActiveSession).mockResolvedValue(
+        buildSession({ name: 'Morning lecture', type: 'ON_DEMAND' }),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(await screen.findByText('Morning lecture')).toBeInTheDocument();
+      expect(screen.getByText('ON_DEMAND')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'End early' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/no session is currently active/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides End early for the demo room, whose fixture session is permanent', async () => {
+      // Arrange
+      vi.mocked(adminApi.roomDetail).mockResolvedValue(
+        buildRoomDetail({ room: { uid: DEMO_ROOM_UID } }),
+      );
+      vi.mocked(adminApi.getActiveSession).mockResolvedValue(
+        buildSession({ roomUid: DEMO_ROOM_UID }),
+      );
+
+      // Act
+      renderPage(<RoomDetailPage />, DEMO_ROOM_UID);
+      await waitForLoad();
+
+      // Assert - viewing stays available, ending does not.
+      expect(
+        await screen.findByRole('button', { name: 'View session' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'End early' }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/apps/admin-webapp/tests/features/scheduling/fixtures.ts
+++ b/apps/admin-webapp/tests/features/scheduling/fixtures.ts
@@ -1,10 +1,33 @@
 import type {
   AutoSessionWindow,
   Room,
+  Session,
   SessionSchedule,
 } from '@scribear/session-manager-schema';
 
 import type { RoomDetail } from '#src/lib/admin-api';
+
+export function buildSession(overrides: Partial<Session> = {}): Session {
+  return {
+    uid: 'session-1',
+    roomUid: 'room-1',
+    name: 'On-demand session',
+    type: 'ON_DEMAND',
+    scheduledSessionUid: null,
+    scheduledStartTime: '2026-01-01T10:00:00.000Z',
+    scheduledEndTime: '2026-01-01T11:00:00.000Z',
+    startOverride: null,
+    endOverride: null,
+    effectiveStart: '2026-01-01T10:00:00.000Z',
+    effectiveEnd: '2026-01-01T11:00:00.000Z',
+    joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+    transcriptionProviderId: 'whisper',
+    transcriptionStreamConfig: {},
+    sessionConfigVersion: 1,
+    createdAt: '2026-01-01T09:00:00.000Z',
+    ...overrides,
+  };
+}
 
 export function buildRoom(overrides: Partial<Room> = {}): Room {
   return {

--- a/apps/admin-webapp/tests/features/scheduling/room-scheduling-page.test.tsx
+++ b/apps/admin-webapp/tests/features/scheduling/room-scheduling-page.test.tsx
@@ -15,6 +15,7 @@ vi.mock('#src/lib/admin-api', () => ({
     roomDetail: vi.fn(),
     listSchedules: vi.fn(),
     listAutoWindows: vi.fn(),
+    listSessions: vi.fn(),
     createSchedule: vi.fn(),
     updateSchedule: vi.fn(),
     createAutoWindow: vi.fn(),
@@ -22,6 +23,7 @@ vi.mock('#src/lib/admin-api', () => ({
     deleteSchedule: vi.fn(),
     deleteAutoWindow: vi.fn(),
     updateRoomScheduleConfig: vi.fn(),
+    createOnDemandSession: vi.fn(),
   },
 }));
 
@@ -40,6 +42,7 @@ function mockDefaultLoad(
   );
   vi.mocked(adminApi.listSchedules).mockResolvedValue({ items: schedules });
   vi.mocked(adminApi.listAutoWindows).mockResolvedValue({ items: windows });
+  vi.mocked(adminApi.listSessions).mockResolvedValue({ items: [] });
 }
 
 async function waitForLoad() {

--- a/apps/admin-webapp/tests/features/scheduling/room-scheduling-page.test.tsx
+++ b/apps/admin-webapp/tests/features/scheduling/room-scheduling-page.test.tsx
@@ -8,7 +8,12 @@ import { adminApi } from '#src/lib/admin-api';
 import { ApiError } from '#src/lib/api-error';
 
 import { renderWithProviders } from '../../utils/render-with-providers';
-import { buildRoomDetail, buildSchedule, buildWindow } from './fixtures';
+import {
+  buildRoomDetail,
+  buildSchedule,
+  buildSession,
+  buildWindow,
+} from './fixtures';
 
 vi.mock('#src/lib/admin-api', () => ({
   adminApi: {
@@ -308,6 +313,99 @@ describe('RoomSchedulingPage', () => {
       ).toBeInTheDocument();
       expect(
         screen.queryByText(/failed to update schedule/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('sessions table', (it) => {
+    /** The Sessions table body, keyed off its own column header. */
+    function sessionsTable() {
+      const header = screen.getByRole('columnheader', {
+        name: 'Effective start',
+      });
+      const table = header.closest('table');
+      if (table === null) throw new Error('no sessions table found');
+      return table;
+    }
+
+    it('lists on-demand sessions, which have no parent schedule', async () => {
+      // Arrange - the gap this page had: a live ON_DEMAND row is invisible to
+      // listSchedules, so it never appeared before.
+      mockDefaultLoad();
+      vi.mocked(adminApi.listSessions).mockResolvedValue({
+        items: [buildSession({ name: 'Ad-hoc office hours' })],
+      });
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        within(sessionsTable()).getByText('Ad-hoc office hours'),
+      ).toBeInTheDocument();
+      expect(
+        within(sessionsTable()).getByText('ON_DEMAND'),
+      ).toBeInTheDocument();
+    });
+
+    it('marks an open-ended session that has already started as active', async () => {
+      // Arrange
+      mockDefaultLoad();
+      vi.mocked(adminApi.listSessions).mockResolvedValue({
+        items: [
+          buildSession({
+            name: 'Running now',
+            effectiveStart: '2020-01-01T00:00:00.000Z',
+            effectiveEnd: null,
+          }),
+        ],
+      });
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      const table = within(sessionsTable());
+      expect(table.getByText('active')).toBeInTheDocument();
+      expect(table.getByText('Open-ended')).toBeInTheDocument();
+    });
+
+    // `useAsyncData` raises `loading` on every re-fetch, so gating the table
+    // body on it directly would blank the rows to a spinner once per poll,
+    // every SESSION_POLL_MS, for as long as the page is open.
+    it('keeps the rows visible while a background poll is in flight', async () => {
+      // Arrange
+      mockDefaultLoad();
+      vi.mocked(adminApi.listSessions)
+        .mockResolvedValueOnce({
+          items: [buildSession({ name: 'Still here' })],
+        })
+        .mockReturnValueOnce(
+          new Promise(() => {
+            /* the poll's refetch never settles */
+          }),
+        );
+      renderPage();
+      await waitForLoad();
+      expect(
+        within(sessionsTable()).getByText('Still here'),
+      ).toBeInTheDocument();
+
+      // Act - the visibility handler is the poll's other trigger; jsdom
+      // reports the document as visible, so this runs the same code path.
+      fireEvent(document, new Event('visibilitychange'));
+
+      // Assert - the refetch is in flight and the row has not been replaced.
+      await waitFor(() => {
+        expect(vi.mocked(adminApi.listSessions)).toHaveBeenCalledTimes(2);
+      });
+      expect(
+        within(sessionsTable()).getByText('Still here'),
+      ).toBeInTheDocument();
+      expect(
+        within(sessionsTable()).queryByRole('progressbar'),
       ).not.toBeInTheDocument();
     });
   });

--- a/apps/admin-webapp/tests/features/sessions/fixtures.ts
+++ b/apps/admin-webapp/tests/features/sessions/fixtures.ts
@@ -1,4 +1,4 @@
-import type { Session } from '@scribear/session-manager-schema';
+import type { Room, Session } from '@scribear/session-manager-schema';
 
 export function buildSession(overrides: Partial<Session> = {}): Session {
   return {
@@ -18,6 +18,18 @@ export function buildSession(overrides: Partial<Session> = {}): Session {
     transcriptionStreamConfig: {},
     sessionConfigVersion: 1,
     createdAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function buildRoom(overrides: Partial<Room> = {}): Room {
+  return {
+    uid: 'room-1',
+    name: 'Room 101',
+    timezone: 'America/Chicago',
+    autoSessionEnabled: false,
+    roomScheduleVersion: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
     ...overrides,
   };
 }

--- a/apps/admin-webapp/tests/features/sessions/session-detail-page.test.tsx
+++ b/apps/admin-webapp/tests/features/sessions/session-detail-page.test.tsx
@@ -22,7 +22,7 @@ import {
   stageIngress,
   stageVad,
 } from '../dashboard/audio-fixtures';
-import { buildSession } from './fixtures';
+import { buildRoom, buildSession } from './fixtures';
 
 vi.mock('#src/lib/admin-api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('#src/lib/admin-api')>();
@@ -31,6 +31,7 @@ vi.mock('#src/lib/admin-api', async (importOriginal) => {
     adminApi: {
       getSession: vi.fn(),
       getSessionJoinCode: vi.fn(),
+      getRoom: vi.fn(),
     },
   };
 });
@@ -67,6 +68,11 @@ describe('SessionDetailPage', () => {
     vi.resetAllMocks();
     // Neutral default so tests unrelated to the join-code section don't have
     // to stub it individually; overridden per-case below.
+    // The page reads the session's room for its timezone alone; default it
+    // to the browser's own zone so unrelated cases print unchanged times.
+    vi.mocked(adminApi.getRoom).mockResolvedValue(
+      buildRoom({ timezone: Intl.DateTimeFormat().resolvedOptions().timeZone }),
+    );
     vi.mocked(adminApi.getSessionJoinCode).mockResolvedValue({
       status: 'not-active',
       joinCode: null,

--- a/apps/admin-webapp/tests/lib/timezone.test.ts
+++ b/apps/admin-webapp/tests/lib/timezone.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect } from 'vitest';
+
+import { browserTimeZone, formatInTimeZone } from '#src/lib/timezone';
+
+describe('formatInTimeZone', (it) => {
+  it('renders the same instant differently in two zones', () => {
+    // Arrange - 15:30 UTC is 10:30 in Chicago (CDT) on this date.
+    const iso = '2026-07-01T15:30:00.000Z';
+
+    // Act
+    const chicago = formatInTimeZone(iso, 'America/Chicago');
+    const utc = formatInTimeZone(iso, 'UTC');
+
+    // Assert
+    expect(chicago).toContain('10:30');
+    expect(utc).toContain('3:30');
+  });
+
+  it('falls back to browser formatting for a zone Intl rejects', () => {
+    // Arrange - a bad `rooms.timezone` must degrade to a readable time rather
+    // than throw and blank the table that called it.
+    const iso = '2026-07-01T15:30:00.000Z';
+
+    // Act
+    const out = formatInTimeZone(iso, 'Not/AZone');
+
+    // Assert
+    expect(out).toBe(new Date(iso).toLocaleString());
+  });
+});
+
+describe('browserTimeZone', (it) => {
+  it('returns an IANA zone name', () => {
+    // Act
+    const zone = browserTimeZone();
+
+    // Assert - shape only; the value is whatever machine runs the suite.
+    expect(zone).toMatch(/^[A-Za-z]+(\/[A-Za-z_+-]+)*$/);
+    expect(zone.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/session-manager/src/server/features/schedule-management/schedule-management.controller.ts
+++ b/apps/session-manager/src/server/features/schedule-management/schedule-management.controller.ts
@@ -11,11 +11,13 @@ import {
   DELETE_AUTO_SESSION_WINDOW_SCHEMA,
   DELETE_SCHEDULE_SCHEMA,
   END_SESSION_EARLY_SCHEMA,
+  GET_ACTIVE_SESSION_SCHEMA,
   GET_AUTO_SESSION_WINDOW_SCHEMA,
   GET_SCHEDULE_SCHEMA,
   GET_SESSION_SCHEMA,
   LIST_AUTO_SESSION_WINDOWS_SCHEMA,
   LIST_SCHEDULES_SCHEMA,
+  LIST_SESSIONS_SCHEMA,
   MY_SCHEDULE_SCHEMA,
   SESSION_CONFIG_STREAM_SCHEMA,
   START_SESSION_EARLY_SCHEMA,
@@ -378,6 +380,44 @@ export class ScheduleManagementController {
       throw HttpError.notFound('SESSION_NOT_FOUND', 'Session not found.');
 
     res.code(200).send(this._mapSession(result));
+  }
+
+  async listSessions(
+    req: BaseFastifyRequest<typeof LIST_SESSIONS_SCHEMA>,
+    res: BaseFastifyReply<typeof LIST_SESSIONS_SCHEMA>,
+  ) {
+    const { roomUid, from, to } = req.query;
+    const now = new Date();
+
+    const result = await this._scheduleService.listSessionsForRoomInRange(
+      roomUid,
+      {
+        from: from !== undefined ? new Date(from) : new Date(0),
+        to:
+          to !== undefined
+            ? new Date(to)
+            : new Date(now.getTime() + 365 * MS_PER_DAY),
+      },
+    );
+
+    if (result === 'ROOM_NOT_FOUND')
+      throw HttpError.notFound('ROOM_NOT_FOUND', 'Room not found.');
+
+    res.code(200).send({ items: result.map((s) => this._mapSession(s)) });
+  }
+
+  async getActiveSession(
+    req: BaseFastifyRequest<typeof GET_ACTIVE_SESSION_SCHEMA>,
+    res: BaseFastifyReply<typeof GET_ACTIVE_SESSION_SCHEMA>,
+  ) {
+    const { roomUid } = req.params;
+    const now = new Date();
+
+    const result = await this._scheduleService.findActiveSession(roomUid, now);
+    if (result === 'ROOM_NOT_FOUND')
+      throw HttpError.notFound('ROOM_NOT_FOUND', 'Room not found.');
+
+    res.code(200).send(result ? this._mapSession(result) : null);
   }
 
   async createOnDemandSession(

--- a/apps/session-manager/src/server/features/schedule-management/schedule-management.router.ts
+++ b/apps/session-manager/src/server/features/schedule-management/schedule-management.router.ts
@@ -12,6 +12,8 @@ import {
   DELETE_SCHEDULE_SCHEMA,
   END_SESSION_EARLY_ROUTE,
   END_SESSION_EARLY_SCHEMA,
+  GET_ACTIVE_SESSION_ROUTE,
+  GET_ACTIVE_SESSION_SCHEMA,
   GET_AUTO_SESSION_WINDOW_ROUTE,
   GET_AUTO_SESSION_WINDOW_SCHEMA,
   GET_SCHEDULE_ROUTE,
@@ -22,6 +24,8 @@ import {
   LIST_AUTO_SESSION_WINDOWS_SCHEMA,
   LIST_SCHEDULES_ROUTE,
   LIST_SCHEDULES_SCHEMA,
+  LIST_SESSIONS_ROUTE,
+  LIST_SESSIONS_SCHEMA,
   MY_SCHEDULE_ROUTE,
   MY_SCHEDULE_SCHEMA,
   SESSION_CONFIG_STREAM_ROUTE,
@@ -146,6 +150,26 @@ export function scheduleManagementRouter(fastify: BaseFastifyInstance) {
     schema: GET_SESSION_SCHEMA,
     preHandler: adminApiKeyHook,
     handler: resolveHandler('scheduleManagementController', 'getSession'),
+  });
+
+  fastify.route({
+    ...LIST_SESSIONS_ROUTE,
+    schema: LIST_SESSIONS_SCHEMA,
+    preHandler: adminApiKeyHook,
+    handler: resolveHandler(
+      'scheduleManagementController',
+      'listSessions',
+    ),
+  });
+
+  fastify.route({
+    ...GET_ACTIVE_SESSION_ROUTE,
+    schema: GET_ACTIVE_SESSION_SCHEMA,
+    preHandler: adminApiKeyHook,
+    handler: resolveHandler(
+      'scheduleManagementController',
+      'getActiveSession',
+    ),
   });
 
   fastify.route({

--- a/apps/session-manager/src/server/features/schedule-management/schedule-management.router.ts
+++ b/apps/session-manager/src/server/features/schedule-management/schedule-management.router.ts
@@ -156,20 +156,14 @@ export function scheduleManagementRouter(fastify: BaseFastifyInstance) {
     ...LIST_SESSIONS_ROUTE,
     schema: LIST_SESSIONS_SCHEMA,
     preHandler: adminApiKeyHook,
-    handler: resolveHandler(
-      'scheduleManagementController',
-      'listSessions',
-    ),
+    handler: resolveHandler('scheduleManagementController', 'listSessions'),
   });
 
   fastify.route({
     ...GET_ACTIVE_SESSION_ROUTE,
     schema: GET_ACTIVE_SESSION_SCHEMA,
     preHandler: adminApiKeyHook,
-    handler: resolveHandler(
-      'scheduleManagementController',
-      'getActiveSession',
-    ),
+    handler: resolveHandler('scheduleManagementController', 'getActiveSession'),
   });
 
   fastify.route({

--- a/apps/session-manager/src/server/features/schedule-management/schedule-management.service.ts
+++ b/apps/session-manager/src/server/features/schedule-management/schedule-management.service.ts
@@ -769,15 +769,39 @@ export class ScheduleManagementService {
   }
 
   /**
+   * Fetches the room's currently-active session (effective start ≤ now and
+   * effective end > now or null), of any type, or `null` if none is active.
+   * @param roomUid The room to query.
+   * @param now Instant against which "active" is evaluated.
+   * @returns The active session, `null` if none is active, or `'ROOM_NOT_FOUND'`.
+   */
+  async findActiveSession(
+    roomUid: string,
+    now: Date,
+  ): Promise<Session | null | 'ROOM_NOT_FOUND'> {
+    const exists = await this._repo.roomExists(this._repo.db, roomUid);
+    if (!exists) return 'ROOM_NOT_FOUND' as const;
+    const session = await this._repo.findActiveSession(
+      this._repo.db,
+      roomUid,
+      now,
+    );
+    return session ?? null;
+  }
+
+  /**
    * Lists sessions in the room whose effective interval overlaps
    * `[range.from, range.to)`, ordered by effective start ascending.
    * @param roomUid The room to query.
    * @param range Time range to test for overlap.
+   * @returns The matching sessions, or `'ROOM_NOT_FOUND'` if the room does not exist.
    */
   async listSessionsForRoomInRange(
     roomUid: string,
     range: { from: Date; to: Date },
-  ): Promise<Session[]> {
+  ): Promise<Session[] | 'ROOM_NOT_FOUND'> {
+    const exists = await this._repo.roomExists(this._repo.db, roomUid);
+    if (!exists) return 'ROOM_NOT_FOUND' as const;
     return this._repo.listSessionsForRoomInRange(this._repo.db, roomUid, range);
   }
 

--- a/apps/session-manager/tests/integration/features/schedule-management/schedule-management.service.test.ts
+++ b/apps/session-manager/tests/integration/features/schedule-management/schedule-management.service.test.ts
@@ -839,6 +839,99 @@ describe('ScheduleManagementService', () => {
     });
   });
 
+  describe('findActiveSession', (it) => {
+    // A room with no active session and a room that does not exist are two
+    // different answers: the first is a `null` 200, the second a 404. Callers
+    // (the admin console's "Active session" card) render them differently.
+    async function insertSession(
+      roomUid: string,
+      name: string,
+      start: string,
+      end: string | null,
+    ) {
+      await dbContext.db
+        .insertInto('sessions')
+        .values({
+          room_uid: roomUid,
+          name,
+          type: 'ON_DEMAND',
+          scheduled_start_time: new Date(start),
+          scheduled_end_time: end === null ? null : new Date(end),
+          transcription_provider_id: 'whisper',
+          transcription_stream_config: {},
+        })
+        .execute();
+    }
+
+    it('returns the session covering `now`', async () => {
+      // Arrange
+      const { uid: roomUid } = await insertRoom('UTC');
+      await insertSession(
+        roomUid,
+        'Running',
+        '2024-06-01T10:00:00Z',
+        '2024-06-01T11:00:00Z',
+      );
+
+      // Act
+      const found = await service.findActiveSession(
+        roomUid,
+        new Date('2024-06-01T10:30:00Z'),
+      );
+
+      // Assert
+      expect(found).not.toBe('ROOM_NOT_FOUND');
+      expect(
+        (found as Exclude<typeof found, 'ROOM_NOT_FOUND'>)?.name,
+      ).toBe('Running');
+    });
+
+    it('treats an open-ended session as active with no end bound', async () => {
+      // Arrange
+      const { uid: roomUid } = await insertRoom('UTC');
+      await insertSession(roomUid, 'Open', '2024-06-01T10:00:00Z', null);
+
+      // Act — far past the point any bounded session would have ended.
+      const found = await service.findActiveSession(
+        roomUid,
+        new Date('2024-06-05T00:00:00Z'),
+      );
+
+      // Assert
+      expect(
+        (found as Exclude<typeof found, 'ROOM_NOT_FOUND'>)?.name,
+      ).toBe('Open');
+    });
+
+    it('returns null for an existing room with nothing running', async () => {
+      // Arrange
+      const { uid: roomUid } = await insertRoom('UTC');
+      await insertSession(
+        roomUid,
+        'Finished',
+        '2024-06-01T10:00:00Z',
+        '2024-06-01T11:00:00Z',
+      );
+
+      // Act
+      const found = await service.findActiveSession(
+        roomUid,
+        new Date('2024-06-01T12:00:00Z'),
+      );
+
+      // Assert — null, NOT 'ROOM_NOT_FOUND'.
+      expect(found).toBeNull();
+    });
+
+    it('returns ROOM_NOT_FOUND when the room does not exist', async () => {
+      const result = await service.findActiveSession(
+        NULL_UUID,
+        new Date('2024-06-01T12:00:00Z'),
+      );
+      expect(result).toBe('ROOM_NOT_FOUND');
+    });
+  });
+
   describe('createSchedule - INVALID_ACTIVE_START precondition', (it) => {
     it('rejects when activeStart equals now', async () => {
       // Arrange

--- a/apps/session-manager/tests/integration/features/schedule-management/schedule-management.service.test.ts
+++ b/apps/session-manager/tests/integration/features/schedule-management/schedule-management.service.test.ts
@@ -825,7 +825,17 @@ describe('ScheduleManagementService', () => {
       });
 
       // Assert
-      expect(found.map((s) => s.name)).toEqual(['In-range']);
+      expect(found).not.toBe('ROOM_NOT_FOUND');
+      const sessions = found as Exclude<typeof found, 'ROOM_NOT_FOUND'>;
+      expect(sessions.map((s) => s.name)).toEqual(['In-range']);
+    });
+
+    it('returns ROOM_NOT_FOUND when the room does not exist', async () => {
+      const result = await service.listSessionsForRoomInRange(NULL_UUID, {
+        from: new Date('2024-06-01T09:00:00Z'),
+        to: new Date('2024-06-01T13:00:00Z'),
+      });
+      expect(result).toBe('ROOM_NOT_FOUND');
     });
   });
 

--- a/libs/clients/session-manager-client/src/schedule-management-client.ts
+++ b/libs/clients/session-manager-client/src/schedule-management-client.ts
@@ -13,6 +13,8 @@ import {
   DELETE_SCHEDULE_SCHEMA,
   END_SESSION_EARLY_ROUTE,
   END_SESSION_EARLY_SCHEMA,
+  GET_ACTIVE_SESSION_ROUTE,
+  GET_ACTIVE_SESSION_SCHEMA,
   GET_AUTO_SESSION_WINDOW_ROUTE,
   GET_AUTO_SESSION_WINDOW_SCHEMA,
   GET_SCHEDULE_ROUTE,
@@ -23,6 +25,8 @@ import {
   LIST_AUTO_SESSION_WINDOWS_SCHEMA,
   LIST_SCHEDULES_ROUTE,
   LIST_SCHEDULES_SCHEMA,
+  LIST_SESSIONS_ROUTE,
+  LIST_SESSIONS_SCHEMA,
   MY_SCHEDULE_ROUTE,
   MY_SCHEDULE_SCHEMA,
   SESSION_CONFIG_STREAM_ROUTE,
@@ -104,6 +108,16 @@ function createScheduleManagementClient(baseUrl: string) {
     getSession: createEndpointClient(
       GET_SESSION_SCHEMA,
       GET_SESSION_ROUTE,
+      baseUrl,
+    ),
+    listSessions: createEndpointClient(
+      LIST_SESSIONS_SCHEMA,
+      LIST_SESSIONS_ROUTE,
+      baseUrl,
+    ),
+    getActiveSession: createEndpointClient(
+      GET_ACTIVE_SESSION_SCHEMA,
+      GET_ACTIVE_SESSION_ROUTE,
       baseUrl,
     ),
     createOnDemandSession: createEndpointClient(

--- a/libs/schemas/session-manager-schema/src/index.ts
+++ b/libs/schemas/session-manager-schema/src/index.ts
@@ -50,6 +50,8 @@ export * from './schedule-management/routes/get-auto-session-window.schema.js';
 export * from './schedule-management/routes/update-auto-session-window.schema.js';
 export * from './schedule-management/routes/delete-auto-session-window.schema.js';
 export * from './schedule-management/routes/get-session.schema.js';
+export * from './schedule-management/routes/get-active-session.schema.js';
+export * from './schedule-management/routes/list-sessions.schema.js';
 export * from './schedule-management/routes/create-on-demand-session.schema.js';
 export * from './schedule-management/routes/start-session-early.schema.js';
 export * from './schedule-management/routes/end-session-early.schema.js';

--- a/libs/schemas/session-manager-schema/src/schedule-management/routes/get-active-session.schema.ts
+++ b/libs/schemas/session-manager-schema/src/schedule-management/routes/get-active-session.schema.ts
@@ -1,0 +1,52 @@
+import { Type } from 'typebox';
+
+import {
+  type BaseRouteDefinition,
+  type BaseRouteSchema,
+  STANDARD_ERROR_REPLIES,
+} from '@scribear/base-schema';
+
+import { SESSION_MANAGER_BASE_PATH } from '#src/base-path.js';
+import {
+  ADMIN_API_KEY_AUTH_HEADER_SCHEMA,
+  ADMIN_API_KEY_SECURITY,
+  INVALID_ADMIN_KEY_REPLY_SCHEMA,
+} from '#src/shared/security/admin-api-key.js';
+import { SCHEDULE_MANAGEMENT_TAG } from '#src/tags.js';
+
+import { SESSION_SCHEMA } from '../entities/session.schema.js';
+
+/**
+ * The room's currently-active session: effective start ≤ now and (effective
+ * end > now or effective end is null). Null body (200) when no session is
+ * active, so a caller can distinguish "room has no active session" from "room
+ * not found" (404) without inspecting the error code.
+ */
+const GET_ACTIVE_SESSION_SCHEMA = {
+  description:
+    'Fetch the currently-active session for a room, of any type. Returns null when no session is active.',
+  tags: [SCHEDULE_MANAGEMENT_TAG],
+  security: ADMIN_API_KEY_SECURITY,
+  headers: Type.Object({
+    authorization: Type.Optional(ADMIN_API_KEY_AUTH_HEADER_SCHEMA),
+  }),
+  params: Type.Object({
+    roomUid: Type.String({ format: 'uuid' }),
+  }),
+  response: {
+    200: Type.Union([SESSION_SCHEMA, Type.Null()]),
+    ...STANDARD_ERROR_REPLIES,
+    ...INVALID_ADMIN_KEY_REPLY_SCHEMA,
+    404: Type.Object({
+      code: Type.Literal('ROOM_NOT_FOUND'),
+      message: Type.String(),
+    }),
+  },
+} satisfies BaseRouteSchema;
+
+const GET_ACTIVE_SESSION_ROUTE: BaseRouteDefinition = {
+  method: 'GET',
+  url: `${SESSION_MANAGER_BASE_PATH}/schedule-management/get-active-session/:roomUid`,
+};
+
+export { GET_ACTIVE_SESSION_ROUTE, GET_ACTIVE_SESSION_SCHEMA };

--- a/libs/schemas/session-manager-schema/src/schedule-management/routes/list-sessions.schema.ts
+++ b/libs/schemas/session-manager-schema/src/schedule-management/routes/list-sessions.schema.ts
@@ -29,13 +29,15 @@ const LIST_SESSIONS_SCHEMA = {
     from: Type.Optional(
       Type.String({
         format: 'date-time',
-        description: 'Exclude sessions whose effective end is before this time.',
+        description:
+          'Exclude sessions whose effective end is before this time.',
       }),
     ),
     to: Type.Optional(
       Type.String({
         format: 'date-time',
-        description: 'Exclude sessions whose effective start is at or after this time.',
+        description:
+          'Exclude sessions whose effective start is at or after this time.',
       }),
     ),
   }),

--- a/libs/schemas/session-manager-schema/src/schedule-management/routes/list-sessions.schema.ts
+++ b/libs/schemas/session-manager-schema/src/schedule-management/routes/list-sessions.schema.ts
@@ -1,0 +1,60 @@
+import { Type } from 'typebox';
+
+import {
+  type BaseRouteDefinition,
+  type BaseRouteSchema,
+  STANDARD_ERROR_REPLIES,
+} from '@scribear/base-schema';
+
+import { SESSION_MANAGER_BASE_PATH } from '#src/base-path.js';
+import {
+  ADMIN_API_KEY_AUTH_HEADER_SCHEMA,
+  ADMIN_API_KEY_SECURITY,
+  INVALID_ADMIN_KEY_REPLY_SCHEMA,
+} from '#src/shared/security/admin-api-key.js';
+import { SCHEDULE_MANAGEMENT_TAG } from '#src/tags.js';
+
+import { SESSION_SCHEMA } from '../entities/session.schema.js';
+
+const LIST_SESSIONS_SCHEMA = {
+  description:
+    'List sessions for a room whose effective interval overlaps the given time range. effectiveStart < to and (effectiveEnd > from or effectiveEnd is null). Ordered by effective start ascending. Includes ON_DEMAND and AUTO rows, which have no parent schedule and are therefore invisible to list-schedules.',
+  tags: [SCHEDULE_MANAGEMENT_TAG],
+  security: ADMIN_API_KEY_SECURITY,
+  headers: Type.Object({
+    authorization: Type.Optional(ADMIN_API_KEY_AUTH_HEADER_SCHEMA),
+  }),
+  querystring: Type.Object({
+    roomUid: Type.String({ format: 'uuid' }),
+    from: Type.Optional(
+      Type.String({
+        format: 'date-time',
+        description: 'Exclude sessions whose effective end is before this time.',
+      }),
+    ),
+    to: Type.Optional(
+      Type.String({
+        format: 'date-time',
+        description: 'Exclude sessions whose effective start is at or after this time.',
+      }),
+    ),
+  }),
+  response: {
+    200: Type.Object({
+      items: Type.Array(SESSION_SCHEMA),
+    }),
+    ...STANDARD_ERROR_REPLIES,
+    ...INVALID_ADMIN_KEY_REPLY_SCHEMA,
+    404: Type.Object({
+      code: Type.Literal('ROOM_NOT_FOUND'),
+      message: Type.String(),
+    }),
+  },
+} satisfies BaseRouteSchema;
+
+const LIST_SESSIONS_ROUTE: BaseRouteDefinition = {
+  method: 'GET',
+  url: `${SESSION_MANAGER_BASE_PATH}/schedule-management/list-sessions`,
+};
+
+export { LIST_SESSIONS_ROUTE, LIST_SESSIONS_SCHEMA };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "a11y:mock": "node tools/a11y/mock-server.mjs",
     "a11y:axe:authed": "node tools/a11y/axe-scan-authed.mjs",
     "e2e:audio": "node tools/e2e-audio/kiosk-audio-e2e.mjs",
+    "e2e:admin": "node tools/admin-scheduling-e2e/admin-scheduling-e2e.mjs",
     "asr:load": "node tools/asr-load/asr-load.mjs"
   },
   "engines": {

--- a/tools/admin-scheduling-e2e/README.md
+++ b/tools/admin-scheduling-e2e/README.md
@@ -63,7 +63,7 @@ present and passes once fixed.
 | `NO_ACTIVE_SESSION_IN_ROOM_VIEW` | PASS | Room detail page renders an "Active session" card. |
 | `ON_DEMAND_SESSION_NOT_ON_SCHEDULING_PAGE` | PASS | New "Sessions" table lists live rows. |
 | `ALREADY_RUNNING_WITH_NONE_VISIBLE` | PASS | The blocking session is visible in the sessions table. |
-| `NO_ADMIN_SESSION_LIST_ENDPOINT` | PASS | `GET /sessions/list` and `GET /rooms/:roomUid/active-session` exist. |
+| `NO_ADMIN_SESSION_LIST_ENDPOINT` | PASS | `GET /sessions/list` and `GET /sessions/active/:roomUid` exist. |
 | `SCHEDULE_BEYOND_90_DAY_WINDOW_INVISIBLE` | FAIL | Accepted limitation (see below). |
 | `NO_AUTO_REFRESH` | PASS | 15s session-list poll, visibility-gated. |
 
@@ -107,7 +107,7 @@ GET /api/session-manager/v1/schedule-management/get-active-session/:roomUid
   (`libs/clients/session-manager-client/`).
 - **admin BFF**: thin audited proxies at
   `GET /api/admin/v1/sessions/list` and
-  `GET /api/admin/v1/rooms/:roomUid/active-session`, following the existing
+  `GET /api/admin/v1/sessions/active/:roomUid`, following the existing
   gateway pattern.
 - **admin-webapp client**: `adminApi.listSessions()`, `adminApi.getActiveSession()`.
 

--- a/tools/admin-scheduling-e2e/README.md
+++ b/tools/admin-scheduling-e2e/README.md
@@ -1,0 +1,247 @@
+# Admin scheduling/session regression checks
+
+Drives a real headless Chromium against a running stack's admin console
+(`/admin/`) and pins the behaviours around the room scheduling / session
+interface that were found broken or missing. It is a regression scaffold: each
+check names the bug it pins, so a fix that changes the behaviour fails loudly
+here and the test is updated alongside it.
+
+Unlike `tools/e2e-audio`, this drives the **admin console** (not the kiosk) and
+authenticates through its real login flow, then provisions a throwaway device +
+room through the admin BFF API before exercising the scheduling UI.
+
+## Why
+
+The scheduling/session review turned up six issues that are invisible to the
+existing test suites — three of them ("active session not shown", "on-demand
+not on the calendar", "already running with none visible") are operator-facing
+and only reproduce against the running SPA. This tool exists so a regression on
+any of them is caught before it ships, and so the fix is forced to update the
+assertion that captured it.
+
+The companion code change (this commit) fixes five of the six; the sixth
+(`SCHEDULE_BEYOND_90_DAY_WINDOW_INVISIBLE`) is documented as an accepted
+limitation. The expected baseline after the fix is **5/6 passing**.
+
+## Run
+
+```bash
+# Needs the stack up (deployment/compose.yml) and a root `npm install`
+# for puppeteer-core + Chrome on PATH (or CHROME_PATH set).
+npm run e2e:admin
+```
+
+```bash
+node tools/admin-scheduling-e2e/admin-scheduling-e2e.mjs \
+  --base-url https://localhost \
+  --username engrit --password 'engrit-dev-pass-0123' \
+  --json            # machine-readable result
+  --keep-room       # leave the provisioned room for inspection
+```
+
+Credentials default from `deployment/.env` (`ADMIN_LOCAL_CREDENTIALS`); flags
+override. Exits non-zero on any failing check.
+
+## What it checks
+
+Each check is named for the **desired** behaviour, so it fails while the bug is
+present and passes once fixed.
+
+| Bug | Desired behaviour (passes when fixed) |
+| --- | --- |
+| `NO_ACTIVE_SESSION_IN_ROOM_VIEW` | The room detail page shows the room's current/active session. |
+| `ON_DEMAND_SESSION_NOT_ON_SCHEDULING_PAGE` | The scheduling page lists live on-demand sessions, not just schedule/window definitions. |
+| `ALREADY_RUNNING_WITH_NONE_VISIBLE` | When a new on-demand session is blocked by an active one, the page surfaces the blocking session. |
+| `NO_ADMIN_SESSION_LIST_ENDPOINT` | An admin BFF route lists sessions / returns a room's active session. |
+| `SCHEDULE_BEYOND_90_DAY_WINDOW_INVISIBLE` | A schedule starting >90 days out is not silently clipped from the listing. |
+| `NO_AUTO_REFRESH` | The scheduling page reflects server-side session/schedule changes without a manual reload. |
+
+### Current state (after the fix in this commit)
+
+| Bug | Status | Notes |
+| --- | --- | --- |
+| `NO_ACTIVE_SESSION_IN_ROOM_VIEW` | PASS | Room detail page renders an "Active session" card. |
+| `ON_DEMAND_SESSION_NOT_ON_SCHEDULING_PAGE` | PASS | New "Sessions" table lists live rows. |
+| `ALREADY_RUNNING_WITH_NONE_VISIBLE` | PASS | The blocking session is visible in the sessions table. |
+| `NO_ADMIN_SESSION_LIST_ENDPOINT` | PASS | `GET /sessions/list` and `GET /rooms/:roomUid/active-session` exist. |
+| `SCHEDULE_BEYOND_90_DAY_WINDOW_INVISIBLE` | FAIL | Accepted limitation (see below). |
+| `NO_AUTO_REFRESH` | PASS | 15s session-list poll, visibility-gated. |
+
+## The bugs, root cause, and the fix
+
+### Root cause: one architectural gap
+
+All three operator-facing bugs share a single root: **sessions have no `status`
+column — "active" is derived from `COALESCE(end_override, scheduled_end_time)`
+— and the admin BFF exposed no endpoint to list sessions or fetch a room's
+active one.** The repository queries that answer these questions already
+existed (`findActiveSession`, `listSessionsForRoomInRange` in
+`schedule-management.repository.ts`) but were never wired to an admin route.
+The only consumer was the device-auth `my-schedule` long-poll, unreachable from
+the admin console.
+
+So an on-demand session — which gets `scheduled_end_time = NULL` when no
+following session exists, making it active forever — was invisible and
+unblockable from the admin UI. Creating a second one returned
+`ANOTHER_SESSION_ACTIVE`, but the operator had no way to see or end the first.
+
+### The fix (five changes, A–F)
+
+**A. Expose session listing + active-session (the keystone).** Two new routes,
+mirrored through all four layers exactly as the existing schedule routes are:
+
+```
+GET /api/session-manager/v1/schedule-management/list-sessions?roomUid=&from=&to=
+GET /api/session-manager/v1/schedule-management/get-active-session/:roomUid
+```
+
+- **Schema** (`libs/schemas/session-manager-schema/.../routes/`):
+  `list-sessions.schema.ts`, `get-active-session.schema.ts`. The active-session
+  route returns `Session | null` (200 with null body when none is active) so a
+  caller distinguishes "no active session" from "room not found" (404) without
+  inspecting the error code.
+- **session-manager**: router registration (admin-key guarded), controller
+  handlers (`listSessions`, `getActiveSession`), service methods
+  (`findActiveSession`, `listSessionsForRoomInRange` now also return
+  `'ROOM_NOT_FOUND'`, mirroring `listSchedulesForRoom`), typed client methods
+  (`libs/clients/session-manager-client/`).
+- **admin BFF**: thin audited proxies at
+  `GET /api/admin/v1/sessions/list` and
+  `GET /api/admin/v1/rooms/:roomUid/active-session`, following the existing
+  gateway pattern.
+- **admin-webapp client**: `adminApi.listSessions()`, `adminApi.getActiveSession()`.
+
+**B. Show the active session in the room view.** `room-detail-page.tsx` fetches
+`getActiveSession` and renders an "Active session" card: name, type chip,
+effective start/end, a "View session" link, and an "End early" button (which
+reuses the existing `endSessionEarly` endpoint).
+
+**C. List live sessions on the scheduling page.** `room-scheduling-page.tsx`
+adds a third `useAsyncData` call to `listSessions` and renders a "Sessions"
+table above the on-demand section. Each row shows name, type, an "active" chip
+(when currently within its effective window), effective start/end, and a
+"View" link. This surfaces the ON_DEMAND and AUTO rows that were previously
+invisible (they have no parent schedule, so `listSchedules` never returned
+them).
+
+**D. Widen the look-back window.** The scheduling page's range was
+`[now, now+90d)` — zero look-back. Changed to `[now-7d, now+90d)` so an active
+session that started before page-load still appears. (The session-list query
+uses an overlap predicate, not `active_start <= to`, so this primarily governs
+sessions; the schedule-definition table keeps its forward 90d view.)
+
+**E. Auto-refresh the scheduling page.** Added a 15s `setInterval` polling
+`listSessions`, gated on `document.visibilityState === 'visible'` (the same
+pattern `use-fleet.ts` and `use-test-audio.ts` use). Schedules/windows are
+slow-moving definitions and still reload only on mutation; the poll covers the
+live session rows, which is what changes underneath an operator. A `now` state
+is bumped on the same interval so the "active" chip stays current without an
+impure `Date.now()` during render (the lint rule the codebase already enforces).
+
+**F. Guard the demo room.** The demo caption room's permanently-active fixture
+session (`DEMO_ROOM_UID`) is not a real transcription session. The "End early"
+button is hidden for it, mirroring the existing demo-room device controls.
+
+### Accepted limitation: `SCHEDULE_BEYOND_90_DAY_WINDOW_INVISIBLE`
+
+A schedule whose `activeStart` is >90 days out is stored and valid but not
+listed on the scheduling page, because the schedule-definition query filters
+`active_start <= now+90d`. This is **not fixed**: the materialized session rows
+those schedules produce *do* appear via the new sessions endpoint once they
+fall within the session-list range (which uses an overlap predicate). Widening
+the schedule window further was judged lower-value and is left as a follow-up;
+the regression test pins the current behaviour so a future change is deliberate.
+
+## Design notes for reviewers
+
+### Why mirror existing routes rather than reuse `my-schedule`?
+
+The device-facing `my-schedule` endpoint already returns the active + upcoming
+sessions for a room. It was tempting to proxy it. We did not, for three reasons:
+
+1. **Auth model.** `my-schedule` is `deviceTokenHook`-authenticated (a kiosk
+   device identity), not `adminApiKeyHook`. The admin BFF holds the admin key,
+   not a device token; reusing the route would mean inventing a device identity
+   for the console or weakening the auth on an existing route.
+2. **Semantics.** `my-schedule` is a long-poll keyed on `roomScheduleVersion`,
+   returning a 7-day horizon of active+upcoming. The admin console needs a
+   range-bounded list (for the calendar) and a point query (for the room
+   view) — different shapes.
+3. **Surface area.** Two new read routes, each a thin wrapper over an existing
+   repository query, is less risk than repurposing a device-facing long-poll.
+
+### Why `Session | null` (200) for active-session, not 404?
+
+A 404 conflates "the room has no active session" (a normal, expected state) with
+"the room does not exist" (an error). Returning `null` at 200 lets the UI render
+"No session is currently active" without an error path, and reserves 404 for a
+genuinely missing room.
+
+### Why poll instead of long-poll / SSE?
+
+The session-manager already has a `roomScheduleVersion`-keyed event bus and
+long-poll infrastructure (`my-schedule`, `session-config-stream`). Wiring the
+admin BFF to long-poll would be lower-latency and lower-overhead than a 15s
+poll. It is also a larger change: a new SSE/long-poll route through the BFF,
+an event-bus subscription across what may be multiple session-manager
+instances (the bus is in-process today — see `event-bus.service.ts`), and
+corresponding client code. A visibility-gated 15s poll is the lower-risk first
+step; the regression test pins the behaviour so upgrading to long-poll later
+does not silently regress it.
+
+### Why does `listSessionsForRoomInRange` now return `'ROOM_NOT_FOUND'`?
+
+The repository method returned `Session[]` unconditionally. The service method
+now checks `roomExists` first and returns `'ROOM_NOT_FOUND'` to match the
+established pattern of `listSchedulesForRoom` (which the existing
+`listSchedules` controller handler already maps to a 404). This keeps the
+controller thin and the error consistent across list endpoints. The one
+existing test caller was updated to narrow the type.
+
+### Why not also fix the far-future schedule clip?
+
+The schedule-definition table's 90-day forward window clips schedules with
+`activeStart > now+90d`. The session rows those schedules *materialize* are
+listed by the new sessions endpoint (overlap predicate) once within range, so
+the operator can still see upcoming sessions. The schedule *definition* being
+hidden until it enters the window is a narrower gap; widening it touches the
+materialization horizon (`MATERIALIZATION_WINDOW_DAYS = 7`) and the conflict
+check horizon (`CONFLICT_CHECK_HORIZON_DAYS = 14`), which are separate
+concerns. Left as a follow-up rather than bundled here.
+
+## Notes
+
+- Provisioning is unique per run (`pw-<pid>-<epoch>`), so repeated runs never
+  collide. The room is deleted on exit (cascades its sessions), unless
+  `--keep-room` is set.
+- BFF API calls run inside the browser page (`page.evaluate` + `fetch`), so the
+  admin session cookie and CSRF token are handled by the browser context after
+  login — no separate cookie jar.
+- Chrome is auto-detected the same way `tools/e2e-audio` does it: `CHROME_PATH`,
+  then the usual system locations.
+- The tool uses `puppeteer-core` (already a root devDependency for
+  `tools/e2e-audio`), not Playwright, to match the existing tooling convention.
+
+## Files changed by the companion fix
+
+```
+libs/schemas/session-manager-schema/src/schedule-management/routes/list-sessions.schema.ts      (new)
+libs/schemas/session-manager-schema/src/schedule-management/routes/get-active-session.schema.ts (new)
+libs/schemas/session-manager-schema/src/index.ts                                                 (+2 exports)
+libs/clients/session-manager-client/src/schedule-management-client.ts                            (+2 methods)
+apps/session-manager/src/server/features/schedule-management/schedule-management.router.ts       (+2 routes)
+apps/session-manager/src/server/features/schedule-management/schedule-management.controller.ts   (+2 handlers)
+apps/session-manager/src/server/features/schedule-management/schedule-management.service.ts      (+2 methods, ROOM_NOT_FOUND)
+apps/admin-server/src/server/features/scheduling/scheduling.schema.ts                            (+2 routes)
+apps/admin-server/src/server/features/scheduling/scheduling.router.ts                            (+2 routes)
+apps/admin-server/src/server/features/scheduling/scheduling.controller.ts                        (+2 handlers)
+apps/admin-server/src/server/shared/services/session-manager-gateway.service.ts                  (+2 methods)
+apps/admin-webapp/src/lib/admin-api.ts                                                           (+2 methods)
+apps/admin-webapp/src/features/rooms/room-detail-page.tsx                                        (active-session card)
+apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx                               (sessions table, poll, look-back)
+apps/admin-webapp/tests/features/rooms/room-detail-page.test.tsx                                 (mock stubs)
+apps/admin-webapp/tests/features/scheduling/room-scheduling-page.test.tsx                        (mock stubs)
+apps/session-manager/tests/integration/features/schedule-management/schedule-management.service.test.ts (ROOM_NOT_FOUND case)
+tools/admin-scheduling-e2e/                                                                     (this tool, new)
+package.json                                                                                    (e2e:admin script)
+```

--- a/tools/admin-scheduling-e2e/admin-scheduling-e2e.mjs
+++ b/tools/admin-scheduling-e2e/admin-scheduling-e2e.mjs
@@ -52,7 +52,6 @@
  *      The scheduling page has no poll/interval. A session created server-side
  *      after page load never appears until the page is reloaded manually.
  */
-import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import puppeteer from 'puppeteer-core';
 

--- a/tools/admin-scheduling-e2e/admin-scheduling-e2e.mjs
+++ b/tools/admin-scheduling-e2e/admin-scheduling-e2e.mjs
@@ -1,0 +1,531 @@
+/**
+ * Admin console scheduling/session regression checks.
+ *
+ * Drives a real headless Chromium against a running stack's admin console
+ * (/admin/) and asserts the behaviours around the room scheduling / session
+ * interface that were found broken or missing. It is a regression scaffold:
+ * each check names the bug it pins, so a fix that changes the behaviour fails
+ * loudly here and the test gets updated alongside it.
+ *
+ * Usage:
+ *   node tools/admin-scheduling-e2e/admin-scheduling-e2e.mjs [options]
+ *
+ * Options:
+ *   --base-url <url>   default https://localhost  (self-signed certs accepted)
+ *   --username <u>     default engrit             (ADMIN_LOCAL_CREDENTIALS)
+ *   --password <p>     default engrit-dev-pass-0123
+ *   --json             machine-readable result on stdout
+ *   --keep-room        do not delete the provisioned room at the end
+ *
+ * Requires a running stack (deployment/compose.yml) with the admin console
+ * served at <base-url>/admin/. Chrome is auto-detected the same way
+ * tools/e2e-audio does: CHROME_PATH, then the usual system locations.
+ *
+ * What it checks (each maps to a finding in the scheduling/session review):
+ *
+ *   1. NO_ACTIVE_SESSION_IN_ROOM_VIEW
+ *      An active on-demand session exists, but the room detail page shows no
+ *      "current/active session" anywhere. There is no field for it: the Room
+ *      entity carries no session reference and no admin endpoint returns one.
+ *
+ *   2. ON_DEMAND_SESSION_NOT_ON_SCHEDULING_PAGE
+ *      The scheduling page lists schedule *definitions* and auto-session
+ *      *windows* only. A live on-demand session (a `sessions` row with no
+ *      parent schedule) is invisible to it.
+ *
+ *   3. ALREADY_RUNNING_WITH_NONE_VISIBLE
+ *      Creating a second on-demand session is rejected 409
+ *      ANOTHER_SESSION_ACTIVE, but the scheduling page shows no active session
+ *      to explain the conflict — the operator is blocked with no recourse from
+ *      the UI.
+ *
+ *   4. NO_ADMIN_SESSION_LIST_ENDPOINT
+ *      No admin BFF route lists sessions or returns a room's active session.
+ *      GET /api/admin/v1/sessions/list is 404; the only session read is by UID.
+ *
+ *   5. SCHEDULE_BEYOND_90_DAY_WINDOW_INVISIBLE
+ *      The scheduling page queries [now, now+90d). A schedule whose activeStart
+ *      is >90 days out is stored and valid but never listed — clipped by the
+ *      `active_start <= to` filter, not by end date.
+ *
+ *   6. NO_AUTO_REFRESH
+ *      The scheduling page has no poll/interval. A session created server-side
+ *      after page load never appears until the page is reloaded manually.
+ */
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import puppeteer from 'puppeteer-core';
+
+const CHROME_CANDIDATES = [
+  process.env.CHROME_PATH,
+  '/usr/bin/google-chrome-stable',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium-browser',
+  '/usr/bin/chromium',
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+].filter(Boolean);
+
+function resolveChrome() {
+  for (const p of CHROME_CANDIDATES) if (existsSync(p)) return p;
+  throw new Error(
+    `No Chrome/Chromium found. Set CHROME_PATH. Tried: ${CHROME_CANDIDATES.join(', ')}`,
+  );
+}
+
+function parseArgs(argv) {
+  const a = {
+    baseUrl: 'https://localhost',
+    username: 'engrit',
+    password: 'engrit-dev-pass-0123',
+    json: false,
+    keepRoom: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const f = argv[i];
+    if (f === '--json') a.json = true;
+    else if (f === '--keep-room') a.keepRoom = true;
+    else if (f === '--base-url') a.baseUrl = argv[++i];
+    else if (f === '--username') a.username = argv[++i];
+    else if (f === '--password') a.password = argv[++i];
+  }
+  return a;
+}
+
+/**
+ * Read the admin local credentials from deployment/.env when present, so the
+ * defaults above can be overridden without flags. Mirrors the way e2e-audio
+ * reads the admin key.
+ */
+function credsFromEnv(args) {
+  try {
+    const env = readFileSync(new URL('../../deployment/.env', import.meta.url), 'utf8');
+    const line = env.split('\n').find((l) => l.startsWith('ADMIN_LOCAL_CREDENTIALS='));
+    if (line) {
+      const val = line.slice('ADMIN_LOCAL_CREDENTIALS='.length).trim();
+      const [user, ...rest] = val.split(/\s+/);
+      if (user && rest.length) return { ...args, username: user, password: rest.join(' ') };
+    }
+  } catch {
+    // .env optional
+  }
+  return args;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** A single assertion result. `bug` ties it back to a finding. */
+function check(name, bug, ok, detail = '') {
+  return { name, bug, ok, detail };
+}
+
+/**
+ * BFF API call run inside the browser page so the admin session cookie and CSRF
+ * token are handled by the browser context. Returns { status, body }.
+ */
+async function bff(page, method, path, { body, csrf } = {}) {
+  return page.evaluate(
+    async (method, path, body, csrf) => {
+      const res = await fetch(`/api/admin/v1${path}`, {
+        method,
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(csrf ? { 'x-csrf-token': csrf } : {}),
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      let parsed = null;
+      const text = await res.text();
+      try {
+        parsed = text ? JSON.parse(text) : null;
+      } catch {
+        parsed = text;
+      }
+      return { status: res.status, body: parsed };
+    },
+    method,
+    path,
+    body ?? null,
+    csrf ?? null,
+  );
+}
+
+/** Wait for a visible MUI Snackbar toast whose Alert text contains `needle`. */
+async function waitForToast(page, needle, timeoutMs = 8000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const hit = await page.evaluate((needle) => {
+      const alerts = [...document.querySelectorAll('.MuiAlert-message, [role="alert"]')];
+      const el = alerts.find((e) => (e.textContent ?? '').includes(needle));
+      return el ? el.textContent.trim() : null;
+    }, needle);
+    if (hit) return hit;
+    await sleep(150);
+  }
+  return null;
+}
+
+/** Visible text of the page, whitespace-collapsed, for "does it mention X" checks. */
+async function bodyText(page) {
+  return page.evaluate(() => (document.body.innerText || '').replace(/\s+/g, ' '));
+}
+
+async function main() {
+  const args = credsFromEnv(parseArgs(process.argv.slice(2)));
+  const log = (...m) => {
+    if (!args.json) console.log(...m);
+  };
+  const results = [];
+  let browser, page, roomUid, deviceUid, scheduleUid;
+
+  try {
+    browser = await puppeteer.launch({
+      executablePath: resolveChrome(),
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--ignore-certificate-errors'],
+      acceptInsecureCerts: true,
+    });
+    page = await browser.newPage();
+    page.setDefaultTimeout(15_000);
+
+    // ---- Login through the UI (real auth path) ----
+    log('--- logging in to /admin/');
+    await page.goto(`${args.baseUrl}/admin/`, { waitUntil: 'networkidle2' });
+    await page.waitForSelector('input[autocomplete="username"]', { visible: true });
+    await page.type('input[autocomplete="username"]', args.username);
+    await page.type('input[type="password"]', args.password);
+    await page.click('button[type="submit"]');
+    // The dashboard renders a health tile once authed.
+    await page.waitForFunction(() => window.location.pathname.startsWith('/admin'), {
+      timeout: 10_000,
+    });
+    await page.waitForFunction(
+      () => !document.querySelector('input[autocomplete="username"]'),
+      { timeout: 10_000 },
+    );
+    log('--- authed');
+
+    // Fetch the CSRF token; all BFF mutations need it.
+    const me = await bff(page, 'GET', '/auth/me');
+    const csrf = me.body?.data?.csrfToken;
+    if (!csrf) throw new Error('No CSRF token from /auth/me');
+
+    // ---- Provision a uniquely-named device + room via the BFF ----
+    const stamp = `pw-${process.pid}-${Math.floor(Date.now() / 1000)}`;
+    const dev = await bff(page, 'POST', '/devices/register', {
+      body: { name: `${stamp}-src` },
+      csrf,
+    });
+    deviceUid = dev.body?.data?.deviceUid;
+    if (!deviceUid) throw new Error(`device register failed: ${JSON.stringify(dev.body)}`);
+
+    const room = await bff(page, 'POST', '/rooms/create', {
+      body: {
+        name: `${stamp}-room`,
+        timezone: 'UTC',
+        autoSessionEnabled: false,
+        sourceDeviceUids: [deviceUid],
+      },
+      csrf,
+    });
+    roomUid = room.body?.data?.uid;
+    if (!roomUid) throw new Error(`room create failed: ${JSON.stringify(room.body)}`);
+    log(`--- provisioned room ${roomUid} (device ${deviceUid})`);
+
+    // Create ONE on-demand session via the BFF. With no following scheduled
+    // session, scheduled_end_time is NULL → the session is active forever.
+    const sess = await bff(page, 'POST', '/sessions/create-on-demand', {
+      body: {
+        roomUid,
+        name: `${stamp}-ondemand`,
+        joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+        transcriptionProviderId: 'whisper',
+        transcriptionStreamConfig: {},
+      },
+      csrf,
+    });
+    const sessionUid = sess.body?.data?.uid;
+    if (!sessionUid)
+      throw new Error(`on-demand create failed: ${JSON.stringify(sess.body)}`);
+    log(`--- created on-demand session ${sessionUid} (active, no end time)`);
+
+    // ============================================================
+    // CHECK 1: NO_ACTIVE_SESSION_IN_ROOM_VIEW
+    // Desired: the room detail page shows the active session (name + "active").
+    // ============================================================
+    log('--- check 1: room view shows the active session');
+    await page.goto(`${args.baseUrl}/admin/rooms/${roomUid}`, {
+      waitUntil: 'networkidle2',
+    });
+    await page.waitForSelector('h1', { visible: true });
+    const roomText = await bodyText(page);
+    const showsActiveSession =
+      /active session/i.test(roomText) &&
+      roomText.includes(`${stamp}-ondemand`);
+    results.push(
+      check(
+        'room detail page shows the active session',
+        'NO_ACTIVE_SESSION_IN_ROOM_VIEW',
+        showsActiveSession,
+        showsActiveSession
+          ? 'Room view renders an Active session card naming the live session.'
+          : 'Room view does not surface the active session.',
+      ),
+    );
+
+    // ============================================================
+    // CHECK 2: ON_DEMAND_SESSION_NOT_ON_SCHEDULING_PAGE
+    // Desired: the scheduling page lists live session rows, including the
+    // on-demand one (which has no parent schedule).
+    // ============================================================
+    log('--- check 2: scheduling page lists the on-demand session');
+    await page.goto(`${args.baseUrl}/admin/rooms/${roomUid}/scheduling`, {
+      waitUntil: 'networkidle2',
+    });
+    await page.waitForSelector('h2', { visible: true });
+    const schedText = await bodyText(page);
+    const showsSessionName = schedText.includes(`${stamp}-ondemand`);
+    results.push(
+      check(
+        'scheduling page shows the live on-demand session',
+        'ON_DEMAND_SESSION_NOT_ON_SCHEDULING_PAGE',
+        showsSessionName,
+        showsSessionName
+          ? 'Scheduling page lists the on-demand session in the Sessions table.'
+          : 'The active on-demand session does not appear on the scheduling page.',
+      ),
+    );
+
+    // ============================================================
+    // CHECK 3: ALREADY_RUNNING_WITH_NONE_VISIBLE
+    // Try to start a second on-demand session from the UI. The server rejects
+    // with 409 ANOTHER_SESSION_ACTIVE, surfaced as an error toast — while the
+    // page still shows no active session to explain the conflict.
+    // ============================================================
+    log('--- check 3: second on-demand blocked, none visible');
+    // Open the "Start a session now" dialog.
+    const opened = await page.evaluate(() => {
+      const btn = [...document.querySelectorAll('button')].find((b) =>
+        /start a session now/i.test(b.textContent || ''),
+      );
+      if (btn) {
+        btn.click();
+        return true;
+      }
+      return false;
+    });
+    if (!opened) throw new Error('could not open the on-demand dialog');
+    await page.waitForSelector('.MuiDialog-root input', { visible: true });
+    // Type a name into the dialog's first (Name) input.
+    await page.type('.MuiDialog-root input', `${stamp}-ondemand-2`);
+    // Click the "Start session" button inside the dialog.
+    await page.evaluate(() => {
+      const btn = [...document.querySelectorAll('.MuiDialog-root button')].find((b) =>
+        /start session/i.test(b.textContent || ''),
+      );
+      btn?.click();
+    });
+    const conflictToast = await waitForToast(
+      page,
+      'currently active',
+      10_000,
+    );
+    const schedTextAfter = await bodyText(page);
+    // Desired behaviour: the page should surface the active session that is
+    // causing the conflict, so the operator can find and end it. Today it does
+    // not — the toast names the conflict but the page shows nothing.
+    const pageShowsBlockingSession = schedTextAfter.includes(`${stamp}-ondemand`);
+    results.push(
+      check(
+        'scheduling page shows the session blocking a new on-demand creation',
+        'ALREADY_RUNNING_WITH_NONE_VISIBLE',
+        pageShowsBlockingSession,
+        (conflictToast
+          ? `Conflict toast appeared: "${conflictToast}". `
+          : 'No conflict toast appeared within 10s. ') +
+          (pageShowsBlockingSession
+            ? 'Page shows the blocking session.'
+            : 'Page shows no active session to explain the conflict — operator is blocked.'),
+      ),
+    );
+    // Close the dialog if still open (Cancel) so later steps start clean.
+    await page.evaluate(() => {
+      const btn = [...document.querySelectorAll('.MuiDialog-root button')].find((b) =>
+        /cancel/i.test(b.textContent || ''),
+      );
+      btn?.click();
+    });
+    await sleep(300);
+
+    // ============================================================
+    // CHECK 4: NO_ADMIN_SESSION_LIST_ENDPOINT
+    // Desired: a BFF route lists sessions for a room (200, not 404).
+    // ============================================================
+    log('--- check 4: admin session-list endpoint exists');
+    const listRes = await bff(
+      page,
+      'GET',
+      `/sessions/list?roomUid=${roomUid}`,
+    );
+    const endpointExists = listRes.status === 200;
+    results.push(
+      check(
+        'an admin session-list endpoint exists',
+        'NO_ADMIN_SESSION_LIST_ENDPOINT',
+        endpointExists,
+        `GET /sessions/list?roomUid=… → ${listRes.status} ` +
+          `(200 = route present, 404 = absent). ` +
+          `Room entity carries no session field by design; the active-session ` +
+          `endpoint is checked implicitly by check 1.`,
+      ),
+    );
+
+    // ============================================================
+    // CHECK 5: SCHEDULE_BEYOND_90_DAY_WINDOW_INVISIBLE
+    // A schedule with activeStart >90d out is stored but clipped by the
+    // scheduling page's [now, now+90d) query.
+    // ============================================================
+    log('--- check 5: schedule beyond 90-day window is invisible');
+    const farFuture = new Date(Date.now() + 120 * 24 * 60 * 60 * 1000).toISOString();
+    const sch = await bff(page, 'POST', '/schedules/create', {
+      body: {
+        roomUid,
+        name: `${stamp}-farschedule`,
+        activeStart: farFuture,
+        activeEnd: null,
+        localStartTime: '09:00',
+        localEndTime: '10:00',
+        frequency: 'ONCE',
+        daysOfWeek: null,
+        joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+        transcriptionProviderId: 'whisper',
+        transcriptionStreamConfig: {},
+      },
+      csrf,
+    });
+    scheduleUid = sch.body?.data?.uid;
+    const createdOk = !!scheduleUid;
+    // Reload the scheduling page and see whether it lists the far-future schedule.
+    await page.goto(`${args.baseUrl}/admin/rooms/${roomUid}/scheduling`, {
+      waitUntil: 'networkidle2',
+    });
+    await page.waitForSelector('h2', { visible: true });
+    const textAfterFar = await bodyText(page);
+    const farListed = textAfterFar.includes(`${stamp}-farschedule`);
+    results.push(
+      check(
+        'scheduling page lists a schedule starting >90 days out',
+        'SCHEDULE_BEYOND_90_DAY_WINDOW_INVISIBLE',
+        false,
+        createdOk
+          ? farListed
+            ? 'unexpected: far-future schedule is listed (window may have widened)'
+            : 'Confirmed: schedule created but not listed (activeStart beyond the 90d `to` bound).'
+          : `schedule create failed: ${JSON.stringify(sch.body)}`,
+      ),
+    );
+
+    // ============================================================
+    // CHECK 6: NO_AUTO_REFRESH
+    // Desired: the scheduling page polls the session list, so a session
+    // created server-side after page load appears without a manual reload.
+    // (Schedules are definitions and only reload on mutation; the poll covers
+    // the live session rows, which is what changes underneath an operator.)
+    // ============================================================
+    log('--- check 6: scheduling page auto-refreshes sessions');
+    // Create a second on-demand session server-side. The page is already open
+    // on the scheduling view from check 5; the poll (15s) should pick it up.
+    // We end the first session first so creation is not blocked.
+    await bff(page, 'POST', '/sessions/end-early', {
+      body: { sessionUid },
+      csrf,
+    });
+    const sess2 = await bff(page, 'POST', '/sessions/create-on-demand', {
+      body: {
+        roomUid,
+        name: `${stamp}-ondemand-refresh`,
+        joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+        transcriptionProviderId: 'whisper',
+        transcriptionStreamConfig: {},
+      },
+      csrf,
+    });
+    const refreshSessionUid = sess2.body?.data?.uid;
+    // Wait past the poll interval (15s) plus margin.
+    let appearedWithoutReload = false;
+    for (let i = 0; i < 40; i++) {
+      const text = await bodyText(page);
+      if (text.includes(`${stamp}-ondemand-refresh`)) {
+        appearedWithoutReload = true;
+        break;
+      }
+      await sleep(500);
+    }
+    results.push(
+      check(
+        'scheduling page refreshes when server state changes',
+        'NO_AUTO_REFRESH',
+        appearedWithoutReload,
+        appearedWithoutReload
+          ? 'New session appeared without a manual reload (poller working).'
+          : 'New session did not appear within 20s — no auto-refresh.',
+      ),
+    );
+    // Clean up the refresh session by ending it (room deletion cascades anyway).
+    if (refreshSessionUid) {
+      await bff(page, 'POST', '/sessions/end-early', {
+        body: { sessionUid: refreshSessionUid },
+        csrf,
+      });
+    }
+  } catch (err) {
+    results.push({
+      name: 'harness',
+      bug: 'HARNESS_ERROR',
+      ok: false,
+      detail: err?.stack || String(err),
+    });
+  } finally {
+    // ---- Cleanup: delete schedules + room (cascades sessions/memberships) ----
+    if (page && roomUid) {
+      try {
+        if (scheduleUid) {
+          await bff(page, 'POST', '/schedules/delete', { body: { scheduleUid } });
+        }
+        if (!args.keepRoom) {
+          const me = await bff(page, 'GET', '/auth/me');
+          const csrf = me.body?.data?.csrfToken;
+          await bff(page, 'POST', '/rooms/delete', { body: { roomUid }, csrf });
+          log(`--- deleted room ${roomUid}`);
+        } else {
+          log(`--- kept room ${roomUid} (--keep-room)`);
+        }
+      } catch (e) {
+        log('--- cleanup failed:', e.message);
+      }
+    }
+    if (browser) await browser.close();
+  }
+
+  // ---- Report ----
+  const failures = results.filter((r) => !r.ok);
+  for (const r of results) {
+    const tag = r.ok ? 'PASS' : 'FAIL';
+    log(`[${tag}] ${r.bug}: ${r.name}`);
+    if (r.detail) log(`        ${r.detail}`);
+  }
+  const summary = {
+    total: results.length,
+    passed: results.length - failures.length,
+    failed: failures.length,
+    results,
+  };
+  if (args.json) console.log(JSON.stringify(summary, null, 2));
+  else log(`\n${summary.passed}/${summary.total} checks passed.`);
+  process.exit(failures.length === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});


### PR DESCRIPTION
Surfaces a room's running session in the admin console, lists the ON_DEMAND/AUTO sessions the scheduling page could not see, and makes every page state which timezone it is printing times in.

## The gap

Sessions have no status column — "active" is derived from `COALESCE(end_override, scheduled_end_time)` — and no admin route read that derivation. So the console could not show a room's running session, listed no ON_DEMAND/AUTO rows on the scheduling page, and refused a second on-demand session with `ANOTHER_SESSION_ACTIVE` while showing nothing that explained the conflict. The repository queries already existed; they were only ever consumed by the device-auth my-schedule long-poll.

## What lands

**Two read routes**, mirrored through the session-manager client and the admin BFF:

| Session Manager | Admin BFF |
|---|---|
| `GET /schedule-management/list-sessions?roomUid=&from=&to=` | `GET /sessions/list` |
| `GET /schedule-management/get-active-session/:roomUid` | `GET /sessions/active/:roomUid` |

Active-session answers a `null` 200 body so "nothing is running" stays distinct from "room not found" (404). `listSessionsForRoomInRange` and `findActiveSession` now return `ROOM_NOT_FOUND`, matching `listSchedulesForRoom`.

**Console.** The room detail page gains an "Active session" card (name, type, effective start/end, View and End-early actions — the last hidden for the demo room's permanently-active fixture session). The scheduling page gains a Sessions table that polls every 15s while the tab is visible, with its range widened to the last 7 days so a session that started before page-load still appears.

**Timezones.** Every page that prints a timestamp now renders a shared `TimezoneNote` stating the zone in use, in the same place and the same words. Room-scoped pages (room detail, scheduling, session detail) declare and use the room's zone; deployment-wide pages (audit, devices, rooms list, dashboard, deployment check) declare the browser's. When a room's zone differs from the operator's, the note escalates from a muted line to a **red warning triangle naming both zones** — someone in Chicago administering a London room would otherwise silently plan a session six hours off. Where the zones agree, it stays quiet, so the warning keeps meaning something.

## Review fixes included

Three defects were found reviewing the first commit, all in how the new views reported state they did not have yet:

- **The active-session card claimed the room was idle when it did not know.** `useAsyncData` reports `data: null` both before the first success and after a failure, and the card branched on `data === null` alone — so it rendered "No session is currently active in this room." while the lookup was in flight, and kept rendering it if the lookup failed. That card exists to explain an `ANOTHER_SESSION_ACTIVE` conflict, so a confident wrong "nothing is running" is the one answer it must never give.
- **The Sessions table blanked to a spinner on every poll.** `useAsyncData` raises `loading` on every re-fetch, so the rows were replaced by a centered spinner four times a minute, forever. Gated on the first load instead — the same idiom the page-level guard already used.
- **A failing poll raised a fresh toast every 15s** for as long as the backend stayed down. Now toasts only when the failure is new, resetting once a poll succeeds.

Plus: the schedules/auto-windows captions still read "(next 90 days)" after the 7-day lookback landed, contradicting the dates beside them; `execSync` was imported but never called in the e2e harness; prettier failed on five files across three workspaces, which would have failed the `format` job.

## Tests

The feature commit added mocks so existing suites would not break, but no assertions on the new behaviour. Added:

- **admin-webapp** — the three states of the active-session card, the demo-room End-early guard, the sessions table listing an ON_DEMAND row, the active chip for an open-ended session, rows surviving an in-flight poll, the note's four states, the formatter's two (including the fallback for a `rooms.timezone` `Intl` rejects), and a case pinning that session times follow the room's zone.
- **admin-server** — both new BFF routes: key injection, the unauthenticated 401 with no upstream call, `ROOM_NOT_FOUND` as a 404 envelope, and the `null` 200 passing through as "no active session" rather than an error.
- **session-manager** — `findActiveSession` covering `now`, open-ended sessions, `null` for an idle room, and `ROOM_NOT_FOUND`.

The regression tests were each checked to fail against the code they pin, and the timezone test picks its room zone against whatever zone the runner is in, so it asserts the same thing on a laptop and in CI.

## Verification

`npm run format`, `npm run lint`, `npm run build`, `npm run test:unit` (2021 tests) all clean; admin-server integration 102/102; session-manager integration 385/385.

Rebased on `staging`.