### PR TITLE
Work through the actionable FOLLOWUPS items

### DIFF
--- a/.changeset/audio-meter-speech-headroom-zones.md
+++ b/.changeset/audio-meter-speech-headroom-zones.md
@@ -1,0 +1,21 @@
+---
+'@scribear/monitoring-sidecar': patch
+'@scribear/scribear-nginx': patch
+---
+
+Default the standalone audio meter's peak zones to -12 / -3 dBFS.
+
+The zone boundaries are applied to the held sample peak, but the defaults were
+taken from EBU alignment level, which is an RMS convention. A sine at -18 dBFS
+RMS peaks at -15.01 dBFS — 3 dB above the old warn boundary — so a correctly
+levelled, perfectly healthy speech signal rendered amber. For a lecture-room
+speech meter the boundary exists to guard headroom, which peak defines, so the
+"speech headroom" preset already present in the meter's own zone selector is
+the right default. Both alignment presets remain selectable.
+
+nginx's pinned CSP hashes cover the meter page's inline scripts and were
+recomputed to match.
+
+The admin dashboard's `rmsDbfsHigh` (-6 dBFS) is deliberately unchanged: it is
+an RMS threshold in a different system, and only its comment claimed parity
+with the meter's peak default.

--- a/.changeset/binary-before-auth-drop-and-count.md
+++ b/.changeset/binary-before-auth-drop-and-count.md
@@ -1,0 +1,30 @@
+---
+'@scribear/monitoring-sidecar': minor
+---
+
+Export the binary-before-auth drop counters, and stop transcription-service
+closing the socket on an early binary frame.
+
+A binary frame arriving before AUTH — or, on transcription-service, before
+CONFIG — used to close the socket with 1008. That turns a recoverable client
+ordering bug into a silent outage: the client auto-reconnects, re-sends AUTH,
+its first audio chunk again beats AUTH_OK, and the loop repeats forever with
+no audio delivered and nothing naming the cause. node-server hit exactly this
+and was fixed the same way; transcription-service now drops the frame, counts
+it, and leaves the connection open. A peer that never completes the handshake
+at all is still closed by the existing `ws_init_timeout` watchdog.
+
+node-server's `binaryBeforeAuthDropsTotal` had been counted and serialised for
+some time but consumed by nothing — no registry counter, no `/metrics` series,
+no panel, no alert. It and transcription-service's two new counters are now
+wired through the sidecar as:
+
+- `scribear_node_binary_before_auth_drops_total`
+- `scribear_asr_binary_dropped_before_auth_total` (per provider)
+- `scribear_asr_binary_dropped_before_config_total` (per provider)
+
+All three wire fields are optional, so a node-server or transcription-service
+built before this change is polled without failing validation: absent records
+no increment rather than a zero.
+
+No alert thresholds — none of these counters has a measured baseline yet.

--- a/.changeset/session-manager-cursor-millisecond-tiebreak.md
+++ b/.changeset/session-manager-cursor-millisecond-tiebreak.md
@@ -1,0 +1,19 @@
+---
+'@scribear/session-manager': patch
+---
+
+Fix cursor pagination repeating rows created inside the same millisecond.
+
+`_listByCreatedAt` filtered on `date_trunc('milliseconds', created_at)` but
+ordered on the raw column. `created_at` is a `timestamptz` and keeps
+microseconds, while the cursor round-trips through a JS `Date` and an ISO-8601
+string and can only ever name a millisecond — so for rows sharing a
+millisecond the ordering and the filter disagreed about which side of the
+cursor a row fell on. A row ordered into page N by its microseconds could
+still satisfy the `uid` tiebreak and be returned again on page N+1.
+
+Both the device and room repositories now order on the same truncated
+expression their cursor predicate uses. This was the cause of the
+intermittent `list-devices` / `list-rooms` pagination test failures; both
+suites gained a regression test that forces the collision rather than waiting
+for it.

--- a/.changeset/subtitle-variant-heading-order.md
+++ b/.changeset/subtitle-variant-heading-order.md
@@ -1,0 +1,24 @@
+---
+'@scribear/admin-webapp': patch
+'@scribear/visualizer-ui': patch
+---
+
+Stop MUI's subtitle variants emitting stray `<h6>` elements (WCAG 2.1 AA,
+`heading-order`).
+
+MUI's `Typography` maps the `subtitle1` and `subtitle2` *variants* to an `h6`
+*element* via its default `variantMapping`, whether or not the text is a
+heading, and this repo has no `variantMapping` override. Any decorative small
+text therefore entered the document outline at level 6.
+
+- Session-calendar column labels are labels, not sections, and landed at `h6`
+  under a page whose last heading is `h2`. They render as text now; the grid
+  contributes no headings at all.
+- The visualizer drawer's panel title is in a shared UI library that cannot
+  know its host's heading levels, so any fixed level is a violation in some
+  host. It renders as text rather than guessing.
+- The Documentation and Deployment Check pages set `variant="h5"` without
+  `component`, so each had an `h5` as its top heading and no `h1` at all —
+  every other page in the console uses `variant="h5" component="h1"`. Their
+  card and finding titles are real subsections and now say so with
+  `component="h2"`, which is also how a screen-reader user moves between them.

--- a/.changeset/ws-client-stale-send-queue.md
+++ b/.changeset/ws-client-stale-send-queue.md
@@ -1,0 +1,28 @@
+---
+'@scribear/base-websocket-client': minor
+'@scribear/node-server-client': minor
+---
+
+Stop replaying stale audio onto a reconnected source socket.
+
+The send queue buffers up to 64 messages while the socket is down and flushes
+every one of them the instant it reopens. On the source route that queue is
+audio: microphone capture keeps running across a reconnect, because the
+capture callback has no idea the socket dropped. A reconnect therefore
+delivered up to 6.4 s of audio the room finished saying seconds earlier, in
+one burst, as if it were current.
+
+`WebSocketClient` gains an opt-in `sendQueueMaxAgeMs`. Buffered messages older
+than it are dropped at flush time rather than sent. The default is unchanged —
+unset means never expire, which is right for a control channel where a late
+message still matters.
+
+The node-server **source** route sets it to 1 s. Everything a source sends is
+time-critical: a queued `timeSyncPing` carries the client clock reading from
+when it was queued, so a stale one poisons the offset it exists to measure,
+and `sourceState` is re-seeded on every open anyway. The client route and
+every other consumer are unaffected.
+
+Dropped messages are now counted and readable via `sendQueueDrops`, overflow
+included — previously both were entirely silent, and a client dropping every
+frame looks from the far end exactly like a client with nothing to say.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,169 @@
+# Contributing
+
+Setup, architecture and API reference live in the
+**[wiki](https://github.com/scribear/scribear/wiki)**; branch and release
+mechanics live in [`RELEASING.md`](RELEASING.md). This file is for something the
+wiki does not cover: the mistakes this codebase has actually made, written down
+as rules so they are not made again.
+
+Each rule below is here because it cost real debugging time on this repo. The
+evidence is kept with the rule — a rule without its incident tends to get
+optimised away by the next person who finds it inconvenient.
+
+## Reviewing monitoring, alerting and scheduling code
+
+### Assume every guard is censored by the fault it detects
+
+**Any guard, floor, denominator, fallback label, or capacity estimate should be
+assumed censored under the exact condition it exists to detect, until proven
+otherwise.**
+
+When you write a threshold, ask what happens to *the inputs of the threshold
+itself* during the failure. Five instances of this in this repo's monitoring
+code, all found after the fact:
+
+- A tail-latency rule required 100 *passes* in its window before it would fire.
+  Dropping a period is precisely what removes a pass, so the floor climbed out of
+  reach exactly as the fault got severe.
+- `UNLABELED_PROVIDER = "unknown"` was commented "should stay near zero". It took
+  **100%** of drops during a saturation collapse, because the label is lost by
+  deregistration and mass deregistration *is* what a collapse looks like.
+  Meanwhile the `whisper` series showed a perfectly healthy provider during a
+  total outage.
+- A capacity estimator's naive form would *raise* the ceiling as the service
+  collapsed, because measured per-session cost stops rising once busy pegs at
+  1.0. (Caught at design time; the ratchet is the fix.)
+- `CapacityEstimator.clean_samples` never advances for a worker degraded from its
+  first session, so it never leaves warm-up and `admit()` returns `True` forever.
+- A service key left at its `CHANGEME` default can never surface as its own
+  config-check finding, because that key guards the endpoint that would report
+  it.
+
+### Check which direction your metric moves under the failure
+
+Before alerting on a metric, confirm its slope under the fault. `asr_rtf`
+*falls* as transcription saturates — an alert written for "RTF goes up when
+things get bad" never fires.
+
+Corollary: **when you replace a metric because its slope was wrong, audit the
+guards and denominators around it for the same error.** They were written in the
+same sitting by the same reasoning and are wrong the same way.
+
+### Metrics that nothing consumes are not monitoring
+
+A counter that is defined, incremented and exported but has no series, alert,
+dashboard panel or UI is a comment with a performance cost. Either wire it to a
+consumer in the same change, or don't add it.
+
+## Merging long-lived branches
+
+### A clean merge of a moved file is the highest-risk case, not the lowest
+
+**When a long-lived branch *extracts* or *moves* code into new files, the moved
+copy is a snapshot of the fork point — and merging it silently reverts
+everything that landed in the original since.**
+
+Because the extracted files are *new paths*, git merges them with **zero
+conflicts** and says nothing. This happened here: a branch forked, pulled five
+dialogs out of `room-scheduling-page.tsx` into standalone files, and meanwhile
+five commits modified that same dialog code on `staging` (a MUI major upgrade,
+a set of WCAG fixes, a lazy-initial-state cleanup, a set-state-in-effect
+migration, and an ESLint major bump). Measured: `daysError` — a shipped WCAG 2.1
+AA fix that replaced toast-only validation with a persistent inline field error —
+appeared 6 times in `staging`'s version and 0 times in the extracted files. A
+closed accessibility finding was being silently re-opened.
+
+**Detection, because review will not catch it:** for any file a branch deletes or
+guts, run
+
+```sh
+git log <fork-point>..<target-branch> -- <that-file>
+```
+
+and check every commit in that range against wherever the code went. Conflict
+count is not a measure of merge risk.
+
+## Protocols and cross-service schemas
+
+### Auth is a property of the connection, not the session
+
+**Any credential sent once per socket is a bug if the client can reconnect.**
+Three clients here spoke the same protocol; one used `onHandshake` and was
+immune, the other two sent auth from `on('open')` and broke on every *second*
+connection. It was invisible in testing because the WS client reconnects
+silently.
+
+### New fields in a published schema are `Type.Optional`
+
+**Every field added to a cross-service published schema must be `Type.Optional`
+unless both sides ship atomically.** A required field in a Redis-published
+telemetry schema means the whole snapshot fails strict validation and the node
+*vanishes from the dashboard* for the length of a rolling deploy — the dashboard
+you would be watching during that deploy.
+
+### Reject bad input by dropping and counting, not by closing
+
+Killing a connection on unexpected input (e.g. binary before auth) turns a
+recoverable client bug into a silent outage: the client reconnects, fails the
+same way, and nothing names the cause. Drop the offending data, increment a
+counter that is actually consumed, and let the connection live.
+
+## Testing
+
+### A feature with a "currently active" notion needs a fixture that is active now
+
+Every session-manager fixture used a far-future window in a room with
+`autoSessionEnabled: false`. That is how a 500 that broke *every* on-demand
+session in *every* auto-enabled room survived **341 passing integration tests**.
+If the feature has a notion of "live", at least one fixture must be live at the
+moment the suite runs.
+
+### Deterministic ordering needs a tiebreak
+
+Rows created inside the same millisecond tie on a `created_at` cursor, and the
+resulting test fails a couple of runs in ten. Any keyset/cursor pagination needs
+a unique tiebreak column in both the `ORDER BY` and the cursor.
+
+### In a monorepo with shared schema packages, the schema change is the blast radius
+
+Run the **root** build and unit tests, not the workspace's, when you touch
+anything under `libs/schemas` or another shared package.
+
+### A commit can pass every local check and still not build
+
+Typecheck, lint and tests all read the **filesystem**, not the git index — so an
+un-`git add`ed directory is invisible to all of them and CI is the first thing to
+see it. `git status` after committing is the check.
+
+## Working with AI coding agents
+
+These are here because this repo is developed with agents and they fail in
+specific, repeatable ways.
+
+- **A background agent reporting "completed" is a claim about its own turn
+  ending, not proof the task finished.** One reported success having built ten
+  images and never run `docker compose up`. Verify a delegated task's *end
+  state*, not its self-report.
+- **A working tree is shared mutable state between concurrent agents.** An agent
+  reading a checkout during a two-minute commit-split correctly reported that an
+  entire feature had vanished. Do that kind of surgery in a scratch clone or
+  behind a stash.
+- **Reading a peer branch's diff is often worth more than either branch's own
+  review.** Two independent investigations here converged on the same root cause
+  and each had built something the other hadn't.
+
+## Accessibility
+
+The admin console and the webapps are held to WCAG 2.1 AA. Two repo-specific
+traps:
+
+- **MUI's `Typography` maps `variant="subtitle2"` to an `<h6>` *element*** via
+  the default `variantMapping`, whether or not the text is a heading. Decorative
+  or label text using `subtitle2` silently enters the document outline at level
+  6, which under an `h1`/`h2` page is a `heading-order` violation. Pass
+  `component="p"` or `component="span"` on any `subtitle2`/`subtitle1` that is
+  not a real section heading.
+- `npm run a11y:axe` (and `a11y:axe:authed`) run the automated sweep, but a
+  handful of findings — live-region announcements, small-viewport reflow — can
+  only be closed by a human with a screen reader. Automated pass is not the same
+  as done.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ deployment/               # Docker Compose stack for running the full system
 
 ## Start here, by audience
 
-**New here / just curious / thinking about joining** — start at the wiki [Home](https://github.com/scribear/scribear/wiki/Home) page for the full architecture picture, and [`RELEASING.md`](RELEASING.md) for how branches (`staging`/`main`) and releases work.
+**New here / just curious / thinking about joining** — start at the wiki [Home](https://github.com/scribear/scribear/wiki/Home) page for the full architecture picture, [`RELEASING.md`](RELEASING.md) for how branches (`staging`/`main`) and releases work, and [`CONTRIBUTING.md`](CONTRIBUTING.md) for the repo-specific rules this codebase has learned the hard way (monitoring guards, long-lived-branch merges, protocol and schema compatibility, accessibility traps).
 
 **Frontend developers** (client-webapp, kiosk-webapp, standalone-webapp, `libs/ui`, `libs/store`) — see the wiki [Developing Frontend](https://github.com/scribear/scribear/wiki/Developing-Frontend) page to get an app running locally, and [Connecting From Frontend](https://github.com/scribear/scribear/wiki/Connecting-From-Frontend) for the session-token/websocket protocol these apps speak.
 
@@ -37,7 +37,7 @@ deployment/               # Docker Compose stack for running the full system
 
 **Deployment & production** — see the wiki [Deployment](https://github.com/scribear/scribear/wiki/Deployment) page for the Docker Compose stack, and [`RELEASING.md`](RELEASING.md#container-tags) for how image tags map to branches (`staging` → `staging`/`staging-<sha>`, `main` → `latest`/`v<version>`). **Upgrading an existing deployment — read [`deployment/UPGRADING.md`](deployment/UPGRADING.md) first**: `deployment/.env` is untracked and does not update when you pull, so releases that add a required key will refuse to start until you add it. Evaluating the stack on a staging box — see [`deployment/monitoring/README.md`](deployment/monitoring/README.md) for the opt-in, zero-click Prometheus + Grafana fleet dashboard.
 
-**AI coding agents / LLMs** — read this file and [`RELEASING.md`](RELEASING.md) first, then the wiki [Documentation](https://github.com/scribear/scribear/wiki/Documentation) page before making assumptions about API shapes, message protocols, or config — it's the authoritative machine-actionable reference. This is an npm workspace monorepo: `npm install` at the root installs everything, and `npm run build|lint|format|test:unit|test:integration` at the root run across all workspaces (`--workspace <path>` to scope to one). CI/CD is in `.github/workflows/` (`node-ci`/`node-cd`, `python-ci`/`python-cd`) and the composite actions it uses are in `.github/actions/`.
+**AI coding agents / LLMs** — read this file, [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`RELEASING.md`](RELEASING.md) first, then the wiki [Documentation](https://github.com/scribear/scribear/wiki/Documentation) page before making assumptions about API shapes, message protocols, or config — it's the authoritative machine-actionable reference. This is an npm workspace monorepo: `npm install` at the root installs everything, and `npm run build|lint|format|test:unit|test:integration` at the root run across all workspaces (`--workspace <path>` to scope to one). CI/CD is in `.github/workflows/` (`node-ci`/`node-cd`, `python-ci`/`python-cd`) and the composite actions it uses are in `.github/actions/`.
 
 ## Full wiki index
 

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  'b21ede2f99d92cd72b6a35c209125d05b1fb36974718353c110cce814160975c';
+  '007d11634d59db730a2d5894b32f1e1a016ede13ccb893cea82427ba3850f73c';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/apps/admin-webapp/src/features/config-check/config-check-page.tsx
+++ b/apps/admin-webapp/src/features/config-check/config-check-page.tsx
@@ -113,7 +113,17 @@ const FindingCard = ({
         <Box sx={{ color: `${meta?.color ?? 'info'}.main`, mt: '2px' }}>
           {meta?.icon}
         </Box>
-        <Typography variant="subtitle1" sx={{ flexGrow: 1, fontWeight: 600 }}>
+        {/* `component="h2"`: MUI maps the `subtitle1` variant to an `<h6>`,
+            which under this page's `h1` skips four levels. The severity
+            groups above are `Divider`/`Chip` decoration rather than
+            headings, so each finding is the first subsection level under the
+            page title - and heading navigation is how a screen-reader user
+            walks the findings list. */}
+        <Typography
+          variant="subtitle1"
+          component="h2"
+          sx={{ flexGrow: 1, fontWeight: 600 }}
+        >
           {finding.title}
         </Typography>
         {escalatesInProduction && (
@@ -240,7 +250,7 @@ export const ConfigCheckPage = () => {
           flexWrap: 'wrap',
         }}
       >
-        <Typography variant="h5" sx={{ flexGrow: 1 }}>
+        <Typography variant="h5" component="h1" sx={{ flexGrow: 1 }}>
           Deployment Check
         </Typography>
         <Chip
@@ -352,7 +362,10 @@ export const ConfigCheckPage = () => {
           critical misconfigurations would bury the thing that needs acting on.
           The intro paragraph points here so a reader knows it exists. */}
       <Divider sx={{ mt: 4, mb: 2 }} />
-      <Typography variant="h6" sx={{ mb: 0.5 }}>
+      {/* `component="h2"` for the same reason as the finding titles: the
+          `h6` variant would skip four levels under the page `h1`, and this
+          is a peer section of the findings list, not a sub-part of one. */}
+      <Typography variant="h6" component="h2" sx={{ mb: 0.5 }}>
         Deployed versions
       </Typography>
       <Typography

--- a/apps/admin-webapp/src/features/dashboard/audio-meter-bar.tsx
+++ b/apps/admin-webapp/src/features/dashboard/audio-meter-bar.tsx
@@ -14,8 +14,10 @@ const METER_MAX_DB = 0;
 
 /**
  * Zone tick positions on the bar, in dBFS. The "hot" tick at -6 dBFS matches
- * `AUDIO_THRESHOLDS.rmsDbfsHigh` and the standalone meter's crit boundary; the
- * "low" tick at -50 dBFS matches `AUDIO_THRESHOLDS.rmsDbfsLow`.
+ * `AUDIO_THRESHOLDS.rmsDbfsHigh`, an RMS threshold specific to this
+ * dashboard (not tied to the standalone meter's peak-zone default, which is a
+ * different quantity and can default independently); the "low" tick at
+ * -50 dBFS matches `AUDIO_THRESHOLDS.rmsDbfsLow`.
  */
 const TICK_HOT_DB = -6;
 const TICK_LOW_DB = -50;

--- a/apps/admin-webapp/src/features/dashboard/capacity-meter-bar.tsx
+++ b/apps/admin-webapp/src/features/dashboard/capacity-meter-bar.tsx
@@ -33,18 +33,19 @@ export interface CapacityMeterBarProps {
 
 /**
  * Live-sessions-vs-estimated-ceiling meter, one provider's "N / N*"
- * (PLAN-AdmissionControl.md §5).
+ * (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §5).
  *
  * Follows `AudioMeterBar`'s pattern rather than reusing it: that component's
  * range is a fixed -60..0 dBFS with audio-specific tick marks, which would
  * have to be force-fit to represent a session count against a ceiling that
  * moves as the estimator re-measures it. This is a plain 0..N* bar instead.
  *
- * `capacity.applicable === false` (a non-`local` provider, e.g. `lumen_granite`)
- * renders "not applicable" text and no bar at all — a capacity ceiling is a
- * local-worker-pool question, and a remote API's real constraint (upstream
- * rate limits) is a different, deferred one; showing a bar here would invite
- * reading it as a real number (PLAN-AdmissionControl.md §5: "leave a clear
+ * `capacity.applicable === false` (a non-`local` provider, e.g.
+ * `lumen_granite`) renders "not applicable" text and no bar at all — a capacity
+ * ceiling is a local-worker-pool question, and a remote API's real constraint
+ * (upstream rate limits) is a different, deferred one; showing a bar here would
+ * invite reading it as a real number
+ * (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §5: "leave a clear
  * gap... rather than a fake number").
  *
  * The numeric "N / N*" is always rendered as visible text beside the bar —

--- a/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
+++ b/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
@@ -73,8 +73,8 @@ const AUDIO_STATUS_ORDER: AudioStatus[] = ['crit', 'warn', 'unknown', 'good'];
 
 /**
  * Audio conventions the roll-up must label on the surface
- * (PLAN-MONITORING-DASHBOARD.md §60), matching the standalone page's wording
- * (`audio-meter.html`'s "Plain: -3.01 dBFS" reference option).
+ * (2026-07-19-01-PLAN-MONITORING-DASHBOARD.md §60), matching the standalone
+ * page's wording (`audio-meter.html`'s "Plain: -3.01 dBFS" reference option).
  *
  * A plain JS string, not a JSX string attribute: JSX attribute literals do not
  * process `\u`/`\n` escapes, so writing this inline renders them verbatim.
@@ -125,11 +125,11 @@ const ProviderStatusRow = ({ providers }: { providers: MergedProvider[] }) => {
 };
 
 /**
- * Per-provider capacity readout: live sessions against the estimator's
- * current ceiling (PLAN-AdmissionControl.md §5). One row per provider, same
- * bar/text pattern as the session cards' audio strip — a bar is drawn only
- * for a `local` provider; a `remote` one (`lumen_granite`) shows "not
- * applicable" rather than a fabricated number, since its real capacity
+ * Per-provider capacity readout: live sessions against the estimator's current
+ * ceiling (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §5). One row
+ * per provider, same bar/text pattern as the session cards' audio strip — a bar
+ * is drawn only for a `local` provider; a `remote` one (`lumen_granite`) shows
+ * "not applicable" rather than a fabricated number, since its real capacity
  * question is upstream rate limits, not a local worker pool.
  *
  * Each row also carries `sessionsRefusedCapacityTotal` — sessions this
@@ -576,7 +576,8 @@ const SessionCard = ({
  * Fleet audio roll-up: a stat row an operator scans first — sessions silent /
  * clipping / no-telemetry / OK. When `sessionAudio` is empty across the board,
  * this is where the "pipeline metering unavailable — use the standalone meter"
- * state and the Phase-0 link live (PLAN-MONITORING-DASHBOARD.md §6.238).
+ * state and the Phase-0 link live (2026-07-19-01-PLAN-MONITORING-DASHBOARD.md
+ * §6.238).
  */
 const FleetAudioRollup = ({
   sessions,
@@ -669,8 +670,9 @@ const FleetAudioRollup = ({
 
 /**
  * Live fleet view for the dashboard: a provider status row plus a
- * filter/sort/status grid of every active session (`PLAN-fleet-and-testaudio.md`
- * §B.4, adapted to session-centric telemetry — see `fleet-status.ts`).
+ * filter/sort/status grid of every active session
+ * (`archived-plans/2026-07-19-03-PLAN-fleet-and-testaudio.md` §B.4, adapted to
+ * session-centric telemetry — see `fleet-status.ts`).
  */
 export const FleetPanel = () => {
   const { snapshot, sessionEvents, connected, available } = useFleet();

--- a/apps/admin-webapp/src/features/dashboard/fleet-status.ts
+++ b/apps/admin-webapp/src/features/dashboard/fleet-status.ts
@@ -95,10 +95,12 @@ export const AUDIO_STATUS_COLOR: Record<AudioStatus, StatusColor> = {
  * later per-room baseline work (D3 of PLAN-AUDIOVIZ) has one place to replace.
  *
  * The clipping threshold (1 % of samples) and the silence flag come straight
- * from the publisher's `AudioLevelStats`. `rmsDbfsHigh` (-6 dBFS) is the
- * standalone meter's default peak-zone crit boundary (`audio-meter.html`'s
- * "Peak zones" control); `rmsDbfsLow` (-50 dBFS) is *not* from the standalone
- * meter — it sits between its -60 dBFS floor and its -40 dBFS scale step, i.e.
+ * from the publisher's `AudioLevelStats`. `rmsDbfsHigh` (-6 dBFS) is an RMS
+ * threshold in this dashboard's own system — it is not tied to the standalone
+ * meter's peak-zone default (`audio-meter.html`'s "Peak zones" control), which
+ * applies to a different quantity (held peak, not RMS) and defaults
+ * elsewhere; `rmsDbfsLow` (-50 dBFS) is *not* from the standalone meter — it
+ * sits between its -60 dBFS floor and its -40 dBFS scale step, i.e.
  * low enough that a working room mic never reads there. The SNR threshold
  * (10 dB) is the point below which speech intelligibility degrades measurably.
  * These are first-cut constants, not tuned values — see

--- a/apps/admin-webapp/src/features/dashboard/fleet-status.ts
+++ b/apps/admin-webapp/src/features/dashboard/fleet-status.ts
@@ -13,10 +13,11 @@ import type {
 
 /**
  * `SessionSnapshot.roomUid` is opaque telemetry, not a link to room-management
- * data (`PLAN-fleet-and-testaudio.md` §B.4's `RoomTelemetry` grouping predates
- * the real B1.7 schema and doesn't exist on the wire). The grid below is
- * therefore still session-centric: one card per `sessionUid`, not per room -
- * `roomUid` is surfaced and searchable on the card, not used to group it.
+ * data (`archived-plans/2026-07-19-03-PLAN-fleet-and-testaudio.md` §B.4's
+ * `RoomTelemetry` grouping predates the real B1.7 schema and doesn't exist on
+ * the wire). The grid below is therefore still session-centric: one card per
+ * `sessionUid`, not per room - `roomUid` is surfaced and searchable on the
+ * card, not used to group it.
  */
 export type FleetStatus = 'good' | 'warn' | 'crit' | 'idle';
 
@@ -104,7 +105,7 @@ export const AUDIO_STATUS_COLOR: Record<AudioStatus, StatusColor> = {
  * low enough that a working room mic never reads there. The SNR threshold
  * (10 dB) is the point below which speech intelligibility degrades measurably.
  * These are first-cut constants, not tuned values — see
- * PLAN-MONITORING-DASHBOARD.md §59 on per-room baselines.
+ * 2026-07-19-01-PLAN-MONITORING-DASHBOARD.md §59 on per-room baselines.
  */
 export const AUDIO_THRESHOLDS = {
   /**
@@ -598,7 +599,8 @@ export function useFilteredSessions(
   ]);
 }
 
-// ---- Provider capacity (PLAN-AdmissionControl.md §5) ----
+// ---- Provider capacity
+// (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §5) ----
 
 export type CapacityStatus = 'good' | 'warn' | 'crit' | 'unknown';
 
@@ -617,11 +619,12 @@ export const CAPACITY_STATUS_COLOR: Record<CapacityStatus, StatusColor> = {
 /**
  * `live / estimated` at or above this ratio is `warn` ("near the ceiling").
  * Deliberately the estimator's own `TARGET_BUSY` default
- * (`transcription_service`'s `CapacityEstimator`, PLAN-AdmissionControl.md
- * §3): N* is already sized so that admitting up to it keeps busy fraction
- * near `TARGET_BUSY`, so a live count approaching N* is the UI's own signal
- * that the worker is approaching the same headroom boundary the estimator
- * was tuned around — not a second, independently-chosen number.
+ * (`transcription_service`'s `CapacityEstimator`,
+ * archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3): N* is already
+ * sized so that admitting up to it keeps busy fraction near `TARGET_BUSY`, so a
+ * live count approaching N* is the UI's own signal that the worker is
+ * approaching the same headroom boundary the estimator was tuned around — not a
+ * second, independently-chosen number.
  */
 export const CAPACITY_WARN_RATIO = 0.85;
 
@@ -632,11 +635,11 @@ export const CAPACITY_WARN_RATIO = 0.85;
 export interface ProviderCapacity {
   /**
    * `false` for a non-`local` provider (`remote`, `debug`, `unknown`) — a
-   * remote API's capacity question is upstream rate limits, not a local
-   * worker pool (PLAN-AdmissionControl.md §5), and is explicitly out of scope
-   * for this readout. Taken from the first reporting host's `kind`: a
-   * `providerKey` names one implementation, so every host reporting it is
-   * expected to agree.
+   * remote API's capacity question is upstream rate limits, not a local worker
+   * pool (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §5), and is
+   * explicitly out of scope for this readout. Taken from the first reporting
+   * host's `kind`: a `providerKey` names one implementation, so every host
+   * reporting it is expected to agree.
    */
   applicable: boolean;
   /** Current session count, summed across every host serving this provider. */
@@ -683,9 +686,9 @@ export function deriveProviderCapacity(
  * `unknown` when capacity has not been measured yet (never a fabricated
  * `good`/`crit`); `crit` only when live sessions exceed the estimate, which
  * `CapacityEstimator.admit()` should never let happen — rendered anyway
- * (PLAN-AdmissionControl.md §5: "render sanely if it does") rather than
- * assumed impossible on a UI that must survive its own assumptions being
- * wrong.
+ * (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §5: "render sanely if
+ * it does") rather than assumed impossible on a UI that must survive its own
+ * assumptions being wrong.
  */
 export function deriveCapacityStatus(
   capacity: ProviderCapacity,

--- a/apps/admin-webapp/src/features/documentation/documentation-page.tsx
+++ b/apps/admin-webapp/src/features/documentation/documentation-page.tsx
@@ -84,7 +84,7 @@ const DOC_LINKS: DocLink[] = [
 export const DocumentationPage = () => {
   return (
     <Box>
-      <Typography variant="h5" gutterBottom>
+      <Typography variant="h5" component="h1" gutterBottom>
         Documentation
       </Typography>
       <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
@@ -111,7 +111,17 @@ export const DocumentationPage = () => {
                     sx={{ alignItems: 'center', mb: 1 }}
                   >
                     {link.icon}
-                    <Typography variant="subtitle1" sx={{ flexGrow: 1 }}>
+                    {/* `component="h2"`: MUI would map the `subtitle1`
+                        variant to an `<h6>`, which under this page's `h1`
+                        skips four levels. Each card is a real subsection
+                        directly under the page title - and headings are how
+                        a screen-reader user moves between the cards - so h2
+                        is both valid and the correct semantics. */}
+                    <Typography
+                      variant="subtitle1"
+                      component="h2"
+                      sx={{ flexGrow: 1 }}
+                    >
                       {link.title}
                     </Typography>
                     <OpenInNewIcon fontSize="small" color="action" />

--- a/apps/admin-webapp/src/features/sessions/session-calendar-grid.tsx
+++ b/apps/admin-webapp/src/features/sessions/session-calendar-grid.tsx
@@ -77,8 +77,17 @@ export const SessionCalendarGrid = ({
           variant="outlined"
           sx={{ flex: '0 0 220px', position: 'relative', height: 600 }}
         >
+          {/* `component="p"` is load-bearing: MUI maps the `subtitle2`
+              *variant* to an `<h6>` element regardless of what the text is,
+              so without this a column label - a room name or an ISO date -
+              would enter the document outline at level 6, under a page whose
+              last heading is an `h2`. That skips four levels and fails axe's
+              heading-order rule. These are labels for the columns beside
+              them, not sections of the page, so the right fix is to keep the
+              type scale and drop the heading element. */}
           <Typography
             variant="subtitle2"
+            component="p"
             sx={{ p: 1, borderBottom: 1, borderColor: 'divider' }}
           >
             {col.label}

--- a/apps/admin-webapp/src/features/test-audio/params-meta.ts
+++ b/apps/admin-webapp/src/features/test-audio/params-meta.ts
@@ -8,7 +8,7 @@ import type {
 
 /**
  * Ranges, defaults and captions for the two synthetic sources
- * (`PLAN-TestAudioDevices.md` §2.1 and §2.2).
+ * (`archived-plans/2026-07-27-01-PLAN-TestAudioDevices.md` §2.1 and §2.2).
  *
  * The captions are the point of this file. §2.2 was a table of claims about what
  * each fault was *expected* to show up as, and the plan was explicit that the
@@ -21,8 +21,9 @@ import type {
  * taken against a live GPU stack (`cuda128`, RTX 5070 Ti, `faster-whisper`
  * `turbo`, one device at a time, 120 s per knob) — the raw numbers, the exact
  * alert text and the baseline they are differences from are in
- * `MEASURED-TestAudio-Faults.md`. Four of the nine original claims were wrong or
- * half right, and those captions now say what actually happens instead. Two
+ * `archived-plans/2026-07-27-01-MEASURED-TestAudio-Faults.md`. Four of the nine
+ * original claims were wrong or half right, and those captions now say what
+ * actually happens instead. Two
  * things a reader should carry: the numbers are hardware-dependent where the
  * caption says so, and a knob whose caption says "nothing moves" is reporting a
  * measured absence, not an untested guess. `speedup` was additionally measured
@@ -92,8 +93,9 @@ export interface FaultKnob {
   /** Appended to the value in the accessible value text and the readout. */
   unit: string;
   /** What turning this knob up **was measured to do**, named concretely enough
-   *  to go and look at. See `MEASURED-TestAudio-Faults.md` for the run each
-   *  number comes from. */
+   *  to go and look at. See
+   *  `archived-plans/2026-07-27-01-MEASURED-TestAudio-Faults.md` for the run
+   *  each number comes from. */
   caption: string;
 }
 

--- a/apps/admin-webapp/src/features/test-audio/test-audio-page.tsx
+++ b/apps/admin-webapp/src/features/test-audio/test-audio-page.tsx
@@ -12,7 +12,8 @@ import { GoodSourceCard } from './good-source-card';
 import { useTestAudio } from './use-test-audio';
 
 /**
- * Operator test-audio devices (`PLAN-TestAudioDevices.md` §4).
+ * Operator test-audio devices
+ * (`archived-plans/2026-07-27-01-PLAN-TestAudioDevices.md` §4).
  *
  * Two synthetic sources pointed at their own rooms, parameterized live: one
  * plays good speech at a level you choose, the other reproduces every audio

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -390,11 +390,11 @@ export interface TranscriptionWorker {
     roomUid: string | null;
   }[];
   /**
-   * N* (PLAN-AdmissionControl.md §3/§5): this worker's current auto-tuned
-   * session ceiling, or the operator-pinned `max_sessions` when set. Always
-   * present, sometimes `null` - `null` means "not measured yet" (warm-up, or
-   * a worker that has never had a clean measurement window), never zero or
-   * unlimited. Do not render it as either.
+   * N* (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3/§5): this
+   * worker's current auto-tuned session ceiling, or the operator-pinned
+   * `max_sessions` when set. Always present, sometimes `null` - `null` means
+   * "not measured yet" (warm-up, or a worker that has never had a clean
+   * measurement window), never zero or unlimited. Do not render it as either.
    */
   estimatedCapacitySessions: number | null;
 }

--- a/apps/admin-webapp/tests/features/dashboard/fleet-status.test.ts
+++ b/apps/admin-webapp/tests/features/dashboard/fleet-status.test.ts
@@ -537,7 +537,8 @@ describe('formatClippingPct', (it) => {
   });
 });
 
-// ---- Provider capacity (PLAN-AdmissionControl.md §5) ----
+// ---- Provider capacity
+// (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §5) ----
 
 function buildWorker(
   overrides: Partial<TranscriptionWorker> = {},

--- a/apps/admin-webapp/tests/features/documentation/documentation-page.test.tsx
+++ b/apps/admin-webapp/tests/features/documentation/documentation-page.test.tsx
@@ -59,6 +59,22 @@ describe('DocumentationPage', (it) => {
     }
   });
 
+  it('gives the page an h1 and each card an h2 (SC 1.3.1, heading-order)', () => {
+    renderWithProviders(<DocumentationPage />);
+
+    // The page title carries the `h5` type scale but must be the `h1`, the
+    // way every other page in this console does it. The card titles use the
+    // `subtitle1` variant, which MUI maps to an `<h6>` element by default —
+    // four levels below the page title, which axe reports as heading-order.
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Documentation' }),
+    ).toBeInTheDocument();
+    expect(screen.queryAllByRole('heading', { level: 6 })).toHaveLength(0);
+    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(
+      EXPECTED_LINKS.length,
+    );
+  });
+
   it('announces that the cards open a new tab (SC 3.2.5)', () => {
     renderWithProviders(<DocumentationPage />);
 

--- a/apps/admin-webapp/tests/features/kiosk-setup/schedule-step.test.tsx
+++ b/apps/admin-webapp/tests/features/kiosk-setup/schedule-step.test.tsx
@@ -418,9 +418,9 @@ describe('ScheduleStep', () => {
 
     it('still fires onCreated when createAutoWindow succeeds but the master-switch update fails', async () => {
       // Arrange: documents current behavior per
-      // PLAN-Future-todo-wizard-tests.md 1e — the window itself was created,
-      // so onCreated firing is treated here as the intended outcome even
-      // though the master-switch enable failed.
+      // archived-plans/2026-07-23-02-PLAN-Future-todo-wizard-tests.md 1e — the
+      // window itself was created, so onCreated firing is treated here as the
+      // intended outcome even though the master-switch enable failed.
       mockDefaultLoad({ autoSessionEnabled: false });
       const onCreated = vi.fn();
       renderWithProviders(

--- a/apps/admin-webapp/tests/features/sessions/session-calendar-grid.test.tsx
+++ b/apps/admin-webapp/tests/features/sessions/session-calendar-grid.test.tsx
@@ -126,6 +126,31 @@ describe('SessionCalendarGrid', () => {
     expect(region).toHaveFocus();
   });
 
+  it('renders column labels as text, not as headings', () => {
+    // MUI maps the `subtitle2` variant to an `<h6>` element unless
+    // `component` says otherwise, so an unadorned column label would enter
+    // the document outline four levels below the host page's last `h2` and
+    // fail axe's heading-order rule. The labels are labels; the grid
+    // contributes no headings at all.
+    render(
+      <SessionCalendarGrid
+        columns={[
+          { key: 'room-a', label: 'Room A' },
+          { key: 'room-b', label: 'Room B' },
+        ]}
+        sessions={[]}
+        getColumnKeyForSession={(s) => s.roomUid}
+        onSessionClick={() => {
+          /* noop */
+        }}
+        showUuids={false}
+      />,
+    );
+
+    expect(screen.getByText('Room A')).toBeInTheDocument();
+    expect(screen.queryAllByRole('heading')).toHaveLength(0);
+  });
+
   it('shows the session uid when showUuids is true', () => {
     const session = makeSession({ uid: 'sess-visible-uid' });
 

--- a/apps/monitoring-sidecar/.env.example
+++ b/apps/monitoring-sidecar/.env.example
@@ -59,8 +59,8 @@ ADMIN_SERVER_BASE_URL=http://127.0.0.1:8003
 TRANSCRIPTION_SERVICE_BASE_URL=http://127.0.0.1:8000
 
 # --- Alert thresholds ------------------------------------------------------
-# Defaults from PLAN-MONITORING-DASHBOARD.md §4. Every one is tunable; the plan
-# is explicit that the right value is deployment-specific.
+# Defaults from 2026-07-19-01-PLAN-MONITORING-DASHBOARD.md §4. Every one is
+# tunable; the plan is explicit that the right value is deployment-specific.
 ALERT_RATE_WINDOW_SEC=120
 ALERT_UPSTREAM_CHURN_COUNT=3
 ALERT_DECODE_DROP_COUNT=10

--- a/apps/monitoring-sidecar/src/server/shared/metrics/metric-types.ts
+++ b/apps/monitoring-sidecar/src/server/shared/metrics/metric-types.ts
@@ -8,8 +8,8 @@
  * it is cheaper than adapting a library.
  *
  * Nothing is persisted. Restarting the sidecar zeroes every metric; that is an
- * accepted trade (see PLAN-MONITORING-DASHBOARD.md §9 item 1 — "in-memory only,
- * live snapshot", trends deferred).
+ * accepted trade (see 2026-07-19-01-PLAN-MONITORING-DASHBOARD.md §9 item 1 —
+ * "in-memory only, live snapshot", trends deferred).
  */
 
 /** Label set attached to a single metric series. */

--- a/apps/monitoring-sidecar/src/server/shared/metrics/metrics-registry.service.ts
+++ b/apps/monitoring-sidecar/src/server/shared/metrics/metrics-registry.service.ts
@@ -30,7 +30,7 @@ export class MetricsRegistry {
   //
   // Log inference was lossy by construction: it depended on the log level, on
   // the collector being attached for the whole window, and on nothing rotating
-  // out. See PLAN-B1.1-node-server-status.md §5.
+  // out. See archived-plans/2026-07-20-01-PLAN-B1.1-node-server-status.md §5.
 
   /**
    * SAFP frames rejected by the decoder. Rising on the node side means the

--- a/apps/monitoring-sidecar/src/server/shared/metrics/metrics-registry.service.ts
+++ b/apps/monitoring-sidecar/src/server/shared/metrics/metrics-registry.service.ts
@@ -567,6 +567,35 @@ export class MetricsRegistry {
     'Transcription buffers that produced no speech, by kind.',
   );
 
+  /**
+   * Binary frames a source sent before its AUTH handshake completed, or before
+   * session configuration completed, respectively. The transcription-service
+   * counterpart of {@link nodeBinaryBeforeAuthDropsTotal} — the identical
+   * reconnect-loop fix applied on the other side of the same handshake, so a
+   * source that starts streaming too early is dropped and counted rather than
+   * closed 1008 and left to loop.
+   *
+   * Per provider, unlike the node-server counterpart: transcription-service
+   * multiplexes several providers behind one process, so a drop is only
+   * actionable once it is attributed to one of them.
+   *
+   * Optional on the wire: a transcription-service built before the
+   * reconnect-loop fix does not send `binaryDroppedBeforeAuthTotal` or
+   * `binaryDroppedBeforeConfigTotal` at all, and a rolling upgrade means the
+   * sidecar polls exactly that service. A poll that omits them records no
+   * increment that round rather than treating it as zero.
+   */
+  readonly asrBinaryDroppedBeforeAuthTotal = new Counter(
+    'scribear_asr_binary_dropped_before_auth_total',
+    'Binary frames dropped because a source began streaming before its AUTH handshake completed, by provider.',
+  );
+
+  /** See {@link asrBinaryDroppedBeforeAuthTotal}; the config-handshake half of the same fix. */
+  readonly asrBinaryDroppedBeforeConfigTotal = new Counter(
+    'scribear_asr_binary_dropped_before_config_total',
+    'Binary frames dropped because a source began streaming before session configuration completed, by provider.',
+  );
+
   // --- A3: probe-derived --------------------------------------------------
 
   /** 1 when the probe returned healthy, 0 otherwise. Labelled service/probe. */
@@ -709,6 +738,8 @@ export class MetricsRegistry {
       this.asrAudioDroppedBufferFullTotal,
       this.asrAudioDroppedBufferFullSecondsTotal,
       this.asrNoSpeechTotal,
+      this.asrBinaryDroppedBeforeAuthTotal,
+      this.asrBinaryDroppedBeforeConfigTotal,
       this.probeTransitionsTotal,
       this.canaryRunsTotal,
       this.canaryTranscriptsTotal,

--- a/apps/monitoring-sidecar/src/server/shared/metrics/metrics-registry.service.ts
+++ b/apps/monitoring-sidecar/src/server/shared/metrics/metrics-registry.service.ts
@@ -101,6 +101,22 @@ export class MetricsRegistry {
     'Connections closed for not authenticating in time.',
   );
 
+  /**
+   * Binary audio frames a source sent before its AUTH handshake completed,
+   * dropped rather than closing the socket. Without this, a source that
+   * starts streaming before AUTH_OK would instead be closed 1008
+   * `binary-before-auth` and reconnect-loop, since each reconnect re-sends
+   * AUTH and the next first chunk again beats AUTH_OK.
+   *
+   * Optional on the wire (`STATUS_PROCESS_SCHEMA.summary.binaryBeforeAuthDropsTotal`
+   * predates this field on older node-server builds), so a poll that omits it
+   * simply records no increment that round rather than treating it as zero.
+   */
+  readonly nodeBinaryBeforeAuthDropsTotal = new Counter(
+    'scribear_node_binary_before_auth_drops_total',
+    'Binary frames dropped because a source began streaming before its AUTH handshake completed.',
+  );
+
   /** Source registrations that threw, closing the socket with 1011. */
   readonly nodeOrchestratorFailuresTotal = new Counter(
     'scribear_node_orchestrator_failures_total',
@@ -672,6 +688,7 @@ export class MetricsRegistry {
       this.nodeAuthFailuresTotal,
       this.nodeAuthSuccessTotal,
       this.nodeAuthTimeoutsTotal,
+      this.nodeBinaryBeforeAuthDropsTotal,
       this.nodeOrchestratorFailuresTotal,
       this.nodePendingChunkEvictionsTotal,
       this.nodeLatencySamplesTotal,

--- a/apps/monitoring-sidecar/src/server/shared/node-status/node-status-poller.service.ts
+++ b/apps/monitoring-sidecar/src/server/shared/node-status/node-status-poller.service.ts
@@ -116,6 +116,17 @@ export class NodeStatusPollerService extends AbsoluteStatusPoller<NodeStatusBody
       { service },
       s.authTimeoutsTotal,
     );
+    // Optional on the wire: absent from a node-server that predates the
+    // counter. Skipping the advance entirely (rather than defaulting to 0)
+    // means a mixed-version fleet neither throws nor silently zeroes a delta
+    // against whatever this series last held.
+    if (s.binaryBeforeAuthDropsTotal !== undefined) {
+      this._advance(
+        this._metrics.nodeBinaryBeforeAuthDropsTotal,
+        { service },
+        s.binaryBeforeAuthDropsTotal,
+      );
+    }
     this._advance(
       this._metrics.nodeOrchestratorFailuresTotal,
       { service },

--- a/apps/monitoring-sidecar/src/server/shared/transcription-metrics/transcription-metrics-poller.service.ts
+++ b/apps/monitoring-sidecar/src/server/shared/transcription-metrics/transcription-metrics-poller.service.ts
@@ -216,6 +216,23 @@ export class TranscriptionMetricsPollerService extends AbsoluteStatusPoller<Tran
       );
     }
 
+    // Optional on the wire (the reconnect-loop fix predates these on older
+    // transcription-service builds), so a service too old to send them simply
+    // reports no drops rather than failing the whole poll — same shape as the
+    // buffer-full pair above, and for the same reason.
+    if (c.binaryDroppedBeforeAuthTotal !== undefined) {
+      this._foldProvider(
+        c.binaryDroppedBeforeAuthTotal,
+        this._metrics.asrBinaryDroppedBeforeAuthTotal,
+      );
+    }
+    if (c.binaryDroppedBeforeConfigTotal !== undefined) {
+      this._foldProvider(
+        c.binaryDroppedBeforeConfigTotal,
+        this._metrics.asrBinaryDroppedBeforeConfigTotal,
+      );
+    }
+
     // Dropped periods, and whether they are being reported at all.
     //
     // The support gauge is not redundant with the counter. A healthy service

--- a/apps/monitoring-sidecar/src/server/shared/transcription-metrics/transcription-metrics.schema.ts
+++ b/apps/monitoring-sidecar/src/server/shared/transcription-metrics/transcription-metrics.schema.ts
@@ -129,6 +129,29 @@ export const TRANSCRIPTION_METRICS_BODY_SCHEMA = Type.Object({
     noWordsTotal: Type.Array(COUNTER_SERIES),
     decodeDropsTotal: Type.Array(COUNTER_SERIES),
     /**
+     * Binary frames dropped because they arrived before authentication
+     * completed, and before session configuration completed, respectively —
+     * the reconnect-loop fix on transcription-service's side of the same
+     * handshake node-server already applies (see
+     * `MetricsRegistry.nodeBinaryBeforeAuthDropsTotal`). Without it, a source
+     * that starts streaming before the handshake finishes used to have its
+     * socket closed 1008, and a source's auto-reconnect turns that into a
+     * loop: it re-authenticates, its first chunk again beats the ordering it
+     * just violated, and no audio is ever delivered. The frame is dropped
+     * instead and counted, so a client stuck in that pattern is still visible.
+     *
+     * Optional for the same reason as `audioDroppedBufferFullTotal`: a
+     * transcription-service predating this change does not send them, and
+     * during a rolling upgrade the sidecar polls exactly that service —
+     * requiring these fields would turn every transcription metric into a
+     * `malformed` poll for the duration of the upgrade. Absent means no drops
+     * are being reported, not zero; there is no fallback signal and no
+     * behaviour that differs between the two, so neither needs a support
+     * gauge.
+     */
+    binaryDroppedBeforeAuthTotal: Type.Optional(Type.Array(COUNTER_SERIES)),
+    binaryDroppedBeforeConfigTotal: Type.Optional(Type.Array(COUNTER_SERIES)),
+    /**
      * Job periods in which a job never ran, because the pass before it overran.
      *
      * The exact count of the failure the T1 rules are all circling: the worker

--- a/apps/monitoring-sidecar/tests/fixtures/fake-node-status.ts
+++ b/apps/monitoring-sidecar/tests/fixtures/fake-node-status.ts
@@ -131,7 +131,12 @@ export function statusBody(
   overrides: Partial<
     Omit<FakeStatusBody, 'summary' | 'sessions' | 'secretPlaceholders'>
   > & {
-    summary?: Partial<typeof ZERO_SUMMARY>;
+    // Not in `ZERO_SUMMARY`: absent by default, matching a node-server that
+    // predates this field. A test opts in explicitly to exercise the
+    // present case.
+    summary?: Partial<typeof ZERO_SUMMARY> & {
+      binaryBeforeAuthDropsTotal?: number;
+    };
     sessions?: FakeSessionInput[];
     secretPlaceholders?: Partial<FakeSecretPlaceholders>;
   } = {},

--- a/apps/monitoring-sidecar/tests/fixtures/fake-transcription-metrics.ts
+++ b/apps/monitoring-sidecar/tests/fixtures/fake-transcription-metrics.ts
@@ -77,6 +77,11 @@ export function histogramSeries(
  * `asrDroppedPeriodsTotal` is deliberately **not** here, so the default body is
  * the older-service shape that omits it — the case the tail alert's p99 fallback
  * exists for. A test that wants the counter reported passes it explicitly.
+ *
+ * `binaryDroppedBeforeAuthTotal` / `binaryDroppedBeforeConfigTotal` are
+ * likewise absent by default, for the same reason: they predate this change
+ * on an older transcription-service, and the default body should model that
+ * service rather than one that already sends everything.
  */
 const EMPTY_COUNTERS = {
   jobsCompletedTotal: [],

--- a/apps/monitoring-sidecar/tests/integration/node-status-poller.test.ts
+++ b/apps/monitoring-sidecar/tests/integration/node-status-poller.test.ts
@@ -85,6 +85,57 @@ describe('node-server status poller (B1.1 PR 4)', () => {
       ).toBe(8);
     });
 
+    it('folds binary-before-auth drops the same way as the other summary counters', async () => {
+      // Arrange
+      const { metrics, poller } = await createPoller();
+      node.setBody(statusBody({ summary: { binaryBeforeAuthDropsTotal: 5 } }));
+
+      // Act
+      await poller.pollOnce();
+      node.setBody(statusBody({ summary: { binaryBeforeAuthDropsTotal: 9 } }));
+      await poller.pollOnce();
+
+      // Assert - 9 total events seen, not 5 + 9
+      expect(
+        metrics.nodeBinaryBeforeAuthDropsTotal.get({ service: SERVICE }),
+      ).toBe(9);
+    });
+
+    it('does not throw or record a delta when an older node-server omits the field', async () => {
+      // Arrange - the field is optional on the wire for backward-compat with
+      // publishers that predate it, so a body that simply never mentions it
+      // must not be treated as reporting zero drops.
+      const { metrics, poller } = await createPoller();
+
+      // Act
+      const result = await poller.pollOnce();
+
+      // Assert - a counter with no series recorded reads as 0, same as any
+      // other counter never advanced; the point is that this poll neither
+      // threw nor recorded a spurious delta.
+      expect(result.ok).toBe(true);
+      expect(
+        metrics.nodeBinaryBeforeAuthDropsTotal.get({ service: SERVICE }),
+      ).toBe(0);
+    });
+
+    it('resumes recording once an upgraded node-server starts reporting it', async () => {
+      // Arrange - a poll that omits the field must leave a later poll free to
+      // pick up counting from whatever the endpoint reports next, rather than
+      // computing a delta against nothing.
+      const { metrics, poller } = await createPoller();
+      await poller.pollOnce();
+
+      // Act
+      node.setBody(statusBody({ summary: { binaryBeforeAuthDropsTotal: 3 } }));
+      await poller.pollOnce();
+
+      // Assert
+      expect(
+        metrics.nodeBinaryBeforeAuthDropsTotal.get({ service: SERVICE }),
+      ).toBe(3);
+    });
+
     it('keeps the rolling window meaningful for the alert rules', async () => {
       // Arrange
       const { metrics, poller } = await createPoller();

--- a/apps/monitoring-sidecar/tests/integration/transcription-metrics-poller.test.ts
+++ b/apps/monitoring-sidecar/tests/integration/transcription-metrics-poller.test.ts
@@ -413,6 +413,103 @@ describe('transcription-service metrics poller (B1.2 PR 5)', () => {
         0,
       );
     });
+
+    it('folds binary-before-auth and binary-before-config drops per provider', async () => {
+      // Arrange — the reconnect-loop fix's counters. Two providers, since a
+      // multi-provider deployment must not conflate one's drops with another's.
+      const { metrics, poller } = await createPoller();
+      service.setBody(
+        metricsBody({
+          counters: {
+            binaryDroppedBeforeAuthTotal: [
+              { labels: WHISPER, value: 2 },
+              { labels: LUMEN_GRANITE, value: 5 },
+            ],
+            binaryDroppedBeforeConfigTotal: [{ labels: WHISPER, value: 3 }],
+          },
+        }),
+      );
+
+      // Act
+      await poller.pollOnce();
+
+      // Assert
+      expect(metrics.asrBinaryDroppedBeforeAuthTotal.get(providerLabels)).toBe(
+        2,
+      );
+      expect(
+        metrics.asrBinaryDroppedBeforeAuthTotal.get({
+          service: SERVICE,
+          providerKey: 'lumen_granite',
+        }),
+      ).toBe(5);
+      expect(
+        metrics.asrBinaryDroppedBeforeConfigTotal.get(providerLabels),
+      ).toBe(3);
+    });
+
+    it('differences binary-before-auth and binary-before-config across polls', async () => {
+      // Arrange — these are lifetime totals like every other counter here, so
+      // only the delta between polls may land, not the reported figure itself.
+      const { metrics, poller } = await createPoller();
+      service.setBody(
+        metricsBody({
+          counters: {
+            binaryDroppedBeforeAuthTotal: [{ labels: WHISPER, value: 4 }],
+            binaryDroppedBeforeConfigTotal: [{ labels: WHISPER, value: 6 }],
+          },
+        }),
+      );
+      await poller.pollOnce();
+
+      // Act
+      service.setBody(
+        metricsBody({
+          counters: {
+            binaryDroppedBeforeAuthTotal: [{ labels: WHISPER, value: 9 }],
+            binaryDroppedBeforeConfigTotal: [{ labels: WHISPER, value: 8 }],
+          },
+        }),
+      );
+      await poller.pollOnce();
+
+      // Assert — the running total tracks the endpoint's own lifetime figure,
+      // which is only true if each poll folded a delta rather than re-adding
+      // the reported total (that bug would have left auth at 13, not 9).
+      expect(metrics.asrBinaryDroppedBeforeAuthTotal.get(providerLabels)).toBe(
+        9,
+      );
+      expect(
+        metrics.asrBinaryDroppedBeforeConfigTotal.get(providerLabels),
+      ).toBe(8);
+    });
+
+    it('polls a service too old to report binary-before-auth/config drops without failing', async () => {
+      // Arrange — both fields are optional precisely so that a
+      // transcription-service predating the reconnect-loop fix still produces
+      // a healthy poll instead of a `malformed` one that takes every
+      // transcription metric down with it. The default fixture body already
+      // omits both fields; this test asserts that omission is handled, not
+      // just unexercised.
+      const { metrics, poller, errors } = await createPoller();
+      service.setBody(
+        metricsBody({
+          counters: { bufferOverflowTotal: [{ labels: WHISPER, value: 1 }] },
+        }),
+      );
+
+      // Act
+      await poller.pollOnce();
+
+      // Assert — the poll succeeded, its other counters landed, and absence
+      // recorded no increment rather than a reported zero.
+      expect(errors).toEqual([]);
+      expect(metrics.asrBufferOverflowTotal.get(providerLabels)).toBe(1);
+      expect(metrics.asrBinaryDroppedBeforeAuthTotal.entries()).toHaveLength(0);
+      expect(metrics.asrBinaryDroppedBeforeConfigTotal.entries()).toHaveLength(
+        0,
+      );
+    });
   });
 
   describe('quantile gauges', (it) => {

--- a/apps/monitoring-sidecar/tests/unit/audio-meter-dsp.test.ts
+++ b/apps/monitoring-sidecar/tests/unit/audio-meter-dsp.test.ts
@@ -191,11 +191,14 @@ describe('level measurement', (it) => {
     const readings = core.read();
 
     // Assert — the zone boundaries are peak thresholds (§4.1), and this tone's
-    // peak is 3.01 dB above its RMS, so a -18 dBFS *RMS* alignment tone sits
-    // just inside the amber band. That is the convention, not a rounding error:
-    // the boundary guards headroom, which peak defines.
+    // peak is 3.01 dB above its RMS, so a -18 dBFS *RMS* alignment tone peaks
+    // at -15.01 dBFS — below the -12 dBFS warn boundary used by the default
+    // "speech headroom" zones. A correctly-levelled alignment tone therefore
+    // reads 'good', which is the point of picking peak-based defaults that
+    // don't mistake a healthy signal for a hot one.
     expect(Math.abs(readings.rmsDb - -18)).toBeLessThan(TOLERANCE_DB);
     expect(Math.abs(readings.heldPeakDb - -15.01)).toBeLessThan(TOLERANCE_DB);
+    expect(readings.zone).toBe('good');
   });
 
   it('classifies a hot signal as warning and a near-clipping one as critical', () => {
@@ -204,11 +207,12 @@ describe('level measurement', (it) => {
     const hot = newCore();
 
     // Act
-    feed(warm, 2, sine(amplitudeForRmsDb(-12), 1000));
-    feed(hot, 2, sine(amplitudeForRmsDb(-3), 1000));
+    feed(warm, 2, sine(amplitudeForRmsDb(-10), 1000));
+    feed(hot, 2, sine(amplitudeForRmsDb(-5), 1000));
 
-    // Assert — the boundaries are peak-based, so a -12 dBFS RMS sine (peak
-    // -9 dBFS) is amber and a -3 dBFS RMS sine (peak 0 dBFS) is red.
+    // Assert — the boundaries are peak-based (default -12/-3 dBFS), so a
+    // -10 dBFS RMS sine (peak ~-7 dBFS, inside the band) is amber and a
+    // -5 dBFS RMS sine (peak ~-2 dBFS, past the critical boundary) is red.
     expect(warm.read().zone).toBe('warning');
     expect(hot.read().zone).toBe('critical');
   });

--- a/apps/node-server/src/server/features/transcription-stream/events/session-status.events.ts
+++ b/apps/node-server/src/server/features/transcription-stream/events/session-status.events.ts
@@ -7,8 +7,8 @@ import type { ChannelDefinition } from '#src/server/shared/services/event-bus.se
  * `AT_CAPACITY` means the Transcription Service explicitly refused the
  * connection (WebSocket close 1013, "try again later") rather than the
  * connection dropping or the service crashing - see
- * `PLAN-AdmissionControl.md` §4, "node-server must distinguish 'service
- * refused' from 'service crashed'". Mirrored in
+ * `archived-plans/2026-07-27-02-PLAN-AdmissionControl.md` §4, "node-server must
+ * distinguish 'service refused' from 'service crashed'". Mirrored in
  * `@scribear/node-server-schema`'s `sessionStatus` message; keep both in
  * sync.
  */

--- a/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
@@ -141,7 +141,8 @@ interface SessionState {
    * Close code from the upstream's most recent `close` event, or `null` if it
    * has never closed. Recorded so `_setStatus` can distinguish a capacity
    * refusal (1013) from any other disconnect ("service crashed"-shaped
-   * disconnects included) - see `PLAN-AdmissionControl.md` §4. Stale values
+   * disconnects included) - see
+   * `archived-plans/2026-07-27-02-PLAN-AdmissionControl.md` §4. Stale values
    * are harmless: `_setStatus` only consults this while
    * `upstream.state !== 'OPEN'`, and it is overwritten on every subsequent
    * close.
@@ -632,7 +633,8 @@ export class TranscriptionOrchestratorService {
     });
     // Record the close code/reason so `_setStatus` can tell a capacity
     // refusal (1013) apart from any other disconnect - see
-    // `PLAN-AdmissionControl.md` §4. This fires AFTER the `stateChange` this
+    // `archived-plans/2026-07-27-02-PLAN-AdmissionControl.md` §4. This fires
+    // AFTER the `stateChange` this
     // same close triggers (the client emits `close` last in `_handleClose`),
     // so the `stateChange` listener's `_setStatus` call above still sees the
     // previous close code; publish again here once the new one is recorded.

--- a/apps/node-server/src/server/shared/services/latency-window.ts
+++ b/apps/node-server/src/server/shared/services/latency-window.ts
@@ -9,8 +9,8 @@
  *
  * Raw samples are retained rather than Prometheus-style bucket counts because
  * the dashboard's latency panels are specified in terms of exact percentiles
- * (PLAN-MONITORING-DASHBOARD.md §7 B1.4), and buckets would only give
- * interpolated ones. The summary shape deliberately matches the histogram
+ * (2026-07-19-01-PLAN-MONITORING-DASHBOARD.md §7 B1.4), and buckets would only
+ * give interpolated ones. The summary shape deliberately matches the histogram
  * series transcription-service reports from `GET /metrics/status`, so the two
  * services' latency panels can share a renderer.
  *

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
@@ -603,9 +603,9 @@ describe('TranscriptionOrchestratorService', () => {
     });
   });
 
-  // PLAN-AdmissionControl.md §4: node-server must distinguish "service
-  // refused" (capacity) from "service crashed" instead of collapsing both
-  // into the same `transcriptionServiceConnected: false`.
+  // archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4: node-server must
+  // distinguish "service refused" (capacity) from "service crashed" instead of
+  // collapsing both into the same `transcriptionServiceConnected: false`.
   describe('close-code disconnect reason (AdmissionControl §4)', (it) => {
     it('reports "at-capacity" after the upstream closes with 1013', async () => {
       // Arrange

--- a/apps/node-server/vitest.config.ts
+++ b/apps/node-server/vitest.config.ts
@@ -19,9 +19,10 @@ export default mergeConfig(
         // B1: dev-only swagger plugin — two register calls, no production impact.
         // B4: type-only module (AppDependencies interface + declare module) — no
         //     runtime code beyond a side-effect import.
-        // B5: trivial transport/wiring — one-line registrations and {status:'ok'}
-        //     handlers exercised by integration. Unit tests would be pure
-        //     coverage-chasing; see PLAN-MORE-TESTCOVERAGE.md §B5.
+        // B5: trivial transport/wiring — one-line registrations and
+        //     {status:'ok'} handlers exercised by integration. Unit tests would
+        //     be pure coverage-chasing; see
+        //     archived-plans/2026-07-25-01-PLAN-MORE-TESTCOVERAGE.md §B5.
         //
         // Additional low-risk files: thin transport controllers and routers
         // that delegate to unit-tested services. Integration-covered by design.

--- a/apps/session-manager/src/server/features/device-management/device-management.repository.ts
+++ b/apps/session-manager/src/server/features/device-management/device-management.repository.ts
@@ -195,8 +195,22 @@ export class DeviceManagementRepository {
   }
 
   /**
-   * Executes the chronological pagination path. Orders by `created_at` ascending,
-   * breaking ties by `uid` ascending. The cursor encodes `(createdAt, uid)`.
+   * Executes the chronological pagination path. Orders by `created_at`
+   * ascending, breaking ties by `uid` ascending. The cursor encodes
+   * `(createdAt, uid)`.
+   *
+   * Both the ordering key and the cursor predicate truncate `created_at` to
+   * milliseconds, and they have to agree. `created_at` is a `timestamptz`
+   * with microsecond resolution, but the cursor round-trips through a JS
+   * `Date` and an ISO-8601 string, neither of which can carry more than
+   * milliseconds - so the cursor can only ever name a millisecond. Ordering
+   * on the raw column while filtering on the truncated one lets the two
+   * disagree about which side of the cursor a row falls on: rows sharing a
+   * millisecond but differing in microseconds get ordered by their
+   * microseconds into page N, then re-selected by the `uid` tiebreak into
+   * page N+1, duplicating rows and inflating the page. Registering three
+   * rows inside one millisecond is enough to hit it, which is why the
+   * pagination tests were intermittently failing.
    */
   private async _listByCreatedAt(
     base: BaseDeviceQuery,
@@ -205,14 +219,15 @@ export class DeviceManagementRepository {
   ) {
     const cursor = rawCursor ? decodeCursor(rawCursor) : null;
     const createdAtCursor = cursor?.type === 'createdAt' ? cursor : null;
+    const orderKey = sql`date_trunc('milliseconds', devices.created_at)`;
 
     if (createdAtCursor) {
       const ts = new Date(createdAtCursor.createdAt);
       base = base.where((eb) =>
         eb.or([
-          eb(sql`date_trunc('milliseconds', devices.created_at)`, '>', ts),
+          eb(orderKey, '>', ts),
           eb.and([
-            eb(sql`date_trunc('milliseconds', devices.created_at)`, '=', ts),
+            eb(orderKey, '=', ts),
             eb('devices.uid', '>', createdAtCursor.uid),
           ]),
         ]),
@@ -220,7 +235,7 @@ export class DeviceManagementRepository {
     }
 
     const rows = (await base
-      .orderBy('devices.created_at', 'asc')
+      .orderBy(orderKey, 'asc')
       .orderBy('devices.uid', 'asc')
       .limit(limit + 1)
       .execute()) as DeviceRow[];

--- a/apps/session-manager/src/server/features/room-management/room-management.repository.ts
+++ b/apps/session-manager/src/server/features/room-management/room-management.repository.ts
@@ -163,8 +163,15 @@ export class RoomManagementRepository {
   }
 
   /**
-   * Executes the chronological pagination path. Orders by `created_at` ascending,
-   * breaking ties by `uid` ascending. The cursor encodes `(createdAt, uid)`.
+   * Executes the chronological pagination path. Orders by `created_at`
+   * ascending, breaking ties by `uid` ascending. The cursor encodes
+   * `(createdAt, uid)`.
+   *
+   * The ordering key and the cursor predicate both truncate `created_at` to
+   * milliseconds and must stay in agreement - see the equivalent method in
+   * `device-management.repository.ts` for why ordering on the raw
+   * microsecond column while filtering on the truncated one duplicates rows
+   * across pages.
    */
   private async _listByCreatedAt(
     base: BaseRoomQuery,
@@ -173,22 +180,20 @@ export class RoomManagementRepository {
   ) {
     const cursor = rawCursor ? decodeCursor(rawCursor) : null;
     const createdAtCursor = cursor?.type === 'createdAt' ? cursor : null;
+    const orderKey = sql`date_trunc('milliseconds', created_at)`;
 
     if (createdAtCursor) {
       const ts = new Date(createdAtCursor.createdAt);
       base = base.where((eb) =>
         eb.or([
-          eb(sql`date_trunc('milliseconds', created_at)`, '>', ts),
-          eb.and([
-            eb(sql`date_trunc('milliseconds', created_at)`, '=', ts),
-            eb('uid', '>', createdAtCursor.uid),
-          ]),
+          eb(orderKey, '>', ts),
+          eb.and([eb(orderKey, '=', ts), eb('uid', '>', createdAtCursor.uid)]),
         ]),
       );
     }
 
     const rows = (await base
-      .orderBy('created_at', 'asc')
+      .orderBy(orderKey, 'asc')
       .orderBy('uid', 'asc')
       .limit(limit + 1)
       .execute()) as RoomRow[];

--- a/apps/session-manager/tests/integration/features/device-management/device-management.routes.test.ts
+++ b/apps/session-manager/tests/integration/features/device-management/device-management.routes.test.ts
@@ -243,6 +243,74 @@ describe('Device Management Routes', () => {
       expect(secondBody.items).toHaveLength(1);
       expect(secondBody.nextCursor).toBeNull();
     });
+
+    it('does not repeat a row when rows share a millisecond', async () => {
+      // Arrange - `created_at` is a `timestamptz` and keeps microseconds, but
+      // the cursor round-trips through a JS `Date` and an ISO-8601 string, so
+      // it can only name a millisecond. These three rows share one
+      // millisecond and differ only below it, and their uids are ordered
+      // against their microseconds on purpose: uid(A) sorts after uid(B),
+      // which is the case that used to duplicate A onto page two when the
+      // query ordered on the raw column but filtered on the truncated one.
+      // Registering three devices back to back lands in one millisecond often
+      // enough that the test above failed roughly two runs in eight; this one
+      // forces the collision instead of waiting for it.
+      await dbContext.db.deleteFrom('rooms').execute();
+      await dbContext.db.deleteFrom('devices').execute();
+
+      const uidB = '00000000-0000-4000-8000-000000000001';
+      const uidC = '00000000-0000-4000-8000-000000000002';
+      const uidA = '00000000-0000-4000-8000-000000000003';
+      await dbContext.db
+        .insertInto('devices')
+        .values(
+          [
+            { uid: uidA, name: 'Device A', micros: '000100' },
+            { uid: uidB, name: 'Device B', micros: '000200' },
+            { uid: uidC, name: 'Device C', micros: '000300' },
+          ].map(({ uid, name, micros }) => ({
+            uid,
+            name,
+            created_at: `2026-01-01T00:00:00.${micros}Z`,
+            // devices_active_has_hash: a pending device carries an
+            // activation code and expiry and no hash.
+            activation_code: `code-${uid}`,
+            expiry: '2030-01-01T00:00:00.000Z',
+          })),
+        )
+        .execute();
+
+      // Act - walk both pages
+      const firstRes = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/list-devices?limit=2`,
+        headers: { authorization: ADMIN_HEADER },
+      });
+      const firstBody = firstRes.json<{
+        items: { uid: string }[];
+        nextCursor: string | null;
+      }>();
+      const secondRes = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/list-devices?limit=2&cursor=${firstBody.nextCursor!}`,
+        headers: { authorization: ADMIN_HEADER },
+      });
+      const secondBody = secondRes.json<{
+        items: { uid: string }[];
+        nextCursor: string | null;
+      }>();
+
+      // Assert - every row is returned exactly once across the two pages
+      expect(firstRes.statusCode).toBe(200);
+      expect(secondRes.statusCode).toBe(200);
+      expect(firstBody.items).toHaveLength(2);
+      expect(secondBody.items).toHaveLength(1);
+      expect(secondBody.nextCursor).toBeNull();
+
+      const seen = [...firstBody.items, ...secondBody.items].map((d) => d.uid);
+      expect(new Set(seen).size).toBe(3);
+      expect([...seen].sort()).toEqual([uidB, uidC, uidA].sort());
+    });
   });
 
   describe('GET /get-device/:deviceUid', (it) => {

--- a/apps/session-manager/tests/integration/features/room-management/room-management.routes.test.ts
+++ b/apps/session-manager/tests/integration/features/room-management/room-management.routes.test.ts
@@ -21,7 +21,7 @@ const NULL_UUID = '00000000-0000-0000-0000-000000000000';
 
 describe('Room Management Routes', () => {
   const server = useServer();
-  useDb(['rooms', 'devices']);
+  const dbContext = useDb(['rooms', 'devices']);
 
   async function registerDevice(name = 'Test Device') {
     const res = await server.fastify.inject({
@@ -281,6 +281,66 @@ describe('Room Management Routes', () => {
       }>();
       expect(secondBody.items).toHaveLength(1);
       expect(secondBody.nextCursor).toBeNull();
+    });
+
+    it('does not repeat a row when rows share a millisecond', async () => {
+      // Arrange - the cursor can only name a millisecond (it round-trips
+      // through a JS `Date` and an ISO-8601 string), while `created_at` keeps
+      // microseconds. These three rooms share a millisecond and differ only
+      // below it, with uid(A) deliberately sorting after uid(B) - the case
+      // that duplicated a row across pages while the query ordered on the raw
+      // column but filtered on the truncated one. See the same test in
+      // `device-management.routes.test.ts`.
+      const uidB = '00000000-0000-4000-9000-000000000001';
+      const uidC = '00000000-0000-4000-9000-000000000002';
+      const uidA = '00000000-0000-4000-9000-000000000003';
+      await dbContext.db
+        .insertInto('rooms')
+        .values(
+          [
+            { uid: uidA, name: 'Room A', micros: '000100' },
+            { uid: uidB, name: 'Room B', micros: '000200' },
+            { uid: uidC, name: 'Room C', micros: '000300' },
+          ].map(({ uid, name, micros }) => ({
+            uid,
+            name,
+            timezone: 'UTC',
+            auto_session_enabled: false,
+            created_at: `2026-01-01T00:00:00.${micros}Z`,
+          })),
+        )
+        .execute();
+
+      // Act - walk both pages
+      const firstRes = await server.fastify.inject({
+        method: 'GET',
+        url: `${ROOM_BASE}/list-rooms?limit=2`,
+        headers: { authorization: ADMIN_HEADER },
+      });
+      const firstBody = firstRes.json<{
+        items: { uid: string }[];
+        nextCursor: string | null;
+      }>();
+      const secondRes = await server.fastify.inject({
+        method: 'GET',
+        url: `${ROOM_BASE}/list-rooms?limit=2&cursor=${firstBody.nextCursor!}`,
+        headers: { authorization: ADMIN_HEADER },
+      });
+      const secondBody = secondRes.json<{
+        items: { uid: string }[];
+        nextCursor: string | null;
+      }>();
+
+      // Assert - every row is returned exactly once across the two pages
+      expect(firstRes.statusCode).toBe(200);
+      expect(secondRes.statusCode).toBe(200);
+      expect(firstBody.items).toHaveLength(2);
+      expect(secondBody.items).toHaveLength(1);
+      expect(secondBody.nextCursor).toBeNull();
+
+      const seen = [...firstBody.items, ...secondBody.items].map((r) => r.uid);
+      expect(new Set(seen).size).toBe(3);
+      expect([...seen].sort()).toEqual([uidB, uidC, uidA].sort());
     });
   });
 

--- a/apps/session-manager/tests/integration/features/session-auth/session-auth.routes.test.ts
+++ b/apps/session-manager/tests/integration/features/session-auth/session-auth.routes.test.ts
@@ -59,7 +59,10 @@ describe('Session Auth Routes', () => {
     return { deviceUid, token };
   }
 
-  async function createRoomWithSource(sourceDeviceUid: string) {
+  async function createRoomWithSource(
+    sourceDeviceUid: string,
+    autoSessionEnabled = false,
+  ) {
     const res = await server.fastify.inject({
       method: 'POST',
       url: `${ROOM_BASE}/create-room`,
@@ -67,11 +70,46 @@ describe('Session Auth Routes', () => {
       body: {
         name: 'Test Room',
         timezone: 'America/New_York',
-        autoSessionEnabled: false,
+        autoSessionEnabled,
         sourceDeviceUids: [sourceDeviceUid],
       },
     });
     return res.json<{ uid: string }>().uid;
+  }
+
+  /**
+   * Gives a room an auto-session window that is open right now: every day of
+   * the week, all day, active since 2020.
+   *
+   * Every other fixture in this file uses `autoSessionEnabled: false`, which
+   * short-circuits the auto-session reconciler before it does anything - so
+   * none of them exercise the interaction between a standing on-demand
+   * session and a materialized AUTO slot. That gap is not hypothetical: a 500
+   * that broke on-demand sessions in *every* auto-enabled room once survived
+   * the entire integration suite, because no fixture was ever live at the
+   * moment the suite ran.
+   */
+  async function enableLiveAutoSessionWindow(roomUid: string) {
+    const res = await server.fastify.inject({
+      method: 'POST',
+      url: `${SCHEDULE_BASE}/create-auto-session-window`,
+      headers: { authorization: ADMIN_HEADER },
+      body: {
+        roomUid,
+        localStartTime: '00:00:00',
+        localEndTime: '23:59:59',
+        daysOfWeek: ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'],
+        activeStart: '2020-01-01T00:00:00.000Z',
+        activeEnd: null,
+        joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+        transcriptionProviderId: 'whisper',
+        transcriptionStreamConfig: {},
+      },
+    });
+    // Asserted, not assumed: a fixture that quietly 400s would leave the room
+    // with no live window at all, and every test built on it would pass while
+    // exercising precisely the path it was written to cover.
+    expect(res.statusCode).toBe(201);
   }
 
   async function addDeviceToRoom(roomUid: string, deviceUid: string) {
@@ -597,6 +635,35 @@ describe('Session Auth Routes', () => {
       }>();
       expect(body.sessionToken).toEqual(expect.any(String));
       expect(body.sessionTokenExpiresAt).toEqual(expect.any(String));
+      expect(body.scopes.sort()).toStrictEqual(
+        ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'].sort(),
+      );
+    });
+
+    it('grants the source device its scopes in a room whose auto-session window is live now', async () => {
+      // Arrange - the same happy path as above, but in a room that has
+      // auto-sessions enabled *and* a window open at this moment, so the
+      // auto-session reconciler actually runs against a standing on-demand
+      // session rather than short-circuiting. Every other fixture here is
+      // auto-disabled, which is how a 500 on this exact combination once
+      // survived the whole suite.
+      const source = await setupActivatedDevice('Source Device');
+      const roomUid = await createRoomWithSource(source.deviceUid, true);
+      await enableLiveAutoSessionWindow(roomUid);
+      const sessionUid = await createOnDemandSession(roomUid);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/exchange-device-token`,
+        headers: { cookie: `DEVICE_TOKEN=${source.token}` },
+        body: { sessionUid },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{ sessionToken: string; scopes: string[] }>();
+      expect(body.sessionToken).toEqual(expect.any(String));
       expect(body.scopes.sort()).toStrictEqual(
         ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'].sort(),
       );

--- a/apps/session-manager/vitest.config.ts
+++ b/apps/session-manager/vitest.config.ts
@@ -17,12 +17,14 @@ export default mergeConfig(
         // B4: type-only module (AppDependencies interface + declare module) — no
         //     runtime code beyond a side-effect import.
         // B5: trivial transport/wiring — single fastify.route call exercised by
-        //     integration. See PLAN-MORE-TESTCOVERAGE.md §B5.
+        //     integration. See
+        //     archived-plans/2026-07-25-01-PLAN-MORE-TESTCOVERAGE.md §B5.
         //
         // Additional low-risk files: thin transport controllers, routers, and
-        // data-access repositories that are integration-covered by design
-        // (real Postgres testcontainer). Excluding from coverage so the unit
-        // report stops flagging them as ❌; see PLAN-MORE-TESTCOVERAGE.md §B5/§B6.
+        // data-access repositories that are integration-covered by design (real
+        // Postgres testcontainer). Excluding from coverage so the unit report
+        // stops flagging them as ❌; see
+        // archived-plans/2026-07-25-01-PLAN-MORE-TESTCOVERAGE.md §B5/§B6.
         exclude: [
           'src/index.ts',
           'src/migrate.ts',

--- a/apps/test-audio-generator/README.md
+++ b/apps/test-audio-generator/README.md
@@ -6,9 +6,10 @@ Derives the two operator test-audio devices' credentials and runs them.
 - **`fault`** — one knob per audio fault the stack claims to report, all
   independently settable, all defaulting to zero.
 
-An operator drives both from the admin console's Test Audio page, which talks to
-admin-server's test-audio BFF, which proxies here. The contract is
-`PLAN-TestAudioDevices.md`; §2 is this service's API.
+An operator drives both from the admin console's Test Audio page, which
+talks to admin-server's test-audio BFF, which proxies here. The contract is
+`archived-plans/2026-07-27-01-PLAN-TestAudioDevices.md`; §2 is this
+service's API.
 
 ---
 

--- a/cpu-findings.md
+++ b/cpu-findings.md
@@ -185,4 +185,4 @@ work per period. The CPU fix removed the waste *around* the inference; this is
 about the amount of inference asked for.
 
 Options, costs and a recommendation are in
-`~/scribear2/NEXTSTEPS-CPU-Whisper.md`.
+`~/scribear2/archived-plans/2026-07-26-02-NEXTSTEPS-CPU-Whisper.md`.

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -126,8 +126,9 @@ Prometheus (scrapes `monitoring-sidecar:80/metrics`, the fleet's own
 aggregated Prometheus endpoint — nothing else, no new secrets) and Grafana
 (auto-provisioned datasource and a seed fleet-overview dashboard, zero manual
 UI configuration). See [`deployment/monitoring/README.md`](monitoring/README.md)
-for how to turn it on and reach it, and `PLAN-Grafana-Monitoring.md` in the
-repo root for the design rationale.
+for how to turn it on and reach it, and
+`archived-plans/2026-07-28-01-PLAN-Grafana-Monitoring.md` (outside this repo,
+in `~/scribear2/`) for the design rationale.
 
 To opt in, add four keys to `.env` (see `.env.example`):
 

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -676,7 +676,8 @@ services:
       - backend
     restart: unless-stopped
 
-  # Metrics + dashboards for evaluators (see PLAN-Grafana-Monitoring.md).
+  # Metrics + dashboards for evaluators (see
+  # archived-plans/2026-07-28-01-PLAN-Grafana-Monitoring.md).
   #
   # OFF BY DEFAULT, via the profile - same mechanism `autoupdate` uses below.
   # Scrapes exactly one target: monitoring-sidecar's own /metrics, which
@@ -708,7 +709,8 @@ services:
   # Dashboards on top of the Prometheus above. Datasource and the seed
   # fleet-overview dashboard are both auto-provisioned from files mounted
   # read-only below - a fresh `up` on this profile needs zero clicks in the
-  # Grafana UI beyond logging in (PLAN-Grafana-Monitoring.md invariant 4).
+  # Grafana UI beyond logging in
+  # (archived-plans/2026-07-28-01-PLAN-Grafana-Monitoring.md invariant 4).
   #
   # Loopback-bound by default: Grafana has real auth (an admin password),
   # unlike Prometheus above, but a staging box is often on a routable

--- a/deployment/monitoring/README.md
+++ b/deployment/monitoring/README.md
@@ -4,8 +4,9 @@ An opt-in, zero-click fleet-health dashboard for anyone evaluating ScribeAR on
 their own staging box. `docker compose --profile monitoring up -d` and a
 working Grafana dashboard — sessions, RTF, dropped periods, worker health,
 canary status — is already there, sourced from metrics the stack already
-produces. See `PLAN-Grafana-Monitoring.md` in the repo root for the full
-design rationale; this file is the operator-facing "how do I use it" doc.
+produces. See `archived-plans/2026-07-28-01-PLAN-Grafana-Monitoring.md`
+(outside this repo, in `~/scribear2/`) for the full design rationale; this
+file is the operator-facing "how do I use it" doc.
 
 **Not a production-grade, long-retention, HA monitoring stack.** This is an
 evaluation/staging quick-win. Outgrow it by pointing Prometheus at your own
@@ -68,8 +69,9 @@ deployment_grafana_data` additionally drops their data for a clean slate.
 ## Pointing your own Grafana at this Prometheus
 
 Prometheus is backend-network-only by design (it ships with no
-authentication of its own — see `PLAN-Grafana-Monitoring.md §2`), so an
-external Grafana cannot reach it as-is. Two honest options, no third:
+authentication of its own — see
+`archived-plans/2026-07-28-01-PLAN-Grafana-Monitoring.md §2`), so an external
+Grafana cannot reach it as-is. Two honest options, no third:
 
 1. **Run your Grafana inside this compose network** (e.g. as another service
    in a `compose.override.yml` on the `backend` network) and point it at
@@ -114,4 +116,4 @@ dashboard cannot show a capacity-ceiling-vs-live-sessions panel the way
 `admin-webapp`'s `CapacityMeterBar` does. `scribear_ws_close_total` broken
 out by close code (see the "WebSocket close codes" panel) gives an indirect
 signal today — a spike in code `1013` — until that gap is closed. See
-`PLAN-Grafana-Monitoring.md §7`.
+`archived-plans/2026-07-28-01-PLAN-Grafana-Monitoring.md §7`.

--- a/deployment/monitoring/grafana/dashboards/scribear-fleet-overview.json
+++ b/deployment/monitoring/grafana/dashboards/scribear-fleet-overview.json
@@ -1,7 +1,7 @@
 {
   "uid": "scribear-fleet-overview",
   "title": "ScribeAR Fleet Overview",
-  "description": "Seed dashboard for the opt-in `monitoring` compose profile (PLAN-Grafana-Monitoring.md). Sourced entirely from monitoring-sidecar's /metrics. Portable: swap the Prometheus variable above to point this at your own Prometheus.",
+  "description": "Seed dashboard for the opt-in `monitoring` compose profile (archived-plans/2026-07-28-01-PLAN-Grafana-Monitoring.md). Sourced entirely from monitoring-sidecar's /metrics. Portable: swap the Prometheus variable above to point this at your own Prometheus.",
   "tags": ["scribear"],
   "timezone": "browser",
   "schemaVersion": 39,
@@ -182,7 +182,7 @@
     {
       "id": 6,
       "title": "WebSocket close codes",
-      "description": "scribear_ws_close_total, summed by close code. A spike in 1013 today is the only indirect signal of admission-control refusals until the sidecar re-exports sessions_refused_capacity_total directly (PLAN-Grafana-Monitoring.md §7).",
+      "description": "scribear_ws_close_total, summed by close code. A spike in 1013 today is the only indirect signal of admission-control refusals until the sidecar re-exports sessions_refused_capacity_total directly (archived-plans/2026-07-28-01-PLAN-Grafana-Monitoring.md §7).",
       "type": "timeseries",
       "gridPos": { "x": 12, "y": 14, "w": 12, "h": 8 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },

--- a/deployment/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/deployment/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -2,8 +2,8 @@
 # ../dashboards to /var/lib/grafana/dashboards) so every JSON file there loads
 # automatically on startup - no "Import dashboard" click, ever, for the
 # bundled setup. A second dashboard (e.g. GPU-specific, see
-# PLAN-Grafana-Monitoring.md §10) is a sibling JSON file in that directory,
-# not a change here.
+# archived-plans/2026-07-28-01-PLAN-Grafana-Monitoring.md §10) is a sibling
+# JSON file in that directory, not a change here.
 apiVersion: 1
 
 providers:

--- a/deployment/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/deployment/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,6 +1,7 @@
 # Auto-provisions the one Prometheus this stack ships, on every Grafana
-# start - no "Add data source" click required (PLAN-Grafana-Monitoring.md
-# invariant 4). `uid` is fixed so the seed dashboard's ${DS_PROMETHEUS}
+# start - no "Add data source" click required
+# (archived-plans/2026-07-28-01-PLAN-Grafana-Monitoring.md invariant 4).
+# `uid` is fixed so the seed dashboard's ${DS_PROMETHEUS}
 # template variable (see ../dashboards/dashboards.yml and
 # ../../dashboards/scribear-fleet-overview.json) resolves to it deterministically
 # on every provisioned stack, without hardcoding a datasource UID into the

--- a/deployment/monitoring/prometheus.yml
+++ b/deployment/monitoring/prometheus.yml
@@ -3,8 +3,8 @@
 # Exactly one target: monitoring-sidecar, which already aggregates the whole
 # fleet's status into a single unauthenticated Prometheus text endpoint (it is
 # backend-network-only, so "unauthenticated" is safe here - see
-# PLAN-Grafana-Monitoring.md §2 for why every other service's authed endpoint
-# is deliberately NOT scraped directly).
+# archived-plans/2026-07-28-01-PLAN-Grafana-Monitoring.md §2 for why every
+# other service's authed endpoint is deliberately NOT scraped directly).
 global:
   scrape_interval: 15s
 

--- a/final-summary.md
+++ b/final-summary.md
@@ -5,8 +5,10 @@ live rebuilt stack. Wiki updated and published. `explore/apple-silicon` pushed
 separately as findings only, no PR.
 
 Detail lives in `cpu-findings.md` (the investigation),
-`~/scribear2/LESSONSLEARNED-CPU-Whisper.md` (surprises and out-of-scope findings),
-and `~/scribear2/NEXTSTEPS-CPU-Whisper.md` (what is left, with the open decisions).
+`~/scribear2/archived-plans/2026-07-26-02-LESSONSLEARNED-CPU-Whisper.md`
+(surprises and out-of-scope findings), and
+`~/scribear2/archived-plans/2026-07-26-02-NEXTSTEPS-CPU-Whisper.md` (what is
+left, with the open decisions).
 
 ---
 

--- a/infra/scribear-nginx/nginx.conf
+++ b/infra/scribear-nginx/nginx.conf
@@ -300,7 +300,7 @@ http {
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
 
-            add_header Content-Security-Policy "default-src 'none'; script-src 'sha256-RWNlfOyAl35IBnodBIF4L/PTN52DEr4n99OXyrXEas4=' 'sha256-8tT+VI7MV9h248c3XwAAU9tXmFKbMwPQp2Vlt/MwXrY=' blob:; style-src 'unsafe-inline'; img-src data:; connect-src 'none'; base-uri 'none'; form-action 'none'" always;
+            add_header Content-Security-Policy "default-src 'none'; script-src 'sha256-cvuOF6nLjJ7dOwm1C5Dv/0uscuJEn9F12UxmpRXCMgc=' 'sha256-GP9R8iEpGPEEOCZjlpw9k9lackP5HwhBkdUm+wK1h0U=' blob:; style-src 'unsafe-inline'; img-src data:; connect-src 'none'; base-uri 'none'; form-action 'none'" always;
             # Re-declare HSTS for the same reason the block below does.
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         }

--- a/infra/scribear-redis/src/telemetry/transcription-host-snapshot.schema.ts
+++ b/infra/scribear-redis/src/telemetry/transcription-host-snapshot.schema.ts
@@ -57,7 +57,7 @@ export const TRANSCRIPTION_WORKER_SCHEMA = Type.Object({
   }),
   estimatedCapacitySessions: Type.Union([Type.Integer(), Type.Null()], {
     description:
-      'N* (PLAN-AdmissionControl.md §3/§5): the current auto-tuned session ceiling for this worker, or the operator-pinned `max_sessions` when set. Always present, never absent, because the publisher always has an estimator to ask - but null while the worker is still warming up (too few clean measurement windows yet) or has never had a clean window. Null means "not measured yet", never zero or unlimited - do not render it as either.',
+      'N* (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3/§5): the current auto-tuned session ceiling for this worker, or the operator-pinned `max_sessions` when set. Always present, never absent, because the publisher always has an estimator to ask - but null while the worker is still warming up (too few clean measurement windows yet) or has never had a clean window. Null means "not measured yet", never zero or unlimited - do not render it as either.',
   }),
 });
 
@@ -91,7 +91,7 @@ export const PROVIDER_HEALTH_SCHEMA = Type.Object({
   activeSessions: Type.Integer(),
   sessionsRefusedCapacityTotal: Type.Integer({
     description:
-      'Sessions refused at admission (PLAN-AdmissionControl.md §4) because the worker they landed on had no capacity for them - monotonic since process start, same caveat as invalidProviderKeyRejects. Always 0 for a remote provider: remote providers are never subject to local admission control, so this is the honest reading for lumen_granite and friends, not a gap.',
+      'Sessions refused at admission (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4) because the worker they landed on had no capacity for them - monotonic since process start, same caveat as invalidProviderKeyRejects. Always 0 for a remote provider: remote providers are never subject to local admission control, so this is the honest reading for lumen_granite and friends, not a gap.',
   }),
   model: Type.Union([Type.String(), Type.Null()]),
   modelLoaded: Type.Union([Type.Boolean(), Type.Null()], {

--- a/infra/scribear-redis/tests/unit/telemetry-schemas.test.ts
+++ b/infra/scribear-redis/tests/unit/telemetry-schemas.test.ts
@@ -153,8 +153,8 @@ describe('transcription worker schema', () => {
   it('should accept a null estimatedCapacitySessions', () => {
     // "Not measured yet" (warm-up) - the estimator always has an answer to
     // give, but not always a real one, so this field is always present and
-    // sometimes null rather than sometimes absent (PLAN-AdmissionControl.md
-    // §5).
+    // sometimes null rather than sometimes absent
+    // (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §5).
     //
     // Assert
     expect(

--- a/libs/audio-meter-page/audio-meter.html
+++ b/libs/audio-meter-page/audio-meter.html
@@ -514,9 +514,9 @@
           <div>
             <label for="zones">Peak zones (green ≤ / red &gt;), dBFS</label>
             <select id="zones">
-              <option value="-18,-6" selected>-18 / -6 (EBU alignment)</option>
+              <option value="-18,-6">-18 / -6 (EBU alignment)</option>
               <option value="-20,-6">-20 / -6 (SMPTE alignment)</option>
-              <option value="-12,-3">-12 / -3 (speech headroom)</option>
+              <option value="-12,-3" selected>-12 / -3 (speech headroom)</option>
             </select>
           </div>
           <div>
@@ -594,8 +594,17 @@
            */
           rmsReferenceOffsetDb: 0,
           loudnessTargetLufs: -23,
-          peakWarnDb: -18,
-          peakCriticalDb: -6,
+          /**
+           * These are PEAK thresholds, applied to the held sample peak, not
+           * RMS. EBU/SMPTE alignment levels (-18/-20 dBFS) are RMS
+           * conventions: a sine at -18 dBFS RMS peaks at -15.01 dBFS, 3 dB
+           * above that boundary, so a healthy, correctly-levelled speech
+           * signal would render amber. -12/-3 ("speech headroom") guards
+           * headroom against the actual peak instead and is the right
+           * default for a lecture-room speech meter.
+           */
+          peakWarnDb: -12,
+          peakCriticalDb: -3,
         };
 
         var DB_FLOOR = -120;
@@ -1105,8 +1114,10 @@
       const options = {
         rmsReferenceOffsetDb: 0,
         loudnessTargetLufs: -23,
-        peakWarnDb: -18,
-        peakCriticalDb: -6,
+        // Peak vs. RMS alignment-level rationale: see DEFAULTS in the
+        // meter-dsp script above.
+        peakWarnDb: -12,
+        peakCriticalDb: -3,
         silenceThresholdDb: -60,
       };
 

--- a/libs/clients/base-websocket-client/src/index.ts
+++ b/libs/clients/base-websocket-client/src/index.ts
@@ -5,6 +5,7 @@ export type {
   ConnectionState,
   BackoffOptions,
   SendQueueOverflow,
+  SendQueueDrops,
   ConnectParams,
   WebSocketClientOptions,
   WebSocketClientEvents,

--- a/libs/clients/base-websocket-client/src/websocket-client.ts
+++ b/libs/clients/base-websocket-client/src/websocket-client.ts
@@ -144,6 +144,22 @@ interface WebSocketClientOptions<S extends BaseWebSocketRouteSchema> {
    */
   sendQueueOverflow?: SendQueueOverflow;
   /**
+   * Maximum age, in milliseconds, of a message buffered while not `OPEN`.
+   * Anything older is dropped when the queue is flushed instead of being
+   * sent. Defaults to `undefined`: buffered messages never expire, which is
+   * the right behaviour for a control channel where every message still
+   * matters however late it lands.
+   *
+   * Set this on a channel carrying realtime data, where a message that missed
+   * its moment is not merely late but wrong. The queue holds
+   * {@link sendQueueLimit} messages regardless of how long the socket was
+   * down, so without an age bound a reconnect flushes the whole backlog onto
+   * the fresh socket in one burst - for a 100 ms audio chunk and the default
+   * limit of 64, that is 6.4 s of stale audio delivered as if it were
+   * current.
+   */
+  sendQueueMaxAgeMs?: number;
+  /**
    * `bufferedAmount` threshold in bytes. When the socket is `OPEN` and the
    * underlying send buffer exceeds this value, the overflow policy is applied
    * instead of sending. Defaults to 65536 (64 KiB). Set to `Infinity` to
@@ -190,11 +206,30 @@ interface WebSocketClientEvents<S extends BaseWebSocketRouteSchema> {
 /**
  * Tagged union of outbound frames waiting for the socket to reach `OPEN`.
  * Text frames carry a pre-serialized JSON string; binary frames carry the
- * raw buffer.
+ * raw buffer. `queuedAt` is the wall-clock time the message was buffered,
+ * used only to enforce {@link WebSocketClientOptions.sendQueueMaxAgeMs}.
  */
-type QueuedSend =
+type QueuedSend = { queuedAt: number } & (
   | { kind: 'text'; payload: string }
-  | { kind: 'binary'; payload: Buffer | ArrayBuffer };
+  | { kind: 'binary'; payload: Buffer | ArrayBuffer }
+);
+
+/**
+ * Messages the queue discarded rather than sending, by reason. `overflow` is
+ * the queue hitting {@link WebSocketClientOptions.sendQueueLimit} (or the
+ * socket's `bufferedAmount` exceeding the high-water mark while `OPEN`);
+ * `stale` is a message that outlived
+ * {@link WebSocketClientOptions.sendQueueMaxAgeMs} before the socket came
+ * back.
+ *
+ * Both are counted because both are silent otherwise: a client that drops
+ * every frame it sends looks, from the far end, exactly like a client that
+ * had nothing to say.
+ */
+interface SendQueueDrops {
+  overflow: number;
+  stale: number;
+}
 
 /**
  * Stops a socket's errors reaching this client, without leaving it with no
@@ -256,6 +291,7 @@ export class WebSocketClient<
   private readonly _backoff: BackoffOptions;
   private readonly _sendQueueLimit: number;
   private readonly _sendQueueOverflow: SendQueueOverflow;
+  private readonly _sendQueueMaxAgeMs: number;
   private readonly _backpressureHighWaterMark: number;
   private readonly _stableConnectionThresholdMs: number;
 
@@ -263,6 +299,7 @@ export class WebSocketClient<
   private _retryTimer: ReturnType<typeof setTimeout> | null = null;
   private _stableTimer: ReturnType<typeof setTimeout> | null = null;
   private _sendQueue: QueuedSend[] = [];
+  private _sendQueueDrops: SendQueueDrops = { overflow: 0, stale: 0 };
   private _handshakeRouter: EventEmitter<{
     message: (msg: ServerMessage<S>) => void;
   }> | null = null;
@@ -284,6 +321,7 @@ export class WebSocketClient<
     this._backoff = { ...DEFAULT_BACKOFF, ...options.backoff };
     this._sendQueueLimit = options.sendQueueLimit ?? 64;
     this._sendQueueOverflow = options.sendQueueOverflow ?? 'drop-oldest';
+    this._sendQueueMaxAgeMs = options.sendQueueMaxAgeMs ?? Infinity;
     this._backpressureHighWaterMark =
       options.backpressureHighWaterMark ?? 65536;
     this._stableConnectionThresholdMs =
@@ -302,6 +340,19 @@ export class WebSocketClient<
    */
   get attempt(): number {
     return this._attempt;
+  }
+
+  /**
+   * Lifetime count of outbound messages this client discarded instead of
+   * sending, by reason. See {@link SendQueueDrops}.
+   *
+   * Exposed because these drops are otherwise invisible from both ends: the
+   * caller's `send`/`sendBinary` returns exactly the same way whether the
+   * message went out or not, and the far end cannot tell a client that
+   * dropped everything from a client with nothing to say.
+   */
+  get sendQueueDrops(): Readonly<SendQueueDrops> {
+    return { ...this._sendQueueDrops };
   }
 
   /**
@@ -347,7 +398,7 @@ export class WebSocketClient<
    */
   send(message: ClientMessage<S>): void {
     const payload = JSON.stringify(message);
-    this._enqueue({ kind: 'text', payload });
+    this._enqueue({ kind: 'text', payload, queuedAt: Date.now() });
   }
 
   /**
@@ -356,7 +407,7 @@ export class WebSocketClient<
    * @param data Binary payload to send.
    */
   sendBinary(data: Buffer | ArrayBuffer): void {
-    this._enqueue({ kind: 'binary', payload: data });
+    this._enqueue({ kind: 'binary', payload: data, queuedAt: Date.now() });
   }
 
   /**
@@ -375,6 +426,7 @@ export class WebSocketClient<
       // bufferedAmount exceeds high-water mark - apply overflow policy.
       // drop-oldest and drop-newest both drop the current item since there
       // is no queue to rearrange when the socket is already open.
+      this._sendQueueDrops.overflow += 1;
       if (this._sendQueueOverflow === 'error') {
         this.emit(
           'error',
@@ -387,6 +439,7 @@ export class WebSocketClient<
     }
 
     if (this._sendQueueLimit === 0) {
+      this._sendQueueDrops.overflow += 1;
       if (this._sendQueueOverflow === 'error') {
         this.emit('error', new Error('Send queue is disabled (limit 0).'));
       }
@@ -394,6 +447,7 @@ export class WebSocketClient<
     }
 
     if (this._sendQueue.length >= this._sendQueueLimit) {
+      this._sendQueueDrops.overflow += 1;
       switch (this._sendQueueOverflow) {
         case 'drop-oldest':
           this._sendQueue.shift();
@@ -416,13 +470,23 @@ export class WebSocketClient<
   }
 
   /**
-   * Drain every buffered send item onto the live socket, in order.
+   * Drain every buffered send item onto the live socket, in order, dropping
+   * any that outlived `sendQueueMaxAgeMs` while the socket was down.
+   *
+   * The expiry check belongs here rather than at enqueue time: how long a
+   * message waits is decided by how long the socket stays down, which is not
+   * known when it is buffered.
    */
   private _flushQueue(): void {
     if (this._ws === null) return;
+    const oldestAllowed = Date.now() - this._sendQueueMaxAgeMs;
     while (this._sendQueue.length > 0) {
       const item = this._sendQueue.shift();
       if (item === undefined) break;
+      if (item.queuedAt < oldestAllowed) {
+        this._sendQueueDrops.stale += 1;
+        continue;
+      }
       this._ws.send(item.payload);
     }
   }
@@ -726,6 +790,7 @@ export type {
   ConnectionState,
   BackoffOptions,
   SendQueueOverflow,
+  SendQueueDrops,
   ConnectParams,
   WebSocketClientOptions,
   WebSocketClientEvents,

--- a/libs/clients/base-websocket-client/tests/unit/websocket-client.test.ts
+++ b/libs/clients/base-websocket-client/tests/unit/websocket-client.test.ts
@@ -427,6 +427,74 @@ describe('WebSocketClient', () => {
     expect(currentSocket().send).toHaveBeenCalledWith(data);
   });
 
+  it('drops buffered messages older than sendQueueMaxAgeMs instead of replaying them', () => {
+    // Arrange - a realtime channel: capture keeps producing while the socket
+    // is down, so without an age bound the whole backlog lands on the fresh
+    // socket at once, seconds after the audio it carries was spoken.
+    const client = new WebSocketClient({
+      schema: TEST_SCHEMA,
+      route: TEST_ROUTE,
+      baseUrl: BASE_URL,
+      params: { params: { room: 'r1' } },
+      sendQueueMaxAgeMs: 1000,
+    });
+    client.start();
+    const stale = new ArrayBuffer(4);
+    const fresh = new ArrayBuffer(8);
+
+    // Act - one frame buffered well before the reconnect, one just before it
+    client.sendBinary(stale);
+    vi.advanceTimersByTime(1500);
+    client.sendBinary(fresh);
+    currentSocket().onopen!({ type: 'open' });
+
+    // Assert - only the frame that still means something is delivered
+    expect(currentSocket().send).toHaveBeenCalledTimes(1);
+    expect(currentSocket().send).toHaveBeenCalledWith(fresh);
+    expect(client.sendQueueDrops).toEqual({ overflow: 0, stale: 1 });
+  });
+
+  it('keeps buffered messages indefinitely when sendQueueMaxAgeMs is unset', () => {
+    // Arrange - the default: a control channel, where a message still matters
+    // however late it lands.
+    const client = new WebSocketClient({
+      schema: TEST_SCHEMA,
+      route: TEST_ROUTE,
+      baseUrl: BASE_URL,
+      params: { params: { room: 'r1' } },
+    });
+    client.start();
+    const data = new ArrayBuffer(4);
+
+    // Act
+    client.sendBinary(data);
+    vi.advanceTimersByTime(600_000);
+    currentSocket().onopen!({ type: 'open' });
+
+    // Assert
+    expect(currentSocket().send).toHaveBeenCalledWith(data);
+    expect(client.sendQueueDrops.stale).toBe(0);
+  });
+
+  it('counts messages the queue dropped for overflow', () => {
+    // Arrange - overflow drops are otherwise silent under both drop policies:
+    // `send` returns identically whether the message went out or not.
+    const client = new WebSocketClient({
+      schema: TEST_SCHEMA,
+      route: TEST_ROUTE,
+      baseUrl: BASE_URL,
+      params: { params: { room: 'r1' } },
+      sendQueueLimit: 2,
+    });
+    client.start();
+
+    // Act - four sends into a queue that holds two
+    for (let i = 0; i < 4; i += 1) client.sendBinary(new ArrayBuffer(1));
+
+    // Assert
+    expect(client.sendQueueDrops).toEqual({ overflow: 2, stale: 0 });
+  });
+
   it('drops the newest message silently when the queue is full under drop-newest policy', () => {
     // Arrange
     const client = new WebSocketClient({

--- a/libs/clients/node-server-client/src/create-node-server-client.ts
+++ b/libs/clients/node-server-client/src/create-node-server-client.ts
@@ -42,6 +42,24 @@ function createNodeServerClient(baseUrl: string): NodeServerClient {
       TRANSCRIPTION_STREAM_SCHEMA,
       TRANSCRIPTION_STREAM_SOURCE_ROUTE,
       baseUrl,
+      {
+        // Everything a source sends is time-critical, so nothing it buffered
+        // during an outage is worth delivering afterwards. Capture keeps
+        // running while the socket is down - the microphone callback does not
+        // know about reconnects - so the send queue fills with audio chunks,
+        // and on reconnect the default behaviour flushes the whole backlog
+        // onto the fresh socket at once: up to 64 chunks, 6.4 s of audio the
+        // room finished saying seconds ago, delivered as if it were current.
+        // The text messages on this route are no better aged: a `timeSyncPing`
+        // carries the client clock reading from when it was queued, so a stale
+        // one poisons the offset it is supposed to measure, and `sourceState`
+        // is re-seeded on every `open` anyway.
+        //
+        // One second is roughly the point past which late captions have
+        // already missed the utterance they belong to, while still absorbing
+        // a blip shorter than the backoff's initial delay.
+        sendQueueMaxAgeMs: 1000,
+      },
     ),
     transcriptionStreamClient: createWebSocketClient(
       TRANSCRIPTION_STREAM_SCHEMA,

--- a/libs/clients/transcription-service-client/src/create-transcription-service-client.ts
+++ b/libs/clients/transcription-service-client/src/create-transcription-service-client.ts
@@ -21,8 +21,9 @@ interface TranscriptionServiceClient {
  * every consumer of this client gets the same deliberate policy rather than
  * inheriting `WebSocketClient`'s bare defaults by accident.
  *
- * Per `PLAN-AdmissionControl.md` §4: close 1013 ("try again later") is how
- * the transcription service now refuses a session for being at capacity.
+ * Per `archived-plans/2026-07-27-02-PLAN-AdmissionControl.md` §4: close 1013
+ * ("try again later") is how the transcription service now refuses a session
+ * for being at capacity.
  * 1013 is deliberately NOT added to `normalCloseCodes` - capacity is
  * transient (it frees up as other sessions end), so the right behavior is to
  * keep retrying, not give up. But "keep retrying forever" needs a policy

--- a/libs/schemas/node-server-schema/src/transcription-stream/routes/transcription-stream.schema.ts
+++ b/libs/schemas/node-server-schema/src/transcription-stream/routes/transcription-stream.schema.ts
@@ -38,8 +38,8 @@ export enum LatencyKind {
  * `AT_CAPACITY` means the Transcription Service explicitly refused the
  * connection (WebSocket close 1013, "try again later") rather than the
  * connection dropping or the service crashing - see
- * `PLAN-AdmissionControl.md` §4, "node-server must distinguish 'service
- * refused' from 'service crashed'". Mirrors the local
+ * `archived-plans/2026-07-27-02-PLAN-AdmissionControl.md` §4, "node-server must
+ * distinguish 'service refused' from 'service crashed'". Mirrors the local
  * `TranscriptionServiceDisconnectReason` in node-server's
  * `session-status.events.ts`; keep both in sync.
  */

--- a/libs/schemas/session-manager-schema/src/test-audio/test-audio.constants.ts
+++ b/libs/schemas/session-manager-schema/src/test-audio/test-audio.constants.ts
@@ -3,8 +3,9 @@
  * devices, and their standing sessions.
  *
  * These exist so that the synthetic audio sources described in
- * `PLAN-TestAudioDevices.md` need no hand provisioning at all. The Session
- * Manager seeds every row below under a **fixed uid** when
+ * `archived-plans/2026-07-27-01-PLAN-TestAudioDevices.md` need no hand
+ * provisioning at all. The Session Manager seeds every row below under a
+ * **fixed uid** when
  * `TEST_AUDIO_DEVICE_SECRET` is set (`TestAudioRoomsSeeder`), and the generator
  * derives its own credentials from the same secret and the same uids
  * ({@link deriveTestAudioDeviceToken}). Neither side is ever told a value the

--- a/libs/ui/visualizer-ui/src/components/visualizer-drawer.tsx
+++ b/libs/ui/visualizer-ui/src/components/visualizer-drawer.tsx
@@ -28,8 +28,16 @@ export const VisualizerDrawer = ({
 }: VisualizerDrawerProps) => (
   <Drawer anchor="right" open={open} onClose={onClose}>
     <Stack sx={{ width: 240, p: 2 }} spacing={1}>
+      {/* `component="p"`, not a heading element: MUI maps the `subtitle1`
+          *variant* to an `<h6>` by default, and this is a shared component
+          rendered into host pages whose surrounding heading levels this
+          library cannot know. Emitting a fixed level would be a
+          heading-order violation in any host that does not happen to end at
+          `h5`. If a host ever needs this to be a real heading, it should be
+          promoted by passing the level in, not guessed here. */}
       <Typography
         variant="subtitle1"
+        component="p"
         sx={{
           fontWeight: 'bold',
         }}

--- a/tools/a11y/README.md
+++ b/tools/a11y/README.md
@@ -73,6 +73,6 @@ that the app is accessible. Full coverage requires:
    settings drawer, and re-scan.
 3. **Manual review** — keyboard-only walkthrough and a screen-reader pass
    (NVDA/VoiceOver + a braille display for the live-caption region). See the
-   `PLAN-WCAG-Frontends.md` planning doc for the full checklist and the
-   live-caption ARIA design, and the **Accessibility (WCAG 2.1 AA)** wiki page
-   for day-to-day dev guidance.
+   `archived-plans/2026-07-24-02-PLAN-WCAG-Frontends.md` planning doc for the
+   full checklist and the live-caption ARIA design, and the **Accessibility
+   (WCAG 2.1 AA)** wiki page for day-to-day dev guidance.

--- a/tools/a11y/axe-scan.mjs
+++ b/tools/a11y/axe-scan.mjs
@@ -11,7 +11,7 @@
  *
  * These are SPAs, so the scan waits for the React root to render before
  * running axe. Automated tools catch ~30-40% of WCAG issues; pair this with
- * the manual review in PLAN-WCAG-Frontends.md.
+ * the manual review in archived-plans/2026-07-24-02-PLAN-WCAG-Frontends.md.
  */
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';

--- a/tools/audio-meter-crosscheck/README.md
+++ b/tools/audio-meter-crosscheck/README.md
@@ -1,6 +1,7 @@
 # Audio meter cross-check fixtures
 
-`PLAN-AUDIOVIZ.md` §9 asks for one gate above all others:
+`archived-plans/2026-07-24-04-PLAN-AUDIOVIZ.md` §9 asks for one gate above
+all others:
 
 > drive a session with a known WAV through a real stack and confirm the
 > dashboard's dBFS agrees with the standalone meter fed the same file to within a
@@ -48,7 +49,7 @@ measurement points (`stages[]`, each with its own `levels`, `vad` and cumulative
 `audioSeconds`), and the dashboard renders the **headline stage** — the
 lowest-depth stage that reports levels, because that is the measurement closest
 to the source and therefore the one that answers "is the room's audio reaching
-us" (`PLAN-AUDIOVIZ.md` §12.6).
+us" (`archived-plans/2026-07-24-04-PLAN-AUDIOVIZ.md` §12.6).
 
 Carrying a number faithfully is therefore no longer sufficient: the render path
 also has to pick the right one out of several. So the render leg now asserts, in
@@ -105,7 +106,8 @@ digit. The `limitedTones` fixtures pin the positive case and both sides of the
 threshold, because a rule that only stops false alarms would be just as wrong as
 one that only catches them.
 
-This was a producer change, which `PLAN-AUDIOVIZ.md` §11 put out of scope. It was
+This was a producer change, which
+`archived-plans/2026-07-24-04-PLAN-AUDIOVIZ.md` §11 put out of scope. It was
 brought into scope deliberately once the gate showed the dashboard was lying
 about real rooms.
 
@@ -187,8 +189,9 @@ and none of them expressible against a table of expected DSP values:
   the reader's business, and the mirrors here are hand-written on purpose.
 
 Closing the browser hop needs a compose-level harness that scrapes the rendered
-dashboard. It remains tracked as outstanding in `NEXTSTEPS-AUDIOVIZ.md`, and the
-render leg is already unit covered, which is why the browser was judged the least
+dashboard. It remains tracked as outstanding in
+`archived-plans/2026-07-24-04-NEXTSTEPS-AUDIOVIZ.md`, and the render leg is
+already unit covered, which is why the browser was judged the least
 valuable rung.
 
 ## Running the live-stack leg

--- a/transcription_service/src/shared/config/config.py
+++ b/transcription_service/src/shared/config/config.py
@@ -54,13 +54,13 @@ class EnvSchema(BaseModel):
     # "silent" means anything.
     AUDIO_SILENCE_THRESHOLD: float = 0.01
 
-    # Defaulted, reachable from `.env` on purpose (PLAN-AdmissionControl.md
-    # §3). This subsystem has a documented regret about tuning knobs that
-    # exist only as compose-file edits, never as `.env` values -
-    # `ALERT_RTF_P95` and its two siblings, a number a CPU deployment must
-    # currently discover for itself and hand-set with no `.env` path to do so.
-    # These three are the manual override the plan calls out by name, and are
-    # not repeating that mistake.
+    # Defaulted, reachable from `.env` on purpose
+    # (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3). This subsystem
+    # has a documented regret about tuning knobs that exist only as compose-file
+    # edits, never as `.env` values - `ALERT_RTF_P95` and its two siblings, a
+    # number a CPU deployment must currently discover for itself and hand-set
+    # with no `.env` path to do so. These three are the manual override the plan
+    # calls out by name, and are not repeating that mistake.
     TARGET_BUSY: float = 0.85
     MIN_SESSIONS: int = 1
     MAX_SESSIONS: int | None = None
@@ -232,7 +232,7 @@ class Config:
     def target_busy(self) -> float:
         """
         Headroom fraction the capacity estimator's ceiling aims at
-        (PLAN-AdmissionControl.md §3)
+        (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3)
 
         Dimensionless, and deliberately the same number on every device: the
         hardware-specific part (per-session cost) is measured by the
@@ -244,8 +244,8 @@ class Config:
     @property
     def min_sessions(self) -> int:
         """
-        Floor under the capacity estimator's ceiling (PLAN-AdmissionControl.md
-        §3)
+        Floor under the capacity estimator's ceiling
+        (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3)
 
         Exists so a mis-measurement - a noisy or unlucky window - can never
         take a worker's admitted capacity to zero.
@@ -256,7 +256,7 @@ class Config:
     def max_sessions(self) -> int | None:
         """
         Operator hard pin on a worker's session capacity
-        (PLAN-AdmissionControl.md §3)
+        (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3)
 
         None leaves the estimator auto-tuning, which is the shipped default.
         Set, it disables auto-tuning entirely and the estimate is exactly this

--- a/transcription_service/src/shared/utils/worker_pool/capacity_estimator.py
+++ b/transcription_service/src/shared/utils/worker_pool/capacity_estimator.py
@@ -1,12 +1,14 @@
 """
-Per-worker capacity estimator (PLAN-AdmissionControl.md §3)
+Per-worker capacity estimator
+(archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3)
 
 Estimates how many concurrent sessions one worker can serve before it falls
 behind, from nothing but the stream of completed job executions the pool
 already reports to a JobObserver. Written and validated in shadow mode first,
 so the decision logic was exercised against real sweeps before it was ever
 allowed to refuse anyone; `admit()` is now consulted by
-TranscriptionProviderRegistry.create_session (PLAN-AdmissionControl.md §4).
+TranscriptionProviderRegistry.create_session
+(archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4).
 
 Why per worker and not pool-wide: a pool can run several providers/contexts
 across several workers, and one worker runs one job at a time, so N sessions
@@ -40,8 +42,10 @@ it is meant to detect:
   It only advances on windows the gates accepted, so a worker that is
   degraded from its very first session never leaves warm-up, reports `None`
   forever, and therefore admits unconditionally forever. That is not
-  hypothetical: `LESSONSLEARNED-AdmissionControl.md` measured 52.9% drop
-  share at a *single* session on CPU with `vad_detector: true` - above
+  hypothetical:
+  `archived-plans/2026-07-27-02-LESSONSLEARNED-AdmissionControl.md` measured
+  52.9% drop share at a *single* session on CPU with `vad_detector: true` -
+  above
   ELEVATED_DROP_SHARE before a second session ever arrives. The plan's stated
   posture (an over-admission is visible and self-corrects; a wrong refusal is
   invisible) says permissive is the right default here, and substituting

--- a/transcription_service/src/transcription_provider_interface/transcription_client_error.py
+++ b/transcription_service/src/transcription_provider_interface/transcription_client_error.py
@@ -4,8 +4,9 @@ Defines Error classes used by TranscriptionProviders
 
 # WebSocket close reason a capacity refusal is sent with, stated once here
 # rather than at the point of the close. The node server keys "refused" apart
-# from "crashed" off this exact string (PLAN-AdmissionControl.md §4), so it is a
-# wire contract, not a log message - two literals would drift.
+# from "crashed" off this exact string
+# (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4), so it is a wire
+# contract, not a log message - two literals would drift.
 AT_CAPACITY_REASON = "at-capacity"
 
 
@@ -27,7 +28,7 @@ class TranscriptionClientError(Exception):
 class TranscriptionCapacityError(Exception):
     """
     Represents a session refused because the worker it was placed on has no
-    capacity for it (PLAN-AdmissionControl.md §4)
+    capacity for it (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4)
 
     Deliberately NOT a subclass of TranscriptionClientError, and deliberately
     not routed through it. TranscriptionClientError closes the socket with

--- a/transcription_service/src/transcription_provider_interface/transcription_session_interface.py
+++ b/transcription_service/src/transcription_provider_interface/transcription_session_interface.py
@@ -53,8 +53,9 @@ class TranscriptionSessionInterface(ABC, EventEmitter):
         None is a positive statement, not a missing implementation. It means
         "this session's cost is not a claim on a local worker's ASR throughput,
         so the per-worker capacity estimate does not describe it" - the shape
-        `PLAN-AdmissionControl.md` §5 already uses for a remote provider's
-        capacity, which is reported as "not applicable" rather than as a
+        `archived-plans/2026-07-27-02-PLAN-AdmissionControl.md` §5
+        already uses for a remote provider's capacity, which is reported as
+        "not applicable" rather than as a
         fabricated number. Defaulting to None is also the safe direction under
         this plan's stated posture: a provider added later is admitted rather
         than refused until someone deliberately opts it in, and an

--- a/transcription_service/src/webserver/create_webserver.py
+++ b/transcription_service/src/webserver/create_webserver.py
@@ -51,8 +51,9 @@ def create_webserver(config: Config, logger: Logger):
     # restart, and a consumer can only correlate them if the uid matches.
     process_identity = create_process_identity()
     metrics_registry = MetricsRegistry(process_identity=process_identity)
-    # PLAN-AdmissionControl.md §3/§4. Constructed here, next to
-    # metrics_registry, because both are fed by the same job_observer below and
+    # archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3/§4. Constructed
+    # here, next to metrics_registry, because both are fed by the same
+    # job_observer below and
     # both are threaded onward the same way - the estimator now reaching the
     # provider registry (which enforces admission) as well as metrics_router
     # (which reports its snapshot).

--- a/transcription_service/src/webserver/features/metrics/metrics_controller.py
+++ b/transcription_service/src/webserver/features/metrics/metrics_controller.py
@@ -93,11 +93,12 @@ class MetricsController:
             metrics_registry    - In-memory telemetry store
             provider_registry   - Owner of the worker pool and providers
             capacity_estimator  - Per-worker capacity estimator
-                                    (PLAN-AdmissionControl.md §3). Read here
-                                    through snapshot() only; the enforcing
-                                    caller is TranscriptionProviderRegistry,
-                                    and this controller must stay side effect
-                                    free so a poll can never move a decision.
+                                    (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md
+                                    §3). Read here through snapshot() only; the
+                                    enforcing caller is
+                                    TranscriptionProviderRegistry, and this
+                                    controller must stay side effect free so a
+                                    poll can never move a decision.
         """
         self._metrics = metrics_registry
         self._providers = provider_registry
@@ -204,11 +205,12 @@ class MetricsController:
                     self._metrics.binary_dropped_before_config_total
                 ),
                 # Sessions the admission check turned away
-                # (PLAN-AdmissionControl.md §4). Zero series is the healthy
-                # steady state, so this is one of the few counters here whose
-                # *absence* of movement is the signal; it is reported anyway
-                # because an operator asking "is anyone being refused" must be
-                # able to get "no" as an answer rather than silence.
+                # (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4).
+                # Zero series is the healthy steady state, so this is one of the
+                # few counters here whose *absence* of movement is the signal; it
+                # is reported anyway because an operator asking "is anyone being
+                # refused" must be able to get "no" as an answer rather than
+                # silence.
                 "sessionsRefusedCapacityTotal": _counter_series(
                     self._metrics.sessions_refused_capacity_total
                 ),

--- a/transcription_service/src/webserver/features/metrics/metrics_controller.py
+++ b/transcription_service/src/webserver/features/metrics/metrics_controller.py
@@ -192,6 +192,17 @@ class MetricsController:
                 "decodeDropsTotal": _counter_series(
                     self._metrics.decode_drops_total
                 ),
+                # The reconnect-loop fix: a binary frame that outran auth or
+                # config is dropped rather than closing the socket 1008, which
+                # a source's auto-reconnect would otherwise turn into a loop
+                # that never delivers audio. Counted so a client stuck in that
+                # pattern is still visible to an operator.
+                "binaryDroppedBeforeAuthTotal": _counter_series(
+                    self._metrics.binary_dropped_before_auth_total
+                ),
+                "binaryDroppedBeforeConfigTotal": _counter_series(
+                    self._metrics.binary_dropped_before_config_total
+                ),
                 # Sessions the admission check turned away
                 # (PLAN-AdmissionControl.md §4). Zero series is the healthy
                 # steady state, so this is one of the few counters here whose

--- a/transcription_service/src/webserver/features/metrics/metrics_router.py
+++ b/transcription_service/src/webserver/features/metrics/metrics_router.py
@@ -40,7 +40,8 @@ def metrics_router(
         metrics_registry        - In-memory telemetry store
         provider_registry       - Owner of the worker pool and providers
         capacity_estimator      - Shadow-mode per-worker capacity estimator
-                                    (PLAN-AdmissionControl.md §3)
+                                    (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md
+                                    §3)
 
     Returns:
         FastAPI router

--- a/transcription_service/src/webserver/features/transcription_stream/transcription_stream_controller.py
+++ b/transcription_service/src/webserver/features/transcription_stream/transcription_stream_controller.py
@@ -142,8 +142,9 @@ class TranscriptionStreamController(WebsocketHandler):
         TranscriptionStreamService once auth has completed and a config has
         not yet been received.
 
-        This is also the capacity-admission point (PLAN-AdmissionControl.md
-        §4): `service.start()` below reaches the registry, which registers the
+        This is also the capacity-admission point
+        (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4):
+        `service.start()` below reaches the registry, which registers the
         session's job, checks the worker it actually landed on and raises
         `TranscriptionCapacityError` if that worker is full. The refusal
         propagates out of here to `_handle_error`, which maps it to a 1013
@@ -371,7 +372,7 @@ class TranscriptionStreamController(WebsocketHandler):
         # for the service being busy. 1013 ("Try Again Later") is the IANA
         # registry's code for exactly this, and the reason string is what lets
         # the node server report "refused" rather than "crashed"
-        # (PLAN-AdmissionControl.md §4).
+        # (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4).
         if isinstance(error, TranscriptionCapacityError):
             self.close(1013, error.message)
             return True

--- a/transcription_service/src/webserver/features/transcription_stream/transcription_stream_controller.py
+++ b/transcription_service/src/webserver/features/transcription_stream/transcription_stream_controller.py
@@ -276,16 +276,44 @@ class TranscriptionStreamController(WebsocketHandler):
         """
         Treat any binary client message as a SAFP-framed chunk of source
         audio. Auth and config are enforced before the frame is decoded so an
-        unauthenticated peer is rejected regardless of framing; a malformed
-        frame from an authenticated peer is dropped (the node server already
-        validated the CRC, so this is defense in depth).
+        out-of-order frame never reaches a session; a malformed frame from an
+        authenticated, configured peer is dropped separately below (the node
+        server already validated the CRC, so this is defense in depth).
+
+        A frame that arrives before auth, or before config, is dropped and
+        counted rather than closing the socket - mirroring the fix already
+        applied on the node-server side (see
+        `transcription-stream.controller.ts`'s `socket.on('message', ...)`
+        handler). Closing here turns a recoverable client bug into a silent
+        reconnect loop: a source that starts streaming before AUTH_OK (or
+        before its CONFIG has been processed) would be closed 1008, the
+        client's auto-reconnect immediately re-sends AUTH, its first chunk
+        again beats AUTH_OK, and the cycle repeats forever with no audio ever
+        delivered and nothing naming the cause. The frame is worthless here
+        regardless - there is no session yet to hand it to - so dropping it is
+        strictly the better failure mode: the socket stays open long enough to
+        finish auth/config, after which audio flows normally. The init-timeout
+        watchdog (`_init_timeout`) still closes a socket that never completes
+        the handshake at all.
         """
         if not self._is_authenticated:
-            self.close(1008, "Audio chunk before authentication")
+            self._metrics_registry.record_binary_dropped_before_auth(
+                self._provider_key
+            )
+            self._logger.debug(
+                "Dropping binary frame received before authentication",
+                context={"provider_key": self._provider_key},
+            )
             return
 
         if self._service is None:
-            self.close(1008, "Audio chunk before configuration")
+            self._metrics_registry.record_binary_dropped_before_config(
+                self._provider_key
+            )
+            self._logger.debug(
+                "Dropping binary frame received before configuration",
+                context={"provider_key": self._provider_key},
+            )
             return
 
         try:

--- a/transcription_service/src/webserver/features/transcription_stream/transcription_stream_service.py
+++ b/transcription_service/src/webserver/features/transcription_stream/transcription_stream_service.py
@@ -80,7 +80,8 @@ class TranscriptionStreamService(EventEmitter):
 
         Also raises TranscriptionCapacityError when the registry refuses the
         session because the worker it was placed on is at capacity
-        (PLAN-AdmissionControl.md §4) - a 1013 close, not a 1007 one. Nothing
+        (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4) - a 1013
+        close, not a 1007 one. Nothing
         is wired up when that happens: the registry has already torn the
         session back down, and the two `on()` calls below are never reached, so
         this service holds no session and `close()` has nothing to undo.

--- a/transcription_service/src/webserver/shared/metrics/metrics_registry.py
+++ b/transcription_service/src/webserver/shared/metrics/metrics_registry.py
@@ -156,6 +156,23 @@ class MetricsRegistry:
             "decode_drops_total",
             "Audio frames dropped because they failed to decode, by provider",
         )
+        # The reconnect-loop fix (mirrors node-server's recordBinaryBeforeAuthDrop):
+        # a binary frame that arrives before auth or before config used to close
+        # the socket 1008, which a source's auto-reconnect turns into an
+        # infinite loop - it re-authenticates, its first chunk again beats the
+        # ordering it just violated, and no audio is ever delivered. Counted
+        # rather than silently discarded so a client stuck in that pattern is
+        # still visible to an operator.
+        self.binary_dropped_before_auth_total = Counter(
+            "binary_dropped_before_auth_total",
+            "Binary frames dropped because they arrived before authentication "
+            "completed, by provider",
+        )
+        self.binary_dropped_before_config_total = Counter(
+            "binary_dropped_before_config_total",
+            "Binary frames dropped because they arrived before session "
+            "configuration completed, by provider",
+        )
         # The refusal half of admission control (PLAN-AdmissionControl.md §4).
         # Counted here rather than left to the close-code statistics because a
         # refusal is otherwise indistinguishable from a client that hung up:
@@ -258,6 +275,36 @@ class MetricsRegistry:
             provider_key    - Provider the connection was opened against
         """
         self.decode_drops_total.inc(
+            {"provider_key": provider_key or UNLABELED_PROVIDER}
+        )
+
+    def record_binary_dropped_before_auth(self, provider_key: str) -> None:
+        """
+        Counts one binary frame dropped because it arrived before
+        authentication completed
+
+        Recorded in the FastAPI process, like `record_decode_drop`: there is
+        no session yet for the frame to reach.
+
+        Args:
+            provider_key    - Provider the connection was opened against
+        """
+        self.binary_dropped_before_auth_total.inc(
+            {"provider_key": provider_key or UNLABELED_PROVIDER}
+        )
+
+    def record_binary_dropped_before_config(self, provider_key: str) -> None:
+        """
+        Counts one binary frame dropped because it arrived before session
+        configuration completed
+
+        Recorded in the FastAPI process, like `record_decode_drop`: there is
+        no session yet for the frame to reach.
+
+        Args:
+            provider_key    - Provider the connection was opened against
+        """
+        self.binary_dropped_before_config_total.inc(
             {"provider_key": provider_key or UNLABELED_PROVIDER}
         )
 

--- a/transcription_service/src/webserver/shared/metrics/metrics_registry.py
+++ b/transcription_service/src/webserver/shared/metrics/metrics_registry.py
@@ -173,7 +173,8 @@ class MetricsRegistry:
             "Binary frames dropped because they arrived before session "
             "configuration completed, by provider",
         )
-        # The refusal half of admission control (PLAN-AdmissionControl.md §4).
+        # The refusal half of admission control
+        # (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4).
         # Counted here rather than left to the close-code statistics because a
         # refusal is otherwise indistinguishable from a client that hung up:
         # both end as a closed socket with no transcript, and only one of them

--- a/transcription_service/src/webserver/shared/provider_health_snapshot/provider_health_snapshot.py
+++ b/transcription_service/src/webserver/shared/provider_health_snapshot/provider_health_snapshot.py
@@ -25,7 +25,8 @@ def _worker(
     Args:
         snapshot            - Point-in-time view of a worker
         capacity_estimator  - Per-worker capacity estimator
-                                (PLAN-AdmissionControl.md §3/§5)
+                                (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md
+                                §3/§5)
 
     Returns:
         JSON-ready worker entry
@@ -58,12 +59,15 @@ def _health(
     Args:
         health              - Provider health snapshot
         capacity_estimator  - Per-worker capacity estimator, merged onto each
-                                owning worker (PLAN-AdmissionControl.md §5)
+                                owning worker
+                                (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md
+                                §5)
         provider_key         - Configured key this provider is registered
                                 under, used to look up its refusal count
         metrics_registry     - Process-wide metrics store, read here for
                                 `sessions_refused_capacity_total`
-                                (PLAN-AdmissionControl.md §4)
+                                (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md
+                                §4)
 
     Returns:
         JSON-ready health entry
@@ -156,20 +160,19 @@ class ProviderHealthSnapshotService:
                                     consumers can tell a restart from a
                                     counter decrease
             capacity_estimator  - Per-worker capacity estimator
-                                    (PLAN-AdmissionControl.md §3). Read here
-                                    through snapshot() only, same as
-                                    MetricsController - this service must stay
-                                    side effect free so a poll can never move
-                                    a decision. create_webserver.py always
+                                    (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md
+                                    §3). Read here through snapshot() only, same
+                                    as MetricsController - this service must
+                                    stay side effect free so a poll can never
+                                    move a decision. create_webserver.py always
                                     constructs one, so this is required rather
                                     than optional.
             metrics_registry     - Process-wide metrics store
-                                    (PLAN-AdmissionControl.md §4). Threaded
-                                    through for the same reason as
+                                    (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md
+                                    §4). Threaded through for the same reason as
                                     capacity_estimator above: both
-                                    `/providers/health` and the Redis
-                                    publisher need
-                                    `sessionsRefusedCapacityTotal` reported
+                                    `/providers/health` and the Redis publisher
+                                    need `sessionsRefusedCapacityTotal` reported
                                     next to `activeSessions`, and this service
                                     is the one join both consumers share.
                                     Read here through snapshot() only, so this

--- a/transcription_service/src/webserver/shared/transcription_provider_registry/transcription_provider_registry.py
+++ b/transcription_service/src/webserver/shared/transcription_provider_registry/transcription_provider_registry.py
@@ -89,13 +89,13 @@ class TranscriptionProviderRegistry:
                                     job execution, used to feed the metrics
                                     registry
             capacity_estimator  - Optional per-worker capacity estimator
-                                    (PLAN-AdmissionControl.md §3). When absent,
-                                    every session is admitted - the same
-                                    behaviour as before admission control
-                                    existed, which is what keeps every existing
-                                    test and every embedding of this class that
-                                    does not care about capacity working
-                                    unchanged.
+                                    (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md
+                                    §3). When absent, every session is admitted
+                                    - the same behaviour as before admission
+                                    control existed, which is what keeps every
+                                    existing test and every embedding of this
+                                    class that does not care about capacity
+                                    working unchanged.
             metrics_registry    - Optional telemetry store, used only to count
                                     capacity refusals. Optional for the same
                                     reason: a refusal that cannot be counted is
@@ -361,7 +361,8 @@ class TranscriptionProviderRegistry:
                 has no capacity for it
 
         ADMISSION IS DECIDED AFTER CONSTRUCTION, ON PURPOSE
-        (PLAN-AdmissionControl.md §4). `admit()` is a per-worker question, and
+        (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4). `admit()` is
+        a per-worker question, and
         which worker a session lands on is chosen by live load balancing inside
         `register_job` - so there is nothing to ask *about* until the session
         has registered. Building the session first and tearing it back down is

--- a/transcription_service/tests/integration/metrics/metrics_test.py
+++ b/transcription_service/tests/integration/metrics/metrics_test.py
@@ -200,10 +200,10 @@ def test_reports_workers_and_capacity(test_client: TestClient):
         assert worker["totalJobsRegistered"] == 0
         assert worker["contextIds"] == []
         assert worker["activeJobs"] == []
-        # The capacity estimator's warm-up default (PLAN-AdmissionControl.md
-        # §3): nothing has called record() yet in a freshly-started test
-        # client, so every worker reads "not measured", never a fabricated
-        # zero.
+        # The capacity estimator's warm-up default
+        # (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3): nothing
+        # has called record() yet in a freshly-started test client, so every
+        # worker reads "not measured", never a fabricated zero.
         assert worker["estimatedCapacitySessions"] is None
 
 

--- a/transcription_service/tests/integration/providers/providers_test.py
+++ b/transcription_service/tests/integration/providers/providers_test.py
@@ -233,9 +233,10 @@ def test_reports_pool_wide_context(test_client: TestClient):
     assert len(body["workers"]) == NUM_WORKERS
     assert all(worker["alive"] for worker in body["workers"])
     assert {worker["workerId"] for worker in body["workers"]} == {0, 1}
-    # PLAN-AdmissionControl.md §5: a freshly-started worker has recorded no
-    # job executions yet, so this reads "not measured", never a fabricated
-    # zero - the same warm-up default /metrics/status reports.
+    # archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §5: a
+    # freshly-started worker has recorded no job executions yet, so this
+    # reads "not measured", never a fabricated zero - the same warm-up
+    # default /metrics/status reports.
     assert all(
         worker["estimatedCapacitySessions"] is None
         for worker in body["workers"]

--- a/transcription_service/tests/unit/shared/config/config_test.py
+++ b/transcription_service/tests/unit/shared/config/config_test.py
@@ -138,9 +138,9 @@ def test_config_load_valid_config(clean_os_environ: None, tmp_path: Path):
     # every existing deployment.
     assert config.audio_silence_threshold == 0.01
     # Same again for the capacity estimator's manual override
-    # (PLAN-AdmissionControl.md §3): the shipped defaults must apply with none
-    # of the three set, or adding them would change every existing
-    # deployment's admitted capacity out from under it.
+    # (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3): the shipped
+    # defaults must apply with none of the three set, or adding them would
+    # change every existing deployment's admitted capacity out from under it.
     assert config.target_busy == 0.85
     assert config.min_sessions == 1
     assert config.max_sessions is None
@@ -250,7 +250,7 @@ def test_config_loads_the_capacity_estimator_overrides_when_set(
     # Need to include clean_os_environ so that fixture is created
     """
     Test configured capacity estimator overrides are read
-    (PLAN-AdmissionControl.md §3)
+    (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3)
 
     All three are the manual override the plan calls out by name - headroom,
     floor and operator pin - and none of them require touching the provider

--- a/transcription_service/tests/unit/shared/utils/audio_meter/audio_meter_test.py
+++ b/transcription_service/tests/unit/shared/utils/audio_meter/audio_meter_test.py
@@ -4,7 +4,8 @@ Unit tests for AudioMeter
 Fixtures are synthesized with numpy rather than committed as binary WAV
 files - a sine tone at a known dBFS, a full-scale square wave, silence, and
 uniform noise are all cheap to generate on the fly and keep tolerances
-parametrizable, per PLAN-B2.1-B2.3-audio-quality-telemetry.md §1.3.
+parametrizable, per
+archived-plans/2026-07-22-01-PLAN-B2.1-B2.3-audio-quality-telemetry.md §1.3.
 """
 
 # pylint: disable=protected-access
@@ -392,7 +393,8 @@ class TestRollingWindowPurge:
 class TestCpuBudget:
     """
     Provisional budget, not independently validated - see
-    PLAN-B2.1-B2.3-audio-quality-telemetry.md §4 open question 1.
+    archived-plans/2026-07-22-01-PLAN-B2.1-B2.3-audio-quality-telemetry.md §4
+    open question 1.
     """
 
     def test_append_and_snapshot_complete_within_budget(self):

--- a/transcription_service/tests/unit/shared/utils/worker_pool/capacity_estimator_test.py
+++ b/transcription_service/tests/unit/shared/utils/worker_pool/capacity_estimator_test.py
@@ -1,5 +1,6 @@
 """
-Unit tests for CapacityEstimator (PLAN-AdmissionControl.md §3/§6)
+Unit tests for CapacityEstimator
+(archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3/§6)
 
 Every test drives the estimator with synthetic JobExecutionObservations
 carrying explicit timestamps, so the sliding window is exercised without a

--- a/transcription_service/tests/unit/transcription_providers/admission_worker_id_test.py
+++ b/transcription_service/tests/unit/transcription_providers/admission_worker_id_test.py
@@ -1,6 +1,6 @@
 """
 Cross-provider tests for `TranscriptionSessionInterface.admission_worker_id`
-(PLAN-AdmissionControl.md §4/§5)
+(archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4/§5)
 
 This is the one property that decides which providers capacity admission
 applies to, so it is pinned here against all three shipped providers at once

--- a/transcription_service/tests/unit/transcription_providers/whisper_streaming_provider/whisper_streaming_bounded_tail_test.py
+++ b/transcription_service/tests/unit/transcription_providers/whisper_streaming_provider/whisper_streaming_bounded_tail_test.py
@@ -1,5 +1,6 @@
 """
-Unit tests for the bounded-tail split (`PLAN-AdmissionControl.md` §2):
+Unit tests for the bounded-tail split
+(`archived-plans/2026-07-27-02-PLAN-AdmissionControl.md` §2):
 `_transcribe_audio` hands Whisper only the oldest `max_transcribe_len_sec`
 (W) seconds of the buffer, front-anchored, and force-finalization still
 purges the buffer back down to `force_finalize_len_sec` (F) - independently

--- a/transcription_service/tests/unit/transcription_providers/whisper_streaming_provider/whisper_streaming_config_test.py
+++ b/transcription_service/tests/unit/transcription_providers/whisper_streaming_provider/whisper_streaming_config_test.py
@@ -1,6 +1,7 @@
 """
 Unit tests for WhisperStreamingProviderConfig's bounded-tail split
-(`PLAN-AdmissionControl.md` §2): `force_finalize_len_sec` (F) and
+(`archived-plans/2026-07-27-02-PLAN-AdmissionControl.md` §2):
+`force_finalize_len_sec` (F) and
 `max_transcribe_len_sec` (W) default to `max_buffer_len_sec` when unset, F
 must be >= W, and `job_period_ms` must not exceed `max_buffer_len_sec` in
 milliseconds.

--- a/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_controller_test.py
+++ b/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_controller_test.py
@@ -600,7 +600,8 @@ async def test_controller_closes_1013_for_a_capacity_refusal(
     versus retry later).
 
     The reason string is a wire contract, not a log line - the node server keys
-    "refused" apart from "crashed" off it (PLAN-AdmissionControl.md §4).
+    "refused" apart from "crashed" off it
+    (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4).
     """
     # Act
     return_value = controller._handle_error(

--- a/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_controller_test.py
+++ b/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_controller_test.py
@@ -294,33 +294,44 @@ async def test_controller_handles_valid_audio_chunk(
 
 
 @pytest.mark.asyncio
-async def test_controller_rejects_valid_audio_chunk_message_before_authentication(
+async def test_controller_drops_audio_chunk_message_before_authentication(
     controller: TranscriptionStreamController,
     mock_provider_registry: MagicMock,
     mock_close_method: MagicMock,
 ):
     """
-    Test that controller rejects valid audio chunk sent before auth message
+    Test that a binary frame sent before auth is dropped and counted rather
+    than closing the socket
+
+    Closing here would let a source's auto-reconnect loop forever: it
+    re-sends AUTH, its first chunk again beats AUTH_OK, and no audio is ever
+    delivered. Dropping keeps the socket alive to finish auth instead.
     """
     # Arrange / Act
     await controller._handle_binary_message(AUDIO_CHUNK)
 
     # Assert
     mock_provider_registry.create_session.assert_not_called()
-    mock_close_method.assert_called_once_with(
-        1008, "Audio chunk before authentication"
+    mock_close_method.assert_not_called()
+    assert (
+        controller._metrics_registry.binary_dropped_before_auth_total.get(
+            {"provider_key": PROVIDER_UID}
+        )
+        == 1
     )
 
 
 @pytest.mark.asyncio
-async def test_controller_rejects_valid_audio_chunk_message_before_configuration(
+async def test_controller_drops_audio_chunk_message_before_configuration(
     controller: TranscriptionStreamController,
     mock_auth_service: MagicMock,
     mock_provider_registry: MagicMock,
     mock_close_method: MagicMock,
 ):
     """
-    Test that controller rejects valid audio chunk sent before config message
+    Test that a binary frame sent before config is dropped and counted rather
+    than closing the socket, for the same reconnect-loop reason as the
+    before-authentication case above
     """
     # Arrange
     mock_auth_service.is_authenticated.return_value = True
@@ -331,8 +342,12 @@ async def test_controller_rejects_valid_audio_chunk_message_before_configuration
 
     # Assert
     mock_provider_registry.create_session.assert_not_called()
-    mock_close_method.assert_called_once_with(
-        1008, "Audio chunk before configuration"
+    mock_close_method.assert_not_called()
+    assert (
+        controller._metrics_registry.binary_dropped_before_config_total.get(
+            {"provider_key": PROVIDER_UID}
+        )
+        == 1
     )
 
 

--- a/transcription_service/tests/unit/webserver/shared/metrics/metrics_registry_test.py
+++ b/transcription_service/tests/unit/webserver/shared/metrics/metrics_registry_test.py
@@ -439,8 +439,9 @@ def test_capacity_refusals_are_counted_per_provider():
     """
     Test refused sessions are counted, labelled by the provider refused for
 
-    The counter behind PLAN-AdmissionControl.md §4's operator visibility. A
-    refusal leaves no other trace on this service: no job is registered for
+    The counter behind archived-plans/2026-07-27-02-PLAN-AdmissionControl.md
+    §4's operator visibility. A refusal leaves no other trace on this
+    service: no job is registered for
     long enough to report anything, and on the wire it is a closed socket -
     which is indistinguishable from a client that hung up. Labelled per
     provider because a host serving a local model and a remote one needs to

--- a/transcription_service/tests/unit/webserver/shared/metrics/metrics_registry_test.py
+++ b/transcription_service/tests/unit/webserver/shared/metrics/metrics_registry_test.py
@@ -391,6 +391,50 @@ def test_decode_drops_are_counted_per_provider():
     assert registry.decode_drops_total.get({"provider_key": "unknown"}) == 1
 
 
+def test_binary_dropped_before_auth_is_counted_per_provider():
+    """
+    Test binary frames dropped for arriving before auth are counted, labelled
+    by provider
+
+    The counter behind the transcription-stream controller's reconnect-loop
+    fix (mirrors node-server's `recordBinaryBeforeAuthDrop`): a frame this
+    early is dropped rather than closing the socket, so this is the only
+    trace it leaves.
+    """
+    # Arrange
+    registry = MetricsRegistry()
+
+    # Act
+    registry.record_binary_dropped_before_auth("whisper")
+    registry.record_binary_dropped_before_auth("whisper")
+    registry.record_binary_dropped_before_auth("")
+
+    # Assert
+    counter = registry.binary_dropped_before_auth_total
+    assert counter.get({"provider_key": "whisper"}) == 2
+    assert counter.get({"provider_key": "unknown"}) == 1
+
+
+def test_binary_dropped_before_config_is_counted_per_provider():
+    """
+    Test binary frames dropped for arriving before config are counted,
+    labelled by provider, and kept separate from the before-auth counter
+    """
+    # Arrange
+    registry = MetricsRegistry()
+
+    # Act
+    registry.record_binary_dropped_before_config("whisper")
+    registry.record_binary_dropped_before_config("whisper")
+    registry.record_binary_dropped_before_config("")
+
+    # Assert
+    counter = registry.binary_dropped_before_config_total
+    assert counter.get({"provider_key": "whisper"}) == 2
+    assert counter.get({"provider_key": "unknown"}) == 1
+    assert registry.binary_dropped_before_auth_total.total() == 0
+
+
 def test_capacity_refusals_are_counted_per_provider():
     """
     Test refused sessions are counted, labelled by the provider refused for

--- a/transcription_service/tests/unit/webserver/shared/provider_health_snapshot/provider_health_snapshot_test.py
+++ b/transcription_service/tests/unit/webserver/shared/provider_health_snapshot/provider_health_snapshot_test.py
@@ -299,7 +299,8 @@ async def test_serializes_owning_workers_like_pool_workers():
 @pytest.mark.asyncio
 async def test_merges_estimated_capacity_onto_workers_and_owning_workers():
     """
-    Test N* (PLAN-AdmissionControl.md §5) lands on both worker lists
+    Test N* (archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §5) lands
+    on both worker lists
 
     Identical to how MetricsController.status() layers this onto
     /metrics/status's `workers[]` - here it must additionally reach each

--- a/transcription_service/tests/unit/webserver/shared/transcription_provider_registry/capacity_admission_test.py
+++ b/transcription_service/tests/unit/webserver/shared/transcription_provider_registry/capacity_admission_test.py
@@ -1,6 +1,6 @@
 """
 Unit tests for capacity admission in TranscriptionProviderRegistry
-(PLAN-AdmissionControl.md §4/§6)
+(archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §4/§6)
 
 These cover the half of admission control that decides and refuses. The
 estimator that supplies N* has its own suite
@@ -249,9 +249,11 @@ def registry(
     """
     Registry pinned to one session per worker
 
-    One is the ceiling this branch's own live CPU sweep measured on the shipped
-    default config (LESSONSLEARNED-AdmissionControl.md), so it is the realistic
-    setting to build the refusal tests on rather than an arbitrarily tiny one.
+    One is the ceiling this branch's own live CPU sweep measured on the
+    shipped default config
+    (archived-plans/2026-07-27-02-LESSONSLEARNED-AdmissionControl.md), so it
+    is the realistic setting to build the refusal tests on rather than an
+    arbitrarily tiny one.
     """
     return make_registry(
         mock_config, mock_logger, pinned_estimator(1), metrics_registry


### PR DESCRIPTION
Works through the actionable items in `FOLLOWUPS.md` — material harvested from
archived plan documents that would otherwise never have been read again. Item 0
(version the plan docs; push `feature/sessions-calendar`) was already done
before this branch started.

Each item was re-verified against the code before being acted on, and two
turned out to be stale or wrong as written — see **Findings that changed the
brief** below.

## Fixes

**`session-manager` cursor pagination repeated rows (§2.8)** — reported as "a
pre-existing flake, three devices registered inside one millisecond tie on the
`created_at` cursor, needs a tiebreak column". There already *was* a `uid`
tiebreak; the real bug is that `_listByCreatedAt` **filtered** on
`date_trunc('milliseconds', created_at)` but **ordered** on the raw column.
`created_at` keeps microseconds, the cursor round-trips through a JS `Date` and
an ISO-8601 string and can only name a millisecond, so the two disagreed about
which side of the cursor a row fell on: a row ordered into page N by its
microseconds could still satisfy the `uid` tiebreak and be returned again on
page N+1. Both repositories now order on the same truncated expression the
cursor uses. Regression tests force the collision (three rows in one
millisecond, uids ordered against their microseconds) instead of waiting for
it — **verified failing without the fix** in both suites, page two returning 2
rows instead of 1.

**Pre-auth binary frames killed the connection (§2.5)** — `transcription_service`
closed 1008 on a binary frame arriving before AUTH or before CONFIG. That turns
a recoverable client ordering bug into a silent outage: the client
auto-reconnects, re-sends AUTH, its first chunk again beats AUTH_OK, and the
loop repeats with no audio delivered and nothing naming the cause. It now drops
the frame, counts it, and leaves the connection open. A peer that never
completes the handshake at all is still closed by the existing
`ws_init_timeout` watchdog, so this does not let an unauthenticated peer hold a
connection.

**Up to 6.4 s of stale audio replayed on reconnect (§2.5)** — the send queue
buffers 64 messages while the socket is down and flushes every one the instant
it reopens. On the source route that queue is audio: microphone capture keeps
running across a reconnect because the capture callback has no idea the socket
dropped. `WebSocketClient` gains an opt-in `sendQueueMaxAgeMs`; the node-server
**source** route sets it to 1 s. Everything a source sends is time-critical — a
queued `timeSyncPing` carries the clock reading from when it was queued, so a
stale one poisons the offset it exists to measure, and `sourceState` is
re-seeded on every open. Default behaviour is unchanged for every other
consumer. Drops are now readable via `sendQueueDrops`, overflow included;
previously both were entirely silent.

**Audio meter defaults made healthy speech read amber (§2.8)** — the zone
boundaries are applied to the held sample **peak**, but the defaults were taken
from EBU alignment level, an **RMS** convention. A sine at −18 dBFS RMS peaks at
−15.01 dBFS, 3 dB above the old warn boundary. Defaults move to the
`-12 / -3` "speech headroom" preset already present in the meter's own
selector; both alignment presets remain selectable. nginx's pinned CSP hashes
cover the page's inline scripts and were recomputed — **independently verified**
by re-hashing the scripts rather than trusting the edit.

**MUI subtitle variants emitted stray `<h6>` elements (§2.8)** — `subtitle1` and
`subtitle2` map to an `h6` *element* whether or not the text is a heading, and
there is no `variantMapping` override anywhere in the repo. Calendar column
labels and the visualizer drawer title now render as text; the Documentation and
Deployment Check pages turned out to have **no `h1` at all** (both set
`variant="h5"` with no `component`, where every other page uses
`variant="h5" component="h1"`), and their card/finding titles are now
`component="h2"`. Each site carries a comment naming the gotcha.

## Monitoring

**Three counters nothing consumed (§2.8)** — node-server's
`binaryBeforeAuthDropsTotal` was counted and serialised but had no registry
counter, no `/metrics` series, no panel and no alert. It and the two new
transcription-service counters are now wired through the sidecar as
`scribear_node_binary_before_auth_drops_total` and
`scribear_asr_binary_dropped_before_{auth,config}_total` (the latter two per
provider). All three wire fields are `Type.Optional`, so a service built before
the change is polled without failing strict validation — absent records no
increment rather than a zero, which is the rolling-upgrade trap `FOLLOWUPS.md`
§1 describes. **No alert thresholds**: none of these has a measured baseline.

## Tests and docs

**A fixture that is live now (§2.5)** — every session-auth fixture used
`autoSessionEnabled: false`, which short-circuits the auto-session reconciler.
Adds a room with auto-sessions enabled and a window open right now. The fixture
**asserts its own 201**: written without that assertion it silently 400'd on
three missing required fields and the test passed anyway while exercising
nothing — the same failure mode as the gap it closes.

**96 dead plan-doc citations (§4)** — every planning-doc filename cited in the
source tree resolved to nothing after the 2026-07-28 rename, across code
comments, eslint-disable reasons, Grafana dashboard descriptions and
operator-facing READMEs. Rewritten to the current names, preserving `§`
suffixes and re-wrapping the comment blocks the longer names overflow. Verified
two ways: no old-style citation survives, and **every rewritten name resolves to
a file that actually exists**. Left alone: the three docs that live in this repo
and were never renamed, and `CHANGELOG.md`/`.changeset` entries, which are
point-in-time release records.

**`CONTRIBUTING.md` (§1)** — the rules this codebase has re-learned repeatedly
existed only in one-off write-ups outside the repo: monitoring guards are
censored by the fault they detect; check a metric's slope under the failure;
extracting code into new files on a long-lived branch merges cleanly while
silently reverting everything that landed in the original since the fork; auth
is a property of the connection, not the session; new cross-service schema
fields must be optional. Linked from the README's onboarding and AI-agent
sections.

## Findings that changed the brief

- **§2.5 "`apps/kiosk-webapp` has no test script at all" is stale.** It has
  `test:unit`, a vitest config and a test suite. No change made.
- **§2.5 "session-manager fixtures need one live-now room" was partly stale.**
  `schedule-management.routes.test.ts` already has one — the regression test
  added when the 500 was found. The genuine gap was the session-auth suite,
  which is what this PR covers.
- **§2.5 says pre-auth binary kills the connection "on both node-server and
  transcription-service".** node-server was already fixed; only the Python side
  still closed.

## Verification

- `session-manager` integration **427/427** against a real Postgres
  testcontainer; unit 591/591.
- `admin-webapp` 417/417 · `node-server` 210/210 · `admin-server` 191/191 ·
  `scribear-redis` 58/58 · `base-websocket-client` 31/31 · sidecar integration
  72/72.
- `transcription_service`: **530/530** unit, `black`/`isort` clean,
  `pylint 10.00/10`.
- `npm run format --workspaces` clean; `npm run lint --workspaces` unchanged
  from baseline.
- The `deployment/compose.yml` drift guard fired on the citation sweep, as
  designed. The change is comment-only — no service, env var, wiring, port or
  volume moved — so `COMPOSE_FILE_VERSION` stays put and only the hash was
  re-pinned, which is the second remedy the guard's own message describes.

**Pre-existing in this checkout, not from this branch:** `@scribear/test-audio-source`
is not linked in `node_modules`, so `monitoring-sidecar` (1 file) and
`test-audio-generator` (3 files) fail at import, and `apps/admin-webapp`
has one `TS2375` in `room-picker.tsx`. All are in files no commit here touches,
and the TS error was **reproduced on a clean `staging` worktree** to confirm it.

## Deliberately not done

`FOLLOWUPS.md` items needing a decision or a measurement rather than a code
change are untouched: the CPU VAD fix (§2.1), the one-session CPU default
(§2.2), the `compute_type` sweep (§2.3), the impossible CPU mean-RTF figure
(§2.4), the security findings raised for a decision (§2.6), and the monitoring
sidecar wire-up (§2.7). `libs/test-audio-source` did not get the stale-frame
expiry: it is a measurement harness, and changing what it delivers under
reconnect changes what it measures, which I had no way to verify here.
