### PR TITLE
fix(transcription): disable session admission enforcement

### DIFF
--- a/transcription_service/src/webserver/create_webserver.py
+++ b/transcription_service/src/webserver/create_webserver.py
@@ -71,8 +71,14 @@ def create_webserver(config: Config, logger: Logger):
         metrics_registry.record_job_execution(observation)
         capacity_estimator.record(observation)
 
+    # Admission enforcement disabled for now: idle (audio-less) connections
+    # register a job and count toward a worker's live_job_count the same as
+    # an active one, so N can cross the ratcheted ceiling from connection
+    # count alone. `capacity_estimator` is still wired into `_observe_job`
+    # below and into /metrics/status + /providers/health, so estimation stays
+    # live in shadow mode - only the refusal in `create_session` is off.
     provider_registry = TranscriptionProviderRegistry(
-        config, logger, _observe_job, capacity_estimator, metrics_registry
+        config, logger, _observe_job, None, metrics_registry
     )
     # One join, two consumers: the /providers/health route below and the
     # telemetry publisher started in the lifespan hook.


### PR DESCRIPTION
## Summary
- Idle (audio-less) connections register a job and count toward a worker's `live_job_count` the same as an actively-streaming one, so opening enough audio-less clients trips the capacity ceiling on their own - observed as flaky refusals unrelated to real load.
- Turn off enforcement in create_session while keeping the estimator wired into `_observe_job` and `/metrics/status` + `/providers/health`, so estimation keeps running in shadow mode until admission can tell idle sessions apart from active ones.

## Follow-up
Admission needs to stop counting a session before it has sent any audio (e.g. gate on first chunk rather than on CONFIG, or exclude never-active sessions from `live_job_count`) before re-enabling enforcement. Tracked in a follow-up PR: defers job registration to a session's first audio chunk and re-enables admission.

## Test plan
- [x] `make test_unit` / `make test_integration` in `transcription_service`
- [x] Manually open several idle (no-audio) client connections against a single worker and confirm none are refused