### PR TITLE
fix(transcription): defer job registration to first audio, re-enable admission

### DIFF
--- a/transcription_service/src/transcription_provider_interface/transcription_provider_interface.py
+++ b/transcription_service/src/transcription_provider_interface/transcription_provider_interface.py
@@ -3,6 +3,7 @@ Defines TranscriptionProviderInterface API for transcription providers
 """
 
 from abc import ABC, abstractmethod
+from typing import Callable
 
 from src.shared.logger import Logger
 from src.shared.utils.worker_pool import WorkerPool
@@ -91,6 +92,54 @@ class TranscriptionProviderInterface(ABC):
     # immutable, so the first increment rebinds it as an instance attribute and
     # no state is ever shared between providers.
     _active_sessions: int = 0
+
+    # None until `bind_admission_check` wires one on, which
+    # TranscriptionProviderRegistry does right after constructing this
+    # provider. A provider built directly - every provider unit test does
+    # this - therefore admits unconditionally, the same fail-open default
+    # admission control has used from the start.
+    _admission_check: Callable[[int | None, Logger], None] | None = None
+
+    def bind_admission_check(
+        self, check: Callable[[int | None, Logger], None]
+    ) -> None:
+        """
+        Wires this provider to the registry's capacity gate
+
+        Args:
+            check   - Callable a session invokes the moment it discovers
+                        which worker (if any) its job landed on. Raises
+                        TranscriptionCapacityError if that worker has no
+                        room; a no-op call is always safe.
+
+        Called once, by TranscriptionProviderRegistry._load_providers,
+        immediately after construction - never by a session, and never
+        more than once per provider.
+        """
+        self._admission_check = check
+
+    def check_admission(self, worker_id: int | None, logger: Logger) -> None:
+        """
+        Asks the registry whether the given worker has room for one more
+        session, raising TranscriptionCapacityError if not
+
+        Args:
+            worker_id   - The worker a session's job just landed on, or None
+                            if this session's cost is not a capacity claim
+                            (see TranscriptionSessionInterface.admission_worker_id)
+            logger      - Logger to attach to a refusal
+
+        A session calls this itself, right after registering its job - not
+        the registry, and not at session construction. Registration is what
+        makes a session a claim on worker capacity at all (an idle,
+        audio-less connection that never registers a job never shows up in
+        any worker's live_job_count), so there is nothing to decide before
+        it happens, and deciding any later would let that session's job sit
+        on a worker it was never granted.
+        """
+        if self._admission_check is None:
+            return
+        self._admission_check(worker_id, logger)
 
     @property
     def job_period_ms(self) -> int | None:

--- a/transcription_service/src/transcription_provider_interface/transcription_session_interface.py
+++ b/transcription_service/src/transcription_provider_interface/transcription_session_interface.py
@@ -40,26 +40,30 @@ class TranscriptionSessionInterface(ABC, EventEmitter):
     def admission_worker_id(self) -> int | None:
         """
         Gets the pool worker this session's compute landed on, or None if the
-        session is not subject to local worker-pool capacity admission
+        session is not subject to local worker-pool capacity admission, or if
+        it has not yet claimed a worker at all
 
         Which worker a session lands on is decided by live load balancing at
         `register_job` time (`WorkerPool._assign_process` picks the least
         utilized worker owning every required context tag), so it is not
-        knowable before the session is constructed. That is why admission
-        control registers first and asks afterwards, and why the answer has to
-        come off the session object: the registry that decides admission never
-        sees the JobHandle.
+        knowable before a job is registered. Registration itself is deferred
+        to the session's first real audio chunk (an idle, audio-less
+        connection registers no job and so is never a capacity claim on
+        anything), which is why this reads None right up until then even for
+        a provider that overrides it - and why the answer has to come off the
+        session object rather than be asked of the registry, which never sees
+        the JobHandle.
 
-        None is a positive statement, not a missing implementation. It means
-        "this session's cost is not a claim on a local worker's ASR throughput,
-        so the per-worker capacity estimate does not describe it" - the shape
-        `PLAN-AdmissionControl.md` §5 already uses for a remote provider's
-        capacity, which is reported as "not applicable" rather than as a
-        fabricated number. Defaulting to None is also the safe direction under
-        this plan's stated posture: a provider added later is admitted rather
-        than refused until someone deliberately opts it in, and an
-        over-admission is visible and self-corrects while a wrong refusal is
-        invisible to everyone including us.
+        None is also a positive statement once a job does exist, not only a
+        "not yet" state. It means "this session's cost is not a claim on a
+        local worker's ASR throughput, so the per-worker capacity estimate
+        does not describe it" - the shape `PLAN-AdmissionControl.md` §5 already
+        uses for a remote provider's capacity, which is reported as "not
+        applicable" rather than as a fabricated number. Defaulting to None is
+        also the safe direction under this plan's stated posture: a provider
+        added later is admitted rather than refused until someone deliberately
+        opts it in, and an over-admission is visible and self-corrects while a
+        wrong refusal is invisible to everyone including us.
 
         Concretely, of the three shipped providers only `whisper-streaming`
         overrides this. `lumen_granite` is a remote-API provider whose capacity

--- a/transcription_service/src/transcription_providers/debug_provider/debug_provider.py
+++ b/transcription_service/src/transcription_providers/debug_provider/debug_provider.py
@@ -2,6 +2,9 @@
 Defines DebugProvider that provides debugging information as "transcriptions"
 """
 
+# The provider/session wiring necessarily mirrors the other providers.
+# pylint: disable=duplicate-code
+
 from src.shared.logger import Logger
 from src.shared.utils.worker_pool import JobException, JobSuccess, WorkerPool
 from src.transcription_provider_interface import (
@@ -51,19 +54,10 @@ class DebugProvider(TranscriptionProviderInterface):
             self.session_uid = session_uid
             self.room_uid = room_uid
 
-            self._job = provider.worker_pool.register_job(
-                (),
-                DEBUG_JOB_PERIOD_MS,
-                DebugProviderJob(self._config),
-                provider.provider_key,
-                session_uid=self.session_uid,
-                room_uid=self.room_uid,
-            )
+            # Not registered here - see _ensure_job. An idle client that never
+            # sends audio must never take a worker's job slot.
+            self._job = None
 
-            self._job.on(self._job.JobResultEvent, self._handle_job_result)
-
-            # Last, so a registration that raises above never counts a session
-            # that did not open.
             provider.session_started()
 
         def _handle_job_result(
@@ -108,15 +102,46 @@ class DebugProvider(TranscriptionProviderInterface):
                 ),
             )
 
+        def _ensure_job(self) -> None:
+            """
+            Registers this session's worker-pool job on the first real audio
+            chunk, not at construction
+
+            Deferred so an idle client - configured but never streaming - never
+            takes a worker's job slot, and so never counts toward that
+            worker's live_job_count for capacity admission. `check_admission`
+            is called for uniformity with the other two providers' sessions,
+            not because it can refuse one here: this session never overrides
+            `admission_worker_id`, so the call is a guaranteed no-op (see
+            TranscriptionSessionInterface.admission_worker_id).
+            """
+            if self._job is not None:
+                return
+
+            self._job = self._provider.worker_pool.register_job(
+                (),
+                DEBUG_JOB_PERIOD_MS,
+                DebugProviderJob(self._config),
+                self._provider.provider_key,
+                session_uid=self.session_uid,
+                room_uid=self.room_uid,
+            )
+            self._job.on(self._job.JobResultEvent, self._handle_job_result)
+            self._provider.check_admission(
+                self.admission_worker_id, self._logger
+            )
+
         def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
             # Debug provider does not track chunk ids; the correlation id is
             # accepted for interface parity and ignored.
             del chunk_id
+            self._ensure_job()
             self._job.queue_data([chunk])
 
         def end_session(self):
             super().end_session()
-            self._job.deregister()
+            if self._job is not None:
+                self._job.deregister()
             self._provider.session_ended()
 
     def __init__(

--- a/transcription_service/src/transcription_providers/lumen_granite_provider/lumen_granite_provider.py
+++ b/transcription_service/src/transcription_providers/lumen_granite_provider/lumen_granite_provider.py
@@ -67,18 +67,10 @@ class LumenGraniteProvider(TranscriptionProviderInterface):
             self.session_uid = session_uid
             self.room_uid = room_uid
 
-            self._job = provider.worker_pool.register_job(
-                (),  # no context - remote endpoint does the work
-                provider.config.job_period_ms,
-                LumenGraniteProviderJob(provider.config),
-                provider.provider_key,
-                session_uid=self.session_uid,
-                room_uid=self.room_uid,
-            )
-            self._job.on(self._job.JobResultEvent, self._handle_job_result)
+            # Not registered here - see _ensure_job. An idle client that never
+            # sends audio must never take a worker's job slot.
+            self._job = None
 
-            # Last, so a registration that raises above never counts a session
-            # that did not open.
             provider.session_started()
 
         def _handle_job_result(
@@ -90,14 +82,45 @@ class LumenGraniteProvider(TranscriptionProviderInterface):
 
             self.emit(self.TranscriptionResultEvent, result.value)
 
+        def _ensure_job(self) -> None:
+            """
+            Registers this session's worker-pool job on the first real audio
+            chunk, not at construction
+
+            Deferred so an idle client - configured but never streaming - never
+            takes a worker's job slot, and so never counts toward that
+            worker's live_job_count for capacity admission. `check_admission`
+            is called for uniformity with the other two providers' sessions,
+            not because it can refuse one here: this session never overrides
+            `admission_worker_id`, so the call is a guaranteed no-op (see
+            TranscriptionSessionInterface.admission_worker_id) - a remote
+            provider's capacity question is upstream rate limits and network
+            latency, explicitly out of scope per §5/§7.
+            """
+            if self._job is not None:
+                return
+
+            self._job = self._provider.worker_pool.register_job(
+                (),  # no context - remote endpoint does the work
+                self._provider.config.job_period_ms,
+                LumenGraniteProviderJob(self._provider.config),
+                self._provider.provider_key,
+                session_uid=self.session_uid,
+                room_uid=self.room_uid,
+            )
+            self._job.on(self._job.JobResultEvent, self._handle_job_result)
+            self._provider.check_admission(self.admission_worker_id, self._log)
+
         def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
+            self._ensure_job()
             self._job.queue_data(
                 [AudioChunkPayload(chunk_id=chunk_id, audio_bytes=chunk)]
             )
 
         def end_session(self):
             super().end_session()
-            self._job.deregister()
+            if self._job is not None:
+                self._job.deregister()
             self._provider.session_ended()
 
     def __init__(

--- a/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_provider.py
+++ b/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_provider.py
@@ -2,6 +2,9 @@
 Defines FasterWhisperStreamingProvider
 """
 
+# The provider/session wiring necessarily mirrors the other providers.
+# pylint: disable=duplicate-code
+
 from dataclasses import asdict
 
 from src.shared.logger import Logger
@@ -68,28 +71,20 @@ class WhisperStreamingProvider(TranscriptionProviderInterface):
             self.session_uid = session_uid
             self.room_uid = room_uid
 
-            self._job = provider.worker_pool.register_job(
-                (
-                    self._provider.config.whisper_context_tag,
-                    self._provider.config.silero_context_tag,
-                ),
-                self._provider.config.job_period_ms,
-                WhisperStreamingProviderJob(self._provider.config),
-                self._provider.provider_key,
-                session_uid=self.session_uid,
-                room_uid=self.room_uid,
-            )
-            self._job.on(self._job.JobResultEvent, self._handle_job_result)
+            # Not registered here - see _ensure_job. An idle client that never
+            # sends audio must never take a worker's job slot, which is also
+            # why admission_worker_id below has to tolerate self._job being
+            # None.
+            self._job = None
 
-            # Last, so a registration that raises above never counts a session
-            # that did not open.
             self._provider.session_started()
 
         @property
         def admission_worker_id(self) -> int | None:
             """
             The worker this session's transcription job was actually assigned
-            to, read off the handle register_job returned
+            to, read off the handle register_job returned - or None if no job
+            has been registered yet
 
             Read from the JobHandle rather than recomputed, because the pool's
             choice is made from live utilization at registration time and any
@@ -97,8 +92,13 @@ class WhisperStreamingProvider(TranscriptionProviderInterface):
             already been made. This is the only shipped provider that overrides
             it: local ASR compute on a pool worker is exactly what the capacity
             estimator measures.
+
+            None before the first audio chunk is exactly the same "not a
+            capacity claim yet" statement the base class makes for a provider
+            excluded outright - see
+            TranscriptionSessionInterface.admission_worker_id.
             """
-            return self._job.worker_id
+            return self._job.worker_id if self._job is not None else None
 
         def _handle_job_result(
             self, result: JobSuccess[TranscriptionResult] | JobException
@@ -125,14 +125,63 @@ class WhisperStreamingProvider(TranscriptionProviderInterface):
             )
             self.emit(self.TranscriptionResultEvent, result.value)
 
+        def _ensure_job(self) -> None:
+            """
+            Registers this session's worker-pool job on the first real audio
+            chunk, not at construction
+
+            Deferred so an idle client - configured but never streaming - never
+            takes a worker's job slot, and so never counts toward that
+            worker's live_job_count for capacity admission
+            (PLAN-AdmissionControl.md §4). `check_admission` is called
+            immediately after registering, before any data is queued to the
+            job, so a refusal can undo the registration and raise before this
+            chunk is ever processed - the same "build then undo" shape
+            admission used at construction time, just relocated to where
+            registration itself now happens.
+
+            A `register_job` that raises (context tags misconfigured, per
+            `describe_health`'s "routed here dies at register_job") now
+            surfaces on the first audio chunk instead of at CONFIG time; the
+            readiness probe and per-provider health already report that
+            misconfiguration independently, so a client still finds out, just
+            not until it would have needed the worker anyway.
+            """
+            if self._job is not None:
+                return
+
+            self._job = self._provider.worker_pool.register_job(
+                (
+                    self._provider.config.whisper_context_tag,
+                    self._provider.config.silero_context_tag,
+                ),
+                self._provider.config.job_period_ms,
+                WhisperStreamingProviderJob(self._provider.config),
+                self._provider.provider_key,
+                session_uid=self.session_uid,
+                room_uid=self.room_uid,
+            )
+            self._job.on(self._job.JobResultEvent, self._handle_job_result)
+
+            try:
+                self._provider.check_admission(
+                    self.admission_worker_id, self._log
+                )
+            except BaseException:
+                self._job.deregister()
+                self._job = None
+                raise
+
         def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
+            self._ensure_job()
             self._job.queue_data(
                 [AudioChunkPayload(chunk_id=chunk_id, audio_bytes=chunk)]
             )
 
         def end_session(self):
             super().end_session()
-            self._job.deregister()
+            if self._job is not None:
+                self._job.deregister()
             self._provider.session_ended()
 
     def __init__(

--- a/transcription_service/src/webserver/create_webserver.py
+++ b/transcription_service/src/webserver/create_webserver.py
@@ -71,14 +71,8 @@ def create_webserver(config: Config, logger: Logger):
         metrics_registry.record_job_execution(observation)
         capacity_estimator.record(observation)
 
-    # Admission enforcement disabled for now: idle (audio-less) connections
-    # register a job and count toward a worker's live_job_count the same as
-    # an active one, so N can cross the ratcheted ceiling from connection
-    # count alone. `capacity_estimator` is still wired into `_observe_job`
-    # below and into /metrics/status + /providers/health, so estimation stays
-    # live in shadow mode - only the refusal in `create_session` is off.
     provider_registry = TranscriptionProviderRegistry(
-        config, logger, _observe_job, None, metrics_registry
+        config, logger, _observe_job, capacity_estimator, metrics_registry
     )
     # One join, two consumers: the /providers/health route below and the
     # telemetry publisher started in the lifespan hook.

--- a/transcription_service/src/webserver/features/transcription_stream/transcription_stream_controller.py
+++ b/transcription_service/src/webserver/features/transcription_stream/transcription_stream_controller.py
@@ -142,15 +142,16 @@ class TranscriptionStreamController(WebsocketHandler):
         TranscriptionStreamService once auth has completed and a config has
         not yet been received.
 
-        This is also the capacity-admission point (PLAN-AdmissionControl.md
-        §4): `service.start()` below reaches the registry, which registers the
-        session's job, checks the worker it actually landed on and raises
-        `TranscriptionCapacityError` if that worker is full. The refusal
-        propagates out of here to `_handle_error`, which maps it to a 1013
-        close. Deliberately not the WebSocket handshake, which is
-        unconditional before anything about the session is known, and
-        deliberately after auth, so an unauthenticated peer can neither
-        consume capacity nor learn anything about it.
+        Capacity admission (PLAN-AdmissionControl.md §4) no longer happens
+        here: a session's worker-pool job registers on its own first audio
+        chunk, not at construction, so there is nothing to ask about yet.
+        `TranscriptionCapacityError` instead surfaces from
+        `_handle_binary_message` below, and is mapped to a 1013 close by the
+        same `_handle_error` this method's own errors go through - deliberately
+        not the WebSocket handshake, which is unconditional before anything
+        about the session is known, and deliberately gated behind auth so an
+        unauthenticated peer can neither consume capacity nor learn anything
+        about it.
         """
         if not self._is_authenticated or self._service is not None:
             self.close(1008, "Unexpected Config Message")

--- a/transcription_service/src/webserver/features/transcription_stream/transcription_stream_service.py
+++ b/transcription_service/src/webserver/features/transcription_stream/transcription_stream_service.py
@@ -70,6 +70,14 @@ class TranscriptionStreamService(EventEmitter):
         self._room_uid = room_uid
         self._session: TranscriptionSessionInterface | None = None
         self._closed = False
+        # Separate from `_closed`: that flag also gates whether `close()` still
+        # has teardown to do, and a chunk error must not skip that teardown -
+        # `end_session()` is what balances the `session_started()` this
+        # session's constructor already ran, so skipping it would leak the
+        # provider's active-session count for good. This only stops
+        # `handle_audio_chunk` from re-entering a session that has already
+        # raised once.
+        self._audio_chunk_failed = False
 
     def start(self):
         """
@@ -78,12 +86,12 @@ class TranscriptionStreamService(EventEmitter):
         TranscriptionClientError if the provider key is unknown; callers
         should treat that as a protocol-level (1007) close.
 
-        Also raises TranscriptionCapacityError when the registry refuses the
-        session because the worker it was placed on is at capacity
-        (PLAN-AdmissionControl.md §4) - a 1013 close, not a 1007 one. Nothing
-        is wired up when that happens: the registry has already torn the
-        session back down, and the two `on()` calls below are never reached, so
-        this service holds no session and `close()` has nothing to undo.
+        Never raises TranscriptionCapacityError - that used to be decided
+        here, synchronously, but a session's job (and therefore the worker it
+        would occupy) is no longer registered at construction. It registers on
+        the session's own first `handle_audio_chunk`, which is also where a
+        capacity refusal now surfaces (PLAN-AdmissionControl.md §4; see
+        handle_audio_chunk below and TranscriptionSessionInterface for why).
         """
         self._session = self._provider_registry.create_session(
             self._provider_key,
@@ -104,10 +112,28 @@ class TranscriptionStreamService(EventEmitter):
         """
         Forward an audio chunk to the underlying session. No-op if the
         service has been closed.
+
+        A session's first chunk can be the one that registers its worker-pool
+        job and finds out - right then - that the worker is at capacity
+        (PLAN-AdmissionControl.md §4; job registration is deferred to first
+        audio, see TranscriptionSessionInterface). That raises
+        TranscriptionCapacityError out of this call, same as any other session
+        error, and this latches `_audio_chunk_failed` before re-raising: the
+        socket close that error triggers is asynchronous, so more chunks can
+        arrive before it lands, and without the latch each one would retry
+        registration against the same full worker and log another refusal for
+        a connection that is already on its way out. Deliberately not
+        `_closed` - `close()` still has to run its teardown once the socket
+        actually disconnects, whatever happened here.
         """
-        if self._closed or self._session is None:
+        if self._closed or self._session is None or self._audio_chunk_failed:
             return
-        self._session.handle_audio_chunk(chunk_id, chunk)
+        try:
+            self._session.handle_audio_chunk(chunk_id, chunk)
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            self._audio_chunk_failed = True
+            raise
 
     def close(self):
         """

--- a/transcription_service/src/webserver/shared/transcription_provider_registry/transcription_provider_registry.py
+++ b/transcription_service/src/webserver/shared/transcription_provider_registry/transcription_provider_registry.py
@@ -6,7 +6,7 @@ transcription providers configured for the service.
 # pylint: disable=import-outside-toplevel
 # Only import providers based on configuration
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable
 
 from src.shared.config import (
     Config,
@@ -243,6 +243,13 @@ class TranscriptionProviderRegistry:
                         provider_key,
                     )
 
+            # Bound per provider_key rather than shared, so a refusal is
+            # always counted and logged against the provider whose session
+            # actually triggered it, not whichever provider happened to be
+            # loaded last.
+            provider.bind_admission_check(
+                self._make_admission_check(provider_key)
+            )
             providers[provider_key] = provider
         return providers
 
@@ -357,88 +364,86 @@ class TranscriptionProviderRegistry:
 
         Raises:
             TranscriptionClientError if provider doesn't exist
-            TranscriptionCapacityError if the worker the session was placed on
-                has no capacity for it
 
-        ADMISSION IS DECIDED AFTER CONSTRUCTION, ON PURPOSE
-        (PLAN-AdmissionControl.md §4). `admit()` is a per-worker question, and
-        which worker a session lands on is chosen by live load balancing inside
-        `register_job` - so there is nothing to ask *about* until the session
-        has registered. Building the session first and tearing it back down is
-        therefore not a shortcut around a missing pre-check; it is the only
-        order in which the question is well posed.
+        NEVER RAISES TranscriptionCapacityError. That used to be decided here,
+        synchronously, because a session's job registered as part of its own
+        construction - so by the time this returned, it had already taken a
+        worker's job slot whether or not the caller ever sent it any audio.
+        That is exactly the failure this method used to cause: an idle,
+        audio-less connection occupied capacity identically to a real one, so
+        opening enough of them could refuse a genuinely busy worker's actual
+        next session, or - worse - refuse each other, entirely independent of
+        real transcription load.
 
-        `end_session()` is the undo, rather than a bespoke rollback path,
-        because it is already exactly the teardown a session that never carried
-        audio needs: it deregisters the job (so the worker's live_job_count
-        drops immediately, leaving no phantom) and decrements the provider's
-        active-session count that this constructor just incremented. A second
-        path would be a second thing to keep in step with it.
+        Registration is deferred to a session's own first `handle_audio_chunk`
+        (see each provider's `_ensure_job`), which is also now where admission
+        is decided - a session calls `provider.check_admission(...)` itself,
+        right after registering, via the callback `_make_admission_check`
+        binds onto its provider at load time. A refusal therefore surfaces
+        from `handle_audio_chunk`, not from here, and propagates out through
+        `TranscriptionStreamService.handle_audio_chunk` exactly like any other
+        session error - no special plumbing needed, since Python exceptions
+        already cross that boundary uncaught.
         """
         if provider_key not in self._providers:
             self._invalid_provider_key_rejects += 1
             raise TranscriptionClientError("Invalid Provider Key")
 
         provider = self._providers[provider_key]
-        session = provider.create_session(
+        return provider.create_session(
             session_config, session_uid, room_uid, logger
         )
 
-        if self._admits(session):
-            return session
-
-        session.end_session()
-        if self._metrics_registry is not None:
-            self._metrics_registry.record_capacity_refusal(provider_key)
-        logger.warning(
-            "Refused session: worker at capacity",
-            context={
-                "provider_key": provider_key,
-                "worker_id": session.admission_worker_id,
-            },
-        )
-        raise TranscriptionCapacityError(AT_CAPACITY_REASON)
-
-    def _admits(self, session: TranscriptionSessionInterface) -> bool:
+    def _make_admission_check(
+        self, provider_key: str
+    ) -> Callable[[int | None, Logger], None]:
         """
-        Whether a just-registered session may keep the worker slot it took
+        Builds the admission callback one provider is bound to at load time
 
         Args:
-            session - The session that has already registered its job
+            provider_key    - The provider this callback decides for, closed
+                                over so a refusal is always counted and logged
+                                against the provider whose session actually
+                                registered the job, not whichever provider
+                                `_load_providers` happened to construct last
 
         Returns:
-            True if the session should be allowed to proceed
+            A callable a session invokes with the worker its job just landed
+            on (or None - see TranscriptionSessionInterface.admission_worker_id).
+            Raises TranscriptionCapacityError if that worker has no room;
+            otherwise returns normally.
 
         Every gate here fails open, which is this plan's stated posture rather
         than laziness: an over-admission is visible, counted and self-corrects,
         while a wrong refusal is invisible and unrecoverable for that user.
-        Three of them are reached in normal operation:
+        Four of them are reached in normal operation:
 
-        1. No estimator configured - admission control is not wired up.
-        2. `admission_worker_id is None` - the session is not a claim on a local
-           worker's ASR throughput (`lumen_granite`, `debug`). See
-           TranscriptionSessionInterface.admission_worker_id for why that is a
-           statement rather than a gap.
+        1. `worker_id is None` - the session is not a claim on a local worker's
+           ASR throughput (`lumen_granite`, `debug`), or it has not yet
+           registered a job at all. See
+           TranscriptionSessionInterface.admission_worker_id for why both are
+           the same statement.
+        2. No estimator configured - admission control is not wired up.
         3. The pool reports no such worker. A worker that vanished between
            registration and this read is a pool fault, not a capacity fault,
            and refusing the user for it would misattribute the outage.
 
-        CONCURRENCY. This runs to completion between `register_job` and the
-        caller's next await point - register, read, decide and (if refused)
-        deregister are all synchronous, on the one event loop thread the pool's
-        registration bookkeeping also runs on. Two sessions arriving together
-        are therefore serialized, and each sees the other's registration
-        reflected in `live_job_count` only if that registration actually
-        happened first. There is no window in which both read a pre-registration
-        count and both get admitted, nor one in which both count the other and
-        both get refused.
+        CONCURRENCY. The session calls this synchronously, immediately after
+        `register_job` returns and before any `await` - register, read, decide
+        and (if refused) deregister all run on the one event loop thread the
+        pool's registration bookkeeping also runs on. Two sessions registering
+        together are therefore serialized, and each sees the other's
+        registration reflected in `live_job_count` only if that registration
+        actually happened first. There is no window in which both read a
+        pre-registration count and both get admitted, nor one in which both
+        count the other and both get refused.
 
         The `- 1` is what makes that true. `admit()` is specified as
         `N == 0 or N + 1 <= N*` where N is the count *before* placing the new
-        session, but by the time this runs the session is already registered and
-        the pool's `live_job_count` includes it. Passing that count raw would
-        ask whether an N+2nd session fits and would refuse the first session on
-        an idle worker, since N would never read as 0.
+        session, but by the time this runs the session is already registered
+        and the pool's `live_job_count` includes it. Passing that count raw
+        would ask whether an N+2nd session fits and would refuse the first
+        session on an idle worker, since N would never read as 0.
 
         TWO KNOWN LIMITATIONS, NAMED RATHER THAN GUARDED:
 
@@ -458,11 +463,36 @@ class TranscriptionProviderRegistry:
           §5's deferral of remote-provider capacity; it is not a claim that they
           cost a worker nothing.
         """
-        if self._capacity_estimator is None:
+
+        def _check(worker_id: int | None, logger: Logger) -> None:
+            if self._admits_worker(worker_id):
+                return
+
+            if self._metrics_registry is not None:
+                self._metrics_registry.record_capacity_refusal(provider_key)
+            logger.warning(
+                "Refused session: worker at capacity",
+                context={"provider_key": provider_key, "worker_id": worker_id},
+            )
+            raise TranscriptionCapacityError(AT_CAPACITY_REASON)
+
+        return _check
+
+    def _admits_worker(self, worker_id: int | None) -> bool:
+        """
+        Whether one more job may keep the worker slot it just took
+
+        Args:
+            worker_id   - The worker a session's job just registered onto, or
+                            None if this session's cost is not a capacity claim
+
+        Returns:
+            True if the session should be allowed to proceed
+        """
+        if worker_id is None:
             return True
 
-        worker_id = session.admission_worker_id
-        if worker_id is None:
+        if self._capacity_estimator is None:
             return True
 
         live_job_count = self._live_job_count(worker_id)

--- a/transcription_service/tests/integration/metrics/metrics_test.py
+++ b/transcription_service/tests/integration/metrics/metrics_test.py
@@ -4,6 +4,7 @@ Integration tests for the /metrics/status endpoint
 
 import asyncio
 import logging
+from os import path
 from unittest.mock import MagicMock
 
 import pytest
@@ -16,6 +17,7 @@ from src.shared.config import (
     TranscriptionProviderUID,
 )
 from src.shared.logger import ContextLogger, Logger
+from src.shared.utils.audio_frame_protocol import encode_audio_frame
 from src.transcription_providers.debug_provider.debug_provider import (
     DEBUG_JOB_PERIOD_MS,
 )
@@ -24,6 +26,18 @@ from src.webserver.create_webserver import create_webserver
 API_KEY = "TEST_KEY"
 METRICS_API_KEY = "TEST_METRICS_KEY"
 TIMEOUT_SEC = 1
+
+AUDIO_DIR = path.normpath(
+    path.join(
+        __file__,
+        "..",
+        "..",
+        "..",
+        "..",
+        "..",
+        "test_audio_files/musical_chords",
+    )
+)
 
 # Two real worker processes are spawned per test using these fixtures, which
 # is well past the global 1s pytest timeout.
@@ -256,10 +270,17 @@ async def test_records_a_real_job_execution(test_client: TestClient):
     in a spawned worker process, its result crosses the result queue, the
     worker pool hook folds it into the registry, and the endpoint reports it -
     labelled with the provider key the session was opened against.
+
+    Job registration is deferred to the session's first audio chunk (an idle
+    session never takes a worker's job slot at all), so one is sent here -
+    config alone no longer registers anything for the sleep below to catch a
+    pass of.
     """
     # Arrange
     headers = {"authorization": f"Bearer {METRICS_API_KEY}"}
     labels = {"provider_key": "debug"}
+    with open(path.join(AUDIO_DIR, "mono_f64le.wav"), "rb") as f:
+        chunk = f.read()
 
     # Act
     with test_client.websocket_connect(
@@ -269,9 +290,11 @@ async def test_records_a_real_job_execution(test_client: TestClient):
         websocket.send_json(
             {
                 "type": "config",
-                "config": {"sample_rate": 16000, "num_channels": 1},
+                # Matches mono_f64le.wav's actual sample rate.
+                "config": {"sample_rate": 48000, "num_channels": 1},
             }
         )
+        websocket.send_bytes(encode_audio_frame("chunk-1", chunk))
         # The debug job's period is 1000ms, so one full period plus slack
         await asyncio.sleep(1.5)
 

--- a/transcription_service/tests/integration/providers/providers_test.py
+++ b/transcription_service/tests/integration/providers/providers_test.py
@@ -3,6 +3,7 @@ Integration tests for the /providers/health endpoint
 """
 
 import logging
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -16,6 +17,7 @@ from src.shared.config import (
     TranscriptionProviderUID,
 )
 from src.shared.logger import ContextLogger, Logger
+from src.shared.utils.audio_frame_protocol import encode_audio_frame
 from src.webserver.create_webserver import create_webserver
 
 API_KEY = "TEST_KEY"
@@ -116,6 +118,31 @@ def _health(client: TestClient):
     )
     assert response.status_code == 200
     return response.json()
+
+
+def _health_once_active(client: TestClient, timeout_sec: float = 5.0):
+    """
+    Polls /providers/health until a worker reports an active job, or gives up
+
+    A synchronous TestClient send only guarantees a message has been handed to
+    the app's receive queue, not that the app has finished acting on it - job
+    registration happens moments later, on the app's own event loop thread. A
+    single immediate read would be racy; this polls briefly instead of relying
+    on a fixed sleep being long enough on a slower machine.
+
+    Args:
+        client       - Test client to read through
+        timeout_sec  - How long to keep polling before giving up and returning
+                        whatever the last read was
+    """
+    deadline = time.monotonic() + timeout_sec
+    body = _health(client)
+    while time.monotonic() < deadline:
+        if any(worker["activeJobs"] for worker in body["workers"]):
+            return body
+        time.sleep(0.05)
+        body = _health(client)
+    return body
 
 
 def test_rejects_request_with_no_credential(test_client: TestClient):
@@ -302,6 +329,14 @@ def test_reports_active_job_correlated_to_session_and_room_uid(
     worker holding its job - the correlation an operator needs to trace a
     saturated worker back to the session/room causing it (B1.7 follow-up,
     part 2 of 2)
+
+    Job registration is deferred to the session's first audio chunk (an idle
+    session never takes a worker's job slot at all), so one is sent here
+    before reading health - config alone no longer registers anything.
+    Registration itself is synchronous with handling that chunk (decoding it
+    is not), so the content does not need to be real audio here - only that
+    /providers/health, polled below, was not read before the server had a
+    chance to process the frame.
     """
     # Act
     with test_client.websocket_connect(
@@ -317,11 +352,12 @@ def test_reports_active_job_correlated_to_session_and_room_uid(
             }
         )
         # start_session() emits synchronously within config handling, so
-        # receiving it proves the session (and its job registration) exists
-        # server-side before the health read below.
+        # receiving it proves the session exists server-side before the audio
+        # chunk below registers its job.
         websocket.receive_json()
+        websocket.send_bytes(encode_audio_frame("chunk-1", b"not-real-audio"))
 
-        body = _health(test_client)
+        body = _health_once_active(test_client)
 
     # Assert
     active_jobs = [

--- a/transcription_service/tests/unit/transcription_providers/admission_worker_id_test.py
+++ b/transcription_service/tests/unit/transcription_providers/admission_worker_id_test.py
@@ -15,6 +15,11 @@ does not describe it.
 Every session here is built over a mocked WorkerPool, so no model is loaded and
 no worker process is spawned; what is being pinned is which worker id each
 session reports, not what the pool does with it.
+
+Every test sends one audio chunk before asserting anything. Job registration -
+and therefore the worker placement `admission_worker_id` reports - is deferred
+to a session's first `handle_audio_chunk`, not its construction, so an idle
+session that never streams never takes a worker's job slot at all.
 """
 
 from unittest.mock import MagicMock
@@ -92,6 +97,7 @@ def test_whisper_session_reports_the_worker_its_job_landed_on(
     session = provider.create_session(
         "unused_config", "session-1", "room-1", mock_logger
     )
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     assert session.admission_worker_id == ASSIGNED_WORKER_ID
@@ -123,6 +129,7 @@ def test_lumen_granite_session_is_excluded_from_capacity_admission(
     session = provider.create_session(
         "unused_config", "session-1", "room-1", mock_logger
     )
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     assert session.admission_worker_id is None
@@ -151,6 +158,7 @@ def test_debug_session_is_excluded_from_capacity_admission(
     session = provider.create_session(
         DEBUG_SESSION_CONFIG, "session-1", "room-1", mock_logger
     )
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     assert session.admission_worker_id is None

--- a/transcription_service/tests/unit/transcription_providers/debug_provider/debug_provider_test.py
+++ b/transcription_service/tests/unit/transcription_providers/debug_provider/debug_provider_test.py
@@ -98,8 +98,16 @@ def test_debug_provider_registers_job_correlated_to_session_and_room_uid(
     """
     Test the session's job is correlated to session_uid/room_uid in the pool's
     worker snapshots - what makes /providers/health show it as an ActiveJob
+
+    Registration is deferred to the first audio chunk (an idle session never
+    takes a worker's job slot), so this sends one before reading the snapshot.
     """
+    # Arrange
+    with open(path.join(AUDIO_DIR, "mono_f64le.wav"), "rb") as f:
+        chunk = f.read()
+
     # Act
+    debug_provider_session.handle_audio_chunk("chunk-1", chunk)
     (snapshot,) = debug_provider_worker_pool.worker_snapshots()
 
     # Assert
@@ -279,7 +287,10 @@ def test_debug_provider_reports_the_period_it_schedules():
     )
 
     # Act
-    provider.create_session(SESSION_CONFIG, None, None, MagicMock(spec=Logger))
+    session = provider.create_session(
+        SESSION_CONFIG, None, None, MagicMock(spec=Logger)
+    )
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     args, _ = mock_worker_pool.register_job.call_args

--- a/transcription_service/tests/unit/transcription_providers/lumen_granite_provider/lumen_granite_session_test.py
+++ b/transcription_service/tests/unit/transcription_providers/lumen_granite_provider/lumen_granite_session_test.py
@@ -87,9 +87,16 @@ def test_create_session_forwards_session_and_room_uid_to_register_job(
     """
     session_uid/room_uid reach worker_pool.register_job, which is what makes
     them show up as an ActiveJob on /providers/health
+
+    Registration is deferred to the first audio chunk (an idle session never
+    takes a worker's job slot), so this sends one before asserting on
+    register_job's call args.
     """
     # Act
-    provider.create_session("unused_config", "session-1", "room-1", mock_logger)
+    session = provider.create_session(
+        "unused_config", "session-1", "room-1", mock_logger
+    )
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     _, kwargs = mock_worker_pool.register_job.call_args
@@ -109,7 +116,8 @@ def test_reported_job_period_is_the_one_register_job_receives(
     reason the reported value is per provider rather than one number.
     """
     # Act
-    provider.create_session("unused_config", None, None, mock_logger)
+    session = provider.create_session("unused_config", None, None, mock_logger)
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     args, _ = mock_worker_pool.register_job.call_args

--- a/transcription_service/tests/unit/transcription_providers/whisper_streaming_provider/whisper_streaming_session_test.py
+++ b/transcription_service/tests/unit/transcription_providers/whisper_streaming_provider/whisper_streaming_session_test.py
@@ -1,7 +1,8 @@
 """
 Unit tests for WhisperStreamingProvider.create_session's session_uid/room_uid
 storage (Part 1 of the monitoring dashboard plan) and their forwarding to
-register_job, which is what surfaces them on /providers/health (Part 2).
+register_job, which is what surfaces them on /providers/health (Part 2), plus
+the capacity-refusal undo (PLAN-AdmissionControl.md §4).
 """
 
 from unittest.mock import MagicMock
@@ -10,6 +11,10 @@ import pytest
 
 from src.shared.logger import Logger
 from src.shared.utils.worker_pool import WorkerPool
+from src.transcription_provider_interface import (
+    AT_CAPACITY_REASON,
+    TranscriptionCapacityError,
+)
 from src.transcription_providers.whisper_streaming_provider import (
     WhisperStreamingProvider,
 )
@@ -92,9 +97,16 @@ def test_create_session_forwards_session_and_room_uid_to_register_job(
     """
     session_uid/room_uid reach worker_pool.register_job, which is what makes
     them show up as an ActiveJob on /providers/health
+
+    Registration is deferred to the first audio chunk (an idle session never
+    takes a worker's job slot), so this sends one before asserting on
+    register_job's call args.
     """
     # Act
-    provider.create_session("unused_config", "session-1", "room-1", mock_logger)
+    session = provider.create_session(
+        "unused_config", "session-1", "room-1", mock_logger
+    )
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     _, kwargs = mock_worker_pool.register_job.call_args
@@ -115,9 +127,44 @@ def test_reported_job_period_is_the_one_register_job_receives(
     register_job would reintroduce exactly that failure one layer down.
     """
     # Act
-    provider.create_session("unused_config", None, None, mock_logger)
+    session = provider.create_session("unused_config", None, None, mock_logger)
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     args, _ = mock_worker_pool.register_job.call_args
     assert provider.job_period_ms == PROVIDER_CONFIG["job_period_ms"]
     assert args[1] == provider.job_period_ms
+
+
+def test_capacity_refusal_deregisters_the_job_and_reraises(
+    provider: WhisperStreamingProvider,
+    mock_logger: MagicMock,
+    mock_worker_pool: MagicMock,
+):
+    """
+    A session refused on its first chunk must not leak the job it just
+    registered
+
+    `_ensure_job` registers before it can know whether the worker has room -
+    the pool only decides who owns a worker at `register_job` time - so a
+    refusal is always an undo, not a rejection that skips registering at all.
+    Left un-deregistered, the worker would keep scheduling a job every period
+    for a session no client is attached to, consuming the very capacity the
+    refusal exists to protect - invisibly, since nothing else would ever call
+    `end_session` on a session the caller never got back.
+    """
+
+    # Arrange
+    def _always_refuse(worker_id, logger):
+        raise TranscriptionCapacityError(AT_CAPACITY_REASON)
+
+    provider.bind_admission_check(_always_refuse)
+    session = provider.create_session("unused_config", None, None, mock_logger)
+    job_handle = mock_worker_pool.register_job.return_value
+
+    # Act / Assert
+    with pytest.raises(TranscriptionCapacityError):
+        session.handle_audio_chunk("chunk-1", b"audio")
+
+    job_handle.deregister.assert_called_once()
+    assert session.admission_worker_id is None

--- a/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_service_test.py
+++ b/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_service_test.py
@@ -181,6 +181,82 @@ def test_handle_audio_chunk_is_no_op_before_start(
     # Assert - no exception raised, no session call attempted (no session yet).
 
 
+def test_handle_audio_chunk_reraises_a_session_error(
+    service: TranscriptionStreamService, fake_session: FakeSession
+):
+    """
+    An error raised by the underlying session (e.g. TranscriptionCapacityError
+    on the first chunk that registers its job) propagates out of
+    handle_audio_chunk rather than being swallowed - the controller relies on
+    this to map it to the right close code.
+    """
+    # Arrange
+    service.start()
+    fake_session.handle_audio_chunk.side_effect = TranscriptionClientError(
+        "at capacity"
+    )
+
+    # Act / Assert
+    with pytest.raises(TranscriptionClientError):
+        service.handle_audio_chunk("chunk-1", b"\x01")
+
+
+def test_handle_audio_chunk_stops_retrying_after_a_session_error(
+    service: TranscriptionStreamService, fake_session: FakeSession
+):
+    """
+    Once a chunk has raised, later chunks are dropped instead of being
+    retried against the same session
+
+    A capacity refusal closes the socket asynchronously, so more chunks can
+    arrive before that close lands. Without this latch each one would retry
+    registration against the same full worker and log another refusal for a
+    connection that is already on its way out.
+    """
+    # Arrange
+    service.start()
+    fake_session.handle_audio_chunk.side_effect = TranscriptionClientError(
+        "at capacity"
+    )
+    with pytest.raises(TranscriptionClientError):
+        service.handle_audio_chunk("chunk-1", b"\x01")
+
+    # Act
+    fake_session.handle_audio_chunk.side_effect = None
+    service.handle_audio_chunk("chunk-2", b"\x02")
+
+    # Assert - the second chunk never reached the session
+    fake_session.handle_audio_chunk.assert_called_once_with("chunk-1", b"\x01")
+
+
+def test_close_still_ends_the_session_after_a_chunk_error(
+    service: TranscriptionStreamService, fake_session: FakeSession
+):
+    """
+    A session that raised out of handle_audio_chunk is still torn down by
+    close(), so its provider's active-session count is not leaked
+
+    The chunk-error latch is deliberately a separate flag from `_closed`:
+    `close()` checks `_closed` to decide whether it still has teardown to do,
+    and end_session() is what balances the session_started() its constructor
+    already ran. If a chunk error had set `_closed` instead, this would never
+    run and the provider would carry that session as active forever.
+    """
+    # Arrange
+    service.start()
+    fake_session.handle_audio_chunk.side_effect = TranscriptionClientError(
+        "at capacity"
+    )
+    with pytest.raises(TranscriptionClientError):
+        service.handle_audio_chunk("chunk-1", b"\x01")
+
+    # Act
+    service.close()
+
+    # Assert
+    fake_session.end_session.assert_called_once()
+
+
 def test_close_ends_underlying_session(
     service: TranscriptionStreamService, fake_session: FakeSession
 ):

--- a/transcription_service/tests/unit/webserver/shared/transcription_provider_registry/capacity_admission_test.py
+++ b/transcription_service/tests/unit/webserver/shared/transcription_provider_registry/capacity_admission_test.py
@@ -14,8 +14,22 @@ transcription host whose one worker is already carrying as many sessions as it
 can transcribe in realtime. Before this, the seventh room was accepted, every
 room degraded together, and nothing said no. The cost of getting this wrong in
 the other direction is a real user with no captions and no way to tell why -
-which is why every gate in `_admits` fails open, and why several of these tests
-pin the *admitting* path rather than the refusing one.
+which is why every gate here fails open, and why several of these tests pin
+the *admitting* path rather than the refusing one.
+
+WHAT MOVED. Admission used to be decided synchronously inside
+`create_session`, because a session's job registered as part of its own
+construction. Registration is now deferred to a session's own first
+`handle_audio_chunk` (an idle, audio-less connection must never take a worker's
+job slot), so `create_session` has nothing to decide any more - see
+`transcription_provider_registry_test.py` for its (unchanged) provider-loading
+and provider-key behaviour. What the registry still owns is the *decision
+itself*: a callable built by `_make_admission_check` and bound onto each
+provider at load time via `bind_admission_check`, which a session calls once
+it has registered and knows which worker (if any) it landed on. These tests
+exercise that callable directly, extracted from the mock provider's
+`bind_admission_check` call - `whisper_streaming_session_test.py` covers a real
+session actually calling it and undoing its own registration on a refusal.
 """
 
 from unittest.mock import MagicMock
@@ -43,7 +57,6 @@ from src.transcription_provider_interface import (
     TranscriptionCapacityError,
     TranscriptionClientError,
     TranscriptionProviderInterface,
-    TranscriptionSessionInterface,
 )
 from src.webserver.shared.metrics import MetricsRegistry
 from src.webserver.shared.transcription_provider_registry import (
@@ -54,7 +67,7 @@ NUM_WORKERS = 2
 PROVIDER_KEY = "asr_0"
 OTHER_PROVIDER_KEY = "asr_1"
 
-# The worker every test's session is placed on. Not 0, so a test that silently
+# The worker every test checks admission for. Not 0, so a test that silently
 # defaulted a worker id somewhere would fail rather than pass by coincidence.
 PLACED_WORKER_ID = 1
 
@@ -78,9 +91,8 @@ def pinned_estimator(max_sessions: int | None) -> CapacityEstimator:
 
     `max_sessions` wins over warm-up inside `_capacity`, so this reports a
     definite N* from the first call without any observations having to be fed
-    in. That keeps these tests about the registry's decision and teardown,
-    which is what they are for; how N* is arrived at is the estimator suite's
-    subject.
+    in. That keeps these tests about the registry's decision, which is what
+    they are for; how N* is arrived at is the estimator suite's subject.
     """
     return CapacityEstimator(
         target_busy=0.85, min_sessions=1, max_sessions=max_sessions
@@ -208,21 +220,6 @@ def metrics_registry():
     return MetricsRegistry()
 
 
-@pytest.fixture
-def mock_session(mock_provider_instances: list[MagicMock]):
-    """
-    The session the first provider hands back, reporting a real placement
-
-    `admission_worker_id` is set rather than left as a bare MagicMock attribute
-    because the whole decision keys on it, and a Mock is truthy - a test that
-    forgot to set it would exercise nothing and still pass.
-    """
-    session = MagicMock(spec=TranscriptionSessionInterface)
-    session.admission_worker_id = PLACED_WORKER_ID
-    mock_provider_instances[0].create_session.return_value = session
-    return session
-
-
 # pylint: disable=unused-argument
 def make_registry(
     config: Config,
@@ -258,20 +255,41 @@ def registry(
     )
 
 
-def test_session_is_refused_when_its_worker_is_already_full(
+def admission_check(provider_instance: MagicMock, provider_index: int = 0):
+    """
+    Gets the admission callable the registry bound onto a mock provider
+
+    Args:
+        provider_instance   - The mock provider whose binding to read
+        provider_index       - Unused, kept for call-site symmetry with the
+                                two-provider fixtures
+
+    A session calls this itself once it has registered a job and knows which
+    worker (if any) it landed on - see `check_admission` on
+    TranscriptionProviderInterface. Extracting it here is what lets these
+    tests exercise the registry's actual decision without standing up a real
+    session.
+    """
+    del provider_index
+    (check,), _ = provider_instance.bind_admission_check.call_args
+    return check
+
+
+def test_admission_check_raises_when_the_worker_is_already_full(
     registry: TranscriptionProviderRegistry,
     mock_worker_pool_instance: MagicMock,
-    mock_session: MagicMock,
+    mock_provider_instances: list[MagicMock],
 ):
     """
-    Test a session lands on a full worker and is refused with the capacity error
+    Test a session whose worker is already full is refused with the capacity
+    error
 
     The measured case: worker 1 is already carrying its one session, a second
-    room connects and the pool routes it there anyway (routing balances load,
+    room's session registers a job and lands there too (routing balances load,
     it does not enforce a ceiling). `live_job_count` is 2 because the new
     session has already registered by the time the check runs - that is the
-    whole point of the register-then-ask order, since the worker is only chosen
-    inside `register_job`.
+    whole point of the register-then-ask order, since the worker is only
+    chosen inside `register_job`.
 
     The type matters as much as the refusal. `TranscriptionCapacityError` is
     not a `TranscriptionClientError`, because that one closes 1007 and blames
@@ -282,60 +300,21 @@ def test_session_is_refused_when_its_worker_is_already_full(
     mock_worker_pool_instance.worker_snapshots.return_value = [
         worker_snapshot(PLACED_WORKER_ID, live_job_count=2)
     ]
+    check = admission_check(mock_provider_instances[0])
 
     # Act / Assert
     with pytest.raises(TranscriptionCapacityError) as refusal:
-        registry.create_session(
-            PROVIDER_KEY,
-            "config",
-            "session-1",
-            "room-1",
-            MagicMock(spec=Logger),
-        )
+        check(PLACED_WORKER_ID, MagicMock(spec=Logger))
 
     assert refusal.value.message == AT_CAPACITY_REASON
     assert not isinstance(refusal.value, TranscriptionClientError)
-
-
-def test_refused_session_is_torn_back_down(
-    registry: TranscriptionProviderRegistry,
-    mock_worker_pool_instance: MagicMock,
-    mock_session: MagicMock,
-):
-    """
-    Test a refused session's job registration does not leak
-
-    Admission has to register before it can ask which worker it got, so a
-    refusal is always an undo. If that undo is skipped the worker keeps a job
-    that will be scheduled every period for a session no client is attached to
-    - it would consume the very capacity the refusal exists to protect, and
-    would do it invisibly, since `/providers/health` would report a live job
-    with a session_uid that hung up.
-
-    `end_session()` is the undo: it deregisters the job (dropping the worker's
-    live_job_count immediately) and decrements the provider's active-session
-    count that the session's constructor just incremented.
-    """
-    # Arrange
-    mock_worker_pool_instance.worker_snapshots.return_value = [
-        worker_snapshot(PLACED_WORKER_ID, live_job_count=2)
-    ]
-
-    # Act
-    with pytest.raises(TranscriptionCapacityError):
-        registry.create_session(
-            PROVIDER_KEY, "config", None, None, MagicMock(spec=Logger)
-        )
-
-    # Assert
-    mock_session.end_session.assert_called_once()
 
 
 def test_refusal_increments_the_counter_under_its_provider_key(
     registry: TranscriptionProviderRegistry,
     mock_worker_pool_instance: MagicMock,
     metrics_registry: MetricsRegistry,
-    mock_session: MagicMock,
+    mock_provider_instances: list[MagicMock],
 ):
     """
     Test each refusal is counted against the provider it was refused for
@@ -344,19 +323,19 @@ def test_refusal_increments_the_counter_under_its_provider_key(
     both end as a closed socket with no transcript, and only one of them means
     the deployment needs more capacity. Labelled by provider key because a host
     serving both a local model and a remote one needs to know which of the two
-    it has run out of.
+    it has run out of - proven here by refusing on the first provider's
+    callback and confirming the second provider's counter is untouched.
     """
     # Arrange
     mock_worker_pool_instance.worker_snapshots.return_value = [
         worker_snapshot(PLACED_WORKER_ID, live_job_count=2)
     ]
+    check = admission_check(mock_provider_instances[0])
 
     # Act
     for _ in range(3):
         with pytest.raises(TranscriptionCapacityError):
-            registry.create_session(
-                PROVIDER_KEY, "config", None, None, MagicMock(spec=Logger)
-            )
+            check(PLACED_WORKER_ID, MagicMock(spec=Logger))
 
     # Assert
     counter = metrics_registry.sessions_refused_capacity_total
@@ -364,49 +343,38 @@ def test_refusal_increments_the_counter_under_its_provider_key(
     assert counter.get({"provider_key": OTHER_PROVIDER_KEY}) == 0
 
 
-def test_admitted_session_is_returned_untouched_and_uncounted(
+def test_admitted_worker_is_not_counted_as_a_refusal(
     registry: TranscriptionProviderRegistry,
     mock_worker_pool_instance: MagicMock,
     metrics_registry: MetricsRegistry,
-    mock_session: MagicMock,
     mock_provider_instances: list[MagicMock],
 ):
     """
-    Test an admitted session behaves exactly as it did before admission control
+    Test a worker under the ceiling admits and counts nothing
 
     The regression this guards is the one nobody would notice in a test that
     only exercised refusals: every session in every healthy deployment takes
-    this path, so "no observable difference" is the property that matters most.
-    The session object handed back is the provider's own, its teardown has not
-    been called, and no refusal was counted.
+    this path, so "no observable difference" is the property that matters
+    most.
 
     `live_job_count` is 1 - this session and nothing else - which is the
-    off-by-one that the `- 1` in `_admits` exists for. `admit()` is specified
-    over N *before* placement, so the count has to have the new session
-    subtracted back out; passing it raw would ask whether a second session fits
-    on a pinned-to-one worker and refuse the first client to ever connect.
+    off-by-one `_admits_worker`'s `- 1` exists for. `admit()` is specified over
+    N *before* placement, so the count has to have the new session subtracted
+    back out; passing it raw would ask whether a second session fits on a
+    pinned-to-one worker and refuse the first client to ever connect.
     """
     # Arrange
     mock_worker_pool_instance.worker_snapshots.return_value = [
         worker_snapshot(PLACED_WORKER_ID, live_job_count=1)
     ]
-    session_logger = MagicMock(spec=Logger)
+    check = admission_check(mock_provider_instances[0])
 
-    # Act
-    session = registry.create_session(
-        PROVIDER_KEY, "config", "session-1", "room-1", session_logger
-    )
-
-    # Assert
-    assert session is mock_session
-    mock_session.end_session.assert_not_called()
-    mock_provider_instances[0].create_session.assert_called_once_with(
-        "config", "session-1", "room-1", session_logger
-    )
+    # Act / Assert - does not raise
+    check(PLACED_WORKER_ID, MagicMock(spec=Logger))
     assert metrics_registry.sessions_refused_capacity_total.entries() == []
 
 
-def test_session_declaring_no_worker_is_never_checked(
+def test_worker_id_none_is_never_checked(
     mock_config: Config,
     mock_logger: Logger,
     mock_worker_pool_instance: MagicMock,
@@ -418,21 +386,22 @@ def test_session_declaring_no_worker_is_never_checked(
     mock_provider_import: MockType,
 ):
     """
-    Test a session reporting no admission worker skips the check entirely
+    Test worker_id=None is never even asked about the estimator
 
     This is how `lumen_granite` and `debug` are excluded (§5/§7 defer remote
     providers: their capacity question is upstream rate limits and latency, not
-    a local worker pool). Both register jobs with an empty context tag tuple,
-    so the worker they land on is whichever was least utilized rather than a
-    placement onto the model that would serve them - `admission_worker_id`
-    returning None is that statement, and the base
+    a local worker pool), and it is also the state before a session has
+    registered a job at all. Both register jobs with an empty context tag
+    tuple, so the worker they land on is whichever was least utilized rather
+    than a placement onto the model that would serve them -
+    `admission_worker_id` returning None is that statement, and the base
     TranscriptionSessionInterface returns None so a provider is excluded until
     it deliberately opts in.
 
     The estimator is pinned at zero, so it would refuse anything it was asked
     about. Asserting `admit` was never *called* rather than just that the
-    session came back proves the exclusion happens before the decision, not
-    that the decision happened to come out permissive.
+    check returned normally proves the exclusion happens before the decision,
+    not that the decision happened to come out permissive.
     """
     # Arrange
     estimator = pinned_estimator(0)
@@ -440,23 +409,15 @@ def test_session_declaring_no_worker_is_never_checked(
     registry = make_registry(
         mock_config, mock_logger, estimator, metrics_registry
     )
-
-    remote_session = MagicMock(spec=TranscriptionSessionInterface)
-    remote_session.admission_worker_id = None
-    mock_provider_instances[0].create_session.return_value = remote_session
+    del registry  # only constructed to drive _load_providers' binding
     mock_worker_pool_instance.worker_snapshots.return_value = [
         worker_snapshot(PLACED_WORKER_ID, live_job_count=99)
     ]
+    check = admission_check(mock_provider_instances[0])
 
-    # Act
-    session = registry.create_session(
-        PROVIDER_KEY, "config", None, None, MagicMock(spec=Logger)
-    )
-
-    # Assert
-    assert session is remote_session
+    # Act / Assert - does not raise
+    check(None, MagicMock(spec=Logger))
     admit.assert_not_called()
-    remote_session.end_session.assert_not_called()
     assert metrics_registry.sessions_refused_capacity_total.entries() == []
 
 
@@ -464,7 +425,7 @@ def test_admits_when_no_estimator_is_wired_up(
     mock_config: Config,
     mock_logger: Logger,
     mock_worker_pool_instance: MagicMock,
-    mock_session: MagicMock,
+    mock_provider_instances: list[MagicMock],
     mock_worker_pool_import: MagicMock,
     mock_context_import: MockType,
     mock_provider_import: MockType,
@@ -480,27 +441,24 @@ def test_admits_when_no_estimator_is_wired_up(
     """
     # Arrange
     registry = make_registry(mock_config, mock_logger, None, None)
+    del registry  # only constructed to drive _load_providers' binding
     mock_worker_pool_instance.worker_snapshots.return_value = [
         worker_snapshot(PLACED_WORKER_ID, live_job_count=50)
     ]
+    check = admission_check(mock_provider_instances[0])
 
-    # Act / Assert
-    assert (
-        registry.create_session(
-            PROVIDER_KEY, "config", None, None, MagicMock(spec=Logger)
-        )
-        is mock_session
-    )
+    # Act / Assert - does not raise
+    check(PLACED_WORKER_ID, MagicMock(spec=Logger))
 
 
 def test_admits_when_the_pool_reports_no_such_worker(
     registry: TranscriptionProviderRegistry,
     mock_worker_pool_instance: MagicMock,
     metrics_registry: MetricsRegistry,
-    mock_session: MagicMock,
+    mock_provider_instances: list[MagicMock],
 ):
     """
-    Test a session whose worker is missing from the pool snapshot is admitted
+    Test a worker missing from the pool snapshot is admitted
 
     Reachable if a worker dies between registration and this read. That is a
     pool fault, and refusing the user for it would report a crashed worker to
@@ -512,15 +470,47 @@ def test_admits_when_the_pool_reports_no_such_worker(
     mock_worker_pool_instance.worker_snapshots.return_value = [
         worker_snapshot(PLACED_WORKER_ID + 1, live_job_count=99)
     ]
+    check = admission_check(mock_provider_instances[0])
 
-    # Act / Assert
-    assert (
-        registry.create_session(
-            PROVIDER_KEY, "config", None, None, MagicMock(spec=Logger)
-        )
-        is mock_session
-    )
+    # Act / Assert - does not raise
+    check(PLACED_WORKER_ID, MagicMock(spec=Logger))
     assert metrics_registry.sessions_refused_capacity_total.entries() == []
+
+
+def test_create_session_never_raises_capacity_error(
+    registry: TranscriptionProviderRegistry,
+    mock_worker_pool_instance: MagicMock,
+    mock_provider_instances: list[MagicMock],
+):
+    """
+    Test create_session returns normally even when the worker it would use is
+    already full
+
+    The contract that changed: a session's job (and therefore its worker
+    placement) no longer registers as part of construction, so there is
+    nothing for `create_session` to ask about any more - see the module
+    docstring. Refusal now happens later, from the session's own first
+    `handle_audio_chunk`, which this mocked session never calls, so nothing
+    here can be refused - proving that the burden of asking has genuinely
+    moved off `create_session`, not just that this particular mock stayed
+    quiet.
+    """
+    # Arrange
+    mock_worker_pool_instance.worker_snapshots.return_value = [
+        worker_snapshot(PLACED_WORKER_ID, live_job_count=99)
+    ]
+    session_logger = MagicMock(spec=Logger)
+
+    # Act
+    session = registry.create_session(
+        PROVIDER_KEY, "config", "session-1", "room-1", session_logger
+    )
+
+    # Assert
+    assert session is mock_provider_instances[0].create_session.return_value
+    mock_provider_instances[0].create_session.assert_called_once_with(
+        "config", "session-1", "room-1", session_logger
+    )
 
 
 def test_unknown_provider_key_still_raises_the_client_error(
@@ -529,10 +519,11 @@ def test_unknown_provider_key_still_raises_the_client_error(
     """
     Test a typo'd provider key is still a 1007 client error, not a 1013
 
-    The two refusals now live in the same method and mean opposite things: one
-    says the caller asked for something that does not exist, the other says the
-    service cannot serve it right now. A client that retried the first forever
-    would never succeed; retrying the second is correct.
+    Unlike capacity, this refusal is still decided synchronously inside
+    `create_session` - a provider key either names a configured provider or it
+    does not, which is knowable immediately and has nothing to do with worker
+    load. A client that retried this forever would never succeed; retrying a
+    capacity refusal is correct.
     """
     # Act / Assert
     with pytest.raises(TranscriptionClientError) as error:


### PR DESCRIPTION
## Summary
Follow-up to #182, which just turned admission enforcement off. This is the real fix.

- Idle (audio-less) connections used to register a job at the CONFIG step and count toward a worker's `live_job_count` identically to an actively-streaming session (admission was decided synchronously in `TranscriptionProviderRegistry.create_session`, right after construction). Opening a couple of idle clients on a lightly-loaded worker was enough to trip `TranscriptionCapacityError` - reported as flaky refusals unrelated to real load.
- A session's worker-pool job now registers on its own first `handle_audio_chunk`, not at construction (`_ensure_job` in each of the three provider session classes: debug, lumen_granite, whisper_streaming). An idle client that never streams therefore never takes a worker's job slot and never counts toward admission at all.
- Capacity admission moves with it: it's decided the moment a session registers a real job, via a `check_admission` callback the registry binds onto each provider at load time (`_make_admission_check`). A refusal deregisters the job it just took and reraises - the same undo-on-refusal shape admission always had, just relocated from construction to first audio.
- `TranscriptionStreamService` gained a separate `_audio_chunk_failed` latch (distinct from `_closed`) so a socket draining in-flight chunks after a refusal doesn't retry registration against the same full worker on every subsequent chunk, while `close()` still runs its normal teardown (balancing the `session_started()` count).
- Admission enforcement is back on in `create_webserver` now that idle connections can no longer trip it on their own.

## Test plan
- [x] `make lint` (pylint 10.00/10 on `src` and `tests`, black/isort clean)
- [x] `make test_unit` (534 passed)
- [x] `make test_integration` (31 passed, 12 skipped - model-dependent)
- [x] Updated integration tests that previously asserted registration/admission happened at CONFIG time to send an audio chunk first (`providers_test.py`, `metrics_test.py`)