### PR TITLE
fix(node-server): tell a source its session already ended

### DIFF
--- a/.changeset/ended-session-source-race.md
+++ b/.changeset/ended-session-source-race.md
@@ -1,0 +1,75 @@
+---
+'@scribear/node-server-schema': minor
+'@scribear/node-server': minor
+'@scribear/monitoring-sidecar': minor
+---
+
+Tell a source that its session is already over, instead of letting it stream
+into a dead one.
+
+A **source** (kiosk or synthetic device) that opened a socket for a session
+whose `effectiveEnd` had already passed was never told. `registerSource`
+published `SessionEndedChannel` from inside its own `await` — `_openSession`
+armed the end timer, found the end in the past, and published synchronously —
+while the connection did not subscribe to that channel until the `await`
+resolved. The publish landed on an empty channel. The source got `authOk`, no
+`sessionEnded`, no close, and went on forwarding audio into a session the server
+considered over, holding an upstream transcription connection for as long as the
+kiosk kept the socket up. Nothing tore it down: teardown is driven by
+`_unregisterSource`, which is driven by a close that never came. `#184` fixed the
+viewer half of this and explicitly did not fix this half.
+
+The likeliest real-world trigger is not the operator race but a **stale kiosk
+schedule**: `kiosk-service.ts`'s `poll.on('error', () => {})` means the schedule
+long-poll can be dead for hours with no signal, and a kiosk acting on a stale
+schedule confidently connects to a session that ended long ago.
+
+**Subscriptions now come before registration, for both roles.** The event bus is
+synchronous, so anything published during `registerSource` reaches this
+connection instead of nobody. This is the ordering the client path had already
+been given, with the comment explaining why; sources now get the same rule. The
+early-return paths (`_closed` mid-await, orchestrator failure) release those
+subscriptions rather than leaving four listeners attached to a dead socket.
+
+**Nothing is written to the socket before `authOk`.** Moving subscriptions above
+registration means a bus message can now fire while the connection has not been
+told its auth succeeded, and both webapp clients hold their WebSocket handshake
+open until it arrives. The service therefore keeps an outbound gate shut until
+the controller reports the send (`onAuthAcknowledged`, replacing
+`publishCurrentStatus`). Live-stream messages that arrive early are dropped —
+`sessionStatus` is superseded by the snapshot sent immediately after `authOk`,
+and transcripts have no replay semantics — which is exactly what happened before,
+when those subscriptions simply did not exist yet. `sessionEnded` is the one
+message that must not be dropped, so it is latched and delivered in protocol
+order: `authOk`, then `sessionEnded`, then close 1000.
+
+**No upstream is dialed for a session that is already over.** `_openSession`
+used to construct and start the upstream *before* `_armEndTimer` discovered the
+end had passed, so an abandoned session took a transcription-service connection
+with it. The effective end is now checked the moment the first config surfaces,
+and `registerSource` throws `SessionAlreadyEndedError` without dialing anything
+and without creating a `SessionState`. That error is distinct from an
+orchestrator failure on purpose: an unreachable Session Manager is *broken* and
+earns 1011, whereas this session is merely *over* and earns a clean 1000 with
+`sessionEnded` — the kiosk already distinguishes those, and collapsing them
+would put a finished session into a reconnect loop. Not creating the state also
+removes the knock-on: no stale `SessionState` lingers in `_sessions` holding an
+upstream, answering `getStatus`, and appearing in `/status` for a session nobody
+is serving.
+
+The single-publisher guarantee `#184` established is untouched: the refusal
+publishes nothing on the bus, so an end-watch a viewer holds is still the only
+thing that announces the end to that session.
+
+**Observability.** A source arriving at a finished session is now counted and
+named, because downstream it is otherwise indistinguishable from an ordinary
+session end (a `1000 session-ended` close either way) while meaning something
+quite different:
+
+- a warn log line, `source registered onto an already-ended session`, carrying
+  the `effectiveEnd` the config reported;
+- `summary.endedSessionRegistrationsTotal` on `GET /status`, optional on the
+  wire so an older publisher does not fail the strict `Value.Check` that the
+  Redis fleet snapshot is read back through;
+- `scribear_node_ended_session_registrations_total` in the monitoring sidecar,
+  which skips the advance rather than recording a zero when the field is absent.

--- a/apps/monitoring-sidecar/src/server/shared/metrics/metrics-registry.service.ts
+++ b/apps/monitoring-sidecar/src/server/shared/metrics/metrics-registry.service.ts
@@ -124,6 +124,24 @@ export class MetricsRegistry {
   );
 
   /**
+   * Source registrations refused because the session was already over. Not a
+   * failure — the socket is closed 1000 with `sessionEnded` and no upstream
+   * is dialed — which is exactly why it needs its own series: downstream it is
+   * indistinguishable from an ordinary session end, while it actually means a
+   * device connected to a session that finished before it arrived. The usual
+   * cause is a kiosk whose schedule long-poll has been failing silently, and
+   * nothing else in the fleet reports that.
+   *
+   * Optional on the wire
+   * (`STATUS_PROCESS_SCHEMA.summary.endedSessionRegistrationsTotal`), so a
+   * poll of an older node-server records no increment rather than a zero.
+   */
+  readonly nodeEndedSessionRegistrationsTotal = new Counter(
+    'scribear_node_ended_session_registrations_total',
+    'Source registrations refused because the session had already reached its effectiveEnd.',
+  );
+
+  /**
    * Audio frames evicted at the per-session pending-chunk cap (§3 N3).
    * Sustained eviction means latency correlation is degrading silently.
    */
@@ -719,6 +737,7 @@ export class MetricsRegistry {
       this.nodeAuthTimeoutsTotal,
       this.nodeBinaryBeforeAuthDropsTotal,
       this.nodeOrchestratorFailuresTotal,
+      this.nodeEndedSessionRegistrationsTotal,
       this.nodePendingChunkEvictionsTotal,
       this.nodeLatencySamplesTotal,
       this.nodeLatencyE2eNegativeTotal,

--- a/apps/monitoring-sidecar/src/server/shared/node-status/node-status-poller.service.ts
+++ b/apps/monitoring-sidecar/src/server/shared/node-status/node-status-poller.service.ts
@@ -132,6 +132,15 @@ export class NodeStatusPollerService extends AbsoluteStatusPoller<NodeStatusBody
       { service },
       s.orchestratorFailuresTotal,
     );
+    // Optional on the wire, skipped rather than defaulted - same reasoning as
+    // `binaryBeforeAuthDropsTotal` above.
+    if (s.endedSessionRegistrationsTotal !== undefined) {
+      this._advance(
+        this._metrics.nodeEndedSessionRegistrationsTotal,
+        { service },
+        s.endedSessionRegistrationsTotal,
+      );
+    }
     this._advance(
       this._metrics.nodePendingChunkEvictionsTotal,
       { service },

--- a/apps/monitoring-sidecar/tests/fixtures/fake-node-status.ts
+++ b/apps/monitoring-sidecar/tests/fixtures/fake-node-status.ts
@@ -132,10 +132,11 @@ export function statusBody(
     Omit<FakeStatusBody, 'summary' | 'sessions' | 'secretPlaceholders'>
   > & {
     // Not in `ZERO_SUMMARY`: absent by default, matching a node-server that
-    // predates this field. A test opts in explicitly to exercise the
+    // predates these fields. A test opts in explicitly to exercise the
     // present case.
     summary?: Partial<typeof ZERO_SUMMARY> & {
       binaryBeforeAuthDropsTotal?: number;
+      endedSessionRegistrationsTotal?: number;
     };
     sessions?: FakeSessionInput[];
     secretPlaceholders?: Partial<FakeSecretPlaceholders>;

--- a/apps/monitoring-sidecar/tests/integration/node-status-poller.test.ts
+++ b/apps/monitoring-sidecar/tests/integration/node-status-poller.test.ts
@@ -101,6 +101,34 @@ describe('node-server status poller (B1.1 PR 4)', () => {
       ).toBe(9);
     });
 
+    it('folds ended-session source registrations, and skips them when omitted', async () => {
+      // Arrange - the stale-schedule signal: a kiosk arriving at a session
+      // that finished before it connected. Optional on the wire like the
+      // counter above, so an older node-server must record no delta rather
+      // than a zero.
+      const { metrics, poller } = await createPoller();
+
+      // Act - a poll with the field absent, then two that report it.
+      await poller.pollOnce();
+      const omitted = metrics.nodeEndedSessionRegistrationsTotal.get({
+        service: SERVICE,
+      });
+      node.setBody(
+        statusBody({ summary: { endedSessionRegistrationsTotal: 2 } }),
+      );
+      await poller.pollOnce();
+      node.setBody(
+        statusBody({ summary: { endedSessionRegistrationsTotal: 7 } }),
+      );
+      await poller.pollOnce();
+
+      // Assert - 7 total events seen, not 2 + 7.
+      expect(omitted).toBe(0);
+      expect(
+        metrics.nodeEndedSessionRegistrationsTotal.get({ service: SERVICE }),
+      ).toBe(7);
+    });
+
     it('does not throw or record a delta when an older node-server omits the field', async () => {
       // Arrange - the field is optional on the wire for backward-compat with
       // publishers that predate it, so a body that simply never mentions it

--- a/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
@@ -96,6 +96,46 @@ export interface SessionSnapshot {
 }
 
 /**
+ * Thrown by {@link TranscriptionOrchestratorService.registerSource} when the
+ * session's `effectiveEnd` has already passed.
+ *
+ * A distinct type rather than a plain `Error` because the two failures a source
+ * registration can have are not the same event and must not close the socket
+ * the same way: an unreachable Session Manager is *broken* and earns 1011
+ * `orchestrator-unavailable`, whereas this session is merely *over* and earns
+ * `sessionEnded` + a clean 1000. The kiosk already distinguishes those - 1000
+ * drops it to IDLE, anything else reconnect-loops - so collapsing them would
+ * put a finished session into a retry loop.
+ *
+ * No registration is created and no upstream is dialed, so there is nothing for
+ * the caller to release.
+ */
+export class SessionAlreadyEndedError extends Error {
+  readonly sessionUid: string;
+
+  constructor(sessionUid: string) {
+    super(`session ${sessionUid} has already reached its effectiveEnd`);
+    this.name = 'SessionAlreadyEndedError';
+    this.sessionUid = sessionUid;
+  }
+}
+
+/**
+ * Whether `session`'s effective end is already in the past.
+ *
+ * Both "no end at all" and "an end we cannot parse" read as *not* over, on
+ * purpose: this predicate gates whether a source is admitted, so its failure
+ * mode has to be admitting a session that has ended (which the end timer then
+ * catches a moment later) rather than refusing one that has not.
+ */
+function hasAlreadyEnded(session: Session): boolean {
+  if (session.effectiveEnd === null) return false;
+  const endMs = Date.parse(session.effectiveEnd);
+  if (Number.isNaN(endMs)) return false;
+  return endMs <= Date.now();
+}
+
+/**
  * Handle returned by {@link TranscriptionOrchestratorService.registerSource}.
  * The caller MUST call `unregister` when the source connection closes. The
  * caller SHOULD call `setMicrophoneActive` when the source's mic state
@@ -319,12 +359,24 @@ export class TranscriptionOrchestratorService {
    * when the source connection closes, and whose `setMicrophoneActive` the
    * caller SHOULD invoke to report mic state. The upstream is torn down when
    * the count returns to 0.
+   *
+   * Throws {@link SessionAlreadyEndedError} if the session is already past its
+   * `effectiveEnd`. Nothing is registered and no upstream is dialed in that
+   * case; the caller is expected to send `sessionEnded` and close 1000.
    */
   async registerSource(sessionUid: string): Promise<SourceHandle> {
     let state = this._sessions.get(sessionUid);
     if (state === undefined) {
       state = await this._openSession(sessionUid);
       this._sessions.set(sessionUid, state);
+    } else if (state.ended) {
+      // A state that has published its end is torn down as soon as its last
+      // source socket finishes closing, so this is a narrow window rather
+      // than a steady state - but a source landing inside that window would
+      // otherwise attach to a session no timer will ever fire for again, and
+      // hang exactly as it did before this check existed.
+      this._recordEndedSessionRegistration(sessionUid, null);
+      throw new SessionAlreadyEndedError(sessionUid);
     }
     // A real session is the authoritative end-timer owner while it exists, so
     // any end-watch a viewer opened before the source arrived stands down now
@@ -663,6 +715,20 @@ export class TranscriptionOrchestratorService {
     const longPoll = this._sessionConfigPollFactory(sessionUid);
     const initial = await this._awaitFirstConfig(longPoll, sessionUid);
 
+    // Checked here - the first moment the end is knowable - rather than left to
+    // `_armEndTimer` at the bottom of this method. By then the upstream has
+    // already been constructed and started, and the transcription service is
+    // the scarcest thing in the deployment (`num_workers: 1`, a low admission
+    // ceiling on a cold process): dialing it for a session we are about to
+    // abandon takes capacity away from a room that is actually running. The
+    // upstream is also only ever torn down by `_unregisterSource`, so an
+    // abandoned one is not reclaimed until its socket closes.
+    if (hasAlreadyEnded(initial)) {
+      longPoll.close();
+      this._recordEndedSessionRegistration(sessionUid, initial.effectiveEnd);
+      throw new SessionAlreadyEndedError(sessionUid);
+    }
+
     // The config the upstream must be (re)told about on every connection. Held
     // in a mutable box rather than read from `initial` so a reconnect after a
     // config bump replays the CURRENT config, not the one this session opened
@@ -844,6 +910,31 @@ export class TranscriptionOrchestratorService {
     this._armEndTimer(sessionUid, state, initial);
 
     return state;
+  }
+
+  /**
+   * Count and name a source registration that arrived after the session was
+   * already over (§3.4 of the plan this fixes).
+   *
+   * Worth its own signal rather than being folded into the ordinary end path:
+   * a session ending under a connected source is routine, whereas a source
+   * *arriving* at a finished session means something upstream is working from
+   * a stale schedule - most likely a kiosk whose `mySchedule` long-poll has
+   * been failing silently for hours. That cause is invisible in every other
+   * series, because from the outside it looks exactly like a normal
+   * registration followed by a normal end.
+   *
+   * @param effectiveEnd The end the session's config reported, when known.
+   */
+  private _recordEndedSessionRegistration(
+    sessionUid: string,
+    effectiveEnd: string | null,
+  ): void {
+    this._metrics.recordEndedSessionRegistration();
+    this._logger.warn(
+      { sessionUid, effectiveEnd },
+      'source registered onto an already-ended session',
+    );
   }
 
   /**

--- a/apps/node-server/src/server/features/transcription-stream/transcription-stream.controller.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-stream.controller.ts
@@ -179,7 +179,11 @@ export class TranscriptionStreamController {
       this._metrics.recordAuthSuccess();
 
       safeSend({ type: TranscriptionStreamServerMessageType.AUTH_OK });
-      service.publishCurrentStatus();
+      // Must follow the AUTH_OK send, never precede it: this is what opens the
+      // service's outbound gate, and it is also where a session that ended
+      // during registration gets its `sessionEnded` + 1000 close - in that
+      // order, after the client has been told its auth succeeded.
+      service.onAuthAcknowledged();
     };
 
     socket.on('close', (code: number, reason: Buffer) => {

--- a/apps/node-server/src/server/features/transcription-stream/transcription-stream.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-stream.service.ts
@@ -13,9 +13,10 @@ import { LatencyChannel } from './events/latency.events.js';
 import { SessionEndedChannel } from './events/session-ended.events.js';
 import { SessionStatusChannel } from './events/session-status.events.js';
 import { TranscriptChannel } from './events/transcript.events.js';
-import type {
-  ClientHandle,
-  SourceHandle,
+import {
+  type ClientHandle,
+  SessionAlreadyEndedError,
+  type SourceHandle,
 } from './transcription-orchestrator.service.js';
 import type { TranscriptionStreamRole } from './transcription-stream.auth.js';
 
@@ -46,7 +47,13 @@ export interface TranscriptionStreamServiceOptions {
  *
  * Role-aware behavior is limited to whether the connection should acquire an
  * orchestrator source registration; both roles subscribe to the per-session
- * transcript / status / ended buses identically.
+ * transcript / status / ended buses identically, and both subscribe *before*
+ * registering anything, so a session end announced during registration is
+ * never missed.
+ *
+ * Nothing is written to the socket until the controller reports that `authOk`
+ * has been sent ({@link TranscriptionStreamService.onAuthAcknowledged}); the
+ * service holds the outbound gate shut until then.
  */
 export class TranscriptionStreamService extends EventEmitter<TranscriptionStreamServiceEvents> {
   private _role: TranscriptionStreamRole;
@@ -68,6 +75,20 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
    * that closed before they ever subscribed.
    */
   private _counted = false;
+  /**
+   * Whether the controller has sent `authOk`. Until it has, nothing may be
+   * written to the socket - see {@link _mayForward}.
+   */
+  private _ready = false;
+  /**
+   * An end signal that arrived before `authOk` and so could not be forwarded
+   * when it happened. Delivered by {@link onAuthAcknowledged}.
+   *
+   * This is the whole point of subscribing before registering: `sessionEnded`
+   * is terminal and nothing resends it, so a connection that misses its own
+   * end signal never learns the session is over.
+   */
+  private _sessionEndedPending = false;
 
   constructor(options: TranscriptionStreamServiceOptions) {
     super();
@@ -86,82 +107,72 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
    *
    * Does NOT emit any messages. The controller is responsible for sending the
    * auth-success protocol response and then invoking
-   * {@link publishCurrentStatus} so the client sees a deterministic initial
-   * snapshot after the success message.
+   * {@link onAuthAcknowledged}, which opens the outbound gate and gives the
+   * client a deterministic initial snapshot after the success message.
    */
   async start(): Promise<void> {
+    // The socket can be closed before `start()` is ever reached (the peer hung
+    // up during auth verification). Bail before subscribing rather than
+    // subscribing and immediately tearing it back down.
+    if (this._isClosed()) return;
+
+    // Subscribed BEFORE any orchestrator registration, and before the await
+    // that registration implies.
+    //
+    // The event bus is synchronous, and registering a source publishes
+    // `sessionEnded` from inside that await whenever the session's config
+    // surfaces an `effectiveEnd` that has already passed. Subscribing
+    // afterwards meant the publish landed on an empty channel: the source was
+    // never told, never closed, and went on streaming audio into a session the
+    // server considered over while holding an upstream transcription
+    // connection open. The client path below has always been ordered this way
+    // for exactly this reason; this is the same rule applied to both roles.
+    this._subscribeToSessionBuses();
+
+    // Counted here rather than in the constructor: a connection costs fan-out
+    // from the moment it is subscribed, which is now this point rather than
+    // after registration. Every exit below runs `_cleanup`, which decrements,
+    // so a registration that fails or a socket that closed mid-await nets to
+    // zero. Both roles count - receive-only clients are what make a large room
+    // expensive (N4), and the orchestrator never sees them.
+    this._metrics.recordConnectionOpen(this._sessionUid);
+    this._counted = true;
+
     if (this._role === 'source') {
-      const handle =
-        await this._transcriptionOrchestratorService.registerSource(
+      let handle: SourceHandle;
+      try {
+        handle = await this._transcriptionOrchestratorService.registerSource(
           this._sessionUid,
         );
+      } catch (err) {
+        if (err instanceof SessionAlreadyEndedError) {
+          // The session is over, not broken. No registration was created and
+          // no upstream was dialed, so there is nothing to release; the
+          // connection stays alive just long enough for the controller to
+          // send `authOk`, after which `onAuthAcknowledged` sends
+          // `sessionEnded` and closes 1000. Deliberately not rethrown: a 1011
+          // here would put a kiosk into a reconnect loop against a session
+          // that is never coming back.
+          this._sessionEndedPending = true;
+          return;
+        }
+        // Genuine orchestrator failure. The controller maps this to 1011 and
+        // closes, which calls `close()` - but unsubscribing here as well keeps
+        // `start()` self-contained, so the subscriptions it took out cannot
+        // outlive it no matter how the caller handles the throw.
+        this._cleanup();
+        throw err;
+      }
       // The connection may have closed while we awaited orchestrator
-      // registration; if so, immediately release the registration and bail
-      // out before subscribing to the buses.
-      if (this._closed) {
+      // registration; if so, release the registration and drop the
+      // subscriptions rather than leaving them attached to a dead socket.
+      if (this._isClosed()) {
         handle.unregister();
+        this._cleanup();
         return;
       }
       this._orchestratorHandle = handle;
     }
-
-    // Counted here rather than in the constructor: a connection only costs
-    // fan-out once it is actually subscribed, and the early return above bails
-    // before this point. Both roles count - receive-only clients are what make
-    // a large room expensive (N4), and the orchestrator never sees them.
-    this._metrics.recordConnectionOpen(this._sessionUid);
-    this._counted = true;
-
-    this._unsubscribeTranscripts = this._eventBusService.subscribe(
-      TranscriptChannel,
-      (transcript) => {
-        if (this._closed) return;
-        this.emit('send', {
-          type: TranscriptionStreamServerMessageType.TRANSCRIPT,
-          final: transcript.final,
-          inProgress: transcript.inProgress,
-        });
-      },
-      this._sessionUid,
-    );
-
-    this._unsubscribeLatency = this._eventBusService.subscribe(
-      LatencyChannel,
-      (latency) => {
-        if (this._closed) return;
-        this.emit('send', {
-          type: TranscriptionStreamServerMessageType.LATENCY_UPDATE,
-          kind: latency.kind,
-          pipelineMs: latency.pipelineMs,
-          e2eMs: latency.e2eMs,
-        });
-      },
-      this._sessionUid,
-    );
-
-    this._unsubscribeSessionStatus = this._eventBusService.subscribe(
-      SessionStatusChannel,
-      (status) => {
-        if (this._closed) return;
-        this.emit('send', {
-          type: TranscriptionStreamServerMessageType.SESSION_STATUS,
-          ...status,
-        });
-      },
-      this._sessionUid,
-    );
-
-    this._unsubscribeSessionEnded = this._eventBusService.subscribe(
-      SessionEndedChannel,
-      () => {
-        if (this._closed) return;
-        this.emit('send', {
-          type: TranscriptionStreamServerMessageType.SESSION_ENDED,
-        });
-        this._closeWith(1000, 'session-ended');
-      },
-      this._sessionUid,
-    );
 
     if (this._role === 'client') {
       // Take out the session's end-watch, so a viewer on a session with no
@@ -177,11 +188,15 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
       const handle = this._transcriptionOrchestratorService.registerClient(
         this._sessionUid,
       );
-      if (this._closed) {
-        // The watch published `sessionEnded` synchronously and this
-        // connection has already been cleaned up; release the registration
-        // rather than leaking it into the ref count.
+      if (this._isClosed()) {
+        // Retained as a guard rather than as a live path: a synchronous
+        // `sessionEnded` from the watch now latches `_sessionEndedPending`
+        // instead of closing (the socket has not seen `authOk` yet), so
+        // nothing here should have closed this connection. If some future
+        // caller manages it anyway, release the registration rather than
+        // leaking it into the ref count.
         handle.unregister();
+        this._cleanup();
         return;
       }
       this._endWatchHandle = handle;
@@ -189,13 +204,34 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
   }
 
   /**
-   * Emit the orchestrator's current session-status snapshot. Called once by
-   * the controller right after the auth-success message so the client sees
-   * the orchestrator's view of connectivity without waiting for the next
-   * transition.
+   * Called by the controller immediately after - and only after - it has sent
+   * the auth-success message. Two duties, both of which have to happen in this
+   * order and nowhere else:
+   *
+   * 1. Open the outbound gate (see {@link _mayForward}). Nothing may reach the
+   *    socket before `authOk`, and the controller is the only thing that knows
+   *    when that has been written.
+   * 2. Deliver either the end signal that arrived while the gate was shut, or
+   *    the orchestrator's current status snapshot, so the client sees the
+   *    server's view of connectivity without waiting for the next transition.
+   *
+   * An already-ended session yields `sessionEnded` + close 1000 instead of a
+   * status snapshot: publishing connectivity for a session that is over would
+   * tell the client to keep waiting for a source that is never coming.
    */
-  publishCurrentStatus(): void {
+  onAuthAcknowledged(): void {
     if (this._closed) return;
+    this._ready = true;
+
+    if (this._sessionEndedPending) {
+      this._sessionEndedPending = false;
+      this.emit('send', {
+        type: TranscriptionStreamServerMessageType.SESSION_ENDED,
+      });
+      this._closeWith(1000, 'session-ended');
+      return;
+    }
+
     const status = this._transcriptionOrchestratorService.getStatus(
       this._sessionUid,
     );
@@ -232,6 +268,113 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
    */
   close(): void {
     this._cleanup();
+  }
+
+  /**
+   * `_closed` behind a call rather than read directly.
+   *
+   * TypeScript keeps property narrowing across an `await`, so a plain
+   * `if (this._closed) return` early in {@link start} would narrow the field
+   * to `false` for every check after the registration await - and those later
+   * checks exist precisely because the socket really can close during it.
+   * Reading through a method leaves each check honest.
+   */
+  private _isClosed(): boolean {
+    return this._closed;
+  }
+
+  /**
+   * Whether a bus message may be written to the socket right now.
+   *
+   * `_ready` is false until the controller has sent `authOk`, and messages
+   * that arrive before then are **dropped**, not queued:
+   *
+   * - Writing anything ahead of `authOk` is a protocol violation. Both the
+   *   kiosk and the client webapp hold their WebSocket handshake open until
+   *   `authOk` arrives, so a message sent earlier reaches a peer that has not
+   *   yet agreed it is connected.
+   * - Nothing of value is lost. `sessionStatus` is superseded moments later by
+   *   the snapshot {@link onAuthAcknowledged} sends, and transcripts and
+   *   latency are live streams with no replay semantics - a connection that
+   *   has not finished authenticating has no claim on them. This is also
+   *   exactly what happened before these subscriptions moved above
+   *   registration: they simply did not exist yet, so the same messages went
+   *   nowhere.
+   *
+   * The one message this must NOT be applied to is `sessionEnded`. It is
+   * terminal and nothing resends it, so its handler latches
+   * {@link _sessionEndedPending} rather than dropping.
+   */
+  private _mayForward(): boolean {
+    return !this._closed && this._ready;
+  }
+
+  /**
+   * Subscribe to the four per-session buses this connection fans out to.
+   *
+   * Extracted so {@link start} can take the subscriptions out before it does
+   * anything that can await or publish, and so the pre-`authOk` policy above
+   * is stated once for every channel rather than re-decided per handler.
+   */
+  private _subscribeToSessionBuses(): void {
+    this._unsubscribeTranscripts = this._eventBusService.subscribe(
+      TranscriptChannel,
+      (transcript) => {
+        if (!this._mayForward()) return;
+        this.emit('send', {
+          type: TranscriptionStreamServerMessageType.TRANSCRIPT,
+          final: transcript.final,
+          inProgress: transcript.inProgress,
+        });
+      },
+      this._sessionUid,
+    );
+
+    this._unsubscribeLatency = this._eventBusService.subscribe(
+      LatencyChannel,
+      (latency) => {
+        if (!this._mayForward()) return;
+        this.emit('send', {
+          type: TranscriptionStreamServerMessageType.LATENCY_UPDATE,
+          kind: latency.kind,
+          pipelineMs: latency.pipelineMs,
+          e2eMs: latency.e2eMs,
+        });
+      },
+      this._sessionUid,
+    );
+
+    this._unsubscribeSessionStatus = this._eventBusService.subscribe(
+      SessionStatusChannel,
+      (status) => {
+        if (!this._mayForward()) return;
+        this.emit('send', {
+          type: TranscriptionStreamServerMessageType.SESSION_STATUS,
+          ...status,
+        });
+      },
+      this._sessionUid,
+    );
+
+    this._unsubscribeSessionEnded = this._eventBusService.subscribe(
+      SessionEndedChannel,
+      () => {
+        if (this._closed) return;
+        if (!this._ready) {
+          // Published while this connection was still registering, i.e. before
+          // the controller could send `authOk`. Remember it: this is the
+          // signal that must never be dropped, and `onAuthAcknowledged`
+          // delivers it in protocol order a moment from now.
+          this._sessionEndedPending = true;
+          return;
+        }
+        this.emit('send', {
+          type: TranscriptionStreamServerMessageType.SESSION_ENDED,
+        });
+        this._closeWith(1000, 'session-ended');
+      },
+      this._sessionUid,
+    );
   }
 
   private _closeWith(code: number, reason: string): void {

--- a/apps/node-server/src/server/shared/services/node-server-metrics.service.ts
+++ b/apps/node-server/src/server/shared/services/node-server-metrics.service.ts
@@ -228,6 +228,7 @@ export class NodeServerMetricsService {
   private _authSuccessTotal = 0;
   private _authTimeoutsTotal = 0;
   private _orchestratorFailuresTotal = 0;
+  private _endedSessionRegistrationsTotal = 0;
   private _latencySamplesTotal = 0;
   private _latencyE2eUnavailableTotal = 0;
   private _latencyE2eNegativeTotal = 0;
@@ -357,6 +358,23 @@ export class NodeServerMetricsService {
   }
 
   /**
+   * A source tried to register on a session that was already past its
+   * `effectiveEnd`. It is refused before any upstream is dialed and closed
+   * 1000 with `sessionEnded`, so this is not an error series - it is the only
+   * evidence that a device is acting on a schedule it should have discarded.
+   *
+   * Counted separately from the ordinary end path because the two look
+   * identical downstream (a `1000 session-ended` close either way) while
+   * meaning opposite things: a session ending under a connected kiosk is
+   * routine, a kiosk *arriving* at a finished session means its schedule
+   * long-poll has most likely been dead for a while - `poll.on('error', ...)`
+   * on the kiosk swallows that failure, so nothing else reports it.
+   */
+  recordEndedSessionRegistration(): void {
+    this._endedSessionRegistrationsTotal += 1;
+  }
+
+  /**
    * A latency sample was published (B1.4).
    *
    * `e2eOutcome` records what happened to the end-to-end figure: `unavailable`
@@ -437,6 +455,7 @@ export class NodeServerMetricsService {
       authSuccessTotal: this._authSuccessTotal,
       authTimeoutsTotal: this._authTimeoutsTotal,
       orchestratorFailuresTotal: this._orchestratorFailuresTotal,
+      endedSessionRegistrationsTotal: this._endedSessionRegistrationsTotal,
       latencySamplesTotal: this._latencySamplesTotal,
       latencyE2eUnavailableTotal: this._latencyE2eUnavailableTotal,
       latencyE2eNegativeTotal: this._latencyE2eNegativeTotal,

--- a/apps/node-server/src/server/shared/services/status-snapshot.service.ts
+++ b/apps/node-server/src/server/shared/services/status-snapshot.service.ts
@@ -51,6 +51,7 @@ export class StatusSnapshotService {
         authSuccessTotal: counters.authSuccessTotal,
         authTimeoutsTotal: counters.authTimeoutsTotal,
         orchestratorFailuresTotal: counters.orchestratorFailuresTotal,
+        endedSessionRegistrationsTotal: counters.endedSessionRegistrationsTotal,
         latencySamplesTotal: counters.latencySamplesTotal,
         latencyE2eUnavailableTotal: counters.latencyE2eUnavailableTotal,
         latencyE2eNegativeTotal: counters.latencyE2eNegativeTotal,

--- a/apps/node-server/tests/integration/features/transcription-stream/transcription-stream.routes.test.ts
+++ b/apps/node-server/tests/integration/features/transcription-stream/transcription-stream.routes.test.ts
@@ -844,6 +844,160 @@ describe('Transcription Stream Routes', () => {
     );
   });
 
+  // The bug this covers: a SOURCE connecting to a session whose `effectiveEnd`
+  // had already passed was never told. `registerSource` published
+  // `SessionEndedChannel` from inside its own await - before that connection
+  // had subscribed to hear it - so the publish landed on an empty channel. The
+  // kiosk was never sent `sessionEnded`, never closed 1000, and went on
+  // streaming audio into a session the server considered over, holding an
+  // upstream transcription connection open for the whole time. PR #184 fixed
+  // the viewer half of this and explicitly did not fix this half.
+  describe('source connecting to an already-ended session', (it) => {
+    /** Sessions in `/status`, i.e. those holding an upstream connection. */
+    async function statusSessionUids(): Promise<string[]> {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: '/api/node-server/v1/status',
+        headers: { authorization: `Bearer ${TEST_SERVICE_API_KEY}` },
+      });
+      expect(res.statusCode).toBe(200);
+      return res
+        .json<{ sessions: { sessionUid: string }[] }>()
+        .sessions.map((s) => s.sessionUid);
+    }
+
+    /** Reads the endedSessionRegistrationsTotal counter off /status. */
+    async function readEndedRegistrations(): Promise<number> {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: '/api/node-server/v1/status',
+        headers: { authorization: `Bearer ${TEST_SERVICE_API_KEY}` },
+      });
+      expect(res.statusCode).toBe(200);
+      return res.json<{
+        summary: { endedSessionRegistrationsTotal: number };
+      }>().summary.endedSessionRegistrationsTotal;
+    }
+
+    /** A fresh on-demand session of its own, so ending it disturbs nothing. */
+    async function seedOwnSession(): Promise<{ uid: string }> {
+      return await seedSession({
+        sessionManagerBaseUrl: inject('sessionManagerBaseUrl'),
+        adminApiKey: inject('adminApiKey'),
+        transcriptionProviderId: 'debug',
+        transcriptionStreamConfig: {
+          sample_rate: DEBUG_SAMPLE_RATE,
+          num_channels: DEBUG_NUM_CHANNELS,
+        },
+      });
+    }
+
+    async function endSessionEarly(sessionUid: string): Promise<void> {
+      const sm = createSessionManagerClient(inject('sessionManagerBaseUrl'));
+      const ended = await sm.scheduleManagement.endSessionEarly({
+        body: { sessionUid },
+        headers: { authorization: `Bearer ${inject('adminApiKey')}` },
+      });
+      expect(ended[1]).toBeNull();
+      expect(ended[0]?.status).toBe(200);
+    }
+
+    function authAsSource(ws: WebSocket, sessionUid: string, id: string): void {
+      ws.send(
+        JSON.stringify({
+          type: TranscriptionStreamClientMessageType.AUTH,
+          sessionToken: signToken({
+            sessionUid,
+            clientId: id,
+            scopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+            exp: FAR_FUTURE,
+          }),
+        }),
+      );
+    }
+
+    it(
+      'sends sessionEnded, closes 1000, and dials no upstream',
+      { timeout: 60_000 },
+      async () => {
+        // Arrange - the stale-schedule case (§4.2): the session is already over
+        // by the time the kiosk arrives.
+        const session = await seedOwnSession();
+        await endSessionEarly(session.uid);
+        const before = await readEndedRegistrations();
+
+        // Act
+        const ws = await server.fastify.injectWS(sourcePath(session.uid));
+        const { messages, stop } = collectMessages(ws);
+        const closed = nextClose(ws);
+        authAsSource(ws, session.uid, 'late-kiosk');
+
+        // Assert - closed 1000 rather than left streaming into a dead session.
+        await expect(closed).resolves.toMatchObject({
+          code: 1000,
+          reason: 'session-ended',
+        });
+
+        // Assert - and told why, in protocol order: `authOk` first, because
+        // both webapp clients hold their handshake open until it arrives.
+        const types = messages.map((m) => m.type);
+        expect(types).toContain(
+          TranscriptionStreamServerMessageType.SESSION_ENDED,
+        );
+        expect(
+          types.indexOf(TranscriptionStreamServerMessageType.AUTH_OK),
+        ).toBe(0);
+        expect(
+          types.indexOf(TranscriptionStreamServerMessageType.SESSION_ENDED),
+        ).toBeGreaterThan(0);
+
+        // Assert - no upstream was dialed for a session that is over. The
+        // transcription service runs `num_workers: 1`; a connection opened for
+        // an abandoned session is only ever reclaimed when its source socket
+        // closes, which in the bug never happened.
+        expect(await statusSessionUids()).not.toContain(session.uid);
+
+        // Assert - and the stale-schedule cause is visible in production
+        // rather than inferred (§3.4).
+        expect(await readEndedRegistrations()).toBe(before + 1);
+
+        stop();
+      },
+    );
+
+    it(
+      'terminates the source when the end lands during its connect (§4.1)',
+      { timeout: 120_000 },
+      async () => {
+        // The genuine race, not the stale schedule: an operator ends the
+        // session in the window between the kiosk's token exchange and its
+        // registration - the exact button pressed during a demo. Either branch
+        // may win (the config fetch returns the already-ended session, or it
+        // returns the live one and the bump arrives moments later), and the
+        // point of the assertion is that BOTH terminate the socket rather than
+        // leaving it streaming.
+        const rounds = 3;
+        for (let round = 0; round < rounds; round++) {
+          // Arrange
+          const session = await seedOwnSession();
+          const ws = await server.fastify.injectWS(sourcePath(session.uid));
+          const closed = nextClose(ws);
+
+          // Act - auth and the early end are issued in the same tick.
+          authAsSource(ws, session.uid, `raced-kiosk-${String(round)}`);
+          await endSessionEarly(session.uid);
+
+          // Assert
+          await expect(closed).resolves.toMatchObject({
+            code: 1000,
+            reason: 'session-ended',
+          });
+          expect(await statusSessionUids()).not.toContain(session.uid);
+        }
+      },
+    );
+  });
+
   describe('client role with live upstream', (it) => {
     it(
       'closes 1008 binary-not-allowed-for-role when an authed client sends binary',

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
@@ -14,6 +14,7 @@ import { SessionEndedChannel } from '#src/server/features/transcription-stream/e
 import { SessionStatusChannel } from '#src/server/features/transcription-stream/events/session-status.events.js';
 import { TranscriptChannel } from '#src/server/features/transcription-stream/events/transcript.events.js';
 import {
+  SessionAlreadyEndedError,
   type SessionConfigPollFactory,
   type SourceHandle,
   TranscriptionOrchestratorService,
@@ -311,6 +312,100 @@ describe('TranscriptionOrchestratorService', () => {
       expect(h.poolFactory).toHaveBeenCalledTimes(1);
       expect(h.transcriptionStreamFactory).toHaveBeenCalledTimes(1);
       expect(h.orchestrator.activeSessionCount).toBe(1);
+    });
+
+    it('refuses a session whose effectiveEnd has already passed', async () => {
+      // The stale-schedule case: a kiosk acting on a schedule it should have
+      // discarded connects to a session that finished before it arrived. It
+      // used to be admitted silently - the end was published from inside this
+      // very call, before the connection had subscribed to hear it - and then
+      // streamed audio into a dead session indefinitely.
+      // Arrange
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(-60_000) }),
+      );
+
+      // Act / Assert
+      await expect(promise).rejects.toBeInstanceOf(SessionAlreadyEndedError);
+      expect(h.orchestrator.activeSessionCount).toBe(0);
+    });
+
+    it('dials no upstream transcription connection for an already-ended session', async () => {
+      // The transcription service is the scarcest thing in the deployment, and
+      // an upstream is only ever torn down by the last source unregistering -
+      // so one opened for a session we are about to refuse would sit there
+      // holding admission capacity away from a room that is actually running.
+      // Arrange
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit('data', fakeSession({ effectiveEnd: isoFromNow(-1) }));
+
+      // Act
+      await expect(promise).rejects.toBeInstanceOf(SessionAlreadyEndedError);
+
+      // Assert - nothing dialed, and the config poll opened to find this out
+      // is closed rather than left running for a session with no connections.
+      expect(h.transcriptionStreamFactory).not.toHaveBeenCalled();
+      expect(h.longPoll.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('counts and names an ended-session registration', async () => {
+      // §3.4: without its own counter this is indistinguishable downstream
+      // from an ordinary session end (a 1000 `session-ended` close either
+      // way), while meaning something quite different - a device working from
+      // a schedule that is hours stale.
+      // Arrange
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit('data', fakeSession({ effectiveEnd: isoFromNow(-1) }));
+
+      // Act
+      await expect(promise).rejects.toBeInstanceOf(SessionAlreadyEndedError);
+
+      // Assert
+      expect(h.metrics.snapshot().endedSessionRegistrationsTotal).toBe(1);
+    });
+
+    it('admits a session that is still running, with no spurious end', async () => {
+      // The other half of the refusal: the check must not fire a moment early
+      // for a live session, which would refuse every kiosk in the fleet.
+      // Arrange
+      const ended: unknown[] = [];
+      h.bus.subscribe(
+        SessionEndedChannel,
+        (m) => {
+          ended.push(m);
+        },
+        SESSION_UID,
+      );
+
+      // Act
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(60_000) }),
+      );
+      await promise;
+
+      // Assert
+      expect(h.orchestrator.activeSessionCount).toBe(1);
+      expect(h.transcriptionStreamFactory).toHaveBeenCalledTimes(1);
+      expect(ended).toHaveLength(0);
+      expect(h.metrics.snapshot().endedSessionRegistrationsTotal).toBe(0);
+    });
+
+    it('admits an open-ended session', async () => {
+      // `effectiveEnd: null` is the shape an on-demand session is created
+      // with, and `Date.parse(null)` NaNs - the refusal must read that as "not
+      // over", not as "cannot tell, so refuse".
+      // Act
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit('data', fakeSession({ effectiveEnd: null }));
+      await promise;
+
+      // Assert
+      expect(h.orchestrator.activeSessionCount).toBe(1);
+      expect(h.metrics.snapshot().endedSessionRegistrationsTotal).toBe(0);
     });
 
     it('publishes sessionDeviceConnected: true on first registration', async () => {
@@ -1122,6 +1217,39 @@ describe('TranscriptionOrchestratorService end-watch', () => {
 
       late.unregister();
       source.unregister();
+    });
+
+    it('leaves nothing behind for a later viewer when a source bounced off an ended session', async () => {
+      // §3.3, the knock-on the refusal has to not have: the end-watch design
+      // assumes a `SessionState` that ends is promptly torn down. A source
+      // admitted onto an ended session used to leave one in `_sessions`
+      // forever - holding a live upstream, still answering `getStatus`, and
+      // still listed by `/status`. Refusing the registration means there is no
+      // such state for a viewer to arrive behind.
+      // Arrange - the source is refused; it took out (and closed) long-poll #0.
+      const refused = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit('data', fakeSession({ effectiveEnd: isoFromNow(-1000) }));
+      await expect(refused).rejects.toBeInstanceOf(SessionAlreadyEndedError);
+      expect(ended).toHaveLength(0);
+
+      // Act - a viewer of the same room joins afterwards, on long-poll #1.
+      const late = h.orchestrator.registerClient(SESSION_UID);
+      h.longPolls[1]?.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(-1000) }),
+      );
+
+      // Assert - told, and told by its own watch rather than by a stale
+      // session state that should never have existed.
+      expect(ended).toHaveLength(1);
+      expect(h.orchestrator.activeSessionCount).toBe(0);
+      expect(h.orchestrator.sessionSnapshots(10).sessions).toHaveLength(0);
+      expect(h.orchestrator.getStatus(SESSION_UID)).toMatchObject({
+        transcriptionServiceConnected: false,
+        sourceDeviceConnected: false,
+      });
+
+      late.unregister();
     });
 
     it('hands the end back to the watch when the source disconnects before the end', async () => {

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.controller.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.controller.test.ts
@@ -7,7 +7,7 @@ interface MockService {
   start: Mock;
   close: Mock;
   handleBinary: Mock;
-  publishCurrentStatus: Mock;
+  onAuthAcknowledged: Mock;
   on: (event: string, cb: (...args: unknown[]) => void) => void;
   emit: (event: string, ...args: unknown[]) => void;
 }
@@ -41,7 +41,7 @@ const {
     start = vi.fn((): Promise<void> => startPromise);
     close = vi.fn();
     handleBinary = vi.fn();
-    publishCurrentStatus = vi.fn();
+    onAuthAcknowledged = vi.fn();
     private _handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
 
     on(event: string, cb: (...args: unknown[]) => void): void {
@@ -194,7 +194,7 @@ describe('TranscriptionStreamController', () => {
       expect(h.socket.send).toHaveBeenCalledWith(AUTH_OK);
       const service = serviceInstances[0]!;
       expect(service.start).toHaveBeenCalledTimes(1);
-      expect(service.publishCurrentStatus).toHaveBeenCalledTimes(1);
+      expect(service.onAuthAcknowledged).toHaveBeenCalledTimes(1);
       expect(h.metrics.recordAuthSuccess).toHaveBeenCalledTimes(1);
 
       vi.advanceTimersByTime(5001);

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.service.test.ts
@@ -7,6 +7,7 @@ import { LatencyChannel } from '#src/server/features/transcription-stream/events
 import { SessionEndedChannel } from '#src/server/features/transcription-stream/events/session-ended.events.js';
 import { SessionStatusChannel } from '#src/server/features/transcription-stream/events/session-status.events.js';
 import { TranscriptChannel } from '#src/server/features/transcription-stream/events/transcript.events.js';
+import { SessionAlreadyEndedError } from '#src/server/features/transcription-stream/transcription-orchestrator.service.js';
 import { TranscriptionStreamService } from '#src/server/features/transcription-stream/transcription-stream.service.js';
 import { EventBusService } from '#src/server/shared/services/event-bus.service.js';
 import { NodeServerMetricsService } from '#src/server/shared/services/node-server-metrics.service.js';
@@ -27,10 +28,35 @@ interface Harness {
   metrics: NodeServerMetricsService;
 }
 
+/**
+ * How many listeners the bus currently holds for a channel keyed by
+ * `SESSION_UID`. Reaches into the bus's private map on purpose: the leak this
+ * guards - a connection that subscribes and then bails out of `start()`
+ * without unsubscribing - is invisible from the outside, because a leaked
+ * listener on a dead connection emits nothing.
+ */
+function busListenerCount(bus: EventBusService, key: string): number {
+  const channels = Reflect.get(bus, '_channels') as
+    | Map<string, Set<unknown>>
+    | undefined;
+  return channels?.get(key)?.size ?? 0;
+}
+
+/** Total listeners this service could have taken out, across all four buses. */
+function allBusListenerCounts(bus: EventBusService): number {
+  return (
+    busListenerCount(bus, TranscriptChannel.key(SESSION_UID)) +
+    busListenerCount(bus, LatencyChannel.key(SESSION_UID)) +
+    busListenerCount(bus, SessionStatusChannel.key(SESSION_UID)) +
+    busListenerCount(bus, SessionEndedChannel.key(SESSION_UID))
+  );
+}
+
 function makeHarness(
   role: 'source' | 'client',
   options: {
     registerThrows?: boolean;
+    registerSessionEnded?: boolean;
     initialStatus?: {
       transcriptionServiceConnected: boolean;
       sourceDeviceConnected: boolean;
@@ -44,6 +70,9 @@ function makeHarness(
   const registerSource = vi.fn(() => {
     if (options.registerThrows) {
       return Promise.reject(new Error('orchestrator-down'));
+    }
+    if (options.registerSessionEnded) {
+      return Promise.reject(new SessionAlreadyEndedError(SESSION_UID));
     }
     return Promise.resolve({
       unregister: unregisterSource,
@@ -288,6 +317,7 @@ describe('TranscriptionStreamService', () => {
 
       // Act - close before resolving the registration.
       const pending = service.start();
+      const whileRegistering = allBusListenerCounts(bus);
       service.close();
       resolveRegister({
         unregister,
@@ -297,11 +327,74 @@ describe('TranscriptionStreamService', () => {
 
       // Assert
       expect(unregister).toHaveBeenCalledTimes(1);
+      // Subscriptions are now taken out before the await, so this path has
+      // four of them to hand back. Leaving them attached would keep a dead
+      // connection on every one of the session's buses for the life of the
+      // process.
+      expect(whileRegistering).toBe(4);
+      expect(allBusListenerCounts(bus)).toBe(0);
+    });
+
+    it('leaves no subscriptions behind when the orchestrator throws', async () => {
+      // The 1011 path. `start()` rethrows for the controller to map, and must
+      // not have left this connection on the buses on its way out.
+      // Arrange
+      const h = makeHarness('source', { registerThrows: true });
+
+      // Act
+      await expect(h.service.start()).rejects.toThrow('orchestrator-down');
+
+      // Assert
+      expect(allBusListenerCounts(h.bus)).toBe(0);
+      expect(h.metrics.subscriberCount(SESSION_UID)).toBe(0);
+    });
+
+    it('subscribes to nothing when the connection closed before start ran', async () => {
+      // Arrange
+      const h = makeHarness('source');
+      h.service.close();
+
+      // Act
+      await h.service.start();
+
+      // Assert
+      expect(allBusListenerCounts(h.bus)).toBe(0);
+      expect(h.registerSource).not.toHaveBeenCalled();
+    });
+
+    it('drops live-stream messages that arrive before authOk', async () => {
+      // Subscribing before registration means these buses can now fire while
+      // the socket has not been told its auth succeeded. Writing to it then is
+      // a protocol violation, and nothing is lost by dropping: the status
+      // snapshot `onAuthAcknowledged` sends supersedes any status published
+      // here, and transcripts have no replay semantics for a connection that
+      // has not finished authenticating.
+      // Arrange
+      const h = makeHarness('client');
+      await h.service.start();
+
+      // Act
+      h.bus.publish(
+        SessionStatusChannel,
+        { transcriptionServiceConnected: true, sourceDeviceConnected: true },
+        SESSION_UID,
+      );
+      h.bus.publish(
+        TranscriptChannel,
+        {
+          final: { text: ['too early'], starts: null, ends: null },
+          inProgress: null,
+        },
+        SESSION_UID,
+      );
+
+      // Assert
+      expect(h.sent).toHaveLength(0);
     });
   });
 
-  describe('publishCurrentStatus', (it) => {
-    it('emits the orchestrator snapshot on demand', async () => {
+  describe('onAuthAcknowledged', (it) => {
+    it('emits the orchestrator snapshot once the controller has sent authOk', async () => {
       // Arrange
       const h = makeHarness('client', {
         initialStatus: {
@@ -312,7 +405,7 @@ describe('TranscriptionStreamService', () => {
       await h.service.start();
 
       // Act
-      h.service.publishCurrentStatus();
+      h.service.onAuthAcknowledged();
 
       // Assert
       expect(h.sent).toEqual([
@@ -331,10 +424,134 @@ describe('TranscriptionStreamService', () => {
       h.service.close();
 
       // Act
-      h.service.publishCurrentStatus();
+      h.service.onAuthAcknowledged();
 
       // Assert
       expect(h.sent).toHaveLength(0);
+    });
+  });
+
+  // The bug: a source connecting to a session whose `effectiveEnd` had already
+  // passed was never told. `registerSource` published `sessionEnded` from
+  // inside its own await, before this connection had subscribed, so the
+  // publish landed on an empty channel - and the source went on streaming
+  // audio into a session the server considered over, holding an upstream
+  // transcription connection for as long as the kiosk kept the socket up.
+  describe('registering onto an already-ended session', (it) => {
+    it('sends sessionEnded and closes 1000, after authOk rather than before it', async () => {
+      // Arrange
+      const h = makeHarness('source', { registerSessionEnded: true });
+
+      // Act - `start()` must not throw: the session is over, not broken, and a
+      // 1011 here would put the kiosk into a reconnect loop against a session
+      // that is never coming back.
+      await h.service.start();
+
+      // Assert - nothing yet. The controller has not written authOk, and both
+      // webapp clients hold their handshake open until it arrives.
+      expect(h.sent).toHaveLength(0);
+      expect(h.closes).toHaveLength(0);
+
+      // Act - the controller sends authOk and reports it.
+      h.service.onAuthAcknowledged();
+
+      // Assert
+      expect(h.sent).toEqual([{ type: 'sessionEnded' }]);
+      expect(h.closes).toEqual([{ code: 1000, reason: 'session-ended' }]);
+    });
+
+    it('sends no status snapshot for a session that is over', async () => {
+      // A `sessionStatus` here reads as "still waiting for a source", which
+      // would tell the client to keep waiting for one that is never coming.
+      // Arrange
+      const h = makeHarness('source', { registerSessionEnded: true });
+      await h.service.start();
+
+      // Act
+      h.service.onAuthAcknowledged();
+
+      // Assert
+      expect(
+        h.sent.find((m) => (m as { type: string }).type === 'sessionStatus'),
+      ).toBeUndefined();
+      expect(h.getStatus).not.toHaveBeenCalled();
+    });
+
+    it('holds no orchestrator registration and no bus subscriptions afterwards', async () => {
+      // Nothing was registered and no upstream was dialed, so there is nothing
+      // to release - but the subscriptions taken out before registering must
+      // still come back off the bus when the connection closes.
+      // Arrange
+      const h = makeHarness('source', { registerSessionEnded: true });
+      await h.service.start();
+
+      // Act
+      h.service.onAuthAcknowledged();
+
+      // Assert
+      expect(h.unregisterSource).not.toHaveBeenCalled();
+      expect(allBusListenerCounts(h.bus)).toBe(0);
+      expect(h.metrics.subscriberCount(SESSION_UID)).toBe(0);
+    });
+
+    it('still delivers an end that lands while the source is registering', async () => {
+      // The §4.1 race rather than the stale-schedule case: registration is
+      // admitted, and the end is published on the bus while the await is still
+      // outstanding. The subscription now exists to hear it; before it moved,
+      // this publish went nowhere.
+      // Arrange
+      let resolveRegister: (handle: {
+        unregister: () => void;
+        setMicrophoneActive: () => void;
+      }) => void = () => undefined;
+      const registerSource = vi.fn(
+        () =>
+          new Promise<{
+            unregister: () => void;
+            setMicrophoneActive: () => void;
+          }>((resolve) => {
+            resolveRegister = resolve;
+          }),
+      );
+      const logger = createMockLogger();
+      const bus = new EventBusService(logger as never);
+      const orchestrator = {
+        registerSource,
+        getStatus: () => ({
+          transcriptionServiceConnected: false,
+          sourceDeviceConnected: false,
+        }),
+        activeSessionCount: 0,
+      } as unknown as ConstructorParameters<
+        typeof TranscriptionStreamService
+      >[0]['transcriptionOrchestratorService'];
+      const service = new TranscriptionStreamService({
+        role: 'source',
+        sessionUid: SESSION_UID,
+        eventBusService: bus,
+        transcriptionOrchestratorService: orchestrator,
+        nodeServerMetricsService: new NodeServerMetricsService(),
+      });
+      const sent: unknown[] = [];
+      const closes: { code: number; reason: string }[] = [];
+      service.on('send', (msg) => {
+        sent.push(msg);
+      });
+      service.on('close', (code, reason) => {
+        closes.push({ code, reason });
+      });
+
+      // Act - the end is published mid-registration, then registration
+      // completes normally.
+      const pending = service.start();
+      bus.publish(SessionEndedChannel, {}, SESSION_UID);
+      resolveRegister({ unregister: vi.fn(), setMicrophoneActive: vi.fn() });
+      await pending;
+      service.onAuthAcknowledged();
+
+      // Assert
+      expect(sent).toEqual([{ type: 'sessionEnded' }]);
+      expect(closes).toEqual([{ code: 1000, reason: 'session-ended' }]);
     });
   });
 
@@ -387,6 +604,8 @@ describe('TranscriptionStreamService', () => {
       // Arrange
       const h = makeHarness('client');
       await h.service.start();
+      // The controller has sent authOk; the outbound gate is open.
+      h.service.onAuthAcknowledged();
 
       // Act
       h.bus.publish(
@@ -410,6 +629,8 @@ describe('TranscriptionStreamService', () => {
       // Arrange
       const h = makeHarness('client');
       await h.service.start();
+      // The controller has sent authOk; the outbound gate is open.
+      h.service.onAuthAcknowledged();
 
       // Act
       h.bus.publish(
@@ -431,6 +652,8 @@ describe('TranscriptionStreamService', () => {
       // Arrange
       const h = makeHarness('client');
       await h.service.start();
+      // The controller has sent authOk; the outbound gate is open.
+      h.service.onAuthAcknowledged();
 
       // Act
       h.bus.publish(
@@ -452,6 +675,8 @@ describe('TranscriptionStreamService', () => {
       // Arrange
       const h = makeHarness('client');
       await h.service.start();
+      // The controller has sent authOk; the outbound gate is open.
+      h.service.onAuthAcknowledged();
 
       // Act
       h.bus.publish(
@@ -475,6 +700,8 @@ describe('TranscriptionStreamService', () => {
       // Arrange
       const h = makeHarness('client');
       await h.service.start();
+      // The controller has sent authOk; the outbound gate is open.
+      h.service.onAuthAcknowledged();
 
       // Act
       h.bus.publish(SessionEndedChannel, {}, SESSION_UID);

--- a/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
+++ b/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
@@ -214,6 +214,17 @@ export const STATUS_PROCESS_SCHEMA = Type.Object({
       description:
         'Source registrations that threw, closing the socket with 1011.',
     }),
+    // Optional for the same reason as `binaryBeforeAuthDropsTotal`: this
+    // record is republished to Redis and read back through a strict
+    // `Value.Check`, so a required field an older publisher omits would drop
+    // the whole snapshot and blank the node in the fleet view for the length
+    // of a rolling deploy.
+    endedSessionRegistrationsTotal: Type.Optional(
+      Type.Integer({
+        description:
+          'Source registrations refused because the session was already past its `effectiveEnd`. Not an error: the socket is closed 1000 with `sessionEnded` and no upstream is dialed. It is the only signal that a device is acting on a stale schedule - most often a kiosk whose `mySchedule` long-poll has been failing silently. Optional for backward-compat with publishers that predate it.',
+      }),
+    ),
     latencySamplesTotal: Type.Integer({
       description:
         'Latency samples published. The denominator for the two figures below.',

--- a/tools/session-corner-cases/README.md
+++ b/tools/session-corner-cases/README.md
@@ -219,7 +219,9 @@ console.
 
 ## What is checked
 
-`--list` prints the current set. As of this commit, 35 checks / ~150 assertions:
+`--list` prints the current set. As of this commit, **35 checks / 172
+assertions**, all green against `bc37f92`, of which 10 pin questionable
+behaviour (BUG-1 ×2, BUG-2 ×2, BUG-3 ×3, QUIRK-3 ×2, QUIRK-4 ×1).
 
 ### Session lifecycle
 


### PR DESCRIPTION
**Stacked on #184** — based on `2026-08-01-SessionChecks`, so this diff is the one commit. Merge #184 first, then retarget to `staging`.

Plan: `2026-08-01-03-PLAN-EndedSessionSourceRace.md`.

## The bug

When a **source** opens a socket for a session whose `effectiveEnd` has already passed, node-server publishes `SessionEndedChannel` from inside `registerSource` — before that connection has subscribed to it (`transcription-stream.service.ts:88-102` subscribes only after the await; `_armEndTimer` publishes synchronously at `delayMs <= 0`).

The source is never told, never closed, and streams audio into a dead session. Worse: `_openSession` **dials the transcription service before** the end is discovered, and nothing tears that upstream down — teardown is driven by the socket closing, which never happens. With `num_workers: 1` one stuck source holds a scarce worker slot indefinitely.

The likeliest real-world trigger isn't the obvious race: a kiosk's schedule long-poll swallows its errors (`kiosk-service.ts:558-560`), so a kiosk acting on an hours-stale schedule will confidently connect to a session that ended long ago.

## The fix

`_openSession` refuses an already-ended session **before dialing the upstream** — which alone kills the bug, since the synchronous publish can then no longer fire during `registerSource`. On top of that, the bus subscriptions move above the `registerSource` await so no event can be missed, covering the residual case (a config bump publishing the end mid-`_openSession`) and making both roles obey one rule.

Signalling is a dedicated `SessionAlreadyEndedError` rather than a bus publish or a new accessor: there is no `EndTimerOwner` to latch for a session we deliberately never opened, and fabricating one would publish a second time for an end an end-watch may already have announced — breaking the single-publisher guarantee from #184. It is deliberately distinct from the 1011 path: an unreachable Session Manager is *broken*, an ended session is *over*, and the kiosk treats 1000 and non-1000 completely differently.

**Protocol hazard found while doing it:** moving the subscriptions up means `registerSource` → `_setStatus` publishes `SessionStatusChannel` synchronously inside the await, so a naive Option A ships a `sessionStatus` **before `authOk` on every source connection** — and both webapps hold their WS handshake open until `AUTH_OK`. The service now holds an outbound gate shut until the controller reports the send (`publishCurrentStatus()` → `onAuthAcknowledged()`). Pre-`authOk` live-stream messages are dropped, which is byte-for-byte the old behaviour; `sessionEnded` is latched and replayed in order: `authOk` → `sessionEnded` → close 1000.

Also closes a narrower hole the plan missed: a second source registering while a latched-ended `SessionState` is still in `_sessions`.

## Observability

Follows the `binaryBeforeAuthDropsTotal` precedent end to end, per CONTRIBUTING's "metrics nothing consumes are not monitoring": a warn log naming the reported `effectiveEnd`, `endedSessionRegistrationsTotal` on `GET /status` (`Type.Optional` — it rides the Redis fleet snapshot through a strict `Value.Check`), and `scribear_node_ended_session_registrations_total` on the sidecar with the advance skipped when the field is absent. This makes the stale-kiosk-schedule cause visible in production rather than inferred.

## Verification

Both new integration tests verified **failing by timeout** against pre-fix code (60 s and 120 s) — the socket is never closed, which is the bug verbatim; 13 pre-existing tests passed in the same run. Behavioural unit failures confirmed with a throwaway probe against the old API: the upstream was dialed for an already-ended session, and `sent` contained only `sessionStatus`, never `sessionEnded`.

Root `build`/`test:unit`/`lint` green; node-server integration **51 passed** (was 49); monitoring-sidecar integration 96 passed.

## Known limitation

The race test runs 3 rounds against a real stack rather than injecting the ordering deterministically. Both branches of the race terminate the socket and that is asserted, but which branch wins on a given round is not forced. No alert threshold on the new counter — no measured baseline, matching how `binaryBeforeAuthDropsTotal` shipped.
