### PR TITLE
fix(clients+session-manager+transcription): stop a healthy idle room reading as a broken one

### DIFF
--- a/.changeset/client-idle-banner-and-token-refresh.md
+++ b/.changeset/client-idle-banner-and-token-refresh.md
@@ -1,0 +1,75 @@
+---
+'@scribear/client-webapp': minor
+'@scribear/core-ui': minor
+---
+
+The viewer stops reporting a healthy room as broken, and stops hammering
+session-manager when it cannot refresh a token.
+
+**The idle room is not a fault.** Immediately after a successful join to a real
+room with nobody streaming yet, the Node Server correctly reports
+`{transcriptionServiceConnected: false, sourceDeviceConnected: false}` — it only
+dials the Transcription Service once a source registers. `deriveConnectionBanner`
+rendered that as a warning, _"Connection to the transcription service was lost.
+Reconnecting…"_, which never cleared. Every real room looked broken; only the
+hardcoded demo room, whose synthetic status hardcodes both flags true, looked
+healthy.
+
+- The slice seeded `sessionStatus` with an all-`false` snapshot, which made the
+  banner's `sessionStatus === null` escape hatch dead code and put the warning
+  up from the instant of a _successful_ join. It is now seeded `null`, so "not
+  yet reported" is distinguishable from "reported bad".
+- The banner branches on `sourceDeviceConnected` first: no source is the normal
+  idle state of a healthy room, so it is informational — _"Waiting for the
+  room's microphone to connect."_ — and deliberately never says "reconnecting".
+  Only a down upstream _while a source is connected_ is a fault.
+- `ConnectionStatusSeverity` gains `'info'` (its own icon and a 11.44:1 color
+  pairing). Informational is not urgent, so it renders as `role="status"` rather
+  than the `role="alert"` warnings and errors keep — interrupting a
+  screen-reader user to say "still waiting" is exactly the assertive-live-region
+  misuse SC 4.1.3 warns about.
+
+The banner's full 27-row input cross-product is now pinned as a literal table.
+
+**Session tokens are decoded correctly.** A ScribeAR session token is not a JWT:
+it is `base64url(payloadJSON).base64url(HMAC)` — two segments, payload first.
+The expiry decoder read `parts[1]`, as a JWT's payload index, so it fed the raw
+signature to `JSON.parse` and returned `null` for every token this system has
+ever issued. Both callers treat `null` as "unknown expiry", so the failure was
+silent and total: no proactive refresh timer was ever armed on any connection,
+and every socket open burned a refresh round-trip before it could send AUTH.
+
+**Failing refreshes now converge instead of looping.** If that refresh call
+failed, the client returned without sending AUTH at all; the Node Server's 5 s
+watchdog closed the socket 1008 `auth-timeout`; and because the socket had been
+open for those 5 s — longer than the transport's 1 s stable-connection threshold
+— the reconnect backoff reset every cycle. The result was an unbounded ~1 s
+hammer loop against session-manager that the user saw only as "Reconnecting…".
+Refresh now retries with exponential backoff against a consecutive-failure
+budget counted _across_ reconnects, so a reconnect cannot refill it, and
+exhausting it is terminal.
+
+**There is a terminal connection state.** `SessionConnectionStatus.TERMINAL` is
+entered when a fault cannot be retried away: a 1008 close whose reason can never
+succeed (`missing-scope`, `session-mismatch`), three consecutive 1008 closes for
+any other reason, an exhausted refresh budget, or a stream schema mismatch. This
+aligns the viewer with the kiosk, which already treated 1008 as terminal. The
+session stays `ACTIVE` in TERMINAL, so the captions already on screen survive
+and the Leave button remains available to rejoin with.
+
+That state is also what finally gives `selectError` a consumer — until now
+"Network error - retrying.", "Failed to refresh session token." and "Session
+stream protocol mismatch." were written to Redux and read by nothing. The field
+is narrowed to "why this session is unrecoverable" and rendered by the banner's
+terminal branch, so every value written there reaches the user.
+
+**Reload resumes visibly.** `start(stored)` did not emit `sessionIdentity`, so
+after a page reload `clientSessionService.session` stayed `null`, every
+`setConnectionStatus`/`setSessionStatus` early-returned, and a reloaded viewer
+got no banner at all — not even with a dead socket. It now re-announces the
+resumed identity.
+
+The viewer also gains the `INVALID_REQUEST` branch that the kiosk already has: a
+session whose transcription provider does not exist on this deployment is
+reported as an error naming what an administrator has to fix, not as a retry
+that can never succeed.

--- a/.changeset/ended-session-source-race.md
+++ b/.changeset/ended-session-source-race.md
@@ -1,0 +1,75 @@
+---
+'@scribear/node-server-schema': minor
+'@scribear/node-server': minor
+'@scribear/monitoring-sidecar': minor
+---
+
+Tell a source that its session is already over, instead of letting it stream
+into a dead one.
+
+A **source** (kiosk or synthetic device) that opened a socket for a session
+whose `effectiveEnd` had already passed was never told. `registerSource`
+published `SessionEndedChannel` from inside its own `await` — `_openSession`
+armed the end timer, found the end in the past, and published synchronously —
+while the connection did not subscribe to that channel until the `await`
+resolved. The publish landed on an empty channel. The source got `authOk`, no
+`sessionEnded`, no close, and went on forwarding audio into a session the server
+considered over, holding an upstream transcription connection for as long as the
+kiosk kept the socket up. Nothing tore it down: teardown is driven by
+`_unregisterSource`, which is driven by a close that never came. `#184` fixed the
+viewer half of this and explicitly did not fix this half.
+
+The likeliest real-world trigger is not the operator race but a **stale kiosk
+schedule**: `kiosk-service.ts`'s `poll.on('error', () => {})` means the schedule
+long-poll can be dead for hours with no signal, and a kiosk acting on a stale
+schedule confidently connects to a session that ended long ago.
+
+**Subscriptions now come before registration, for both roles.** The event bus is
+synchronous, so anything published during `registerSource` reaches this
+connection instead of nobody. This is the ordering the client path had already
+been given, with the comment explaining why; sources now get the same rule. The
+early-return paths (`_closed` mid-await, orchestrator failure) release those
+subscriptions rather than leaving four listeners attached to a dead socket.
+
+**Nothing is written to the socket before `authOk`.** Moving subscriptions above
+registration means a bus message can now fire while the connection has not been
+told its auth succeeded, and both webapp clients hold their WebSocket handshake
+open until it arrives. The service therefore keeps an outbound gate shut until
+the controller reports the send (`onAuthAcknowledged`, replacing
+`publishCurrentStatus`). Live-stream messages that arrive early are dropped —
+`sessionStatus` is superseded by the snapshot sent immediately after `authOk`,
+and transcripts have no replay semantics — which is exactly what happened before,
+when those subscriptions simply did not exist yet. `sessionEnded` is the one
+message that must not be dropped, so it is latched and delivered in protocol
+order: `authOk`, then `sessionEnded`, then close 1000.
+
+**No upstream is dialed for a session that is already over.** `_openSession`
+used to construct and start the upstream *before* `_armEndTimer` discovered the
+end had passed, so an abandoned session took a transcription-service connection
+with it. The effective end is now checked the moment the first config surfaces,
+and `registerSource` throws `SessionAlreadyEndedError` without dialing anything
+and without creating a `SessionState`. That error is distinct from an
+orchestrator failure on purpose: an unreachable Session Manager is *broken* and
+earns 1011, whereas this session is merely *over* and earns a clean 1000 with
+`sessionEnded` — the kiosk already distinguishes those, and collapsing them
+would put a finished session into a reconnect loop. Not creating the state also
+removes the knock-on: no stale `SessionState` lingers in `_sessions` holding an
+upstream, answering `getStatus`, and appearing in `/status` for a session nobody
+is serving.
+
+The single-publisher guarantee `#184` established is untouched: the refusal
+publishes nothing on the bus, so an end-watch a viewer holds is still the only
+thing that announces the end to that session.
+
+**Observability.** A source arriving at a finished session is now counted and
+named, because downstream it is otherwise indistinguishable from an ordinary
+session end (a `1000 session-ended` close either way) while meaning something
+quite different:
+
+- a warn log line, `source registered onto an already-ended session`, carrying
+  the `effectiveEnd` the config reported;
+- `summary.endedSessionRegistrationsTotal` on `GET /status`, optional on the
+  wire so an older publisher does not fail the strict `Value.Check` that the
+  Redis fleet snapshot is read back through;
+- `scribear_node_ended_session_registrations_total` in the monitoring sidecar,
+  which skips the advance rather than recording a zero when the field is absent.

--- a/.changeset/exchange-join-code-enforces-valid-start.md
+++ b/.changeset/exchange-join-code-enforces-valid-start.md
@@ -1,0 +1,34 @@
+---
+'@scribear/session-manager': patch
+---
+
+`exchange-join-code` ignored a join code's `valid_start`, so codes lived up to
+ten minutes instead of five.
+
+The route rejected only `validEnd <= now`. But `fetchJoinCodes` pre-mints the
+*next* code 60 seconds before the current one expires, with
+`validStart = current.validEnd` — a code whose window has not opened yet. With
+no `valid_start` check that code was exchangeable the instant it was minted, so
+its usable life ran from the mint to the end of its own 5-minute window: nearly
+double the intended TTL, and two codes were live at once for the last minute of
+every rotation. `_findOrMintCurrentJoinCode` and `fetchJoinCodes` both already
+applied `validStart <= now`; only the exchange did not.
+
+A code is now exchangeable only inside `[validStart, validEnd)`, matching those
+two. Not-yet-valid answers **404 `JOIN_CODE_NOT_FOUND`**, not 410
+`JOIN_CODE_EXPIRED`: 410 GONE asserts the code is permanently finished when it
+is in fact about to start working, and a status distinct from "unknown" would
+confirm a live-but-unused code to anyone walking the 8-character space and
+waiting.
+
+The handoff flow is unaffected, which is the point of the pre-mint. The kiosk
+renders only `current` in its QR (`nextJoinCode` is stored but never displayed),
+so nothing legitimate ever presents a future code, and the pre-minted code
+becomes exchangeable at exactly the instant the previous one expires — there is
+no gap, because `validStart == previous.validEnd`.
+
+Tested at the boundary on both sides: `validStart - 1ms` is refused,
+`validStart` exactly is accepted. The integration test drives the real handoff —
+back-dates the current code into the 60s window, re-fetches to make the server
+mint `next`, and asserts `next` is refused while `current` still works, then
+that `next` starts working the moment its window opens.

--- a/.changeset/nginx-node-server-sticky-routing.md
+++ b/.changeset/nginx-node-server-sticky-routing.md
@@ -1,0 +1,53 @@
+---
+'@scribear/scribear-nginx': patch
+'@scribear/node-server': patch
+---
+
+`upstream node-server` had no balancing directive, so nginx round-robined a
+service whose state is per-process.
+
+`TranscriptionOrchestratorService`'s own class doc asserts the opposite:
+"Sticky URL routing pins all connections for a given sessionUid to one Node
+Server instance, so the singleton state for a session is always co-located with
+the source connections feeding it." The event bus is in-process, and a session's
+upstream transcription connection lives on whichever instance its *source*
+reached. A viewer routed elsewhere subscribes to a channel nothing publishes on
+and receives no transcripts — no error, no close, no banner, just an empty
+caption view. `docker compose up -d --scale node-server=2` was one word away,
+and nothing about that word looks like it could break captioning.
+
+The upstream now hashes on `$node_server_session_uid`, a `map` over `$uri` that
+captures the session uid from the shared
+`/api/node-server/v1/transcription-stream/<sessionUid>/{source,client}` prefix —
+which is precisely why the route schema puts the uid in the path: "The session
+UID is carried in the URL so the L7 proxy can sticky-route every connection for
+a session to the same Node Server instance." `$uri` rather than `$request_uri`
+so a trailing query string or an encoded path segment cannot send a second
+connection for one session to a different peer.
+
+**`consistent` is deliberately absent, and that is a measurement, not a
+preference.** Ketama is the better algorithm here — a peer joining remaps ~1/N
+of sessions instead of most of them — but it is silently ignored when the
+upstream's server is a `resolve` name, which `node-server`'s is. Verified
+against `nginx:1.29.7-alpine3.23` (this image's base) with two backends behind
+one docker network alias, requesting one session uid repeatedly:
+
+```
+hash $node_server_session_uid consistent;   ->  B A B A B A B A     (round-robin)
+hash $node_server_session_uid;              ->  B B B B B B B B
+```
+
+`nginx -t` passes on both, and at one replica both behave identically — a
+`consistent` version of this fix would have merged green and done nothing. The
+final config was then re-verified verbatim from the repo: two uids held on two
+different peers across 12s and several `valid=5s` re-resolutions, with the
+WebSocket upgrade headers set, and `source` and `client` for the same uid always
+landing together. The cost of plain modulo hashing is that changing the replica
+count re-homes most sessions; that happens on a deploy, when every connection is
+being re-established anyway.
+
+Three unit tests in node-server read the shipped config — same precedent as
+`nginx-status-not-public.test.ts` — and fail if the `hash` directive is dropped,
+if `consistent` is reintroduced, or if the map stops matching the routes it
+derives from the route definitions. `UPGRADING.md` records that scaling
+node-server past one replica is now supported, and was not before.

--- a/.changeset/session-auth-reject-canceled-sessions.md
+++ b/.changeset/session-auth-reject-canceled-sessions.md
@@ -1,0 +1,46 @@
+---
+'@scribear/session-manager': patch
+---
+
+A canceled session still minted session tokens.
+
+`findSessionForAuth` selected `uid`, `room_uid`, `join_code_scopes`,
+`effective_start` and `effective_end` — but not `canceled_at`, and
+`SessionAuthRow` had no such field. Every "is this session live?" decision in
+`session-auth` therefore read start/end only, and cancellation moves neither.
+
+That is not a theoretical gap. `cancel-session` accepts only *upcoming*
+`SCHEDULED` occurrences, so every canceled row starts out in the future and
+time then catches up to its slot. From that moment the session's effective
+window covers now, `isSessionCurrentlyActive` says yes, and
+`exchange-join-code`, `exchange-device-token`, `refresh-session-token`,
+`fetch-join-code` and `admin-fetch-join-code` all hand out credentials for a
+session an operator canceled — including `SEND_AUDIO` to the room's source
+kiosk. Meanwhile `findActiveSession`, `my-schedule` and the `sessions_no_overlap`
+exclusion constraint (narrowed by migration `00000012` to
+`WHERE canceled_at IS NULL`) all correctly treat the row as gone, so the room
+reads as free while its auth surface reads as live.
+
+`canceled_at` is now selected and carried on `SessionAuthRow`, and cancellation
+is terminal on every path. No wire contract changed; each route answers with a
+status it already declared:
+
+- `exchange-join-code`, `exchange-device-token`, `admin-fetch-join-code` —
+  `isSessionCurrentlyActive` returns false, so 409
+  `SESSION_NOT_CURRENTLY_ACTIVE` (and `status: "not-active"` for the admin
+  route, which reports rather than errors).
+- `refresh-session-token` — `isSessionEnded` returns true, so 409
+  `SESSION_ENDED`. This is the path that matters most: a viewer's refresh token
+  outlives every short-lived session token, so without it cancellation never
+  actually removes access.
+- `fetch-join-code` — 404 `SESSION_NOT_FOUND`. Devices are never told about a
+  canceled session by `my-schedule`, so this route does not confirm one exists
+  either; it also mints no code, since a code outlives the request.
+
+Pinned at both levels. The unit tests drive a canceled-but-live `SessionAuthRow`
+through all five paths and assert nothing is signed or persisted. The
+integration tests cancel through the real `cancel-session` endpoint — pushing
+the occurrence forward to satisfy its "still upcoming" precondition, then
+restoring the window to simulate the passage of time — so the row under test is
+produced by the product code, not by the test. All five fail against the old
+behaviour.

--- a/.changeset/transcription-capacity-knobs-in-compose.md
+++ b/.changeset/transcription-capacity-knobs-in-compose.md
@@ -1,0 +1,41 @@
+---
+'@scribear/admin-server': patch
+---
+
+The capacity estimator's three tuning knobs are reachable from `.env`, which
+they were documented as being and were not.
+
+`transcription_service`'s config has read `TARGET_BUSY`, `MIN_SESSIONS` and
+`MAX_SESSIONS` from its environment since they were added, with a comment saying
+they are "reachable from `.env` on purpose" and naming the regret they exist to
+avoid — a previous set of tuning numbers that lived only as compose-file edits,
+which every deployment had to rediscover and hand-set. But none of the three
+appeared in `deployment/compose.yml`, `deployment/.env.example` or
+`deployment/UPGRADING.md`, so a compose operator's only route to them was
+editing the compose file. The same regret, one indirection along.
+
+`compose.yml` now passes all three, `.env.example` documents them, and
+`UPGRADING.md` carries the operator note:
+
+- **`TRANSCRIPTION_TARGET_BUSY`** (`0.85`) — the fraction of a worker the
+  estimated ceiling aims to keep busy.
+- **`TRANSCRIPTION_MIN_SESSIONS`** (`1`) — the floor under that ceiling, so one
+  noisy window cannot report a worker's capacity as zero.
+- **`TRANSCRIPTION_MAX_SESSIONS`** (empty) — the operator's hard pin. It wins
+  over the floor *and* over warm-up, so it applies from the first request rather
+  than after a measurement it has already overruled.
+
+All three default to the values already in use, so a stock deployment behaves
+identically. The estimate remains observe-only — these change what is
+*reported*, not who gets captions.
+
+An empty `MAX_SESSIONS` is now read as "unset". Compose has no way to omit an
+environment key, so a stock stack sends the empty string, which `int | None`
+refuses to parse — without the coercion the container would fail to boot for
+everyone who copied the new file, turning an optional knob into a required one.
+The coercion is narrow on purpose: `MAX_SESSIONS=lots` still stops the service,
+because auto-tuning silently under a value an operator believed was a hard pin is
+a misconfiguration with no symptom to find.
+
+`compose.yml` bumps to **v9**, `EXPECTED_COMPOSE_FILE_VERSION` follows, and the
+drift guard's pinned hash is re-pinned.

--- a/.changeset/transcription-defer-job-registration.md
+++ b/.changeset/transcription-defer-job-registration.md
@@ -1,0 +1,49 @@
+---
+'@scribear/admin-webapp': patch
+---
+
+A transcription session no longer takes a worker's job slot until it actually
+sends audio — and the capacity estimate on the fleet view drops sharply as a
+result.
+
+**The bug.** A session registered its worker-pool job as part of its own
+construction, at CONFIG time. So a client that connected, configured, and then
+streamed nothing occupied a worker identically to one transcribing a lecture: it
+counted toward `live_job_count`, and the worker ran an empty batch for it every
+period. Enough idle connections could refuse a genuinely busy worker's next real
+session — or refuse each other — with no relationship to transcription load at
+all. Observed as flaky refusals nobody could tie to usage.
+
+Registration now happens on a session's own first `handle_audio_chunk` (each
+provider's `_ensure_job`). An audio-less connection registers nothing and is a
+claim on nothing. `TranscriptionProviderRegistry.create_session` therefore
+**never raises `TranscriptionCapacityError`** any more; a refusal surfaces from
+the audio path instead and still closes **1013**, which the node server already
+reads as "refused" rather than "crashed".
+
+**Admission enforcement stays off, deliberately.** `create_webserver` passes no
+estimator to the provider registry, so the estimator observes, records and
+publishes but nothing is ever refused. The fix above is unambiguously correct on
+its own, but it also *lowers* the measured ceiling and by a wide margin: idle
+registered jobs used to run an empty batch every period, adding a distinct
+`job_id` to the estimator's window and inflating the `sessions` denominator of
+`cost_per_session = busy / sessions` while contributing nothing to the numerator.
+A live box measured `estimatedCapacitySessions: 50` under that inflation; with it
+removed, one whisper stream that keeps the single worker busy for half of each
+5000 ms period gives `N* = 1`. Shipping enforcement in the same change as the fix
+that moved the number would mean enforcing a ceiling nobody has watched under
+real load, and a wrong refusal is invisible to the user and unrecoverable for
+that session. So: measure in shadow mode first, on
+`/metrics/status`, `/providers/health` and **Dashboard → fleet view**, then
+decide.
+
+**Expect the fleet view's "estimated capacity" to fall.** That is the inflation
+going away, not capacity being lost. Nothing is refused either before or after.
+
+The register/ask/undo sequence is now one implementation on
+`TranscriptionSessionInterface` rather than three call sites. Only
+`whisper-streaming` wrapped `check_admission` in the deregistration a refusal has
+to undo; `debug` and `lumen_granite` called it bare, which was safe only for as
+long as neither of them overrode `admission_worker_id` — an invariant asserted in
+three docstrings and enforced nowhere, where the failure would have been a job
+registered forever against a session no client ever received.

--- a/.changeset/upstream-1007-invalid-request-reason.md
+++ b/.changeset/upstream-1007-invalid-request-reason.md
@@ -1,0 +1,39 @@
+---
+'@scribear/node-server-schema': minor
+'@scribear/node-server': minor
+'@scribear/kiosk-webapp': minor
+---
+
+A permanently misconfigured session now says so instead of pretending to
+reconnect.
+
+The Transcription Service closes the upstream socket with **1007** when it
+rejects what the Node Server sent — in practice a `transcriptionProviderId`
+that is not a key in the deployment's `provider_config.json`, which raises
+`TranscriptionClientError("Invalid Provider Key")`. `_setStatus` special-cased
+only 1013, so 1007 collapsed into the undistinguished
+`transcriptionServiceConnected: false`, the Node Server's reconnect loop
+re-sent the identical config forever, and every viewer sat on "Connection to
+the transcription service was lost. Reconnecting…" — a promise nothing in the
+system could keep, with nothing anywhere naming the cause.
+
+`TranscriptionServiceDisconnectReason` gains `INVALID_REQUEST =
+'invalid-request'`, in the published `node-server-schema` enum and in
+node-server's local mirror (the two carry doc comments telling you to keep them
+in sync; both are updated). The close-code mapping moves into a named
+`closeCodeToDisconnectReason`, which now covers exactly the two closes the
+transcription service makes *deliberately* — 1013 and 1007 — and leaves every
+other close undistinguished, as before.
+
+The two reasons stay separate on purpose: `AT_CAPACITY` clears on its own when
+load drops, `INVALID_REQUEST` never clears without an operator. The kiosk banner
+reflects that difference — it is the one branch in `deriveConnectionBanner` that
+is an `error` rather than a `warning`, and it says an administrator has to check
+the session's transcription provider rather than promising a retry.
+
+The field is `Type.Optional` and the enum only gains a member, so a client built
+against an older schema still validates every message; it simply falls through
+to the generic branch it uses today.
+
+Not included: the client-webapp banner. `derive-connection-banner.ts` is being
+restructured concurrently; the branch it needs is the mirror of the kiosk's.

--- a/.changeset/upstream-1007-invalid-request-reason.md
+++ b/.changeset/upstream-1007-invalid-request-reason.md
@@ -35,5 +35,6 @@ The field is `Type.Optional` and the enum only gains a member, so a client built
 against an older schema still validates every message; it simply falls through
 to the generic branch it uses today.
 
-Not included: the client-webapp banner. `derive-connection-banner.ts` is being
-restructured concurrently; the branch it needs is the mirror of the kiosk's.
+The client-webapp banner is not in this change — `derive-connection-banner.ts`
+was being restructured concurrently — and landed separately as the mirror of the
+kiosk's branch.

--- a/.changeset/validate-transcription-provider-id.md
+++ b/.changeset/validate-transcription-provider-id.md
@@ -1,0 +1,58 @@
+---
+'@scribear/session-manager-schema': minor
+'@scribear/session-manager': minor
+'@scribear/admin-server': patch
+---
+
+A `transcriptionProviderId` naming no configured provider is now rejected when
+it is typed, not when a room full of people tries to use it.
+
+The field was free-text `Type.String()` on five write paths — `create-schedule`,
+`update-schedule`, `create-auto-session-window`, `update-auto-session-window`
+and `create-on-demand-session` — and nothing checked it. An unknown key made
+transcription-service raise `TranscriptionClientError("Invalid Provider Key")`
+and close the **upstream** socket 1007, node-server retried a permanently
+unsatisfiable request forever, and every viewer of that room saw only the
+generic reconnecting banner. Nothing in the stack named the cause; the typo was
+made once, by an operator, at a keyboard.
+
+Session Manager now validates against `TRANSCRIPTION_PROVIDER_IDS`, a
+comma-separated env var defaulting to the set in
+`provider_config.template.json` (`debug`, `whisper`, `lumen_granite`,
+`crisper_whisper`), so a stock deployment needs no new configuration. A key
+outside it answers **400 `VALIDATION_ERROR`** — already declared on every one of
+those routes via `STANDARD_ERROR_REPLIES`, and the same answer those routes
+already give for `INVALID_ACTIVE_END` and friends, so no wire contract changes —
+with a message naming the accepted keys, because the operator cannot see the
+deployment's provider set from the console.
+
+Three designs were considered:
+
+- **A live lookup** against transcription-service's `/providers/health`.
+  Rejected: it needs `METRICS_API_KEY`, a credential session-manager does not
+  have and should not acquire (it otherwise never talks to transcription-service
+  at all), and it would make creating a session fail whenever
+  transcription-service is unreachable — a worse failure than the one being
+  fixed.
+- **A fixed union in the published schema.** Rejected: `provider_config.json`
+  is operator-editable deployment config, so a hardcoded enum would reject a
+  provider an operator legitimately added and accept one they removed. That is
+  the same mistake as pinning the `Authorization` header to a character class
+  and guessing what an operator's secret manager emits.
+- **Deployment configuration**, which is what shipped. It is wrong loudly in
+  both directions: too narrow and a create fails immediately with the accepted
+  keys in the message; too wide and behaviour is exactly what it is today, which
+  the new `invalid-request` disconnect reason now surfaces to the viewer anyway.
+
+`SHIPPED_TRANSCRIPTION_PROVIDER_IDS` and `TRANSCRIPTION_PROVIDER_ID_SCHEMA` are
+exported from `@scribear/session-manager-schema` so the default and the OpenAPI
+documentation come from one place; the wire type is still a plain string.
+
+`compose.yml` gains the variable next to the `provider_config.json` mount and
+bumps to **v8** (`EXPECTED_COMPOSE_FILE_VERSION` follows), with the operator
+note in `UPGRADING.md`: if you have edited `provider_config.json`, the two files
+now have to agree.
+
+Ten tests, five per level, one per write path, all failing against the old
+behaviour — plus one that walks every shipped id and asserts it is accepted,
+which is as much a guard on the comma-splitting as on the check.

--- a/.changeset/viewer-only-session-end-watch.md
+++ b/.changeset/viewer-only-session-end-watch.md
@@ -1,0 +1,52 @@
+---
+'@scribear/node-server': minor
+---
+
+Tell viewers a session ended even when no source device is attached.
+
+`registerSource` was the only thing that ever created `SessionState`, and
+`SessionState` was the only thing that fetched a session's config or armed the
+timer that publishes `SessionEndedChannel`. Client-role connections never
+touched the orchestrator at all — so a room whose viewers joined before, or
+without, a kiosk had nobody watching the clock. Nothing published
+`sessionEnded`, nothing closed those sockets 1000, and the viewers sat on stale
+captions until a token refresh happened to come back 401/409 `SESSION_ENDED` —
+bounded only by half the 5-minute token lifetime, up to ~2.5 minutes. Demos and
+any viewers-first room hit this every time.
+
+Client connections now take out an **end-watch**: a session-config long-poll and
+a timer, and nothing else. In particular it dials **no upstream transcription
+connection** — a viewer must cost the transcription service zero resources,
+which is exactly the fault `e80eea2` was written for (audio-less connections
+registering a job and eating admission capacity). It reuses the same
+`_sessionConfigPollFactory` a session uses, rather than reading the end once, so
+`startSessionEarly` / `endSessionEarly` move it: `endSessionEarly` sets
+`end_override = now`, which arrives as an already-past end and publishes
+immediately — as does a viewer joining a session that is already over.
+
+The watch is ref-counted, one per session however many viewers share it, and is
+torn down with its long-poll when the last client-role connection leaves.
+
+**Exactly one publisher.** A session can have two end-timer owners over its
+life — the `SessionState` a source opens and the `SessionEndWatch` its viewers
+hold — so:
+
+- while a live `SessionState` exists it is authoritative and the watch holds no
+  timer at all; `registerSource` stands the watch down, `_unregisterSource`
+  hands the timer back when that state is torn down under viewers who outlive
+  the kiosk;
+- `_publishSessionEnded` latches *both* owners whichever one got there first,
+  so the source-side teardown that follows a publish cannot re-arm the watch for
+  an end that has just passed.
+
+The latch is per owner and dies with its owner, deliberately: suppressing a
+publish because some earlier owner announced the same end would silently
+reintroduce the bug for anyone who joins late. A duplicate publish is harmless —
+the connection close it drives is idempotent — a missing one is the whole defect.
+
+A config fetch that fails does **not** close the viewer's socket.
+`registerClient` is synchronous and cannot throw: a source that cannot reach
+Session Manager is useless and rightly gets 1011 `orchestrator-unavailable`, but
+a viewer that cannot is only missing its end signal, and is left exactly as it
+behaved before end-watches existed rather than being disconnected mid-caption.
+The long-poll's own backoff keeps retrying.

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
@@ -50,7 +50,7 @@ export interface ContainerVersion {
  * version.test.ts` fails if the two ever disagree, or if that file changes
  * without someone having made that call.
  */
-export const EXPECTED_COMPOSE_FILE_VERSION = 8;
+export const EXPECTED_COMPOSE_FILE_VERSION = 9;
 
 /**
  * How the running `compose.yml` compares to the one this image was built for.

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
@@ -50,7 +50,7 @@ export interface ContainerVersion {
  * version.test.ts` fails if the two ever disagree, or if that file changes
  * without someone having made that call.
  */
-export const EXPECTED_COMPOSE_FILE_VERSION = 7;
+export const EXPECTED_COMPOSE_FILE_VERSION = 8;
 
 /**
  * How the running `compose.yml` compares to the one this image was built for.

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  'ec1f3812f9643787eb6d9d6f12cee31b6dd44308897d504306f7c756770bcda9';
+  '48fb8bb10beb70b0be5a97beb18cbd3e2b65af5d4dc96f65257ef9668ea960ee';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  '007d11634d59db730a2d5894b32f1e1a016ede13ccb893cea82427ba3850f73c';
+  'ec1f3812f9643787eb6d9d6f12cee31b6dd44308897d504306f7c756770bcda9';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/apps/client-webapp/src/features/session-provider/services/client-session-service-status.ts
+++ b/apps/client-webapp/src/features/session-provider/services/client-session-service-status.ts
@@ -15,11 +15,22 @@ export enum ClientLifecycle {
 /**
  * Sub-status of a session connection while the client is `ACTIVE`. Drives the
  * connection indicator in the UI; not used outside `ACTIVE`.
+ *
+ * `TERMINAL` is the modeled unrecoverable state: the service has stopped
+ * retrying and will not reconnect on its own. It exists because without it a
+ * permanent fault (a rejected session token, a scope mismatch, a schema drift)
+ * is indistinguishable from a flaky network forever - the client reconnects,
+ * fails the same way, resets its backoff because the socket survived long
+ * enough to look "stable", and hammers the server roughly once a second while
+ * the user just sees "Reconnecting…". The session stays `ACTIVE` in TERMINAL
+ * so the transcript already on screen survives and the Leave button remains
+ * available for the user to rejoin.
  */
 export enum SessionConnectionStatus {
   CONNECTING = 'CONNECTING',
   CONNECTED = 'CONNECTED',
   DISCONNECTED = 'DISCONNECTED',
+  TERMINAL = 'TERMINAL',
 }
 
 /**

--- a/apps/client-webapp/src/features/session-provider/services/client-session-service.ts
+++ b/apps/client-webapp/src/features/session-provider/services/client-session-service.ts
@@ -73,6 +73,14 @@ interface ClientSessionServiceEvents {
   transcript: (event: TranscriptEvent) => void;
   latency: (sample: LatencySample) => void;
   joinError: (error: JoinError | null) => void;
+  /**
+   * Why this session is unrecoverable, or `null` to clear. Deliberately
+   * narrow: it used to also carry transient blips ("Network error -
+   * retrying.") that nothing rendered, which is how a session could hammer
+   * session-manager once a second with the user seeing only "Reconnecting…".
+   * Every value emitted here now reaches the user, via the connection
+   * banner's terminal branch.
+   */
   error: (message: string | null) => void;
 }
 
@@ -85,6 +93,48 @@ const TOKEN_REFRESH_FRACTION = 0.5;
 const TOKEN_REFRESH_JITTER = 0.1;
 
 /**
+ * Bounded retry budget for the session-token refresh, counted across
+ * reconnects rather than per socket. A failed refresh means `_authenticateSocket`
+ * never sends AUTH, node-server's 5 s watchdog closes the socket 1008
+ * `auth-timeout`, and the reconnect lands in the same failed refresh - but
+ * because the socket stayed open for those 5 s (longer than the transport's
+ * `stableConnectionThresholdMs`) the backoff counter resets every cycle. The
+ * result is an unbounded ~1 s hammer loop against session-manager that the
+ * user only ever sees as "Reconnecting…". Counting consecutive failures
+ * globally is what makes that loop converge: every cycle spends from the same
+ * budget, and exhausting it is terminal and visible.
+ */
+const REFRESH_MAX_CONSECUTIVE_FAILURES = 5;
+const REFRESH_RETRY_BASE_MS = 300;
+const REFRESH_RETRY_MAX_MS = 2000;
+
+/**
+ * How many consecutive 1008 closes to tolerate before declaring the session
+ * terminal, when the close reason isn't one we recognise as permanent. The
+ * kiosk app already treats any 1008 as terminal; the client is a little more
+ * forgiving because a merely-stale cached token also closes 1008 and is
+ * genuinely fixed by the refresh on the next attempt.
+ */
+const MAX_CONSECUTIVE_AUTH_FAILURES = 3;
+
+/**
+ * Close reasons node-server sends with 1008 that can never succeed on a
+ * retry (see `transcription-stream.auth.ts`): the token was minted for a
+ * different session, or without `RECEIVE_TRANSCRIPTIONS`. Reconnecting with
+ * the same refresh token reproduces both exactly.
+ *
+ * The reason string does reach the browser - node-server passes it to
+ * `socket.close(code, reason)`, so it rides in the close frame and surfaces
+ * as `CloseEvent.reason` - but an empty or unfamiliar reason is not treated
+ * as recoverable either: {@link MAX_CONSECUTIVE_AUTH_FAILURES} bounds the
+ * unrecognised case independently.
+ */
+const PERMANENT_AUTH_CLOSE_REASONS = new Set([
+  'missing-scope',
+  'session-mismatch',
+]);
+
+/**
  * Compute a uniform jitter offset in `[-jitter * base, +jitter * base]`.
  */
 function jitter(baseMs: number, fraction: number): number {
@@ -93,23 +143,52 @@ function jitter(baseMs: number, fraction: number): number {
 }
 
 /**
- * Decode a base64url string (the encoding used by JWT segments) to its raw
- * text. `atob` only accepts standard base64, so map the URL-safe alphabet
- * back first; `atob` itself tolerates the missing `=` padding.
+ * Resolve after `ms`, so an async retry loop can back off without owning a
+ * timer handle. Teardown is detected by the epoch check that follows every
+ * await, not by cancelling this.
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Decode a base64url string to its raw text. `atob` only accepts standard
+ * base64, so map the URL-safe alphabet back first; `atob` itself tolerates
+ * the missing `=` padding.
  */
 function base64UrlDecode(value: string): string {
   return atob(value.replaceAll('-', '+').replaceAll('_', '/'));
 }
 
 /**
- * Decode the `exp` claim of a JWT. Returns `null` if the token can't be
- * parsed (malformed or unsigned).
+ * Number of `.`-separated segments in a session token: `{payload}.{signature}`.
  */
-function decodeJwtExpiryMs(token: string): number | null {
+const SESSION_TOKEN_SEGMENTS = 2;
+
+/**
+ * Read the `exp` claim out of a session token. Returns `null` if the token
+ * can't be parsed.
+ *
+ * A ScribeAR session token is NOT a JWT, despite looking like one: it is
+ * `base64url(payloadJSON).base64url(HMAC-SHA256)` - **two** segments, payload
+ * first (see session-manager's `SessionTokenService.sign`). This function
+ * previously read `parts[1]` as a JWT's payload would be, so it fed the raw
+ * signature to `JSON.parse` and returned `null` for every token ever issued.
+ * Nothing crashed, because both callers treat `null` as "unknown expiry" -
+ * which silently meant the proactive refresh timer was never armed on any
+ * connection, and every socket open burned a refresh round-trip before it
+ * could send AUTH.
+ *
+ * The signature is not checked here; only session-manager and node-server
+ * hold the signing key. This is a scheduling hint, not an authorization
+ * decision - a tampered `exp` can only make this client refresh at the wrong
+ * time, never make a bad token acceptable.
+ */
+function decodeSessionTokenExpiryMs(token: string): number | null {
   const parts = token.split('.');
-  if (parts.length < 2) return null;
+  if (parts.length !== SESSION_TOKEN_SEGMENTS) return null;
   try {
-    const payload = JSON.parse(base64UrlDecode(parts[1] ?? '')) as {
+    const payload = JSON.parse(base64UrlDecode(parts[0] ?? '')) as {
       exp?: number;
     };
     if (typeof payload.exp !== 'number') return null;
@@ -151,6 +230,28 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
    */
   private _epoch = 0;
 
+  /**
+   * Increments on every authentication attempt. The socket reconnects
+   * internally without the epoch changing, so `open` can fire again while a
+   * previous attempt is still awaiting a token refresh; the generation lets
+   * the older attempt bail instead of racing the newer one.
+   */
+  private _authGeneration = 0;
+
+  /**
+   * Consecutive failures, reset on the corresponding success. Both are
+   * deliberately *not* reset by a reconnect - see
+   * {@link REFRESH_MAX_CONSECUTIVE_FAILURES}.
+   */
+  private _refreshFailures = 0;
+  private _authFailures = 0;
+
+  /**
+   * Set once the session has been declared unrecoverable, to keep the
+   * transition one-way for the remainder of this session.
+   */
+  private _terminal = false;
+
   constructor() {
     super();
     const baseUrl = window.location.origin;
@@ -178,6 +279,13 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
     }
 
     this._identity = stored;
+    // Re-announce the resumed identity. Without this the middleware never
+    // dispatches `setActiveSession`, so `clientSessionService.session` stays
+    // null after a page reload, `setConnectionStatus`/`setSessionStatus`
+    // early-return on every event, and the reloaded viewer gets no banner at
+    // all - not even while its socket is dead. The value is identical to what
+    // is already persisted, so re-emitting it is a no-op for storage.
+    this.emit('sessionIdentity', stored);
     this._enterActive(stored);
   }
 
@@ -265,6 +373,9 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
 
   private _enterActive(identity: SessionIdentity): void {
     const epoch = ++this._epoch;
+    this._terminal = false;
+    this._refreshFailures = 0;
+    this._authFailures = 0;
     this._setLifecycle(ClientLifecycle.ACTIVE);
     this.emit('connectionStatus', SessionConnectionStatus.CONNECTING);
     this.emit('error', null);
@@ -301,7 +412,9 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
       switch (msg.type) {
         case TranscriptionStreamServerMessageType.AUTH_OK:
           // Auth acknowledged; transcript and status messages now flow on the
-          // established channel.
+          // established channel. This is the only proof the credential was
+          // accepted, so it's what clears the consecutive-failure budget.
+          this._authFailures = 0;
           break;
         case TranscriptionStreamServerMessageType.TRANSCRIPT:
           this.emit('transcript', {
@@ -342,7 +455,7 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
       }
     });
 
-    socket.on('close', (code) => {
+    socket.on('close', (code, reason) => {
       if (epoch !== this._epoch) return;
       // 1000 = normal close (sessionEnded message received) - session is
       // over and the persisted identity should be cleared.
@@ -353,9 +466,24 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
       // 1008 = auth failure. The cached session token was rejected; drop it
       // so the next reconnect attempt forces a fresh refresh-token exchange
       // before sending AUTH again. WebSocketClient handles the reconnect
-      // backoff internally.
+      // backoff internally - which is exactly the problem when the rejection
+      // is permanent: 1008 is not in its `normalCloseCodes`, so it would
+      // reconnect into the identical rejection forever. Bound it.
       if (code === 1008) {
         this._sessionToken = null;
+        this._authFailures++;
+        if (PERMANENT_AUTH_CLOSE_REASONS.has(reason)) {
+          this._enterTerminal(
+            'This session refused the connection. Leave the session and join again with a new join code.',
+          );
+          return;
+        }
+        if (this._authFailures >= MAX_CONSECUTIVE_AUTH_FAILURES) {
+          this._enterTerminal(
+            'Could not connect to this session. Leave the session and join again with a new join code.',
+          );
+          return;
+        }
       }
       // Note: 1013 ("at capacity") is NOT a code this socket ever receives -
       // and TRANSCRIPTION_STREAM_SCHEMA's closeCodes (1000/1001/1006/1007/
@@ -374,8 +502,13 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
     socket.on('error', (err) => {
       if (epoch !== this._epoch) return;
       if (err instanceof WsSchemaValidationError) {
-        this.emit('error', 'Session stream protocol mismatch.');
-        this.leaveSession();
+        // Client and server disagree about the wire format. Reconnecting
+        // cannot fix a schema drift, and dropping to IDLE (as this used to)
+        // discarded the explanation along with the session - the join dialog
+        // reopened with no indication of what happened.
+        this._enterTerminal(
+          'Session stream protocol mismatch. This app may be out of date - reload the page.',
+        );
       }
     });
 
@@ -385,18 +518,24 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
   /**
    * Send the AUTH message on the freshly-opened socket. Re-runs after every
    * reconnect because the WebSocketClient re-emits `open` on each successful
-   * underlying socket open.
+   * underlying socket open - so it takes a generation and abandons any
+   * earlier attempt still waiting on a refresh.
    */
   private async _authenticateSocket(
     identity: SessionIdentity,
     epoch: number,
   ): Promise<void> {
+    const generation = ++this._authGeneration;
+
     let token = this._sessionToken;
     if (token !== null && this._isTokenExpired(token)) token = null;
 
     if (token === null) {
-      token = await this._refreshSessionToken(identity, epoch);
-      if (epoch !== this._epoch) return;
+      token = await this._refreshWithBackoff(identity, epoch, generation);
+      if (epoch !== this._epoch || generation !== this._authGeneration) return;
+      // Refresh gave up (transiently, or terminally); either way there is
+      // nothing to authenticate with. The socket will be closed by
+      // node-server's auth watchdog, or already has been.
       if (token === null) return;
       this._sessionToken = token;
     }
@@ -410,10 +549,46 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
   }
 
   /**
-   * Trade the refresh token for a fresh session token. On a 401/409, the
+   * Retry {@link _refreshSessionToken} with exponential backoff until it
+   * succeeds or the consecutive-failure budget is exhausted, at which point
+   * the session becomes terminal. Returns `null` if it gave up or if the
+   * attempt was superseded (teardown, or a newer socket open).
+   */
+  private async _refreshWithBackoff(
+    identity: SessionIdentity,
+    epoch: number,
+    generation: number,
+  ): Promise<string | null> {
+    for (;;) {
+      const token = await this._refreshSessionToken(identity, epoch);
+      if (epoch !== this._epoch || generation !== this._authGeneration) {
+        return null;
+      }
+      if (token !== null) return token;
+
+      if (this._refreshFailures >= REFRESH_MAX_CONSECUTIVE_FAILURES) {
+        this._enterTerminal(
+          'Lost access to this session and could not restore it. Leave the session and join again with a new join code.',
+        );
+        return null;
+      }
+
+      const delayMs = Math.min(
+        REFRESH_RETRY_BASE_MS * 2 ** (this._refreshFailures - 1),
+        REFRESH_RETRY_MAX_MS,
+      );
+      await sleep(delayMs + jitter(delayMs, TOKEN_REFRESH_JITTER));
+      if (epoch !== this._epoch || generation !== this._authGeneration) {
+        return null;
+      }
+    }
+  }
+
+  /**
+   * Trade the refresh token for a fresh session token, once. On a 401/409 the
    * session is unrecoverable - clear stored identity and fall back to IDLE.
-   * On a transient failure, surface it to the UI but stay in ACTIVE so the
-   * WebSocketClient's reconnect loop keeps trying.
+   * Any other failure returns `null` after charging the consecutive-failure
+   * budget; retrying and giving up is {@link _refreshWithBackoff}'s job.
    */
   private async _refreshSessionToken(
     identity: SessionIdentity,
@@ -426,18 +601,17 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
 
     if (epoch !== this._epoch) return null;
 
-    if (error instanceof NetworkError) {
-      this.emit('error', 'Network error - retrying.');
-      return null;
-    }
+    // Transient failures are deliberately not written to `error`: the
+    // connection banner already says "Reconnecting…" for all of them, and the
+    // only thing worth telling the user is the point at which retrying stops.
     if (error !== null) {
-      this.emit('error', 'Failed to refresh session token.');
+      this._refreshFailures++;
       return null;
     }
 
     switch (response.status) {
       case 200:
-        this.emit('error', null);
+        this._refreshFailures = 0;
         return response.data.sessionToken;
       // 401 INVALID_REFRESH_TOKEN or 409 SESSION_ENDED: refresh token is no
       // longer usable. Drop the stored identity and return to IDLE so the
@@ -447,11 +621,17 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
         this.leaveSession();
         return null;
       default:
-        this.emit('error', 'Failed to refresh session token.');
+        this._refreshFailures++;
         return null;
     }
   }
 
+  /**
+   * Arm the proactive refresh timer for `token`, so a long-lived viewer keeps
+   * a valid credential without ever having to reconnect to get one. A token
+   * whose expiry can't be read leaves no timer armed - which, until
+   * {@link decodeSessionTokenExpiryMs} was fixed, was every token.
+   */
   private _scheduleTokenRefresh(
     identity: SessionIdentity,
     token: string,
@@ -462,7 +642,7 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
       this._tokenRefreshTimer = null;
     }
 
-    const expiryMs = decodeJwtExpiryMs(token);
+    const expiryMs = decodeSessionTokenExpiryMs(token);
     if (expiryMs === null) return;
 
     const remainingMs = expiryMs - Date.now();
@@ -494,8 +674,9 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
     if (epoch !== this._epoch) return;
     if (this._socket === null) return;
 
-    const token = await this._refreshSessionToken(identity, epoch);
-    if (epoch !== this._epoch) return;
+    const generation = ++this._authGeneration;
+    const token = await this._refreshWithBackoff(identity, epoch, generation);
+    if (epoch !== this._epoch || generation !== this._authGeneration) return;
     if (token === null) return;
 
     this._sessionToken = token;
@@ -507,9 +688,28 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
   }
 
   private _isTokenExpired(token: string): boolean {
-    const expiryMs = decodeJwtExpiryMs(token);
+    const expiryMs = decodeSessionTokenExpiryMs(token);
     if (expiryMs === null) return true;
     return expiryMs <= Date.now();
+  }
+
+  /**
+   * Declare the session unrecoverable: stop every retry loop, tear the socket
+   * down, and tell the user - with the reason - that this session is over and
+   * what to do about it. Stays in {@link ClientLifecycle.ACTIVE} on purpose,
+   * so the captions already on screen survive and the Leave button (which is
+   * bound to ACTIVE) is still there to rejoin with.
+   *
+   * One-way for the rest of the session; `joinSession`/`start` clear it.
+   */
+  private _enterTerminal(message: string): void {
+    if (this._terminal) return;
+    // Bumps the epoch, so every in-flight retry, refresh and timer this
+    // session armed is abandoned rather than merely ignored.
+    this._teardownActiveSession();
+    this._terminal = true;
+    this.emit('error', message);
+    this.emit('connectionStatus', SessionConnectionStatus.TERMINAL);
   }
 
   private _joinErrorFromStatus(status: number): JoinError {

--- a/apps/client-webapp/src/features/session-provider/stores/client-session-service-slice.ts
+++ b/apps/client-webapp/src/features/session-provider/stores/client-session-service-slice.ts
@@ -24,7 +24,15 @@ export interface ClientSessionServiceSliceState {
   session: {
     sessionUid: string;
     connectionStatus: SessionConnectionStatus;
-    sessionStatus: SessionStatusSnapshot;
+    /**
+     * Last `sessionStatus` message node-server sent, or `null` while none has
+     * arrived yet. The null case is load-bearing: seeding it with an
+     * all-`false` snapshot instead made "we have not heard yet" indistinguish-
+     * able from "the upstream is down", and every freshly-joined room rendered
+     * a "transcription service lost, reconnecting…" banner from the moment of
+     * a *successful* join.
+     */
+    sessionStatus: SessionStatusSnapshot | null;
   } | null;
   joinError: JoinError | null;
   error: string | null;
@@ -67,10 +75,7 @@ export const clientSessionServiceSlice = createSlice({
       state.session = {
         sessionUid: action.payload,
         connectionStatus: SessionConnectionStatus.CONNECTING,
-        sessionStatus: {
-          transcriptionServiceConnected: false,
-          sourceDeviceConnected: false,
-        },
+        sessionStatus: null,
       };
     },
     setConnectionStatus: (

--- a/apps/client-webapp/src/features/session-provider/stores/client-session-service-slice.ts
+++ b/apps/client-webapp/src/features/session-provider/stores/client-session-service-slice.ts
@@ -35,6 +35,12 @@ export interface ClientSessionServiceSliceState {
     sessionStatus: SessionStatusSnapshot | null;
   } | null;
   joinError: JoinError | null;
+  /**
+   * Why the current session is unrecoverable, or `null`. Rendered by
+   * `selectConnectionBanner`'s terminal branch - its only consumer, and the
+   * only reason to write anything here. It used to also collect transient
+   * strings ("Network error - retrying.") that no component read.
+   */
   error: string | null;
 }
 

--- a/apps/client-webapp/src/features/session-provider/stores/derive-connection-banner.ts
+++ b/apps/client-webapp/src/features/session-provider/stores/derive-connection-banner.ts
@@ -9,9 +9,10 @@ import { selectSession } from './client-session-service-slice';
 
 /**
  * What {@link ConnectionStatusBanner} (mounted in `root.tsx`) should render,
- * derived from the two independent connection concerns the client tracks:
- * the client's own WebSocket to node-server (`connectionStatus`), and
- * node-server's own upstream link to the Transcription Service
+ * derived from the three independent connection concerns the client tracks:
+ * the client's own WebSocket to node-server (`connectionStatus`), whether the
+ * room has a source device streaming (`sessionStatus.sourceDeviceConnected`),
+ * and node-server's own upstream link to the Transcription Service
  * (`sessionStatus.transcriptionServiceConnected`).
  */
 export type ConnectionBanner =
@@ -27,22 +28,32 @@ export type ConnectionBanner =
  *    upstream state was - there's no live channel to have learned it over -
  *    so the nested transcription-service state is deliberately not reported
  *    alongside it.
- * 2. The client's socket is fine, but the last known `sessionStatus` says
- *    node-server's link to the Transcription Service is down. If the reason
- *    is known to be admission control (`AT_CAPACITY`), say so specifically;
- *    otherwise use a generic "lost the upstream connection" message.
- * 3. Otherwise, nothing to report - the banner is unmounted.
+ * 2. No `sessionStatus` has arrived yet (`null`). The socket is up but
+ *    node-server hasn't reported the room's state, so there is nothing
+ *    truthful to say - no banner.
+ * 3. No source device is connected. This is the *normal idle state of a
+ *    healthy room*: node-server only dials the Transcription Service when a
+ *    source registers, so `transcriptionServiceConnected` is false here too
+ *    and means nothing. Informational, and deliberately free of the word
+ *    "reconnecting" - reporting it as a fault is what made every real room
+ *    look broken while the demo room (which fakes both flags true) looked
+ *    fine.
+ * 4. A source *is* connected but node-server's link to the Transcription
+ *    Service is down. That is a genuine fault. If the reason is known to be
+ *    admission control (`AT_CAPACITY`), say so specifically; otherwise use a
+ *    generic "lost the upstream connection" message.
+ * 5. Otherwise, nothing to report - the banner is unmounted.
  *
- * Every branch here is a retrying/transient state (the client and
- * node-server both keep retrying automatically), matching this feature's
- * "wrong refusal is worse than wrong admission" / fail-open philosophy
- * elsewhere in admission control - so severity is always `'warning'`, never
- * `'error'`. There is currently no modeled terminal/unrecoverable connection
- * state in this service for the socket-drop case (an unrecoverable *session*
- * failure, e.g. an expired refresh token, instead routes through
- * `JoinError`/`leaveSession` and drops the user back to `IDLE`, off this
- * banner's `ACTIVE`-only concern entirely) - if one is added later, that's
- * the natural place for an `'error'` branch here.
+ * Every state here is retrying/transient (the client and node-server both
+ * keep retrying automatically), matching this feature's "wrong refusal is
+ * worse than wrong admission" / fail-open philosophy elsewhere in admission
+ * control - so severity is `'warning'`, or `'info'` where nothing is actually
+ * wrong, never `'error'`. There is currently no modeled terminal/
+ * unrecoverable connection state in this service for the socket-drop case (an
+ * unrecoverable *session* failure, e.g. an expired refresh token, instead
+ * routes through `JoinError`/`leaveSession` and drops the user back to
+ * `IDLE`, off this banner's `ACTIVE`-only concern entirely) - if one is added
+ * later, that's the natural place for an `'error'` branch here.
  */
 export function deriveConnectionBanner(
   connectionStatus: SessionConnectionStatus,
@@ -56,7 +67,18 @@ export function deriveConnectionBanner(
     };
   }
 
-  if (sessionStatus !== null && !sessionStatus.transcriptionServiceConnected) {
+  // Nothing reported yet - "not yet known" is not "known bad".
+  if (sessionStatus === null) return { open: false };
+
+  if (!sessionStatus.sourceDeviceConnected) {
+    return {
+      open: true,
+      severity: 'info',
+      message: "Waiting for the room's microphone to connect.",
+    };
+  }
+
+  if (!sessionStatus.transcriptionServiceConnected) {
     if (
       sessionStatus.transcriptionServiceDisconnectReason ===
       TranscriptionServiceDisconnectReason.AT_CAPACITY

--- a/apps/client-webapp/src/features/session-provider/stores/derive-connection-banner.ts
+++ b/apps/client-webapp/src/features/session-provider/stores/derive-connection-banner.ts
@@ -5,7 +5,7 @@ import type { RootState } from '#src/store/store';
 
 import type { SessionStatusSnapshot } from '../services/client-session-service';
 import { SessionConnectionStatus } from '../services/client-session-service-status';
-import { selectSession } from './client-session-service-slice';
+import { selectError, selectSession } from './client-session-service-slice';
 
 /**
  * What {@link ConnectionStatusBanner} (mounted in `root.tsx`) should render,
@@ -23,42 +23,56 @@ export type ConnectionBanner =
  * Pure derivation of the connection-status banner shown to the user.
  *
  * Priority (most severe/explanatory first):
- * 1. The client's own socket to node-server isn't `CONNECTED` (it's
+ * 1. `TERMINAL` - the service has given up; nothing is retrying and nothing
+ *    below can change. This is the one `'error'` branch, and it renders the
+ *    service's own explanation (`error`) rather than a generic string,
+ *    because the whole point of a terminal state is telling the user *which*
+ *    unrecoverable thing happened and what to do next.
+ * 2. The client's own socket to node-server isn't `CONNECTED` (it's
  *    `CONNECTING` or `DISCONNECTED`). This subsumes whatever node-server's
  *    upstream state was - there's no live channel to have learned it over -
  *    so the nested transcription-service state is deliberately not reported
  *    alongside it.
- * 2. No `sessionStatus` has arrived yet (`null`). The socket is up but
+ * 3. No `sessionStatus` has arrived yet (`null`). The socket is up but
  *    node-server hasn't reported the room's state, so there is nothing
  *    truthful to say - no banner.
- * 3. No source device is connected. This is the *normal idle state of a
+ * 4. No source device is connected. This is the *normal idle state of a
  *    healthy room*: node-server only dials the Transcription Service when a
  *    source registers, so `transcriptionServiceConnected` is false here too
  *    and means nothing. Informational, and deliberately free of the word
  *    "reconnecting" - reporting it as a fault is what made every real room
  *    look broken while the demo room (which fakes both flags true) looked
  *    fine.
- * 4. A source *is* connected but node-server's link to the Transcription
+ * 5. A source *is* connected but node-server's link to the Transcription
  *    Service is down. That is a genuine fault. If the reason is known to be
  *    admission control (`AT_CAPACITY`), say so specifically; otherwise use a
  *    generic "lost the upstream connection" message.
- * 5. Otherwise, nothing to report - the banner is unmounted.
+ * 6. Otherwise, nothing to report - the banner is unmounted.
  *
- * Every state here is retrying/transient (the client and node-server both
- * keep retrying automatically), matching this feature's "wrong refusal is
- * worse than wrong admission" / fail-open philosophy elsewhere in admission
- * control - so severity is `'warning'`, or `'info'` where nothing is actually
- * wrong, never `'error'`. There is currently no modeled terminal/
- * unrecoverable connection state in this service for the socket-drop case (an
- * unrecoverable *session* failure, e.g. an expired refresh token, instead
- * routes through `JoinError`/`leaveSession` and drops the user back to
- * `IDLE`, off this banner's `ACTIVE`-only concern entirely) - if one is added
- * later, that's the natural place for an `'error'` branch here.
+ * Apart from `TERMINAL`, every state here is retrying/transient (the client
+ * and node-server both keep retrying automatically), matching this feature's
+ * "wrong refusal is worse than wrong admission" / fail-open philosophy
+ * elsewhere in admission control - so severity is `'warning'`, or `'info'`
+ * where nothing is actually wrong. An unrecoverable *session* failure (e.g.
+ * an expired refresh token) still routes through `JoinError`/`leaveSession`
+ * and drops the user back to `IDLE`, off this banner's `ACTIVE`-only concern
+ * entirely.
  */
 export function deriveConnectionBanner(
   connectionStatus: SessionConnectionStatus,
   sessionStatus: SessionStatusSnapshot | null,
+  error: string | null = null,
 ): ConnectionBanner {
+  if (connectionStatus === SessionConnectionStatus.TERMINAL) {
+    return {
+      open: true,
+      severity: 'error',
+      message:
+        error ??
+        'Disconnected from this session and unable to reconnect. Leave the session and join again with a new join code.',
+    };
+  }
+
   if (connectionStatus !== SessionConnectionStatus.CONNECTED) {
     return {
       open: true,
@@ -105,6 +119,10 @@ export function deriveConnectionBanner(
  * Selector wrapping {@link deriveConnectionBanner} for the current session
  * state. Returns `{ open: false }` whenever there's no active session (the
  * banner only makes sense during {@link ClientLifecycle.ACTIVE}).
+ *
+ * This is the sole consumer of `selectError`, and the reason that slice field
+ * exists: the service writes the cause of an unrecoverable failure there and
+ * the terminal branch above renders it.
  */
 export const selectConnectionBanner = (state: RootState): ConnectionBanner => {
   const session = selectSession(state);
@@ -112,5 +130,6 @@ export const selectConnectionBanner = (state: RootState): ConnectionBanner => {
   return deriveConnectionBanner(
     session.connectionStatus,
     session.sessionStatus,
+    selectError(state),
   );
 };

--- a/apps/client-webapp/src/features/session-provider/stores/derive-connection-banner.ts
+++ b/apps/client-webapp/src/features/session-provider/stores/derive-connection-banner.ts
@@ -44,16 +44,20 @@ export type ConnectionBanner =
  *    look broken while the demo room (which fakes both flags true) looked
  *    fine.
  * 5. A source *is* connected but node-server's link to the Transcription
- *    Service is down. That is a genuine fault. If the reason is known to be
- *    admission control (`AT_CAPACITY`), say so specifically; otherwise use a
- *    generic "lost the upstream connection" message.
+ *    Service is down. That is a genuine fault, and the reason decides the
+ *    wording: `AT_CAPACITY` clears on its own when load drops, so it promises
+ *    a retry; `INVALID_REQUEST` never clears without an operator, so it is an
+ *    error asking for one; anything else gets the generic "lost the upstream
+ *    connection" message.
  * 6. Otherwise, nothing to report - the banner is unmounted.
  *
- * Apart from `TERMINAL`, every state here is retrying/transient (the client
- * and node-server both keep retrying automatically), matching this feature's
- * "wrong refusal is worse than wrong admission" / fail-open philosophy
- * elsewhere in admission control - so severity is `'warning'`, or `'info'`
- * where nothing is actually wrong. An unrecoverable *session* failure (e.g.
+ * Apart from `TERMINAL` and `INVALID_REQUEST`, every state here is
+ * retrying/transient (the client and node-server both keep retrying
+ * automatically), matching this feature's "wrong refusal is worse than wrong
+ * admission" / fail-open philosophy elsewhere in admission control - so
+ * severity is `'warning'`, or `'info'` where nothing is actually wrong. Only
+ * the two states nothing in the system can recover from on its own are
+ * `'error'`. An unrecoverable *session* failure (e.g.
  * an expired refresh token) still routes through `JoinError`/`leaveSession`
  * and drops the user back to `IDLE`, off this banner's `ACTIVE`-only concern
  * entirely.
@@ -102,6 +106,23 @@ export function deriveConnectionBanner(
         severity: 'warning',
         message:
           'The live transcription service is at capacity. Retrying automatically…',
+      };
+    }
+    // Permanent, unlike every other branch here: the Transcription Service
+    // rejected this session's configuration (close 1007 - typically a
+    // transcriptionProviderId that does not exist on this deployment) and will
+    // reject the identical retry forever. "Reconnecting…" would be a promise
+    // nothing can keep, so this says what has to happen instead, and says it
+    // as an error rather than a warning. Mirrors the kiosk's branch.
+    if (
+      sessionStatus.transcriptionServiceDisconnectReason ===
+      TranscriptionServiceDisconnectReason.INVALID_REQUEST
+    ) {
+      return {
+        open: true,
+        severity: 'error',
+        message:
+          'Live transcription is misconfigured for this room and cannot start. An administrator needs to check the session’s transcription provider.',
       };
     }
     return {

--- a/apps/client-webapp/tests/features/session-provider/services/client-session-service.test.ts
+++ b/apps/client-webapp/tests/features/session-provider/services/client-session-service.test.ts
@@ -1,17 +1,23 @@
 import { EventEmitter } from 'eventemitter3';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { NetworkError } from '@scribear/base-api-client';
 import type { NodeServerClient } from '@scribear/node-server-client';
 import { createNodeServerClient } from '@scribear/node-server-client';
 import {
   TranscriptionServiceDisconnectReason,
+  TranscriptionStreamClientMessageType,
   TranscriptionStreamServerMessageType,
 } from '@scribear/node-server-schema';
 import type { SessionManagerClient } from '@scribear/session-manager-client';
 import { createSessionManagerClient } from '@scribear/session-manager-client';
 
 import { ClientSessionService } from '#src/features/session-provider/services/client-session-service';
-import type { SessionStatusSnapshot } from '#src/features/session-provider/services/client-session-service';
+import type {
+  SessionIdentity,
+  SessionStatusSnapshot,
+} from '#src/features/session-provider/services/client-session-service';
+import { SessionConnectionStatus } from '#src/features/session-provider/services/client-session-service-status';
 
 vi.mock('@scribear/node-server-client', async (importOriginal) => {
   const actual =
@@ -47,29 +53,119 @@ function createFakeSocket() {
   });
 }
 
-const IDENTITY = {
+const IDENTITY: SessionIdentity = {
   sessionUid: 'session-uid',
   sessionRefreshToken: 'refresh-token',
   clientId: 'client-id',
 };
 
-describe('ClientSessionService SESSION_STATUS handling', () => {
-  let fakeSocket: ReturnType<typeof createFakeSocket>;
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+}
 
-  beforeEach(() => {
-    fakeSocket = createFakeSocket();
-    vi.mocked(createNodeServerClient).mockReturnValue({
-      transcriptionStreamClient: vi.fn(() => fakeSocket),
-      transcriptionStreamSource: vi.fn(() => createFakeSocket()),
-    } as unknown as NodeServerClient);
-    vi.mocked(createSessionManagerClient).mockReturnValue({
-      sessionAuth: {
-        exchangeJoinCode: vi.fn(),
-        refreshSessionToken: vi.fn(),
+/**
+ * Mint a session token exactly the way session-manager's
+ * `SessionTokenService.sign` does: `base64url(payloadJSON)` and a base64url
+ * HMAC-SHA256 over that, joined by a `.`. **Two** segments, payload first.
+ *
+ * Reproducing the real minting is the point. The expiry decoder read
+ * `parts[1]` - a JWT's payload index - and so threw on the signature of every
+ * token this system has ever issued; a hand-written three-segment fixture is
+ * what let that pass its tests for as long as it did.
+ */
+async function mintSessionToken(expSeconds: number): Promise<string> {
+  const encoder = new TextEncoder();
+  const encodedPayload = base64UrlEncode(
+    encoder.encode(
+      JSON.stringify({
+        sessionUid: IDENTITY.sessionUid,
+        clientId: IDENTITY.clientId,
+        scopes: ['RECEIVE_TRANSCRIPTIONS'],
+        exp: expSeconds,
+      }),
+    ),
+  );
+  const key = await globalThis.crypto.subtle.importKey(
+    'raw',
+    encoder.encode('test-signing-key'),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await globalThis.crypto.subtle.sign(
+    'HMAC',
+    key,
+    encoder.encode(encodedPayload),
+  );
+  return `${encodedPayload}.${base64UrlEncode(new Uint8Array(signature))}`;
+}
+
+/** The shape the decoder used to assume: a three-segment JWT. */
+function mintJwtShapedToken(expSeconds: number): string {
+  const encoder = new TextEncoder();
+  const seg = (value: object) =>
+    base64UrlEncode(encoder.encode(JSON.stringify(value)));
+  return `${seg({ alg: 'HS256' })}.${seg({ exp: expSeconds })}.signature`;
+}
+
+let fakeSocket: ReturnType<typeof createFakeSocket>;
+let exchangeJoinCode: ReturnType<typeof vi.fn>;
+let refreshSessionToken: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fakeSocket = createFakeSocket();
+  exchangeJoinCode = vi.fn();
+  refreshSessionToken = vi.fn();
+  vi.mocked(createNodeServerClient).mockReturnValue({
+    transcriptionStreamClient: vi.fn(() => fakeSocket),
+    transcriptionStreamSource: vi.fn(() => createFakeSocket()),
+  } as unknown as NodeServerClient);
+  vi.mocked(createSessionManagerClient).mockReturnValue({
+    sessionAuth: { exchangeJoinCode, refreshSessionToken },
+  } as unknown as SessionManagerClient);
+});
+
+/** Response tuple for a successful `refreshSessionToken`. */
+function refreshOk(sessionToken: string) {
+  return [{ status: 200, data: { sessionToken } }, null];
+}
+
+/** Response tuple for a successful `exchangeJoinCode`. */
+function joinOk(sessionToken: string) {
+  return [
+    {
+      status: 200,
+      data: {
+        sessionUid: IDENTITY.sessionUid,
+        sessionRefreshToken: IDENTITY.sessionRefreshToken,
+        clientId: IDENTITY.clientId,
+        sessionToken,
       },
-    } as unknown as SessionManagerClient);
-  });
+    },
+    null,
+  ];
+}
 
+/** Session tokens presented in AUTH messages, in order. */
+function authenticatedTokens(): string[] {
+  return fakeSocket.send.mock.calls
+    .map(
+      ([msg]) =>
+        msg as {
+          type: TranscriptionStreamClientMessageType;
+          sessionToken: string;
+        },
+    )
+    .filter((msg) => msg.type === TranscriptionStreamClientMessageType.AUTH)
+    .map((msg) => msg.sessionToken);
+}
+
+describe('ClientSessionService SESSION_STATUS handling', () => {
   it('passes transcriptionServiceDisconnectReason through when the server includes it', () => {
     const service = new ClientSessionService();
     const statuses: SessionStatusSnapshot[] = [];
@@ -117,5 +213,203 @@ describe('ClientSessionService SESSION_STATUS handling', () => {
     expect(statuses[0]).not.toHaveProperty(
       'transcriptionServiceDisconnectReason',
     );
+  });
+});
+
+describe('ClientSessionService session-token expiry', () => {
+  const NOW_MS = 1_800_000_000_000;
+
+  beforeEach(() => {
+    // Fixed clock, and no jitter, so the refresh delay is exactly half the
+    // remaining lifetime rather than half ±10%.
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('sends AUTH with the token from joinSession without spending a refresh on it', async () => {
+    const token = await mintSessionToken(NOW_MS / 1000 + 600);
+    exchangeJoinCode.mockResolvedValue(joinOk(token));
+    const service = new ClientSessionService();
+
+    await service.joinSession('JOINCODE');
+    fakeSocket.emit('open');
+
+    // The token is valid for ten more minutes; treating it as expired (which
+    // an unreadable `exp` does) burns a refresh round-trip on every single
+    // socket open, and leaves AUTH unsent entirely if that call fails.
+    expect(refreshSessionToken).not.toHaveBeenCalled();
+    expect(authenticatedTokens()).toEqual([token]);
+  });
+
+  it('treats a token whose expiry it cannot read as expired', async () => {
+    // A three-segment JWT is not the format this system issues; refusing to
+    // read an `exp` out of one is the conservative direction.
+    exchangeJoinCode.mockResolvedValue(
+      joinOk(mintJwtShapedToken(NOW_MS / 1000 + 600)),
+    );
+    const refreshed = await mintSessionToken(NOW_MS / 1000 + 600);
+    refreshSessionToken.mockResolvedValue(refreshOk(refreshed));
+    const service = new ClientSessionService();
+
+    await service.joinSession('JOINCODE');
+    fakeSocket.emit('open');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(refreshSessionToken).toHaveBeenCalledTimes(1);
+    expect(authenticatedTokens()).toEqual([refreshed]);
+  });
+
+  it('arms a proactive refresh at half the token lifetime and re-AUTHs in place', async () => {
+    const first = await mintSessionToken(NOW_MS / 1000 + 600);
+    const second = await mintSessionToken(NOW_MS / 1000 + 1200);
+    exchangeJoinCode.mockResolvedValue(joinOk(first));
+    refreshSessionToken.mockResolvedValue(refreshOk(second));
+    const service = new ClientSessionService();
+
+    await service.joinSession('JOINCODE');
+    fakeSocket.emit('open');
+
+    // Just short of the halfway point: nothing should have fired yet.
+    await vi.advanceTimersByTimeAsync(299_000);
+    expect(refreshSessionToken).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(refreshSessionToken).toHaveBeenCalledTimes(1);
+    // Re-AUTH on the *existing* socket - the connection is never dropped to
+    // pick up a new token.
+    expect(authenticatedTokens()).toEqual([first, second]);
+    expect(fakeSocket.terminate).not.toHaveBeenCalled();
+
+    // And the next one is armed off the new token's own lifetime.
+    await vi.advanceTimersByTimeAsync(601_000);
+    expect(refreshSessionToken).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('ClientSessionService terminal states', () => {
+  function trackTerminal(service: ClientSessionService) {
+    const statuses: SessionConnectionStatus[] = [];
+    const errors: (string | null)[] = [];
+    service.on('connectionStatus', (status) => statuses.push(status));
+    service.on('error', (message) => errors.push(message));
+    return { statuses, errors };
+  }
+
+  it('gives up immediately on a 1008 close whose reason can never succeed', () => {
+    const service = new ClientSessionService();
+    const { statuses, errors } = trackTerminal(service);
+
+    service.start(IDENTITY);
+    fakeSocket.emit('close', 1008, 'missing-scope', 1000);
+
+    expect(statuses).toContain(SessionConnectionStatus.TERMINAL);
+    expect(errors.at(-1)).toMatch(/refused the connection/);
+  });
+
+  it('tolerates a couple of unexplained 1008 closes, then gives up', () => {
+    const service = new ClientSessionService();
+    const { statuses } = trackTerminal(service);
+
+    service.start(IDENTITY);
+    // `auth-timeout` is what node-server sends when AUTH never arrived - by
+    // itself recoverable, which is why it is not on the permanent list. What
+    // is not recoverable is it happening every single time: without a bound
+    // this is the ~1 s hammer loop, invisible behind "Reconnecting…".
+    fakeSocket.emit('close', 1008, 'auth-timeout', 1000);
+    expect(statuses).not.toContain(SessionConnectionStatus.TERMINAL);
+    fakeSocket.emit('close', 1008, 'auth-timeout', 1000);
+    expect(statuses).not.toContain(SessionConnectionStatus.TERMINAL);
+    fakeSocket.emit('close', 1008, 'auth-timeout', 1000);
+
+    expect(statuses).toContain(SessionConnectionStatus.TERMINAL);
+  });
+
+  it('does not give up when the 1008s are interrupted by a successful auth', () => {
+    const service = new ClientSessionService();
+    const { statuses } = trackTerminal(service);
+
+    service.start(IDENTITY);
+    fakeSocket.emit('close', 1008, 'token-expired', 1000);
+    fakeSocket.emit('close', 1008, 'token-expired', 1000);
+    fakeSocket.emit('message', {
+      type: TranscriptionStreamServerMessageType.AUTH_OK,
+    });
+    fakeSocket.emit('close', 1008, 'token-expired', 1000);
+    fakeSocket.emit('close', 1008, 'token-expired', 1000);
+
+    expect(statuses).not.toContain(SessionConnectionStatus.TERMINAL);
+  });
+
+  it('gives up once the refresh retry budget is exhausted, and says so', async () => {
+    vi.useFakeTimers();
+    refreshSessionToken.mockResolvedValue([null, new NetworkError('offline')]);
+    const service = new ClientSessionService();
+    const { statuses, errors } = trackTerminal(service);
+
+    service.start(IDENTITY);
+    fakeSocket.emit('open');
+    // Backoff between attempts is 300/600/1200/2400ms, so a few seconds
+    // covers the whole budget however the jitter falls.
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    // Bounded: it stops asking, rather than reconnecting into the same failed
+    // refresh forever.
+    expect(refreshSessionToken).toHaveBeenCalledTimes(5);
+    expect(statuses).toContain(SessionConnectionStatus.TERMINAL);
+    expect(errors.at(-1)).toMatch(/could not restore it/i);
+    expect(fakeSocket.send).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('recovers without going terminal when the refresh eventually succeeds', async () => {
+    vi.useFakeTimers();
+    const token = await mintSessionToken(Date.now() / 1000 + 600);
+    refreshSessionToken
+      .mockResolvedValueOnce([null, new NetworkError('offline')])
+      .mockResolvedValueOnce([null, new NetworkError('offline')])
+      .mockResolvedValue(refreshOk(token));
+    const service = new ClientSessionService();
+    const { statuses } = trackTerminal(service);
+
+    service.start(IDENTITY);
+    fakeSocket.emit('open');
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(refreshSessionToken).toHaveBeenCalledTimes(3);
+    expect(statuses).not.toContain(SessionConnectionStatus.TERMINAL);
+    expect(authenticatedTokens()).toEqual([token]);
+    vi.useRealTimers();
+  });
+});
+
+describe('ClientSessionService resume after reload', () => {
+  it('re-announces the stored identity so the reloaded page has a session', () => {
+    const service = new ClientSessionService();
+    const identities: (SessionIdentity | null)[] = [];
+    service.on('sessionIdentity', (identity) => identities.push(identity));
+
+    service.start(IDENTITY);
+
+    // Without this the middleware never dispatches `setActiveSession`, so
+    // `clientSessionService.session` stays null, every `setConnectionStatus`
+    // early-returns, and the reloaded viewer sees no banner at all - even
+    // with a dead socket.
+    expect(identities).toEqual([IDENTITY]);
+  });
+
+  it('does not announce an identity when there is nothing stored', () => {
+    const service = new ClientSessionService();
+    const identities: (SessionIdentity | null)[] = [];
+    service.on('sessionIdentity', (identity) => identities.push(identity));
+
+    service.start(null);
+
+    expect(identities).toEqual([]);
   });
 });

--- a/apps/client-webapp/tests/features/session-provider/stores/client-session-service-slice.test.ts
+++ b/apps/client-webapp/tests/features/session-provider/stores/client-session-service-slice.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { SessionConnectionStatus } from '#src/features/session-provider/services/client-session-service-status';
+import {
+  clientSessionServiceReducer,
+  setActiveSession,
+  setSessionStatus,
+} from '#src/features/session-provider/stores/client-session-service-slice';
+
+describe('clientSessionServiceSlice', () => {
+  it('seeds sessionStatus as null, not as an all-false snapshot', () => {
+    const state = clientSessionServiceReducer(
+      undefined,
+      setActiveSession('session-uid'),
+    );
+
+    // Seeding {transcriptionServiceConnected: false, sourceDeviceConnected:
+    // false} here made "node-server has not reported yet" indistinguishable
+    // from "node-server reported a dead upstream", and put a fault banner on
+    // screen from the instant of a *successful* join.
+    expect(state.session).toEqual({
+      sessionUid: 'session-uid',
+      connectionStatus: SessionConnectionStatus.CONNECTING,
+      sessionStatus: null,
+    });
+  });
+
+  it('records the first reported sessionStatus', () => {
+    const joined = clientSessionServiceReducer(
+      undefined,
+      setActiveSession('session-uid'),
+    );
+    const state = clientSessionServiceReducer(
+      joined,
+      setSessionStatus({
+        transcriptionServiceConnected: false,
+        sourceDeviceConnected: false,
+      }),
+    );
+
+    expect(state.session?.sessionStatus).toEqual({
+      transcriptionServiceConnected: false,
+      sourceDeviceConnected: false,
+    });
+  });
+
+  it('clears the session on setActiveSession(null)', () => {
+    const joined = clientSessionServiceReducer(
+      undefined,
+      setActiveSession('session-uid'),
+    );
+    expect(
+      clientSessionServiceReducer(joined, setActiveSession(null)).session,
+    ).toBeNull();
+  });
+});

--- a/apps/client-webapp/tests/features/session-provider/stores/derive-connection-banner.test.ts
+++ b/apps/client-webapp/tests/features/session-provider/stores/derive-connection-banner.test.ts
@@ -30,6 +30,12 @@ const UPSTREAM_LOST: ConnectionBanner = {
   severity: 'warning',
   message: 'Connection to the transcription service was lost. Reconnecting…',
 };
+const MISCONFIGURED: ConnectionBanner = {
+  open: true,
+  severity: 'error',
+  message:
+    'Live transcription is misconfigured for this room and cannot start. An administrator needs to check the session\u2019s transcription provider.',
+};
 const CLOSED: ConnectionBanner = { open: false };
 const TERMINAL_FALLBACK: ConnectionBanner = {
   open: true,
@@ -45,10 +51,16 @@ const CONNECTION_STATUSES = [
   SessionConnectionStatus.TERMINAL,
 ] as const;
 
-const REASONS = [
+/**
+ * Every disconnect reason the schema defines, read off the enum rather than
+ * listed by hand: a reason added to `node-server-schema` should fail this
+ * table (as an unexpected input row) rather than silently fall into the
+ * generic branch.
+ */
+const REASONS: (TranscriptionServiceDisconnectReason | undefined)[] = [
   undefined,
-  TranscriptionServiceDisconnectReason.AT_CAPACITY,
-] as const;
+  ...Object.values(TranscriptionServiceDisconnectReason),
+];
 
 function snapshot(
   sourceDeviceConnected: boolean,
@@ -89,8 +101,8 @@ function caseKey(
 /**
  * The complete input space of this pure function, written out as literals
  * rather than re-derived from the implementation: 4 connection statuses x
- * (the `sessionStatus === null` case + 2 x 2 x 2 snapshot combinations) = 36
- * rows. Spot-checking instead of pinning this table is how the "healthy idle
+ * (the `sessionStatus === null` case + 2 x 2 x 3 snapshot combinations, the 3
+ * being every disconnect reason the schema defines plus none) = 52 rows. Spot-checking instead of pinning this table is how the "healthy idle
  * room" case shipped - a successful join with nobody streaming yet was
  * rendered as "Connection to the transcription service was lost.
  * Reconnecting…", forever, on every real room.
@@ -114,6 +126,14 @@ const EXPECTED: Record<string, ConnectionBanner> = {
     SOCKET_DOWN,
   'CONNECTING | source=true transcription=true reason=none': SOCKET_DOWN,
   'CONNECTING | source=true transcription=true reason=at-capacity': SOCKET_DOWN,
+  'CONNECTING | source=false transcription=false reason=invalid-request':
+    SOCKET_DOWN,
+  'CONNECTING | source=false transcription=true reason=invalid-request':
+    SOCKET_DOWN,
+  'CONNECTING | source=true transcription=false reason=invalid-request':
+    SOCKET_DOWN,
+  'CONNECTING | source=true transcription=true reason=invalid-request':
+    SOCKET_DOWN,
   'DISCONNECTED | no-status-yet': SOCKET_DOWN,
   'DISCONNECTED | source=false transcription=false reason=none': SOCKET_DOWN,
   'DISCONNECTED | source=false transcription=false reason=at-capacity':
@@ -126,6 +146,14 @@ const EXPECTED: Record<string, ConnectionBanner> = {
     SOCKET_DOWN,
   'DISCONNECTED | source=true transcription=true reason=none': SOCKET_DOWN,
   'DISCONNECTED | source=true transcription=true reason=at-capacity':
+    SOCKET_DOWN,
+  'DISCONNECTED | source=false transcription=false reason=invalid-request':
+    SOCKET_DOWN,
+  'DISCONNECTED | source=false transcription=true reason=invalid-request':
+    SOCKET_DOWN,
+  'DISCONNECTED | source=true transcription=false reason=invalid-request':
+    SOCKET_DOWN,
+  'DISCONNECTED | source=true transcription=true reason=invalid-request':
     SOCKET_DOWN,
 
   // Own socket up, nothing reported yet: silence, not a guess.
@@ -142,6 +170,10 @@ const EXPECTED: Record<string, ConnectionBanner> = {
   'CONNECTED | source=false transcription=true reason=none': WAITING_FOR_SOURCE,
   'CONNECTED | source=false transcription=true reason=at-capacity':
     WAITING_FOR_SOURCE,
+  'CONNECTED | source=false transcription=false reason=invalid-request':
+    WAITING_FOR_SOURCE,
+  'CONNECTED | source=false transcription=true reason=invalid-request':
+    WAITING_FOR_SOURCE,
 
   // Own socket up, a source IS streaming: now the upstream flag is a real
   // fault signal.
@@ -149,6 +181,11 @@ const EXPECTED: Record<string, ConnectionBanner> = {
   'CONNECTED | source=true transcription=false reason=at-capacity': AT_CAPACITY,
   'CONNECTED | source=true transcription=true reason=none': CLOSED,
   'CONNECTED | source=true transcription=true reason=at-capacity': CLOSED,
+  // Permanent: the upstream rejected this session's configuration and will
+  // reject the identical retry forever, so this is the one non-terminal error.
+  'CONNECTED | source=true transcription=false reason=invalid-request':
+    MISCONFIGURED,
+  'CONNECTED | source=true transcription=true reason=invalid-request': CLOSED,
 
   // Terminal: nothing is retrying, so nothing node-server last said matters.
   'TERMINAL | no-status-yet': TERMINAL_FALLBACK,
@@ -163,6 +200,14 @@ const EXPECTED: Record<string, ConnectionBanner> = {
     TERMINAL_FALLBACK,
   'TERMINAL | source=true transcription=true reason=none': TERMINAL_FALLBACK,
   'TERMINAL | source=true transcription=true reason=at-capacity':
+    TERMINAL_FALLBACK,
+  'TERMINAL | source=false transcription=false reason=invalid-request':
+    TERMINAL_FALLBACK,
+  'TERMINAL | source=false transcription=true reason=invalid-request':
+    TERMINAL_FALLBACK,
+  'TERMINAL | source=true transcription=false reason=invalid-request':
+    TERMINAL_FALLBACK,
+  'TERMINAL | source=true transcription=true reason=invalid-request':
     TERMINAL_FALLBACK,
 };
 
@@ -186,7 +231,7 @@ describe('deriveConnectionBanner', () => {
     // expectation row that no longer corresponds to a reachable input.
     it('has exactly one expectation per reachable input', () => {
       expect([...covered].sort()).toEqual(Object.keys(EXPECTED).sort());
-      expect(covered.size).toBe(36);
+      expect(covered.size).toBe(52);
     });
   });
 

--- a/apps/client-webapp/tests/features/session-provider/stores/derive-connection-banner.test.ts
+++ b/apps/client-webapp/tests/features/session-provider/stores/derive-connection-banner.test.ts
@@ -31,11 +31,18 @@ const UPSTREAM_LOST: ConnectionBanner = {
   message: 'Connection to the transcription service was lost. Reconnecting…',
 };
 const CLOSED: ConnectionBanner = { open: false };
+const TERMINAL_FALLBACK: ConnectionBanner = {
+  open: true,
+  severity: 'error',
+  message:
+    'Disconnected from this session and unable to reconnect. Leave the session and join again with a new join code.',
+};
 
 const CONNECTION_STATUSES = [
   SessionConnectionStatus.CONNECTING,
   SessionConnectionStatus.CONNECTED,
   SessionConnectionStatus.DISCONNECTED,
+  SessionConnectionStatus.TERMINAL,
 ] as const;
 
 const REASONS = [
@@ -57,6 +64,16 @@ function snapshot(
   };
 }
 
+/** Every snapshot the client can hold, including "none reported yet". */
+const ALL_SESSION_STATUSES: (SessionStatusSnapshot | null)[] = [
+  null,
+  ...[false, true].flatMap((source) =>
+    [false, true].flatMap((transcription) =>
+      REASONS.map((reason) => snapshot(source, transcription, reason)),
+    ),
+  ),
+];
+
 function caseKey(
   connectionStatus: SessionConnectionStatus,
   sessionStatus: SessionStatusSnapshot | null,
@@ -71,12 +88,17 @@ function caseKey(
 
 /**
  * The complete input space of this pure function, written out as literals
- * rather than re-derived from the implementation: 3 connection statuses x
- * (the `sessionStatus === null` case + 2 x 2 x 2 snapshot combinations) = 27
+ * rather than re-derived from the implementation: 4 connection statuses x
+ * (the `sessionStatus === null` case + 2 x 2 x 2 snapshot combinations) = 36
  * rows. Spot-checking instead of pinning this table is how the "healthy idle
  * room" case shipped - a successful join with nobody streaming yet was
  * rendered as "Connection to the transcription service was lost.
  * Reconnecting…", forever, on every real room.
+ *
+ * The fourth input, `error`, is `null` throughout this table and covered
+ * separately below: it only reaches the output through the `TERMINAL` branch,
+ * and the "it changes nothing anywhere else" half of that claim is asserted
+ * against this same table rather than duplicated into it.
  */
 const EXPECTED: Record<string, ConnectionBanner> = {
   // Own socket down: it subsumes everything node-server might have said.
@@ -127,6 +149,21 @@ const EXPECTED: Record<string, ConnectionBanner> = {
   'CONNECTED | source=true transcription=false reason=at-capacity': AT_CAPACITY,
   'CONNECTED | source=true transcription=true reason=none': CLOSED,
   'CONNECTED | source=true transcription=true reason=at-capacity': CLOSED,
+
+  // Terminal: nothing is retrying, so nothing node-server last said matters.
+  'TERMINAL | no-status-yet': TERMINAL_FALLBACK,
+  'TERMINAL | source=false transcription=false reason=none': TERMINAL_FALLBACK,
+  'TERMINAL | source=false transcription=false reason=at-capacity':
+    TERMINAL_FALLBACK,
+  'TERMINAL | source=false transcription=true reason=none': TERMINAL_FALLBACK,
+  'TERMINAL | source=false transcription=true reason=at-capacity':
+    TERMINAL_FALLBACK,
+  'TERMINAL | source=true transcription=false reason=none': TERMINAL_FALLBACK,
+  'TERMINAL | source=true transcription=false reason=at-capacity':
+    TERMINAL_FALLBACK,
+  'TERMINAL | source=true transcription=true reason=none': TERMINAL_FALLBACK,
+  'TERMINAL | source=true transcription=true reason=at-capacity':
+    TERMINAL_FALLBACK,
 };
 
 describe('deriveConnectionBanner', () => {
@@ -134,14 +171,7 @@ describe('deriveConnectionBanner', () => {
     const covered = new Set<string>();
 
     for (const connectionStatus of CONNECTION_STATUSES) {
-      for (const sessionStatus of [
-        null,
-        ...[false, true].flatMap((source) =>
-          [false, true].flatMap((transcription) =>
-            REASONS.map((reason) => snapshot(source, transcription, reason)),
-          ),
-        ),
-      ]) {
+      for (const sessionStatus of ALL_SESSION_STATUSES) {
         const key = caseKey(connectionStatus, sessionStatus);
         covered.add(key);
         it(key, () => {
@@ -156,7 +186,34 @@ describe('deriveConnectionBanner', () => {
     // expectation row that no longer corresponds to a reachable input.
     it('has exactly one expectation per reachable input', () => {
       expect([...covered].sort()).toEqual(Object.keys(EXPECTED).sort());
-      expect(covered.size).toBe(27);
+      expect(covered.size).toBe(36);
+    });
+  });
+
+  describe('the error message, the fourth input', () => {
+    const CAUSE = 'This session refused the connection.';
+
+    it('is what TERMINAL renders, in place of the generic fallback', () => {
+      expect(
+        deriveConnectionBanner(SessionConnectionStatus.TERMINAL, null, CAUSE),
+      ).toEqual({ open: true, severity: 'error', message: CAUSE });
+    });
+
+    it('falls back to a generic terminal message when absent', () => {
+      expect(
+        deriveConnectionBanner(SessionConnectionStatus.TERMINAL, null, null),
+      ).toEqual(TERMINAL_FALLBACK);
+    });
+
+    it('changes nothing in any non-terminal state', () => {
+      for (const connectionStatus of CONNECTION_STATUSES) {
+        if (connectionStatus === SessionConnectionStatus.TERMINAL) continue;
+        for (const sessionStatus of ALL_SESSION_STATUSES) {
+          expect(
+            deriveConnectionBanner(connectionStatus, sessionStatus, CAUSE),
+          ).toEqual(EXPECTED[caseKey(connectionStatus, sessionStatus)]);
+        }
+      }
     });
   });
 

--- a/apps/client-webapp/tests/features/session-provider/stores/derive-connection-banner.test.ts
+++ b/apps/client-webapp/tests/features/session-provider/stores/derive-connection-banner.test.ts
@@ -4,93 +4,176 @@ import { TranscriptionServiceDisconnectReason } from '@scribear/node-server-sche
 
 import type { SessionStatusSnapshot } from '#src/features/session-provider/services/client-session-service';
 import { SessionConnectionStatus } from '#src/features/session-provider/services/client-session-service-status';
-import { deriveConnectionBanner } from '#src/features/session-provider/stores/derive-connection-banner';
+import {
+  type ConnectionBanner,
+  deriveConnectionBanner,
+} from '#src/features/session-provider/stores/derive-connection-banner';
 
-const CONNECTED_SNAPSHOT: SessionStatusSnapshot = {
-  transcriptionServiceConnected: true,
-  sourceDeviceConnected: true,
+const SOCKET_DOWN: ConnectionBanner = {
+  open: true,
+  severity: 'warning',
+  message: 'Connection lost. Reconnecting…',
+};
+const WAITING_FOR_SOURCE: ConnectionBanner = {
+  open: true,
+  severity: 'info',
+  message: "Waiting for the room's microphone to connect.",
+};
+const AT_CAPACITY: ConnectionBanner = {
+  open: true,
+  severity: 'warning',
+  message:
+    'The live transcription service is at capacity. Retrying automatically…',
+};
+const UPSTREAM_LOST: ConnectionBanner = {
+  open: true,
+  severity: 'warning',
+  message: 'Connection to the transcription service was lost. Reconnecting…',
+};
+const CLOSED: ConnectionBanner = { open: false };
+
+const CONNECTION_STATUSES = [
+  SessionConnectionStatus.CONNECTING,
+  SessionConnectionStatus.CONNECTED,
+  SessionConnectionStatus.DISCONNECTED,
+] as const;
+
+const REASONS = [
+  undefined,
+  TranscriptionServiceDisconnectReason.AT_CAPACITY,
+] as const;
+
+function snapshot(
+  sourceDeviceConnected: boolean,
+  transcriptionServiceConnected: boolean,
+  reason: TranscriptionServiceDisconnectReason | undefined,
+): SessionStatusSnapshot {
+  return {
+    sourceDeviceConnected,
+    transcriptionServiceConnected,
+    ...(reason !== undefined
+      ? { transcriptionServiceDisconnectReason: reason }
+      : {}),
+  };
+}
+
+function caseKey(
+  connectionStatus: SessionConnectionStatus,
+  sessionStatus: SessionStatusSnapshot | null,
+): string {
+  if (sessionStatus === null) return `${connectionStatus} | no-status-yet`;
+  return (
+    `${connectionStatus} | source=${String(sessionStatus.sourceDeviceConnected)}` +
+    ` transcription=${String(sessionStatus.transcriptionServiceConnected)}` +
+    ` reason=${sessionStatus.transcriptionServiceDisconnectReason ?? 'none'}`
+  );
+}
+
+/**
+ * The complete input space of this pure function, written out as literals
+ * rather than re-derived from the implementation: 3 connection statuses x
+ * (the `sessionStatus === null` case + 2 x 2 x 2 snapshot combinations) = 27
+ * rows. Spot-checking instead of pinning this table is how the "healthy idle
+ * room" case shipped - a successful join with nobody streaming yet was
+ * rendered as "Connection to the transcription service was lost.
+ * Reconnecting…", forever, on every real room.
+ */
+const EXPECTED: Record<string, ConnectionBanner> = {
+  // Own socket down: it subsumes everything node-server might have said.
+  'CONNECTING | no-status-yet': SOCKET_DOWN,
+  'CONNECTING | source=false transcription=false reason=none': SOCKET_DOWN,
+  'CONNECTING | source=false transcription=false reason=at-capacity':
+    SOCKET_DOWN,
+  'CONNECTING | source=false transcription=true reason=none': SOCKET_DOWN,
+  'CONNECTING | source=false transcription=true reason=at-capacity':
+    SOCKET_DOWN,
+  'CONNECTING | source=true transcription=false reason=none': SOCKET_DOWN,
+  'CONNECTING | source=true transcription=false reason=at-capacity':
+    SOCKET_DOWN,
+  'CONNECTING | source=true transcription=true reason=none': SOCKET_DOWN,
+  'CONNECTING | source=true transcription=true reason=at-capacity': SOCKET_DOWN,
+  'DISCONNECTED | no-status-yet': SOCKET_DOWN,
+  'DISCONNECTED | source=false transcription=false reason=none': SOCKET_DOWN,
+  'DISCONNECTED | source=false transcription=false reason=at-capacity':
+    SOCKET_DOWN,
+  'DISCONNECTED | source=false transcription=true reason=none': SOCKET_DOWN,
+  'DISCONNECTED | source=false transcription=true reason=at-capacity':
+    SOCKET_DOWN,
+  'DISCONNECTED | source=true transcription=false reason=none': SOCKET_DOWN,
+  'DISCONNECTED | source=true transcription=false reason=at-capacity':
+    SOCKET_DOWN,
+  'DISCONNECTED | source=true transcription=true reason=none': SOCKET_DOWN,
+  'DISCONNECTED | source=true transcription=true reason=at-capacity':
+    SOCKET_DOWN,
+
+  // Own socket up, nothing reported yet: silence, not a guess.
+  'CONNECTED | no-status-yet': CLOSED,
+
+  // Own socket up, no source streaming: the normal idle state of a healthy
+  // room. `transcription=false` here carries no information - node-server
+  // only dials the Transcription Service once a source registers - so the
+  // source flag decides, including when a stale reason is still attached.
+  'CONNECTED | source=false transcription=false reason=none':
+    WAITING_FOR_SOURCE,
+  'CONNECTED | source=false transcription=false reason=at-capacity':
+    WAITING_FOR_SOURCE,
+  'CONNECTED | source=false transcription=true reason=none': WAITING_FOR_SOURCE,
+  'CONNECTED | source=false transcription=true reason=at-capacity':
+    WAITING_FOR_SOURCE,
+
+  // Own socket up, a source IS streaming: now the upstream flag is a real
+  // fault signal.
+  'CONNECTED | source=true transcription=false reason=none': UPSTREAM_LOST,
+  'CONNECTED | source=true transcription=false reason=at-capacity': AT_CAPACITY,
+  'CONNECTED | source=true transcription=true reason=none': CLOSED,
+  'CONNECTED | source=true transcription=true reason=at-capacity': CLOSED,
 };
 
 describe('deriveConnectionBanner', () => {
-  it('reports the client socket as reconnecting when CONNECTING, regardless of sessionStatus', () => {
-    expect(
-      deriveConnectionBanner(SessionConnectionStatus.CONNECTING, null),
-    ).toEqual({
-      open: true,
-      severity: 'warning',
-      message: 'Connection lost. Reconnecting…',
+  describe('full input cross-product', () => {
+    const covered = new Set<string>();
+
+    for (const connectionStatus of CONNECTION_STATUSES) {
+      for (const sessionStatus of [
+        null,
+        ...[false, true].flatMap((source) =>
+          [false, true].flatMap((transcription) =>
+            REASONS.map((reason) => snapshot(source, transcription, reason)),
+          ),
+        ),
+      ]) {
+        const key = caseKey(connectionStatus, sessionStatus);
+        covered.add(key);
+        it(key, () => {
+          expect(
+            deriveConnectionBanner(connectionStatus, sessionStatus),
+          ).toEqual(EXPECTED[key]);
+        });
+      }
+    }
+
+    // Guards the table both ways: no input row without an expectation, and no
+    // expectation row that no longer corresponds to a reachable input.
+    it('has exactly one expectation per reachable input', () => {
+      expect([...covered].sort()).toEqual(Object.keys(EXPECTED).sort());
+      expect(covered.size).toBe(27);
     });
   });
 
-  it('reports the client socket as reconnecting when DISCONNECTED, even if sessionStatus looks fine', () => {
-    expect(
-      deriveConnectionBanner(
-        SessionConnectionStatus.DISCONNECTED,
-        CONNECTED_SNAPSHOT,
-      ),
-    ).toEqual({
-      open: true,
-      severity: 'warning',
-      message: 'Connection lost. Reconnecting…',
-    });
-  });
-
-  it('does not report the nested transcription-service state when the own socket is down', () => {
-    // Even though the transcription service is also down (and at capacity),
-    // the own-socket message should win - it explains everything else.
-    const result = deriveConnectionBanner(SessionConnectionStatus.CONNECTING, {
-      transcriptionServiceConnected: false,
-      sourceDeviceConnected: true,
-      transcriptionServiceDisconnectReason:
-        TranscriptionServiceDisconnectReason.AT_CAPACITY,
-    });
-    expect(result).toEqual({
-      open: true,
-      severity: 'warning',
-      message: 'Connection lost. Reconnecting…',
-    });
-  });
-
-  it('reports the at-capacity message when connected but the transcription service refused for capacity', () => {
-    const result = deriveConnectionBanner(SessionConnectionStatus.CONNECTED, {
-      transcriptionServiceConnected: false,
-      sourceDeviceConnected: true,
-      transcriptionServiceDisconnectReason:
-        TranscriptionServiceDisconnectReason.AT_CAPACITY,
-    });
-    expect(result).toEqual({
-      open: true,
-      severity: 'warning',
-      message:
-        'The live transcription service is at capacity. Retrying automatically…',
-    });
-  });
-
-  it('reports a generic message when connected but the transcription service is down for an unknown reason', () => {
-    const result = deriveConnectionBanner(SessionConnectionStatus.CONNECTED, {
-      transcriptionServiceConnected: false,
-      sourceDeviceConnected: true,
-    });
-    expect(result).toEqual({
-      open: true,
-      severity: 'warning',
-      message:
-        'Connection to the transcription service was lost. Reconnecting…',
-    });
-  });
-
-  it('closes the banner when connected and the transcription service is connected', () => {
-    expect(
-      deriveConnectionBanner(
+  describe('the regression this table exists for', () => {
+    it('reports a healthy idle room as informational, never as "reconnecting"', () => {
+      const result = deriveConnectionBanner(
         SessionConnectionStatus.CONNECTED,
-        CONNECTED_SNAPSHOT,
-      ),
-    ).toEqual({ open: false });
-  });
-
-  it('closes the banner when connected and there is no sessionStatus yet', () => {
-    expect(
-      deriveConnectionBanner(SessionConnectionStatus.CONNECTED, null),
-    ).toEqual({ open: false });
+        // Exactly what node-server sends immediately after a successful join
+        // to a real room with no kiosk streaming yet.
+        snapshot(false, false, undefined),
+      );
+      expect(result).toEqual({
+        open: true,
+        severity: 'info',
+        message: "Waiting for the room's microphone to connect.",
+      });
+      expect(result.open && result.message).not.toMatch(/reconnect/i);
+    });
   });
 });

--- a/apps/kiosk-webapp/src/features/kiosk-provider/stores/kiosk-slice.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/stores/kiosk-slice.ts
@@ -89,9 +89,11 @@ export type ConnectionBannerState =
  *
  * No session (`connectionStatus === null`) means there is nothing to report
  * - the kiosk isn't participating in a session, so there's no connection to
- * be lost. Every case here is a retrying/transient state (matching this
- * feature's fail-open philosophy elsewhere), so severity is always
- * `'warning'`, never `'error'`.
+ * be lost. Almost every case here is a retrying/transient state (matching
+ * this feature's fail-open philosophy elsewhere) and so is a `'warning'`. The
+ * one exception is `INVALID_REQUEST`: the transcription service rejected this
+ * session's configuration and will reject the identical retry forever, so
+ * there is nothing to wait for and it is reported as an `'error'`.
  */
 export function deriveConnectionBanner(
   connectionStatus: SessionConnectionStatus | null,
@@ -118,6 +120,23 @@ export function deriveConnectionBanner(
         severity: 'warning',
         message:
           'The live transcription service is at capacity. Retrying automatically…',
+      };
+    }
+    // Permanent, unlike every other branch here: the transcription service
+    // rejected this session's configuration (close 1007 - typically a
+    // transcriptionProviderId that does not exist on this deployment) and will
+    // reject the identical retry forever. "Reconnecting…" would be a promise
+    // nothing can keep, so this says what has to happen instead, and says it
+    // as an error rather than a warning.
+    if (
+      sessionStatus.transcriptionServiceDisconnectReason ===
+      TranscriptionServiceDisconnectReason.INVALID_REQUEST
+    ) {
+      return {
+        open: true,
+        severity: 'error',
+        message:
+          'Live transcription is misconfigured for this room and cannot start. An administrator needs to check the session’s transcription provider.',
       };
     }
     return {

--- a/apps/kiosk-webapp/tests/features/kiosk-provider/stores/kiosk-slice.test.ts
+++ b/apps/kiosk-webapp/tests/features/kiosk-provider/stores/kiosk-slice.test.ts
@@ -63,6 +63,26 @@ describe('deriveConnectionBanner', (it) => {
     });
   });
 
+  it('reports a permanent error when the transcription service rejected the request', () => {
+    // Close 1007 - in practice a transcriptionProviderId that is not in the
+    // deployment's provider_config.json. The retry loop re-sends the identical
+    // config forever, so "Reconnecting…" would be a promise nothing can keep.
+    const status = statusSnapshot({
+      transcriptionServiceConnected: false,
+      transcriptionServiceDisconnectReason:
+        TranscriptionServiceDisconnectReason.INVALID_REQUEST,
+    });
+
+    expect(
+      deriveConnectionBanner(SessionConnectionStatus.CONNECTED, status),
+    ).toEqual({
+      open: true,
+      severity: 'error',
+      message:
+        'Live transcription is misconfigured for this room and cannot start. An administrator needs to check the session’s transcription provider.',
+    });
+  });
+
   it('warns generically when the socket is up but the transcription service is down for an unknown reason', () => {
     const status = statusSnapshot({ transcriptionServiceConnected: false });
 

--- a/apps/monitoring-sidecar/src/server/shared/metrics/metrics-registry.service.ts
+++ b/apps/monitoring-sidecar/src/server/shared/metrics/metrics-registry.service.ts
@@ -124,6 +124,24 @@ export class MetricsRegistry {
   );
 
   /**
+   * Source registrations refused because the session was already over. Not a
+   * failure — the socket is closed 1000 with `sessionEnded` and no upstream
+   * is dialed — which is exactly why it needs its own series: downstream it is
+   * indistinguishable from an ordinary session end, while it actually means a
+   * device connected to a session that finished before it arrived. The usual
+   * cause is a kiosk whose schedule long-poll has been failing silently, and
+   * nothing else in the fleet reports that.
+   *
+   * Optional on the wire
+   * (`STATUS_PROCESS_SCHEMA.summary.endedSessionRegistrationsTotal`), so a
+   * poll of an older node-server records no increment rather than a zero.
+   */
+  readonly nodeEndedSessionRegistrationsTotal = new Counter(
+    'scribear_node_ended_session_registrations_total',
+    'Source registrations refused because the session had already reached its effectiveEnd.',
+  );
+
+  /**
    * Audio frames evicted at the per-session pending-chunk cap (§3 N3).
    * Sustained eviction means latency correlation is degrading silently.
    */
@@ -719,6 +737,7 @@ export class MetricsRegistry {
       this.nodeAuthTimeoutsTotal,
       this.nodeBinaryBeforeAuthDropsTotal,
       this.nodeOrchestratorFailuresTotal,
+      this.nodeEndedSessionRegistrationsTotal,
       this.nodePendingChunkEvictionsTotal,
       this.nodeLatencySamplesTotal,
       this.nodeLatencyE2eNegativeTotal,

--- a/apps/monitoring-sidecar/src/server/shared/node-status/node-status-poller.service.ts
+++ b/apps/monitoring-sidecar/src/server/shared/node-status/node-status-poller.service.ts
@@ -132,6 +132,15 @@ export class NodeStatusPollerService extends AbsoluteStatusPoller<NodeStatusBody
       { service },
       s.orchestratorFailuresTotal,
     );
+    // Optional on the wire, skipped rather than defaulted - same reasoning as
+    // `binaryBeforeAuthDropsTotal` above.
+    if (s.endedSessionRegistrationsTotal !== undefined) {
+      this._advance(
+        this._metrics.nodeEndedSessionRegistrationsTotal,
+        { service },
+        s.endedSessionRegistrationsTotal,
+      );
+    }
     this._advance(
       this._metrics.nodePendingChunkEvictionsTotal,
       { service },

--- a/apps/monitoring-sidecar/tests/fixtures/fake-node-status.ts
+++ b/apps/monitoring-sidecar/tests/fixtures/fake-node-status.ts
@@ -132,10 +132,11 @@ export function statusBody(
     Omit<FakeStatusBody, 'summary' | 'sessions' | 'secretPlaceholders'>
   > & {
     // Not in `ZERO_SUMMARY`: absent by default, matching a node-server that
-    // predates this field. A test opts in explicitly to exercise the
+    // predates these fields. A test opts in explicitly to exercise the
     // present case.
     summary?: Partial<typeof ZERO_SUMMARY> & {
       binaryBeforeAuthDropsTotal?: number;
+      endedSessionRegistrationsTotal?: number;
     };
     sessions?: FakeSessionInput[];
     secretPlaceholders?: Partial<FakeSecretPlaceholders>;

--- a/apps/monitoring-sidecar/tests/integration/node-status-poller.test.ts
+++ b/apps/monitoring-sidecar/tests/integration/node-status-poller.test.ts
@@ -101,6 +101,34 @@ describe('node-server status poller (B1.1 PR 4)', () => {
       ).toBe(9);
     });
 
+    it('folds ended-session source registrations, and skips them when omitted', async () => {
+      // Arrange - the stale-schedule signal: a kiosk arriving at a session
+      // that finished before it connected. Optional on the wire like the
+      // counter above, so an older node-server must record no delta rather
+      // than a zero.
+      const { metrics, poller } = await createPoller();
+
+      // Act - a poll with the field absent, then two that report it.
+      await poller.pollOnce();
+      const omitted = metrics.nodeEndedSessionRegistrationsTotal.get({
+        service: SERVICE,
+      });
+      node.setBody(
+        statusBody({ summary: { endedSessionRegistrationsTotal: 2 } }),
+      );
+      await poller.pollOnce();
+      node.setBody(
+        statusBody({ summary: { endedSessionRegistrationsTotal: 7 } }),
+      );
+      await poller.pollOnce();
+
+      // Assert - 7 total events seen, not 2 + 7.
+      expect(omitted).toBe(0);
+      expect(
+        metrics.nodeEndedSessionRegistrationsTotal.get({ service: SERVICE }),
+      ).toBe(7);
+    });
+
     it('does not throw or record a delta when an older node-server omits the field', async () => {
       // Arrange - the field is optional on the wire for backward-compat with
       // publishers that predate it, so a body that simply never mentions it

--- a/apps/node-server/src/server/features/transcription-stream/events/session-status.events.ts
+++ b/apps/node-server/src/server/features/transcription-stream/events/session-status.events.ts
@@ -8,12 +8,20 @@ import type { ChannelDefinition } from '#src/server/shared/services/event-bus.se
  * connection (WebSocket close 1013, "try again later") rather than the
  * connection dropping or the service crashing - see
  * `archived-plans/2026-07-27-02-PLAN-AdmissionControl.md` §4, "node-server must
- * distinguish 'service refused' from 'service crashed'". Mirrored in
- * `@scribear/node-server-schema`'s `sessionStatus` message; keep both in
- * sync.
+ * distinguish 'service refused' from 'service crashed'".
+ *
+ * `INVALID_REQUEST` means the service rejected what we sent as unacceptable
+ * (close 1007), which in practice is a session whose `transcriptionProviderId`
+ * is not a key in the deployment's `provider_config.json`. The reconnect loop
+ * re-sends the same request forever, so this one never clears without an
+ * operator - unlike `AT_CAPACITY`, which clears when load drops.
+ *
+ * Mirrored in `@scribear/node-server-schema`'s `sessionStatus` message; keep
+ * both in sync.
  */
 export enum TranscriptionServiceDisconnectReason {
   AT_CAPACITY = 'at-capacity',
+  INVALID_REQUEST = 'invalid-request',
 }
 
 /**

--- a/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
@@ -96,6 +96,46 @@ export interface SessionSnapshot {
 }
 
 /**
+ * Thrown by {@link TranscriptionOrchestratorService.registerSource} when the
+ * session's `effectiveEnd` has already passed.
+ *
+ * A distinct type rather than a plain `Error` because the two failures a source
+ * registration can have are not the same event and must not close the socket
+ * the same way: an unreachable Session Manager is *broken* and earns 1011
+ * `orchestrator-unavailable`, whereas this session is merely *over* and earns
+ * `sessionEnded` + a clean 1000. The kiosk already distinguishes those - 1000
+ * drops it to IDLE, anything else reconnect-loops - so collapsing them would
+ * put a finished session into a retry loop.
+ *
+ * No registration is created and no upstream is dialed, so there is nothing for
+ * the caller to release.
+ */
+export class SessionAlreadyEndedError extends Error {
+  readonly sessionUid: string;
+
+  constructor(sessionUid: string) {
+    super(`session ${sessionUid} has already reached its effectiveEnd`);
+    this.name = 'SessionAlreadyEndedError';
+    this.sessionUid = sessionUid;
+  }
+}
+
+/**
+ * Whether `session`'s effective end is already in the past.
+ *
+ * Both "no end at all" and "an end we cannot parse" read as *not* over, on
+ * purpose: this predicate gates whether a source is admitted, so its failure
+ * mode has to be admitting a session that has ended (which the end timer then
+ * catches a moment later) rather than refusing one that has not.
+ */
+function hasAlreadyEnded(session: Session): boolean {
+  if (session.effectiveEnd === null) return false;
+  const endMs = Date.parse(session.effectiveEnd);
+  if (Number.isNaN(endMs)) return false;
+  return endMs <= Date.now();
+}
+
+/**
  * Handle returned by {@link TranscriptionOrchestratorService.registerSource}.
  * The caller MUST call `unregister` when the source connection closes. The
  * caller SHOULD call `setMicrophoneActive` when the source's mic state
@@ -319,12 +359,24 @@ export class TranscriptionOrchestratorService {
    * when the source connection closes, and whose `setMicrophoneActive` the
    * caller SHOULD invoke to report mic state. The upstream is torn down when
    * the count returns to 0.
+   *
+   * Throws {@link SessionAlreadyEndedError} if the session is already past its
+   * `effectiveEnd`. Nothing is registered and no upstream is dialed in that
+   * case; the caller is expected to send `sessionEnded` and close 1000.
    */
   async registerSource(sessionUid: string): Promise<SourceHandle> {
     let state = this._sessions.get(sessionUid);
     if (state === undefined) {
       state = await this._openSession(sessionUid);
       this._sessions.set(sessionUid, state);
+    } else if (state.ended) {
+      // A state that has published its end is torn down as soon as its last
+      // source socket finishes closing, so this is a narrow window rather
+      // than a steady state - but a source landing inside that window would
+      // otherwise attach to a session no timer will ever fire for again, and
+      // hang exactly as it did before this check existed.
+      this._recordEndedSessionRegistration(sessionUid, null);
+      throw new SessionAlreadyEndedError(sessionUid);
     }
     // A real session is the authoritative end-timer owner while it exists, so
     // any end-watch a viewer opened before the source arrived stands down now
@@ -663,6 +715,20 @@ export class TranscriptionOrchestratorService {
     const longPoll = this._sessionConfigPollFactory(sessionUid);
     const initial = await this._awaitFirstConfig(longPoll, sessionUid);
 
+    // Checked here - the first moment the end is knowable - rather than left to
+    // `_armEndTimer` at the bottom of this method. By then the upstream has
+    // already been constructed and started, and the transcription service is
+    // the scarcest thing in the deployment (`num_workers: 1`, a low admission
+    // ceiling on a cold process): dialing it for a session we are about to
+    // abandon takes capacity away from a room that is actually running. The
+    // upstream is also only ever torn down by `_unregisterSource`, so an
+    // abandoned one is not reclaimed until its socket closes.
+    if (hasAlreadyEnded(initial)) {
+      longPoll.close();
+      this._recordEndedSessionRegistration(sessionUid, initial.effectiveEnd);
+      throw new SessionAlreadyEndedError(sessionUid);
+    }
+
     // The config the upstream must be (re)told about on every connection. Held
     // in a mutable box rather than read from `initial` so a reconnect after a
     // config bump replays the CURRENT config, not the one this session opened
@@ -844,6 +910,31 @@ export class TranscriptionOrchestratorService {
     this._armEndTimer(sessionUid, state, initial);
 
     return state;
+  }
+
+  /**
+   * Count and name a source registration that arrived after the session was
+   * already over (§3.4 of the plan this fixes).
+   *
+   * Worth its own signal rather than being folded into the ordinary end path:
+   * a session ending under a connected source is routine, whereas a source
+   * *arriving* at a finished session means something upstream is working from
+   * a stale schedule - most likely a kiosk whose `mySchedule` long-poll has
+   * been failing silently for hours. That cause is invisible in every other
+   * series, because from the outside it looks exactly like a normal
+   * registration followed by a normal end.
+   *
+   * @param effectiveEnd The end the session's config reported, when known.
+   */
+  private _recordEndedSessionRegistration(
+    sessionUid: string,
+    effectiveEnd: string | null,
+  ): void {
+    this._metrics.recordEndedSessionRegistration();
+    this._logger.warn(
+      { sessionUid, effectiveEnd },
+      'source registered onto an already-ended session',
+    );
   }
 
   /**

--- a/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
@@ -107,6 +107,46 @@ export interface SourceHandle {
 }
 
 /**
+ * Handle returned by {@link TranscriptionOrchestratorService.registerClient}.
+ * The caller MUST call `unregister` when the client connection closes, so the
+ * session's end-watch is torn down once the last viewer leaves.
+ */
+export interface ClientHandle {
+  unregister: () => void;
+}
+
+/**
+ * Anything that may own the timer that publishes `SessionEndedChannel` for a
+ * session: the real {@link SessionState}, or a source-free
+ * {@link SessionEndWatch}. Named so {@link
+ * TranscriptionOrchestratorService._publishSessionEnded} can latch every
+ * owner a session has, which is what makes "exactly one publish per session
+ * end" hold across both paths.
+ */
+interface EndTimerOwner {
+  /**
+   * Scheduled timer that publishes `SessionEndedChannel` at the session's
+   * `effectiveEnd`. Re-armed on every config update so extensions and
+   * contractions are honored. `null` for open-ended sessions
+   * (`effectiveEnd === null`) and while the owner is disarmed.
+   */
+  endTimer: ReturnType<typeof setTimeout> | null;
+  /**
+   * Last `effectiveEnd` (epoch ms) this owner armed `endTimer` for. Used to
+   * skip re-arming when an unrelated config bump arrives without moving the
+   * end. `null` when nothing is armed.
+   */
+  endTimerArmedFor: number | null;
+  /**
+   * Latches once `SessionEndedChannel` has been published for this session.
+   * Prevents a duplicate publish if a config change races with the timer, if
+   * teardown is already in progress, or if the session's other end-timer
+   * owner reaches the end at the same moment.
+   */
+  ended: boolean;
+}
+
+/**
  * Maps an upstream WebSocket close code onto the reason a viewer is told, or
  * `undefined` when the close carries no information worth distinguishing
  * (1006, 1011, a clean 1000 during teardown...). Only the two codes the
@@ -123,7 +163,7 @@ function closeCodeToDisconnectReason(
   return undefined;
 }
 
-interface SessionState {
+interface SessionState extends EndTimerOwner {
   sourceCount: number;
   /** Monotonic counter for per-source IDs within this session. */
   nextSourceId: number;
@@ -184,23 +224,35 @@ interface SessionState {
    * by {@link MAX_PENDING_CHUNKS}.
    */
   pendingChunks: Map<string, PendingChunk>;
+}
+
+/**
+ * A source-free watch on a session's end, held on behalf of client
+ * (receive-only) connections.
+ *
+ * It is a session-config long-poll and a timer, and nothing else - in
+ * particular it opens NO upstream transcription connection. A viewer must cost
+ * the transcription service zero resources: audio-less connections registering
+ * a job and consuming admission capacity is the exact fault `e80eea2` was
+ * written for.
+ *
+ * Kept in its own map rather than as a `SessionState` with a null upstream so
+ * that everything which iterates real session state (`sessionSnapshots`,
+ * `_setStatus`, `getStatus`) keeps its existing guarantee that a session in
+ * `_sessions` always has an upstream - the same reason `_syntheticStatuses` is
+ * separate.
+ */
+interface SessionEndWatch extends EndTimerOwner {
+  /** Number of client-role connections sharing this watch. */
+  clientCount: number;
+  longPoll: SessionConfigPoll;
   /**
-   * Scheduled timer that publishes `SessionEndedChannel` at the session's
-   * `effectiveEnd`. Re-armed on every config update so extensions/contractions
-   * are honored. `null` for open-ended sessions (`effectiveEnd === null`).
+   * Most recent config the long-poll delivered, or `null` before the first
+   * response. Retained so the watch can re-arm itself from the current
+   * `effectiveEnd` when a source's `SessionState` is torn down under it,
+   * without waiting for the next config bump.
    */
-  endTimer: ReturnType<typeof setTimeout> | null;
-  /**
-   * Last `effectiveEnd` (epoch ms) we armed `endTimer` for. Used to skip
-   * re-arming when an unrelated config bump arrives without changing the end.
-   */
-  endTimerArmedFor: number | null;
-  /**
-   * Latches once the orchestrator has published `SessionEndedChannel` for this
-   * session. Prevents duplicate publishes if a config change races with the
-   * timer or if teardown is already in progress.
-   */
-  ended: boolean;
+  lastSession: Session | null;
 }
 
 /**
@@ -214,11 +266,19 @@ interface SessionState {
  *
  * Each session's upstream is opened lazily on the first source registration
  * and torn down when the source-connection ref count drops back to zero.
- * Client (receive-only) connections never call into the orchestrator; they
- * subscribe to {@link TranscriptChannel} directly.
+ * Client (receive-only) connections take out an *end-watch* instead
+ * ({@link registerClient}): a config long-poll and a timer, no upstream, so a
+ * room full of viewers with no source attached still learns when the session
+ * ends without costing the transcription service anything.
  */
 export class TranscriptionOrchestratorService {
   private _sessions = new Map<string, SessionState>();
+  /**
+   * Source-free end-watches, keyed by sessionUid, one per session with at
+   * least one client-role connection. Deliberately not merged into
+   * `_sessions`: see the note on {@link SessionEndWatch}.
+   */
+  private _endWatches = new Map<string, SessionEndWatch>();
   /**
    * Status overrides for sessions that have no real upstream - only the
    * demo caption room (see `demo-room/`). Kept separate from
@@ -266,6 +326,13 @@ export class TranscriptionOrchestratorService {
       state = await this._openSession(sessionUid);
       this._sessions.set(sessionUid, state);
     }
+    // A real session is the authoritative end-timer owner while it exists, so
+    // any end-watch a viewer opened before the source arrived stands down now
+    // rather than racing this session's own timer. `_unregisterSource` hands
+    // the watch its timer back when this state is torn down.
+    const watch = this._endWatches.get(sessionUid);
+    if (watch !== undefined) this._disarmEndWatch(watch);
+
     const sourceId = state.nextSourceId++;
     state.sourceCount += 1;
     state.sourceMicStates.set(sourceId, undefined);
@@ -276,6 +343,51 @@ export class TranscriptionOrchestratorService {
       },
       setMicrophoneActive: (active: boolean) => {
         this._setSourceMicrophone(sessionUid, sourceId, active);
+      },
+    };
+  }
+
+  /**
+   * Register a client (receive-only) connection for a session. The first
+   * registration opens an {@link SessionEndWatch}; subsequent ones just bump
+   * the ref count, and the watch is torn down when the last client-role
+   * connection for the session disconnects.
+   *
+   * The watch exists so a viewer on a session with **no source attached**
+   * still learns the session ended on time. Without it nothing fetches that
+   * session's config at all, so `SessionEndedChannel` is never published and
+   * the viewer sits on stale captions until its next token refresh happens to
+   * be rejected - up to half the token lifetime.
+   *
+   * Synchronous and infallible on purpose, unlike {@link registerSource}:
+   *
+   * - Synchronous, so a viewer's `authOk` is never made to wait on Session
+   *   Manager. The watch arms itself when the long-poll's first response
+   *   arrives.
+   * - Infallible, so a config fetch that fails cannot disconnect someone who
+   *   is happily receiving captions. A source that cannot reach Session
+   *   Manager is useless and rightly gets 1011; a viewer that cannot is only
+   *   missing its end signal, which degrades to the pre-end-watch behaviour.
+   */
+  registerClient(sessionUid: string): ClientHandle {
+    const existing = this._endWatches.get(sessionUid);
+    if (existing !== undefined) {
+      existing.clientCount += 1;
+    } else if (!this._startEndWatch(sessionUid)) {
+      // Degraded, not fatal - see the doc comment above.
+      return { unregister: () => undefined };
+    }
+
+    // Guarded rather than bare like `SourceHandle.unregister`, which is keyed
+    // by a per-source id: this one only has a count to decrement, and a
+    // double release would drop the watch out from under the viewers still on
+    // it.
+    let released = false;
+    return {
+      unregister: () => {
+        if (released) return;
+        released = true;
+        this._unregisterClient(sessionUid);
       },
     };
   }
@@ -788,18 +900,191 @@ export class TranscriptionOrchestratorService {
     }, delayMs);
   }
 
-  private _publishSessionEnded(sessionUid: string, state: SessionState): void {
-    if (state.ended) return;
-    state.ended = true;
-    if (state.endTimer !== null) {
-      clearTimeout(state.endTimer);
-      state.endTimer = null;
+  /**
+   * Start a source-free end-watch for `sessionUid` on behalf of its first
+   * client connection: a session-config long-poll and nothing else. Returns
+   * `false` if it could not be started, which the caller degrades rather than
+   * propagates.
+   *
+   * The long-poll is the same one `_openSession` uses, deliberately: a
+   * session's `effectiveEnd` moves (`startSessionEarly` / `endSessionEarly`
+   * bump `sessionConfigVersion`), so the watch has to follow config rather
+   * than read the end once. `endSessionEarly` sets `end_override = now`, which
+   * arrives here as an already-past end and publishes immediately.
+   *
+   * The watch is registered and counted BEFORE the poll is started, so a
+   * response that arrives synchronously finds it in `_endWatches` and a
+   * publish it triggers has a ref count to release.
+   */
+  private _startEndWatch(sessionUid: string): boolean {
+    let watch: SessionEndWatch;
+    try {
+      watch = {
+        clientCount: 1,
+        longPoll: this._sessionConfigPollFactory(sessionUid),
+        lastSession: null,
+        endTimer: null,
+        endTimerArmedFor: null,
+        ended: false,
+      };
+    } catch (err) {
+      this._logger.error(
+        { err, sessionUid },
+        'failed to create session end-watch; viewers will not be told when this session ends',
+      );
+      return false;
     }
+
+    watch.longPoll.on('data', (session) => {
+      // Ignore a response that arrives after this watch was torn down or
+      // replaced, mirroring the stale-publish guards on `_sessions`.
+      if (this._endWatches.get(sessionUid) !== watch) return;
+      watch.lastSession = session;
+      this._armEndWatch(sessionUid, watch);
+    });
+    watch.longPoll.on('error', (err) => {
+      // Not terminal: `LongPollClient` retries with backoff on its own, and
+      // this must never reach the viewer's socket. Warn rather than error -
+      // an unreachable Session Manager costs a viewer only its end signal.
+      this._logger.warn(
+        { err, sessionUid },
+        'session-config long-poll error on end-watch',
+      );
+    });
+
+    this._endWatches.set(sessionUid, watch);
+    try {
+      watch.longPoll.start();
+    } catch (err) {
+      this._endWatches.delete(sessionUid);
+      this._logger.error(
+        { err, sessionUid },
+        'failed to start session end-watch; viewers will not be told when this session ends',
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Arm (or re-arm) an end-watch's timer from the config it last saw. Called
+   * on every config-stream response, and again by `_unregisterSource` when a
+   * session's own state is torn down under the watch.
+   *
+   * The watch defers to a live {@link SessionState}: that state already arms a
+   * timer off the same `effectiveEnd`, so while it exists the watch holds no
+   * timer at all and this is where that is enforced. There is therefore never
+   * more than one armed timer per session.
+   */
+  private _armEndWatch(sessionUid: string, watch: SessionEndWatch): void {
+    if (watch.ended) return;
+    const session = watch.lastSession;
+    if (session === null) return;
+
+    const state = this._sessions.get(sessionUid);
+    if (state !== undefined && !state.ended) {
+      this._disarmEndWatch(watch);
+      return;
+    }
+
+    if (session.effectiveEnd === null) {
+      // Open-ended: cancel any prior timer (a previous config may have had a
+      // finite end) and wait for the next config update.
+      this._disarmEndWatch(watch);
+      return;
+    }
+
+    const endMs = Date.parse(session.effectiveEnd);
+    if (watch.endTimerArmedFor === endMs) return;
+
+    if (watch.endTimer !== null) {
+      clearTimeout(watch.endTimer);
+      watch.endTimer = null;
+    }
+    watch.endTimerArmedFor = endMs;
+
+    const delayMs = endMs - Date.now();
+    if (delayMs <= 0) {
+      // Already over - a viewer joining an ended session, or an
+      // `endSessionEarly` that moved the end into the past. Publish now
+      // rather than scheduling a zero-delay timer, exactly as `_armEndTimer`
+      // does, so the viewer is not left hanging.
+      this._publishSessionEnded(sessionUid, watch);
+      return;
+    }
+    watch.endTimer = setTimeout(() => {
+      watch.endTimer = null;
+      // The watch may have been torn down between scheduling and firing (last
+      // viewer disconnected); the map check guards a stale publish.
+      if (this._endWatches.get(sessionUid) !== watch) return;
+      this._publishSessionEnded(sessionUid, watch);
+    }, delayMs);
+  }
+
+  /** Cancel an end-watch's timer, leaving it able to re-arm on a later config. */
+  private _disarmEndWatch(watch: SessionEndWatch): void {
+    if (watch.endTimer !== null) {
+      clearTimeout(watch.endTimer);
+      watch.endTimer = null;
+    }
+    watch.endTimerArmedFor = null;
+  }
+
+  private _unregisterClient(sessionUid: string): void {
+    const watch = this._endWatches.get(sessionUid);
+    if (watch === undefined) return;
+    watch.clientCount -= 1;
+    if (watch.clientCount > 0) return;
+
+    this._endWatches.delete(sessionUid);
+    this._disarmEndWatch(watch);
+    watch.longPoll.close();
+  }
+
+  /**
+   * Publish `SessionEndedChannel` for a session, at most once per end.
+   *
+   * A session can have two end-timer owners over its lifetime - the
+   * {@link SessionState} a source opens and the {@link SessionEndWatch} its
+   * viewers hold - and only one of them is ever armed at a time
+   * (`_armEndWatch` stands the watch down while a live state exists). This
+   * latches *both* regardless, so the loser of any race cannot publish a
+   * second time: in particular the source-side teardown that follows a
+   * publish deletes the state and calls back into `_armEndWatch`, which must
+   * find the watch already latched rather than re-arm it for an end that has
+   * just passed.
+   *
+   * `initiator` is passed rather than looked up because `_openSession` arms
+   * the session's timer before `registerSource` inserts the state into
+   * `_sessions`; a lookup would miss it and leave that state unlatched.
+   */
+  private _publishSessionEnded(
+    sessionUid: string,
+    initiator: EndTimerOwner,
+  ): void {
+    if (initiator.ended) return;
+    this._latchEnded(initiator);
+
+    const state = this._sessions.get(sessionUid);
+    if (state !== undefined && state !== initiator) this._latchEnded(state);
+    const watch = this._endWatches.get(sessionUid);
+    if (watch !== undefined && watch !== initiator) this._latchEnded(watch);
+
     this._logger.info({ sessionUid }, 'session reached effectiveEnd');
     // Connections subscribed on the bus will send `sessionEnded` and close
-    // 1000; their close handlers unregister sources, which drains
-    // `_unregisterSource` to zero and tears down upstream + long-poll.
+    // 1000; their close handlers unregister sources and client end-watch
+    // registrations, which drains `_unregisterSource` / `_unregisterClient` to
+    // zero and tears down upstream + long-poll(s).
     this._eventBus.publish(SessionEndedChannel, {}, sessionUid);
+  }
+
+  /** Mark an end-timer owner as having published, and cancel its timer. */
+  private _latchEnded(owner: EndTimerOwner): void {
+    owner.ended = true;
+    if (owner.endTimer !== null) {
+      clearTimeout(owner.endTimer);
+      owner.endTimer = null;
+    }
   }
 
   private async _awaitFirstConfig(
@@ -847,6 +1132,14 @@ export class TranscriptionOrchestratorService {
       clearTimeout(state.endTimer);
       state.endTimer = null;
     }
+
+    // Viewers outlive the source routinely (the kiosk is unplugged, the room
+    // keeps watching). This state was the session's end-timer owner and has
+    // just gone, so hand the job back to the end-watch if one is held. A
+    // no-op when the state got here by publishing `sessionEnded`, since that
+    // latched the watch too.
+    const watch = this._endWatches.get(sessionUid);
+    if (watch !== undefined) this._armEndWatch(sessionUid, watch);
 
     if (
       state.status.transcriptionServiceConnected ||

--- a/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-orchestrator.service.ts
@@ -106,6 +106,23 @@ export interface SourceHandle {
   setMicrophoneActive: (active: boolean) => void;
 }
 
+/**
+ * Maps an upstream WebSocket close code onto the reason a viewer is told, or
+ * `undefined` when the close carries no information worth distinguishing
+ * (1006, 1011, a clean 1000 during teardown...). Only the two codes the
+ * transcription service chooses *deliberately* are named here; everything else
+ * stays undistinguished, exactly as before this mapping existed.
+ */
+function closeCodeToDisconnectReason(
+  code: number | null,
+): TranscriptionServiceDisconnectReason | undefined {
+  if (code === 1013) return TranscriptionServiceDisconnectReason.AT_CAPACITY;
+  if (code === 1007) {
+    return TranscriptionServiceDisconnectReason.INVALID_REQUEST;
+  }
+  return undefined;
+}
+
 interface SessionState {
   sourceCount: number;
   /** Monotonic counter for per-source IDs within this session. */
@@ -139,9 +156,10 @@ interface SessionState {
   upstream: UpstreamClient;
   /**
    * Close code from the upstream's most recent `close` event, or `null` if it
-   * has never closed. Recorded so `_setStatus` can distinguish a capacity
-   * refusal (1013) from any other disconnect ("service crashed"-shaped
-   * disconnects included) - see
+   * has never closed. Recorded so `_setStatus` can distinguish the closes the
+   * transcription service chooses deliberately - a capacity refusal (1013) and
+   * a rejected request (1007) - from any other disconnect ("service
+   * crashed"-shaped disconnects included) - see
    * `archived-plans/2026-07-27-02-PLAN-AdmissionControl.md` §4. Stale values
    * are harmless: `_setStatus` only consults this while
    * `upstream.state !== 'OPEN'`, and it is overwritten on every subsequent
@@ -358,10 +376,18 @@ export class TranscriptionOrchestratorService {
     // Omitted (not set to `undefined`) when not applicable:
     // `exactOptionalPropertyTypes` treats an explicit `undefined` on an
     // optional TypeBox-derived property as a type error, not "absent".
-    const disconnectReason =
-      !connected && state.lastUpstreamCloseCode === 1013
-        ? TranscriptionServiceDisconnectReason.AT_CAPACITY
-        : undefined;
+    //
+    // 1007 is the other close the upstream makes on purpose: it rejected our
+    // request as unacceptable (a `transcriptionProviderId` absent from the
+    // deployment's `provider_config.json` raises "Invalid Provider Key", which
+    // the transcription service maps to 1007). Unlike 1013 that is permanent -
+    // the retry loop re-sends the identical config and is refused identically,
+    // forever - so it gets its own reason rather than being collapsed into the
+    // undistinguished "disconnected" that reads to a viewer as a transient
+    // blip.
+    const disconnectReason = !connected
+      ? closeCodeToDisconnectReason(state.lastUpstreamCloseCode)
+      : undefined;
     const next: SessionStatusMessage = {
       transcriptionServiceConnected: connected,
       sourceDeviceConnected: state.sourceCount > 0,

--- a/apps/node-server/src/server/features/transcription-stream/transcription-stream.controller.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-stream.controller.ts
@@ -179,7 +179,11 @@ export class TranscriptionStreamController {
       this._metrics.recordAuthSuccess();
 
       safeSend({ type: TranscriptionStreamServerMessageType.AUTH_OK });
-      service.publishCurrentStatus();
+      // Must follow the AUTH_OK send, never precede it: this is what opens the
+      // service's outbound gate, and it is also where a session that ended
+      // during registration gets its `sessionEnded` + 1000 close - in that
+      // order, after the client has been told its auth succeeded.
+      service.onAuthAcknowledged();
     };
 
     socket.on('close', (code: number, reason: Buffer) => {

--- a/apps/node-server/src/server/features/transcription-stream/transcription-stream.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-stream.service.ts
@@ -13,9 +13,10 @@ import { LatencyChannel } from './events/latency.events.js';
 import { SessionEndedChannel } from './events/session-ended.events.js';
 import { SessionStatusChannel } from './events/session-status.events.js';
 import { TranscriptChannel } from './events/transcript.events.js';
-import type {
-  ClientHandle,
-  SourceHandle,
+import {
+  type ClientHandle,
+  SessionAlreadyEndedError,
+  type SourceHandle,
 } from './transcription-orchestrator.service.js';
 import type { TranscriptionStreamRole } from './transcription-stream.auth.js';
 
@@ -46,7 +47,13 @@ export interface TranscriptionStreamServiceOptions {
  *
  * Role-aware behavior is limited to whether the connection should acquire an
  * orchestrator source registration; both roles subscribe to the per-session
- * transcript / status / ended buses identically.
+ * transcript / status / ended buses identically, and both subscribe *before*
+ * registering anything, so a session end announced during registration is
+ * never missed.
+ *
+ * Nothing is written to the socket until the controller reports that `authOk`
+ * has been sent ({@link TranscriptionStreamService.onAuthAcknowledged}); the
+ * service holds the outbound gate shut until then.
  */
 export class TranscriptionStreamService extends EventEmitter<TranscriptionStreamServiceEvents> {
   private _role: TranscriptionStreamRole;
@@ -68,6 +75,20 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
    * that closed before they ever subscribed.
    */
   private _counted = false;
+  /**
+   * Whether the controller has sent `authOk`. Until it has, nothing may be
+   * written to the socket - see {@link _mayForward}.
+   */
+  private _ready = false;
+  /**
+   * An end signal that arrived before `authOk` and so could not be forwarded
+   * when it happened. Delivered by {@link onAuthAcknowledged}.
+   *
+   * This is the whole point of subscribing before registering: `sessionEnded`
+   * is terminal and nothing resends it, so a connection that misses its own
+   * end signal never learns the session is over.
+   */
+  private _sessionEndedPending = false;
 
   constructor(options: TranscriptionStreamServiceOptions) {
     super();
@@ -86,82 +107,72 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
    *
    * Does NOT emit any messages. The controller is responsible for sending the
    * auth-success protocol response and then invoking
-   * {@link publishCurrentStatus} so the client sees a deterministic initial
-   * snapshot after the success message.
+   * {@link onAuthAcknowledged}, which opens the outbound gate and gives the
+   * client a deterministic initial snapshot after the success message.
    */
   async start(): Promise<void> {
+    // The socket can be closed before `start()` is ever reached (the peer hung
+    // up during auth verification). Bail before subscribing rather than
+    // subscribing and immediately tearing it back down.
+    if (this._isClosed()) return;
+
+    // Subscribed BEFORE any orchestrator registration, and before the await
+    // that registration implies.
+    //
+    // The event bus is synchronous, and registering a source publishes
+    // `sessionEnded` from inside that await whenever the session's config
+    // surfaces an `effectiveEnd` that has already passed. Subscribing
+    // afterwards meant the publish landed on an empty channel: the source was
+    // never told, never closed, and went on streaming audio into a session the
+    // server considered over while holding an upstream transcription
+    // connection open. The client path below has always been ordered this way
+    // for exactly this reason; this is the same rule applied to both roles.
+    this._subscribeToSessionBuses();
+
+    // Counted here rather than in the constructor: a connection costs fan-out
+    // from the moment it is subscribed, which is now this point rather than
+    // after registration. Every exit below runs `_cleanup`, which decrements,
+    // so a registration that fails or a socket that closed mid-await nets to
+    // zero. Both roles count - receive-only clients are what make a large room
+    // expensive (N4), and the orchestrator never sees them.
+    this._metrics.recordConnectionOpen(this._sessionUid);
+    this._counted = true;
+
     if (this._role === 'source') {
-      const handle =
-        await this._transcriptionOrchestratorService.registerSource(
+      let handle: SourceHandle;
+      try {
+        handle = await this._transcriptionOrchestratorService.registerSource(
           this._sessionUid,
         );
+      } catch (err) {
+        if (err instanceof SessionAlreadyEndedError) {
+          // The session is over, not broken. No registration was created and
+          // no upstream was dialed, so there is nothing to release; the
+          // connection stays alive just long enough for the controller to
+          // send `authOk`, after which `onAuthAcknowledged` sends
+          // `sessionEnded` and closes 1000. Deliberately not rethrown: a 1011
+          // here would put a kiosk into a reconnect loop against a session
+          // that is never coming back.
+          this._sessionEndedPending = true;
+          return;
+        }
+        // Genuine orchestrator failure. The controller maps this to 1011 and
+        // closes, which calls `close()` - but unsubscribing here as well keeps
+        // `start()` self-contained, so the subscriptions it took out cannot
+        // outlive it no matter how the caller handles the throw.
+        this._cleanup();
+        throw err;
+      }
       // The connection may have closed while we awaited orchestrator
-      // registration; if so, immediately release the registration and bail
-      // out before subscribing to the buses.
-      if (this._closed) {
+      // registration; if so, release the registration and drop the
+      // subscriptions rather than leaving them attached to a dead socket.
+      if (this._isClosed()) {
         handle.unregister();
+        this._cleanup();
         return;
       }
       this._orchestratorHandle = handle;
     }
-
-    // Counted here rather than in the constructor: a connection only costs
-    // fan-out once it is actually subscribed, and the early return above bails
-    // before this point. Both roles count - receive-only clients are what make
-    // a large room expensive (N4), and the orchestrator never sees them.
-    this._metrics.recordConnectionOpen(this._sessionUid);
-    this._counted = true;
-
-    this._unsubscribeTranscripts = this._eventBusService.subscribe(
-      TranscriptChannel,
-      (transcript) => {
-        if (this._closed) return;
-        this.emit('send', {
-          type: TranscriptionStreamServerMessageType.TRANSCRIPT,
-          final: transcript.final,
-          inProgress: transcript.inProgress,
-        });
-      },
-      this._sessionUid,
-    );
-
-    this._unsubscribeLatency = this._eventBusService.subscribe(
-      LatencyChannel,
-      (latency) => {
-        if (this._closed) return;
-        this.emit('send', {
-          type: TranscriptionStreamServerMessageType.LATENCY_UPDATE,
-          kind: latency.kind,
-          pipelineMs: latency.pipelineMs,
-          e2eMs: latency.e2eMs,
-        });
-      },
-      this._sessionUid,
-    );
-
-    this._unsubscribeSessionStatus = this._eventBusService.subscribe(
-      SessionStatusChannel,
-      (status) => {
-        if (this._closed) return;
-        this.emit('send', {
-          type: TranscriptionStreamServerMessageType.SESSION_STATUS,
-          ...status,
-        });
-      },
-      this._sessionUid,
-    );
-
-    this._unsubscribeSessionEnded = this._eventBusService.subscribe(
-      SessionEndedChannel,
-      () => {
-        if (this._closed) return;
-        this.emit('send', {
-          type: TranscriptionStreamServerMessageType.SESSION_ENDED,
-        });
-        this._closeWith(1000, 'session-ended');
-      },
-      this._sessionUid,
-    );
 
     if (this._role === 'client') {
       // Take out the session's end-watch, so a viewer on a session with no
@@ -177,11 +188,15 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
       const handle = this._transcriptionOrchestratorService.registerClient(
         this._sessionUid,
       );
-      if (this._closed) {
-        // The watch published `sessionEnded` synchronously and this
-        // connection has already been cleaned up; release the registration
-        // rather than leaking it into the ref count.
+      if (this._isClosed()) {
+        // Retained as a guard rather than as a live path: a synchronous
+        // `sessionEnded` from the watch now latches `_sessionEndedPending`
+        // instead of closing (the socket has not seen `authOk` yet), so
+        // nothing here should have closed this connection. If some future
+        // caller manages it anyway, release the registration rather than
+        // leaking it into the ref count.
         handle.unregister();
+        this._cleanup();
         return;
       }
       this._endWatchHandle = handle;
@@ -189,13 +204,34 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
   }
 
   /**
-   * Emit the orchestrator's current session-status snapshot. Called once by
-   * the controller right after the auth-success message so the client sees
-   * the orchestrator's view of connectivity without waiting for the next
-   * transition.
+   * Called by the controller immediately after - and only after - it has sent
+   * the auth-success message. Two duties, both of which have to happen in this
+   * order and nowhere else:
+   *
+   * 1. Open the outbound gate (see {@link _mayForward}). Nothing may reach the
+   *    socket before `authOk`, and the controller is the only thing that knows
+   *    when that has been written.
+   * 2. Deliver either the end signal that arrived while the gate was shut, or
+   *    the orchestrator's current status snapshot, so the client sees the
+   *    server's view of connectivity without waiting for the next transition.
+   *
+   * An already-ended session yields `sessionEnded` + close 1000 instead of a
+   * status snapshot: publishing connectivity for a session that is over would
+   * tell the client to keep waiting for a source that is never coming.
    */
-  publishCurrentStatus(): void {
+  onAuthAcknowledged(): void {
     if (this._closed) return;
+    this._ready = true;
+
+    if (this._sessionEndedPending) {
+      this._sessionEndedPending = false;
+      this.emit('send', {
+        type: TranscriptionStreamServerMessageType.SESSION_ENDED,
+      });
+      this._closeWith(1000, 'session-ended');
+      return;
+    }
+
     const status = this._transcriptionOrchestratorService.getStatus(
       this._sessionUid,
     );
@@ -232,6 +268,113 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
    */
   close(): void {
     this._cleanup();
+  }
+
+  /**
+   * `_closed` behind a call rather than read directly.
+   *
+   * TypeScript keeps property narrowing across an `await`, so a plain
+   * `if (this._closed) return` early in {@link start} would narrow the field
+   * to `false` for every check after the registration await - and those later
+   * checks exist precisely because the socket really can close during it.
+   * Reading through a method leaves each check honest.
+   */
+  private _isClosed(): boolean {
+    return this._closed;
+  }
+
+  /**
+   * Whether a bus message may be written to the socket right now.
+   *
+   * `_ready` is false until the controller has sent `authOk`, and messages
+   * that arrive before then are **dropped**, not queued:
+   *
+   * - Writing anything ahead of `authOk` is a protocol violation. Both the
+   *   kiosk and the client webapp hold their WebSocket handshake open until
+   *   `authOk` arrives, so a message sent earlier reaches a peer that has not
+   *   yet agreed it is connected.
+   * - Nothing of value is lost. `sessionStatus` is superseded moments later by
+   *   the snapshot {@link onAuthAcknowledged} sends, and transcripts and
+   *   latency are live streams with no replay semantics - a connection that
+   *   has not finished authenticating has no claim on them. This is also
+   *   exactly what happened before these subscriptions moved above
+   *   registration: they simply did not exist yet, so the same messages went
+   *   nowhere.
+   *
+   * The one message this must NOT be applied to is `sessionEnded`. It is
+   * terminal and nothing resends it, so its handler latches
+   * {@link _sessionEndedPending} rather than dropping.
+   */
+  private _mayForward(): boolean {
+    return !this._closed && this._ready;
+  }
+
+  /**
+   * Subscribe to the four per-session buses this connection fans out to.
+   *
+   * Extracted so {@link start} can take the subscriptions out before it does
+   * anything that can await or publish, and so the pre-`authOk` policy above
+   * is stated once for every channel rather than re-decided per handler.
+   */
+  private _subscribeToSessionBuses(): void {
+    this._unsubscribeTranscripts = this._eventBusService.subscribe(
+      TranscriptChannel,
+      (transcript) => {
+        if (!this._mayForward()) return;
+        this.emit('send', {
+          type: TranscriptionStreamServerMessageType.TRANSCRIPT,
+          final: transcript.final,
+          inProgress: transcript.inProgress,
+        });
+      },
+      this._sessionUid,
+    );
+
+    this._unsubscribeLatency = this._eventBusService.subscribe(
+      LatencyChannel,
+      (latency) => {
+        if (!this._mayForward()) return;
+        this.emit('send', {
+          type: TranscriptionStreamServerMessageType.LATENCY_UPDATE,
+          kind: latency.kind,
+          pipelineMs: latency.pipelineMs,
+          e2eMs: latency.e2eMs,
+        });
+      },
+      this._sessionUid,
+    );
+
+    this._unsubscribeSessionStatus = this._eventBusService.subscribe(
+      SessionStatusChannel,
+      (status) => {
+        if (!this._mayForward()) return;
+        this.emit('send', {
+          type: TranscriptionStreamServerMessageType.SESSION_STATUS,
+          ...status,
+        });
+      },
+      this._sessionUid,
+    );
+
+    this._unsubscribeSessionEnded = this._eventBusService.subscribe(
+      SessionEndedChannel,
+      () => {
+        if (this._closed) return;
+        if (!this._ready) {
+          // Published while this connection was still registering, i.e. before
+          // the controller could send `authOk`. Remember it: this is the
+          // signal that must never be dropped, and `onAuthAcknowledged`
+          // delivers it in protocol order a moment from now.
+          this._sessionEndedPending = true;
+          return;
+        }
+        this.emit('send', {
+          type: TranscriptionStreamServerMessageType.SESSION_ENDED,
+        });
+        this._closeWith(1000, 'session-ended');
+      },
+      this._sessionUid,
+    );
   }
 
   private _closeWith(code: number, reason: string): void {

--- a/apps/node-server/src/server/features/transcription-stream/transcription-stream.service.ts
+++ b/apps/node-server/src/server/features/transcription-stream/transcription-stream.service.ts
@@ -13,7 +13,10 @@ import { LatencyChannel } from './events/latency.events.js';
 import { SessionEndedChannel } from './events/session-ended.events.js';
 import { SessionStatusChannel } from './events/session-status.events.js';
 import { TranscriptChannel } from './events/transcript.events.js';
-import type { SourceHandle } from './transcription-orchestrator.service.js';
+import type {
+  ClientHandle,
+  SourceHandle,
+} from './transcription-orchestrator.service.js';
 import type { TranscriptionStreamRole } from './transcription-stream.auth.js';
 
 type ServerMessage = Static<
@@ -56,6 +59,7 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
   private _unsubscribeSessionStatus: (() => void) | null = null;
   private _unsubscribeSessionEnded: (() => void) | null = null;
   private _orchestratorHandle: SourceHandle | null = null;
+  private _endWatchHandle: ClientHandle | null = null;
   private _closed = false;
   private _metrics: AppDependencies['nodeServerMetricsService'];
   /**
@@ -158,6 +162,30 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
       },
       this._sessionUid,
     );
+
+    if (this._role === 'client') {
+      // Take out the session's end-watch, so a viewer on a session with no
+      // source attached is still told when it ends. Deliberately last: the
+      // watch can publish `sessionEnded` the moment it learns the session is
+      // already over, and the subscription above has to exist by then for
+      // this connection to hear it.
+      //
+      // `registerClient` is synchronous and does not throw - a viewer must
+      // not be disconnected because Session Manager is unreachable - so
+      // unlike the source path there is nothing here for the controller to
+      // map to a 1011.
+      const handle = this._transcriptionOrchestratorService.registerClient(
+        this._sessionUid,
+      );
+      if (this._closed) {
+        // The watch published `sessionEnded` synchronously and this
+        // connection has already been cleaned up; release the registration
+        // rather than leaking it into the ref count.
+        handle.unregister();
+        return;
+      }
+      this._endWatchHandle = handle;
+    }
   }
 
   /**
@@ -229,5 +257,7 @@ export class TranscriptionStreamService extends EventEmitter<TranscriptionStream
     this._unsubscribeSessionEnded = null;
     this._orchestratorHandle?.unregister();
     this._orchestratorHandle = null;
+    this._endWatchHandle?.unregister();
+    this._endWatchHandle = null;
   }
 }

--- a/apps/node-server/src/server/shared/services/node-server-metrics.service.ts
+++ b/apps/node-server/src/server/shared/services/node-server-metrics.service.ts
@@ -228,6 +228,7 @@ export class NodeServerMetricsService {
   private _authSuccessTotal = 0;
   private _authTimeoutsTotal = 0;
   private _orchestratorFailuresTotal = 0;
+  private _endedSessionRegistrationsTotal = 0;
   private _latencySamplesTotal = 0;
   private _latencyE2eUnavailableTotal = 0;
   private _latencyE2eNegativeTotal = 0;
@@ -357,6 +358,23 @@ export class NodeServerMetricsService {
   }
 
   /**
+   * A source tried to register on a session that was already past its
+   * `effectiveEnd`. It is refused before any upstream is dialed and closed
+   * 1000 with `sessionEnded`, so this is not an error series - it is the only
+   * evidence that a device is acting on a schedule it should have discarded.
+   *
+   * Counted separately from the ordinary end path because the two look
+   * identical downstream (a `1000 session-ended` close either way) while
+   * meaning opposite things: a session ending under a connected kiosk is
+   * routine, a kiosk *arriving* at a finished session means its schedule
+   * long-poll has most likely been dead for a while - `poll.on('error', ...)`
+   * on the kiosk swallows that failure, so nothing else reports it.
+   */
+  recordEndedSessionRegistration(): void {
+    this._endedSessionRegistrationsTotal += 1;
+  }
+
+  /**
    * A latency sample was published (B1.4).
    *
    * `e2eOutcome` records what happened to the end-to-end figure: `unavailable`
@@ -437,6 +455,7 @@ export class NodeServerMetricsService {
       authSuccessTotal: this._authSuccessTotal,
       authTimeoutsTotal: this._authTimeoutsTotal,
       orchestratorFailuresTotal: this._orchestratorFailuresTotal,
+      endedSessionRegistrationsTotal: this._endedSessionRegistrationsTotal,
       latencySamplesTotal: this._latencySamplesTotal,
       latencyE2eUnavailableTotal: this._latencyE2eUnavailableTotal,
       latencyE2eNegativeTotal: this._latencyE2eNegativeTotal,

--- a/apps/node-server/src/server/shared/services/status-snapshot.service.ts
+++ b/apps/node-server/src/server/shared/services/status-snapshot.service.ts
@@ -51,6 +51,7 @@ export class StatusSnapshotService {
         authSuccessTotal: counters.authSuccessTotal,
         authTimeoutsTotal: counters.authTimeoutsTotal,
         orchestratorFailuresTotal: counters.orchestratorFailuresTotal,
+        endedSessionRegistrationsTotal: counters.endedSessionRegistrationsTotal,
         latencySamplesTotal: counters.latencySamplesTotal,
         latencyE2eUnavailableTotal: counters.latencyE2eUnavailableTotal,
         latencyE2eNegativeTotal: counters.latencyE2eNegativeTotal,

--- a/apps/node-server/tests/integration/features/transcription-stream/transcription-stream.routes.test.ts
+++ b/apps/node-server/tests/integration/features/transcription-stream/transcription-stream.routes.test.ts
@@ -844,6 +844,160 @@ describe('Transcription Stream Routes', () => {
     );
   });
 
+  // The bug this covers: a SOURCE connecting to a session whose `effectiveEnd`
+  // had already passed was never told. `registerSource` published
+  // `SessionEndedChannel` from inside its own await - before that connection
+  // had subscribed to hear it - so the publish landed on an empty channel. The
+  // kiosk was never sent `sessionEnded`, never closed 1000, and went on
+  // streaming audio into a session the server considered over, holding an
+  // upstream transcription connection open for the whole time. PR #184 fixed
+  // the viewer half of this and explicitly did not fix this half.
+  describe('source connecting to an already-ended session', (it) => {
+    /** Sessions in `/status`, i.e. those holding an upstream connection. */
+    async function statusSessionUids(): Promise<string[]> {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: '/api/node-server/v1/status',
+        headers: { authorization: `Bearer ${TEST_SERVICE_API_KEY}` },
+      });
+      expect(res.statusCode).toBe(200);
+      return res
+        .json<{ sessions: { sessionUid: string }[] }>()
+        .sessions.map((s) => s.sessionUid);
+    }
+
+    /** Reads the endedSessionRegistrationsTotal counter off /status. */
+    async function readEndedRegistrations(): Promise<number> {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: '/api/node-server/v1/status',
+        headers: { authorization: `Bearer ${TEST_SERVICE_API_KEY}` },
+      });
+      expect(res.statusCode).toBe(200);
+      return res.json<{
+        summary: { endedSessionRegistrationsTotal: number };
+      }>().summary.endedSessionRegistrationsTotal;
+    }
+
+    /** A fresh on-demand session of its own, so ending it disturbs nothing. */
+    async function seedOwnSession(): Promise<{ uid: string }> {
+      return await seedSession({
+        sessionManagerBaseUrl: inject('sessionManagerBaseUrl'),
+        adminApiKey: inject('adminApiKey'),
+        transcriptionProviderId: 'debug',
+        transcriptionStreamConfig: {
+          sample_rate: DEBUG_SAMPLE_RATE,
+          num_channels: DEBUG_NUM_CHANNELS,
+        },
+      });
+    }
+
+    async function endSessionEarly(sessionUid: string): Promise<void> {
+      const sm = createSessionManagerClient(inject('sessionManagerBaseUrl'));
+      const ended = await sm.scheduleManagement.endSessionEarly({
+        body: { sessionUid },
+        headers: { authorization: `Bearer ${inject('adminApiKey')}` },
+      });
+      expect(ended[1]).toBeNull();
+      expect(ended[0]?.status).toBe(200);
+    }
+
+    function authAsSource(ws: WebSocket, sessionUid: string, id: string): void {
+      ws.send(
+        JSON.stringify({
+          type: TranscriptionStreamClientMessageType.AUTH,
+          sessionToken: signToken({
+            sessionUid,
+            clientId: id,
+            scopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
+            exp: FAR_FUTURE,
+          }),
+        }),
+      );
+    }
+
+    it(
+      'sends sessionEnded, closes 1000, and dials no upstream',
+      { timeout: 60_000 },
+      async () => {
+        // Arrange - the stale-schedule case (§4.2): the session is already over
+        // by the time the kiosk arrives.
+        const session = await seedOwnSession();
+        await endSessionEarly(session.uid);
+        const before = await readEndedRegistrations();
+
+        // Act
+        const ws = await server.fastify.injectWS(sourcePath(session.uid));
+        const { messages, stop } = collectMessages(ws);
+        const closed = nextClose(ws);
+        authAsSource(ws, session.uid, 'late-kiosk');
+
+        // Assert - closed 1000 rather than left streaming into a dead session.
+        await expect(closed).resolves.toMatchObject({
+          code: 1000,
+          reason: 'session-ended',
+        });
+
+        // Assert - and told why, in protocol order: `authOk` first, because
+        // both webapp clients hold their handshake open until it arrives.
+        const types = messages.map((m) => m.type);
+        expect(types).toContain(
+          TranscriptionStreamServerMessageType.SESSION_ENDED,
+        );
+        expect(
+          types.indexOf(TranscriptionStreamServerMessageType.AUTH_OK),
+        ).toBe(0);
+        expect(
+          types.indexOf(TranscriptionStreamServerMessageType.SESSION_ENDED),
+        ).toBeGreaterThan(0);
+
+        // Assert - no upstream was dialed for a session that is over. The
+        // transcription service runs `num_workers: 1`; a connection opened for
+        // an abandoned session is only ever reclaimed when its source socket
+        // closes, which in the bug never happened.
+        expect(await statusSessionUids()).not.toContain(session.uid);
+
+        // Assert - and the stale-schedule cause is visible in production
+        // rather than inferred (§3.4).
+        expect(await readEndedRegistrations()).toBe(before + 1);
+
+        stop();
+      },
+    );
+
+    it(
+      'terminates the source when the end lands during its connect (§4.1)',
+      { timeout: 120_000 },
+      async () => {
+        // The genuine race, not the stale schedule: an operator ends the
+        // session in the window between the kiosk's token exchange and its
+        // registration - the exact button pressed during a demo. Either branch
+        // may win (the config fetch returns the already-ended session, or it
+        // returns the live one and the bump arrives moments later), and the
+        // point of the assertion is that BOTH terminate the socket rather than
+        // leaving it streaming.
+        const rounds = 3;
+        for (let round = 0; round < rounds; round++) {
+          // Arrange
+          const session = await seedOwnSession();
+          const ws = await server.fastify.injectWS(sourcePath(session.uid));
+          const closed = nextClose(ws);
+
+          // Act - auth and the early end are issued in the same tick.
+          authAsSource(ws, session.uid, `raced-kiosk-${String(round)}`);
+          await endSessionEarly(session.uid);
+
+          // Assert
+          await expect(closed).resolves.toMatchObject({
+            code: 1000,
+            reason: 'session-ended',
+          });
+          expect(await statusSessionUids()).not.toContain(session.uid);
+        }
+      },
+    );
+  });
+
   describe('client role with live upstream', (it) => {
     it(
       'closes 1008 binary-not-allowed-for-role when an authed client sends binary',

--- a/apps/node-server/tests/integration/features/transcription-stream/transcription-stream.routes.test.ts
+++ b/apps/node-server/tests/integration/features/transcription-stream/transcription-stream.routes.test.ts
@@ -10,6 +10,7 @@ import {
   TranscriptionStreamClientMessageType,
   TranscriptionStreamServerMessageType,
 } from '@scribear/node-server-schema';
+import { createSessionManagerClient } from '@scribear/session-manager-client';
 import type { SessionTokenPayload } from '@scribear/session-manager-schema';
 
 import { seedSession } from '#tests/utils/seed-session.js';
@@ -742,6 +743,103 @@ describe('Transcription Stream Routes', () => {
 
         client.stop();
         clientWs.terminate();
+      },
+    );
+  });
+
+  // The bug this covers: `registerSource` was the only thing that ever built
+  // `SessionState`, so a room whose viewers joined before (or without) a kiosk
+  // had nobody fetching its config, nobody arming an end timer, and no
+  // `sessionEnded` ever published. Viewers sat on stale captions until a token
+  // refresh happened to be rejected - up to half the token lifetime.
+  describe('viewer-only session end (no source attached)', (it) => {
+    it(
+      'sends sessionEnded and closes 1000 when the session is ended early',
+      { timeout: 60_000 },
+      async () => {
+        // Arrange - a session of its own, so ending it cannot disturb the
+        // shared streaming fixture. On-demand sessions are created open-ended
+        // (`scheduledEndTime` is the next non-AUTO start, absent here), so
+        // nothing is armed until the early end moves `effectiveEnd` into the
+        // past - the `end_override = now` case.
+        const session = await seedSession({
+          sessionManagerBaseUrl: inject('sessionManagerBaseUrl'),
+          adminApiKey: inject('adminApiKey'),
+          transcriptionProviderId: 'debug',
+          transcriptionStreamConfig: {
+            sample_rate: DEBUG_SAMPLE_RATE,
+            num_channels: DEBUG_NUM_CHANNELS,
+          },
+        });
+
+        const ws = await server.fastify.injectWS(clientPath(session.uid));
+        const { messages, stop } = collectMessages(ws);
+        ws.send(
+          JSON.stringify({
+            type: TranscriptionStreamClientMessageType.AUTH,
+            sessionToken: signToken({
+              sessionUid: session.uid,
+              clientId: 'lonely-viewer',
+              scopes: ['RECEIVE_TRANSCRIPTIONS'],
+              exp: FAR_FUTURE,
+            }),
+          }),
+        );
+        await vi.waitFor(
+          () => {
+            expect(
+              messages.find(
+                (m) => m.type === TranscriptionStreamServerMessageType.AUTH_OK,
+              ),
+            ).toBeDefined();
+          },
+          { timeout: 15_000 },
+        );
+
+        // Assert - the viewer costs the transcription service nothing: no
+        // upstream was dialed, so the session holds no orchestrator state and
+        // does not appear in /status. Opening an upstream for an audio-less
+        // connection is the fault e80eea2 was written for.
+        const status = await server.fastify.inject({
+          method: 'GET',
+          url: '/api/node-server/v1/status',
+          headers: { authorization: `Bearer ${TEST_SERVICE_API_KEY}` },
+        });
+        expect(status.statusCode).toBe(200);
+        const sessions = status.json<{
+          sessions: { sessionUid: string }[];
+        }>().sessions;
+        expect(sessions.map((s) => s.sessionUid)).not.toContain(session.uid);
+
+        // Act - end the session out from under the viewer.
+        const closed = nextClose(ws);
+        const sm = createSessionManagerClient(inject('sessionManagerBaseUrl'));
+        const ended = await sm.scheduleManagement.endSessionEarly({
+          body: { sessionUid: session.uid },
+          headers: { authorization: `Bearer ${inject('adminApiKey')}` },
+        });
+        expect(ended[1]).toBeNull();
+        expect(ended[0]?.status).toBe(200);
+
+        // Assert - the config bump reaches the end-watch's long-poll, which
+        // sees an `effectiveEnd` already in the past and publishes at once.
+        await vi.waitFor(
+          () => {
+            expect(
+              messages.find(
+                (m) =>
+                  m.type === TranscriptionStreamServerMessageType.SESSION_ENDED,
+              ),
+            ).toBeDefined();
+          },
+          { timeout: 20_000 },
+        );
+        await expect(closed).resolves.toMatchObject({
+          code: 1000,
+          reason: 'session-ended',
+        });
+
+        stop();
       },
     );
   });

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
@@ -14,6 +14,7 @@ import { SessionEndedChannel } from '#src/server/features/transcription-stream/e
 import { SessionStatusChannel } from '#src/server/features/transcription-stream/events/session-status.events.js';
 import { TranscriptChannel } from '#src/server/features/transcription-stream/events/transcript.events.js';
 import {
+  SessionAlreadyEndedError,
   type SessionConfigPollFactory,
   type SourceHandle,
   TranscriptionOrchestratorService,
@@ -311,6 +312,100 @@ describe('TranscriptionOrchestratorService', () => {
       expect(h.poolFactory).toHaveBeenCalledTimes(1);
       expect(h.transcriptionStreamFactory).toHaveBeenCalledTimes(1);
       expect(h.orchestrator.activeSessionCount).toBe(1);
+    });
+
+    it('refuses a session whose effectiveEnd has already passed', async () => {
+      // The stale-schedule case: a kiosk acting on a schedule it should have
+      // discarded connects to a session that finished before it arrived. It
+      // used to be admitted silently - the end was published from inside this
+      // very call, before the connection had subscribed to hear it - and then
+      // streamed audio into a dead session indefinitely.
+      // Arrange
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(-60_000) }),
+      );
+
+      // Act / Assert
+      await expect(promise).rejects.toBeInstanceOf(SessionAlreadyEndedError);
+      expect(h.orchestrator.activeSessionCount).toBe(0);
+    });
+
+    it('dials no upstream transcription connection for an already-ended session', async () => {
+      // The transcription service is the scarcest thing in the deployment, and
+      // an upstream is only ever torn down by the last source unregistering -
+      // so one opened for a session we are about to refuse would sit there
+      // holding admission capacity away from a room that is actually running.
+      // Arrange
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit('data', fakeSession({ effectiveEnd: isoFromNow(-1) }));
+
+      // Act
+      await expect(promise).rejects.toBeInstanceOf(SessionAlreadyEndedError);
+
+      // Assert - nothing dialed, and the config poll opened to find this out
+      // is closed rather than left running for a session with no connections.
+      expect(h.transcriptionStreamFactory).not.toHaveBeenCalled();
+      expect(h.longPoll.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('counts and names an ended-session registration', async () => {
+      // §3.4: without its own counter this is indistinguishable downstream
+      // from an ordinary session end (a 1000 `session-ended` close either
+      // way), while meaning something quite different - a device working from
+      // a schedule that is hours stale.
+      // Arrange
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit('data', fakeSession({ effectiveEnd: isoFromNow(-1) }));
+
+      // Act
+      await expect(promise).rejects.toBeInstanceOf(SessionAlreadyEndedError);
+
+      // Assert
+      expect(h.metrics.snapshot().endedSessionRegistrationsTotal).toBe(1);
+    });
+
+    it('admits a session that is still running, with no spurious end', async () => {
+      // The other half of the refusal: the check must not fire a moment early
+      // for a live session, which would refuse every kiosk in the fleet.
+      // Arrange
+      const ended: unknown[] = [];
+      h.bus.subscribe(
+        SessionEndedChannel,
+        (m) => {
+          ended.push(m);
+        },
+        SESSION_UID,
+      );
+
+      // Act
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(60_000) }),
+      );
+      await promise;
+
+      // Assert
+      expect(h.orchestrator.activeSessionCount).toBe(1);
+      expect(h.transcriptionStreamFactory).toHaveBeenCalledTimes(1);
+      expect(ended).toHaveLength(0);
+      expect(h.metrics.snapshot().endedSessionRegistrationsTotal).toBe(0);
+    });
+
+    it('admits an open-ended session', async () => {
+      // `effectiveEnd: null` is the shape an on-demand session is created
+      // with, and `Date.parse(null)` NaNs - the refusal must read that as "not
+      // over", not as "cannot tell, so refuse".
+      // Act
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit('data', fakeSession({ effectiveEnd: null }));
+      await promise;
+
+      // Assert
+      expect(h.orchestrator.activeSessionCount).toBe(1);
+      expect(h.metrics.snapshot().endedSessionRegistrationsTotal).toBe(0);
     });
 
     it('publishes sessionDeviceConnected: true on first registration', async () => {
@@ -1122,6 +1217,39 @@ describe('TranscriptionOrchestratorService end-watch', () => {
 
       late.unregister();
       source.unregister();
+    });
+
+    it('leaves nothing behind for a later viewer when a source bounced off an ended session', async () => {
+      // §3.3, the knock-on the refusal has to not have: the end-watch design
+      // assumes a `SessionState` that ends is promptly torn down. A source
+      // admitted onto an ended session used to leave one in `_sessions`
+      // forever - holding a live upstream, still answering `getStatus`, and
+      // still listed by `/status`. Refusing the registration means there is no
+      // such state for a viewer to arrive behind.
+      // Arrange - the source is refused; it took out (and closed) long-poll #0.
+      const refused = h.orchestrator.registerSource(SESSION_UID);
+      h.longPoll.emit('data', fakeSession({ effectiveEnd: isoFromNow(-1000) }));
+      await expect(refused).rejects.toBeInstanceOf(SessionAlreadyEndedError);
+      expect(ended).toHaveLength(0);
+
+      // Act - a viewer of the same room joins afterwards, on long-poll #1.
+      const late = h.orchestrator.registerClient(SESSION_UID);
+      h.longPolls[1]?.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(-1000) }),
+      );
+
+      // Assert - told, and told by its own watch rather than by a stale
+      // session state that should never have existed.
+      expect(ended).toHaveLength(1);
+      expect(h.orchestrator.activeSessionCount).toBe(0);
+      expect(h.orchestrator.sessionSnapshots(10).sessions).toHaveLength(0);
+      expect(h.orchestrator.getStatus(SESSION_UID)).toMatchObject({
+        transcriptionServiceConnected: false,
+        sourceDeviceConnected: false,
+      });
+
+      late.unregister();
     });
 
     it('hands the end back to the watch when the source disconnects before the end', async () => {

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
@@ -10,6 +10,7 @@ import {
   LatencyChannel,
   type LatencyMessage,
 } from '#src/server/features/transcription-stream/events/latency.events.js';
+import { SessionEndedChannel } from '#src/server/features/transcription-stream/events/session-ended.events.js';
 import { SessionStatusChannel } from '#src/server/features/transcription-stream/events/session-status.events.js';
 import { TranscriptChannel } from '#src/server/features/transcription-stream/events/transcript.events.js';
 import {
@@ -32,8 +33,17 @@ function fakeSession(overrides: Partial<Session> = {}): Session {
     transcriptionProviderId: PROVIDER_KEY,
     transcriptionStreamConfig: { sample_rate: 48000, num_channels: 1 },
     sessionConfigVersion: 1,
+    // Open-ended by default. Explicit rather than absent: an undefined
+    // `effectiveEnd` is not the same shape the config stream ever produces,
+    // and it makes `Date.parse` NaN its way into the end timer.
+    effectiveEnd: null,
     ...overrides,
   } as Session;
+}
+
+/** ISO timestamp `deltaMs` from now; negative for an end already in the past. */
+function isoFromNow(deltaMs: number): string {
+  return new Date(Date.now() + deltaMs).toISOString();
 }
 
 /**
@@ -91,7 +101,14 @@ class FakeUpstream extends EventEmitter {
 interface Harness {
   orchestrator: TranscriptionOrchestratorService;
   bus: EventBusService;
+  /** The first long-poll the orchestrator asked for. */
   longPoll: FakeLongPoll;
+  /**
+   * Every long-poll issued, in order. A session with both a source and
+   * viewers takes out two - the source's `SessionState` and the viewers'
+   * end-watch - and they must be driven independently.
+   */
+  longPolls: FakeLongPoll[];
   upstream: FakeUpstream;
   poolFactory: ReturnType<typeof vi.fn>;
   transcriptionStreamFactory: ReturnType<typeof vi.fn>;
@@ -108,9 +125,14 @@ function makeHarness(
   const bus = new EventBusService(logger as never);
   const longPoll = options.longPoll ?? new FakeLongPoll();
   const upstream = options.upstream ?? new FakeUpstream();
-  const poolFactory = vi.fn(
-    () => longPoll,
-  ) as unknown as SessionConfigPollFactory & ReturnType<typeof vi.fn>;
+  const longPolls: FakeLongPoll[] = [longPoll];
+  let issued = 0;
+  const poolFactory = vi.fn(() => {
+    const poll = longPolls[issued] ?? new FakeLongPoll();
+    if (longPolls[issued] === undefined) longPolls.push(poll);
+    issued += 1;
+    return poll;
+  }) as unknown as SessionConfigPollFactory & ReturnType<typeof vi.fn>;
   const transcriptionStreamFactory = vi.fn(() => upstream);
   const transcriptionServiceClient = {
     transcriptionStream: transcriptionStreamFactory,
@@ -132,6 +154,7 @@ function makeHarness(
     orchestrator,
     bus,
     longPoll,
+    longPolls,
     upstream,
     poolFactory,
     transcriptionStreamFactory,
@@ -835,6 +858,335 @@ describe('TranscriptionOrchestratorService telemetry (B1.1)', () => {
       const snapshot = h.metrics.snapshot();
       expect(snapshot.latencyUnmatchedChunkTotal).toBe(1);
       expect(snapshot.latencySamplesTotal).toBe(0);
+    });
+  });
+});
+
+/**
+ * A viewer connected to a session with no source attached used to learn
+ * nothing about the session ending: `registerSource` was the only thing that
+ * ever created `SessionState`, so with no kiosk in the room nothing fetched
+ * the session's config, no end timer was ever armed, and `SessionEndedChannel`
+ * was never published. The viewer sat on stale captions until its next token
+ * refresh happened to be rejected - bounded only by half the token lifetime,
+ * around 2.5 minutes.
+ */
+describe('TranscriptionOrchestratorService end-watch', () => {
+  let h: Harness;
+  /** Every `SessionEndedChannel` message published for SESSION_UID. */
+  let ended: unknown[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    h = makeHarness();
+    ended = [];
+    h.bus.subscribe(
+      SessionEndedChannel,
+      (m) => {
+        ended.push(m);
+      },
+      SESSION_UID,
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('viewer-only session', (it) => {
+    it('publishes sessionEnded at effectiveEnd with no source ever attached', () => {
+      // Arrange
+      const client = h.orchestrator.registerClient(SESSION_UID);
+      h.longPoll.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(60_000) }),
+      );
+
+      // Act / Assert - nothing before the end.
+      vi.advanceTimersByTime(59_999);
+      expect(ended).toHaveLength(0);
+
+      // Act / Assert - exactly one publish at the end.
+      vi.advanceTimersByTime(2);
+      expect(ended).toHaveLength(1);
+
+      client.unregister();
+    });
+
+    it('opens no upstream transcription connection for a viewer', () => {
+      // A viewer must cost the transcription service nothing. Dialing an
+      // upstream for an audio-less connection is precisely the fault e80eea2
+      // was written for: idle jobs consuming admission capacity.
+      // Arrange / Act
+      const client = h.orchestrator.registerClient(SESSION_UID);
+      h.longPoll.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(60_000) }),
+      );
+      vi.advanceTimersByTime(120_000);
+
+      // Assert
+      expect(h.transcriptionStreamFactory).not.toHaveBeenCalled();
+      expect(h.orchestrator.activeSessionCount).toBe(0);
+      expect(h.orchestrator.sessionSnapshots(10).sessions).toHaveLength(0);
+
+      client.unregister();
+    });
+
+    it('publishes immediately when the session already ended before the viewer joined', () => {
+      // Arrange - a viewer joining a session whose end has passed, and the
+      // shape `endSessionEarly` produces (end_override = now).
+      const client = h.orchestrator.registerClient(SESSION_UID);
+
+      // Act
+      h.longPoll.emit('data', fakeSession({ effectiveEnd: isoFromNow(-1000) }));
+
+      // Assert - synchronous, not scheduled: a zero-delay timer would leave
+      // the viewer hanging until the next tick of an event loop that may be
+      // busy, and the config response is the moment we learn the answer.
+      expect(ended).toHaveLength(1);
+
+      client.unregister();
+    });
+
+    it('follows the end when a later config bump moves it', () => {
+      // Arrange - startSessionEarly / endSessionEarly bump
+      // sessionConfigVersion, so the end a watch armed for can move under it.
+      const client = h.orchestrator.registerClient(SESSION_UID);
+      h.longPoll.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(3_600_000) }),
+      );
+
+      // Act - the session is ended early.
+      h.longPoll.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(-1), sessionConfigVersion: 2 }),
+      );
+
+      // Assert
+      expect(ended).toHaveLength(1);
+
+      client.unregister();
+    });
+
+    it('arms nothing for an open-ended session', () => {
+      // Arrange / Act - the demo caption room's session is exactly this.
+      const client = h.orchestrator.registerClient(SESSION_UID);
+      h.longPoll.emit('data', fakeSession({ effectiveEnd: null }));
+      vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+
+      // Assert
+      expect(ended).toHaveLength(0);
+
+      client.unregister();
+    });
+  });
+
+  describe('ref counting', (it) => {
+    it('shares one watch across viewers and tears it down on the last disconnect', () => {
+      // Arrange
+      const a = h.orchestrator.registerClient(SESSION_UID);
+      const b = h.orchestrator.registerClient(SESSION_UID);
+
+      // Assert - one long-poll for the room, not one per viewer.
+      expect(h.poolFactory).toHaveBeenCalledTimes(1);
+      expect(h.longPoll.start).toHaveBeenCalledTimes(1);
+
+      h.longPoll.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(60_000) }),
+      );
+
+      // Act - one viewer leaves.
+      a.unregister();
+
+      // Assert - the watch survives for the viewer still on it.
+      expect(h.longPoll.close).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(60_001);
+      expect(ended).toHaveLength(1);
+
+      b.unregister();
+    });
+
+    it('closes the long-poll and cancels the timer when the last viewer leaves', () => {
+      // Arrange
+      const a = h.orchestrator.registerClient(SESSION_UID);
+      const b = h.orchestrator.registerClient(SESSION_UID);
+      h.longPoll.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(60_000) }),
+      );
+
+      // Act
+      a.unregister();
+      b.unregister();
+
+      // Assert
+      expect(h.longPoll.close).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(120_000);
+      expect(ended).toHaveLength(0);
+    });
+
+    it('ignores a repeated unregister from the same viewer', () => {
+      // A double release would drop the watch out from under the viewers
+      // still on it; the controller calls close() on two paths.
+      // Arrange
+      const a = h.orchestrator.registerClient(SESSION_UID);
+      const b = h.orchestrator.registerClient(SESSION_UID);
+      h.longPoll.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(60_000) }),
+      );
+
+      // Act
+      a.unregister();
+      a.unregister();
+
+      // Assert
+      expect(h.longPoll.close).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(60_001);
+      expect(ended).toHaveLength(1);
+
+      b.unregister();
+    });
+  });
+
+  describe('coexistence with a real session', (it) => {
+    /**
+     * Register a source for a session that already has an end-watch. The
+     * watch holds long-poll #0, so the session's own poll is #1.
+     */
+    async function registerSourceWith(session: Session): Promise<SourceHandle> {
+      const promise = h.orchestrator.registerSource(SESSION_UID);
+      h.longPolls[1]?.emit('data', session);
+      return await promise;
+    }
+
+    it('publishes once, not twice, when a source is attached to a watched session', async () => {
+      // Arrange - viewer first, then the kiosk arrives. Both learn the same
+      // effectiveEnd from the same config stream; only one may publish.
+      const client = h.orchestrator.registerClient(SESSION_UID);
+      h.longPoll.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(60_000) }),
+      );
+      const source = await registerSourceWith(
+        fakeSession({ effectiveEnd: isoFromNow(60_000) }),
+      );
+
+      // Act
+      vi.advanceTimersByTime(60_001);
+
+      // Assert - one publish, from the session state that owns the end while
+      // it exists; the watch stood down rather than racing it.
+      expect(ended).toHaveLength(1);
+
+      // Act - the publish tears both sides down, in whatever order the bus
+      // delivers. Neither teardown may re-arm anything.
+      source.unregister();
+      client.unregister();
+      vi.advanceTimersByTime(120_000);
+
+      // Assert
+      expect(ended).toHaveLength(1);
+    });
+
+    it('still tells a viewer that arrives after the end was already announced', async () => {
+      // The latch is per end-timer owner and dies with the owner, deliberately:
+      // suppressing a publish because *some* earlier owner announced the same
+      // end would silently reintroduce the original bug for anyone who joins
+      // late. A duplicate publish is harmless - the connection close it
+      // triggers is idempotent - a missing one is the whole defect.
+      // Arrange - a source ends, and its state lingers until its socket
+      // finishes closing.
+      const first = h.orchestrator.registerClient(SESSION_UID);
+      h.longPoll.emit('data', fakeSession({ effectiveEnd: isoFromNow(1000) }));
+      const source = await registerSourceWith(
+        fakeSession({ effectiveEnd: isoFromNow(1000) }),
+      );
+      vi.advanceTimersByTime(1001);
+      expect(ended).toHaveLength(1);
+
+      // Act - the viewers of that announcement are gone; a new one joins.
+      first.unregister();
+      const late = h.orchestrator.registerClient(SESSION_UID);
+      h.longPolls[2]?.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(-1) }),
+      );
+
+      // Assert - told, rather than left hanging on an ended session.
+      expect(ended).toHaveLength(2);
+
+      late.unregister();
+      source.unregister();
+    });
+
+    it('hands the end back to the watch when the source disconnects before the end', async () => {
+      // Arrange - the regression that would otherwise reopen the bug: the
+      // kiosk is unplugged mid-session and the room keeps watching, so the
+      // only armed end timer disappears with the session state.
+      const client = h.orchestrator.registerClient(SESSION_UID);
+      h.longPoll.emit(
+        'data',
+        fakeSession({ effectiveEnd: isoFromNow(60_000) }),
+      );
+      const source = await registerSourceWith(
+        fakeSession({ effectiveEnd: isoFromNow(60_000) }),
+      );
+
+      // Act
+      vi.advanceTimersByTime(30_000);
+      source.unregister();
+      expect(h.orchestrator.activeSessionCount).toBe(0);
+      vi.advanceTimersByTime(30_001);
+
+      // Assert
+      expect(ended).toHaveLength(1);
+
+      client.unregister();
+    });
+  });
+
+  describe('degradation', (it) => {
+    it('does not throw when the config poll cannot be created', () => {
+      // Arrange - a source that cannot reach Session Manager is useless and
+      // rightly gets 1011; a viewer that cannot is only missing its end
+      // signal, and must not be disconnected while captions are flowing.
+      const broken = makeHarness();
+      broken.poolFactory.mockImplementation(() => {
+        throw new Error('session-manager-unreachable');
+      });
+
+      // Act / Assert
+      const client = broken.orchestrator.registerClient(SESSION_UID);
+      expect(() => {
+        client.unregister();
+      }).not.toThrow();
+    });
+
+    it('keeps polling after a long-poll error instead of ending the session', () => {
+      // Arrange
+      const client = h.orchestrator.registerClient(SESSION_UID);
+
+      // Act - the long-poll retries with backoff on its own; the error must
+      // not close the watch and must not be mistaken for an end.
+      h.longPoll.emit('error', new Error('long-poll-broken'));
+
+      // Assert
+      expect(h.longPoll.close).not.toHaveBeenCalled();
+      expect(ended).toHaveLength(0);
+
+      // Act - the retry eventually succeeds and the watch arms as normal.
+      h.longPoll.emit('data', fakeSession({ effectiveEnd: isoFromNow(1000) }));
+      vi.advanceTimersByTime(1001);
+
+      // Assert
+      expect(ended).toHaveLength(1);
+
+      client.unregister();
     });
   });
 });

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-orchestrator.service.test.ts
@@ -637,7 +637,64 @@ describe('TranscriptionOrchestratorService', () => {
       });
     });
 
-    it('leaves the disconnect reason unset for a non-1013 close', async () => {
+    it('reports "invalid-request" after the upstream closes with 1007', async () => {
+      // Arrange - 1007 is what the transcription service closes with for a
+      // TranscriptionClientError, and the one that actually happens is
+      // "Invalid Provider Key": a session whose transcriptionProviderId is not
+      // in the deployment's provider_config.json. The retry loop re-sends the
+      // identical config forever, so collapsing this into the undistinguished
+      // "disconnected" leaves every viewer on a reconnecting banner that can
+      // never resolve.
+      await registerAndDrain(h, SESSION_UID);
+      h.upstream.setOpen();
+
+      const statuses: {
+        transcriptionServiceConnected: boolean;
+        transcriptionServiceDisconnectReason?: string;
+      }[] = [];
+      h.bus.subscribe(
+        SessionStatusChannel,
+        (s) => {
+          statuses.push(s);
+        },
+        SESSION_UID,
+      );
+
+      // Act
+      h.upstream.closeWith(1007, 'Invalid Provider Key');
+
+      // Assert
+      expect(statuses[statuses.length - 1]).toMatchObject({
+        transcriptionServiceConnected: false,
+        transcriptionServiceDisconnectReason: 'invalid-request',
+      });
+      expect(h.orchestrator.getStatus(SESSION_UID)).toMatchObject({
+        transcriptionServiceDisconnectReason: 'invalid-request',
+      });
+    });
+
+    it('does not confuse a capacity refusal with a rejected request', async () => {
+      // Arrange - the two reasons must stay distinguishable in both
+      // directions: at-capacity clears when load drops, invalid-request never
+      // clears without an operator, and a viewer is told different things.
+      await registerAndDrain(h, SESSION_UID);
+      h.upstream.setOpen();
+      h.upstream.closeWith(1007, 'Invalid Provider Key');
+      expect(h.orchestrator.getStatus(SESSION_UID)).toMatchObject({
+        transcriptionServiceDisconnectReason: 'invalid-request',
+      });
+
+      // Act - a later reconnect is refused for capacity instead.
+      h.upstream.setOpen();
+      h.upstream.closeWith(1013, 'at-capacity');
+
+      // Assert
+      expect(h.orchestrator.getStatus(SESSION_UID)).toMatchObject({
+        transcriptionServiceDisconnectReason: 'at-capacity',
+      });
+    });
+
+    it('leaves the disconnect reason unset for an undistinguished close', async () => {
       // Arrange
       await registerAndDrain(h, SESSION_UID);
       h.upstream.setOpen();

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.controller.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.controller.test.ts
@@ -7,7 +7,7 @@ interface MockService {
   start: Mock;
   close: Mock;
   handleBinary: Mock;
-  publishCurrentStatus: Mock;
+  onAuthAcknowledged: Mock;
   on: (event: string, cb: (...args: unknown[]) => void) => void;
   emit: (event: string, ...args: unknown[]) => void;
 }
@@ -41,7 +41,7 @@ const {
     start = vi.fn((): Promise<void> => startPromise);
     close = vi.fn();
     handleBinary = vi.fn();
-    publishCurrentStatus = vi.fn();
+    onAuthAcknowledged = vi.fn();
     private _handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
 
     on(event: string, cb: (...args: unknown[]) => void): void {
@@ -194,7 +194,7 @@ describe('TranscriptionStreamController', () => {
       expect(h.socket.send).toHaveBeenCalledWith(AUTH_OK);
       const service = serviceInstances[0]!;
       expect(service.start).toHaveBeenCalledTimes(1);
-      expect(service.publishCurrentStatus).toHaveBeenCalledTimes(1);
+      expect(service.onAuthAcknowledged).toHaveBeenCalledTimes(1);
       expect(h.metrics.recordAuthSuccess).toHaveBeenCalledTimes(1);
 
       vi.advanceTimersByTime(5001);

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.service.test.ts
@@ -19,6 +19,8 @@ interface Harness {
   bus: EventBusService;
   registerSource: ReturnType<typeof vi.fn>;
   unregisterSource: ReturnType<typeof vi.fn>;
+  registerClient: ReturnType<typeof vi.fn>;
+  unregisterClient: ReturnType<typeof vi.fn>;
   getStatus: ReturnType<typeof vi.fn>;
   sent: unknown[];
   closes: { code: number; reason: string }[];
@@ -48,6 +50,8 @@ function makeHarness(
       setMicrophoneActive,
     });
   });
+  const unregisterClient = vi.fn();
+  const registerClient = vi.fn(() => ({ unregister: unregisterClient }));
   const getStatus = vi.fn(
     () =>
       options.initialStatus ?? {
@@ -58,6 +62,7 @@ function makeHarness(
   );
   const orchestrator = {
     registerSource,
+    registerClient,
     getStatus,
     activeSessionCount: 0,
   } as unknown as ConstructorParameters<
@@ -87,6 +92,8 @@ function makeHarness(
     bus,
     registerSource,
     unregisterSource,
+    registerClient,
+    unregisterClient,
     getStatus,
     sent,
     closes,
@@ -163,15 +170,65 @@ describe('TranscriptionStreamService', () => {
       expect(h.metrics.subscriberCount(SESSION_UID)).toBe(0);
     });
 
-    it('does not register with the orchestrator on client-role start', async () => {
+    it('does not register a source on client-role start', async () => {
       // Arrange
       const h = makeHarness('client');
 
       // Act
       await h.service.start();
 
-      // Assert
+      // Assert - a viewer must never open an upstream transcription
+      // connection; audio-less connections registering a job is what tripped
+      // admission control in e80eea2.
       expect(h.registerSource).not.toHaveBeenCalled();
+    });
+
+    it('takes out the session end-watch on client-role start and releases it on close', async () => {
+      // Arrange - without this a viewer on a source-free session is never
+      // told the session ended: nothing else in node-server fetches that
+      // session's config, so `sessionEnded` is never published and the viewer
+      // sits on stale captions until a token refresh happens to be rejected.
+      const h = makeHarness('client');
+
+      // Act
+      await h.service.start();
+
+      // Assert
+      expect(h.registerClient).toHaveBeenCalledWith(SESSION_UID);
+      expect(h.unregisterClient).not.toHaveBeenCalled();
+
+      // Act
+      h.service.close();
+
+      // Assert - the watch is ref-counted, so a viewer that leaves must
+      // release its share or the watch outlives the room.
+      expect(h.unregisterClient).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not take out an end-watch on source-role start', async () => {
+      // Arrange - the source's own `SessionState` already owns the end timer.
+      const h = makeHarness('source');
+
+      // Act
+      await h.service.start();
+
+      // Assert
+      expect(h.registerClient).not.toHaveBeenCalled();
+    });
+
+    it('releases the end-watch exactly once when close runs more than once', async () => {
+      // Arrange - the controller calls close() on both its own path and the
+      // socket's, and a second decrement would drop the watch out from under
+      // the viewers still on it.
+      const h = makeHarness('client');
+      await h.service.start();
+
+      // Act
+      h.service.close();
+      h.service.close();
+
+      // Assert
+      expect(h.unregisterClient).toHaveBeenCalledTimes(1);
     });
 
     it('propagates orchestrator errors so the controller can map them to 1011', async () => {

--- a/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.service.test.ts
+++ b/apps/node-server/tests/unit/features/transcription-stream/transcription-stream.service.test.ts
@@ -7,6 +7,7 @@ import { LatencyChannel } from '#src/server/features/transcription-stream/events
 import { SessionEndedChannel } from '#src/server/features/transcription-stream/events/session-ended.events.js';
 import { SessionStatusChannel } from '#src/server/features/transcription-stream/events/session-status.events.js';
 import { TranscriptChannel } from '#src/server/features/transcription-stream/events/transcript.events.js';
+import { SessionAlreadyEndedError } from '#src/server/features/transcription-stream/transcription-orchestrator.service.js';
 import { TranscriptionStreamService } from '#src/server/features/transcription-stream/transcription-stream.service.js';
 import { EventBusService } from '#src/server/shared/services/event-bus.service.js';
 import { NodeServerMetricsService } from '#src/server/shared/services/node-server-metrics.service.js';
@@ -27,10 +28,35 @@ interface Harness {
   metrics: NodeServerMetricsService;
 }
 
+/**
+ * How many listeners the bus currently holds for a channel keyed by
+ * `SESSION_UID`. Reaches into the bus's private map on purpose: the leak this
+ * guards - a connection that subscribes and then bails out of `start()`
+ * without unsubscribing - is invisible from the outside, because a leaked
+ * listener on a dead connection emits nothing.
+ */
+function busListenerCount(bus: EventBusService, key: string): number {
+  const channels = Reflect.get(bus, '_channels') as
+    | Map<string, Set<unknown>>
+    | undefined;
+  return channels?.get(key)?.size ?? 0;
+}
+
+/** Total listeners this service could have taken out, across all four buses. */
+function allBusListenerCounts(bus: EventBusService): number {
+  return (
+    busListenerCount(bus, TranscriptChannel.key(SESSION_UID)) +
+    busListenerCount(bus, LatencyChannel.key(SESSION_UID)) +
+    busListenerCount(bus, SessionStatusChannel.key(SESSION_UID)) +
+    busListenerCount(bus, SessionEndedChannel.key(SESSION_UID))
+  );
+}
+
 function makeHarness(
   role: 'source' | 'client',
   options: {
     registerThrows?: boolean;
+    registerSessionEnded?: boolean;
     initialStatus?: {
       transcriptionServiceConnected: boolean;
       sourceDeviceConnected: boolean;
@@ -44,6 +70,9 @@ function makeHarness(
   const registerSource = vi.fn(() => {
     if (options.registerThrows) {
       return Promise.reject(new Error('orchestrator-down'));
+    }
+    if (options.registerSessionEnded) {
+      return Promise.reject(new SessionAlreadyEndedError(SESSION_UID));
     }
     return Promise.resolve({
       unregister: unregisterSource,
@@ -288,6 +317,7 @@ describe('TranscriptionStreamService', () => {
 
       // Act - close before resolving the registration.
       const pending = service.start();
+      const whileRegistering = allBusListenerCounts(bus);
       service.close();
       resolveRegister({
         unregister,
@@ -297,11 +327,74 @@ describe('TranscriptionStreamService', () => {
 
       // Assert
       expect(unregister).toHaveBeenCalledTimes(1);
+      // Subscriptions are now taken out before the await, so this path has
+      // four of them to hand back. Leaving them attached would keep a dead
+      // connection on every one of the session's buses for the life of the
+      // process.
+      expect(whileRegistering).toBe(4);
+      expect(allBusListenerCounts(bus)).toBe(0);
+    });
+
+    it('leaves no subscriptions behind when the orchestrator throws', async () => {
+      // The 1011 path. `start()` rethrows for the controller to map, and must
+      // not have left this connection on the buses on its way out.
+      // Arrange
+      const h = makeHarness('source', { registerThrows: true });
+
+      // Act
+      await expect(h.service.start()).rejects.toThrow('orchestrator-down');
+
+      // Assert
+      expect(allBusListenerCounts(h.bus)).toBe(0);
+      expect(h.metrics.subscriberCount(SESSION_UID)).toBe(0);
+    });
+
+    it('subscribes to nothing when the connection closed before start ran', async () => {
+      // Arrange
+      const h = makeHarness('source');
+      h.service.close();
+
+      // Act
+      await h.service.start();
+
+      // Assert
+      expect(allBusListenerCounts(h.bus)).toBe(0);
+      expect(h.registerSource).not.toHaveBeenCalled();
+    });
+
+    it('drops live-stream messages that arrive before authOk', async () => {
+      // Subscribing before registration means these buses can now fire while
+      // the socket has not been told its auth succeeded. Writing to it then is
+      // a protocol violation, and nothing is lost by dropping: the status
+      // snapshot `onAuthAcknowledged` sends supersedes any status published
+      // here, and transcripts have no replay semantics for a connection that
+      // has not finished authenticating.
+      // Arrange
+      const h = makeHarness('client');
+      await h.service.start();
+
+      // Act
+      h.bus.publish(
+        SessionStatusChannel,
+        { transcriptionServiceConnected: true, sourceDeviceConnected: true },
+        SESSION_UID,
+      );
+      h.bus.publish(
+        TranscriptChannel,
+        {
+          final: { text: ['too early'], starts: null, ends: null },
+          inProgress: null,
+        },
+        SESSION_UID,
+      );
+
+      // Assert
+      expect(h.sent).toHaveLength(0);
     });
   });
 
-  describe('publishCurrentStatus', (it) => {
-    it('emits the orchestrator snapshot on demand', async () => {
+  describe('onAuthAcknowledged', (it) => {
+    it('emits the orchestrator snapshot once the controller has sent authOk', async () => {
       // Arrange
       const h = makeHarness('client', {
         initialStatus: {
@@ -312,7 +405,7 @@ describe('TranscriptionStreamService', () => {
       await h.service.start();
 
       // Act
-      h.service.publishCurrentStatus();
+      h.service.onAuthAcknowledged();
 
       // Assert
       expect(h.sent).toEqual([
@@ -331,10 +424,134 @@ describe('TranscriptionStreamService', () => {
       h.service.close();
 
       // Act
-      h.service.publishCurrentStatus();
+      h.service.onAuthAcknowledged();
 
       // Assert
       expect(h.sent).toHaveLength(0);
+    });
+  });
+
+  // The bug: a source connecting to a session whose `effectiveEnd` had already
+  // passed was never told. `registerSource` published `sessionEnded` from
+  // inside its own await, before this connection had subscribed, so the
+  // publish landed on an empty channel - and the source went on streaming
+  // audio into a session the server considered over, holding an upstream
+  // transcription connection for as long as the kiosk kept the socket up.
+  describe('registering onto an already-ended session', (it) => {
+    it('sends sessionEnded and closes 1000, after authOk rather than before it', async () => {
+      // Arrange
+      const h = makeHarness('source', { registerSessionEnded: true });
+
+      // Act - `start()` must not throw: the session is over, not broken, and a
+      // 1011 here would put the kiosk into a reconnect loop against a session
+      // that is never coming back.
+      await h.service.start();
+
+      // Assert - nothing yet. The controller has not written authOk, and both
+      // webapp clients hold their handshake open until it arrives.
+      expect(h.sent).toHaveLength(0);
+      expect(h.closes).toHaveLength(0);
+
+      // Act - the controller sends authOk and reports it.
+      h.service.onAuthAcknowledged();
+
+      // Assert
+      expect(h.sent).toEqual([{ type: 'sessionEnded' }]);
+      expect(h.closes).toEqual([{ code: 1000, reason: 'session-ended' }]);
+    });
+
+    it('sends no status snapshot for a session that is over', async () => {
+      // A `sessionStatus` here reads as "still waiting for a source", which
+      // would tell the client to keep waiting for one that is never coming.
+      // Arrange
+      const h = makeHarness('source', { registerSessionEnded: true });
+      await h.service.start();
+
+      // Act
+      h.service.onAuthAcknowledged();
+
+      // Assert
+      expect(
+        h.sent.find((m) => (m as { type: string }).type === 'sessionStatus'),
+      ).toBeUndefined();
+      expect(h.getStatus).not.toHaveBeenCalled();
+    });
+
+    it('holds no orchestrator registration and no bus subscriptions afterwards', async () => {
+      // Nothing was registered and no upstream was dialed, so there is nothing
+      // to release - but the subscriptions taken out before registering must
+      // still come back off the bus when the connection closes.
+      // Arrange
+      const h = makeHarness('source', { registerSessionEnded: true });
+      await h.service.start();
+
+      // Act
+      h.service.onAuthAcknowledged();
+
+      // Assert
+      expect(h.unregisterSource).not.toHaveBeenCalled();
+      expect(allBusListenerCounts(h.bus)).toBe(0);
+      expect(h.metrics.subscriberCount(SESSION_UID)).toBe(0);
+    });
+
+    it('still delivers an end that lands while the source is registering', async () => {
+      // The §4.1 race rather than the stale-schedule case: registration is
+      // admitted, and the end is published on the bus while the await is still
+      // outstanding. The subscription now exists to hear it; before it moved,
+      // this publish went nowhere.
+      // Arrange
+      let resolveRegister: (handle: {
+        unregister: () => void;
+        setMicrophoneActive: () => void;
+      }) => void = () => undefined;
+      const registerSource = vi.fn(
+        () =>
+          new Promise<{
+            unregister: () => void;
+            setMicrophoneActive: () => void;
+          }>((resolve) => {
+            resolveRegister = resolve;
+          }),
+      );
+      const logger = createMockLogger();
+      const bus = new EventBusService(logger as never);
+      const orchestrator = {
+        registerSource,
+        getStatus: () => ({
+          transcriptionServiceConnected: false,
+          sourceDeviceConnected: false,
+        }),
+        activeSessionCount: 0,
+      } as unknown as ConstructorParameters<
+        typeof TranscriptionStreamService
+      >[0]['transcriptionOrchestratorService'];
+      const service = new TranscriptionStreamService({
+        role: 'source',
+        sessionUid: SESSION_UID,
+        eventBusService: bus,
+        transcriptionOrchestratorService: orchestrator,
+        nodeServerMetricsService: new NodeServerMetricsService(),
+      });
+      const sent: unknown[] = [];
+      const closes: { code: number; reason: string }[] = [];
+      service.on('send', (msg) => {
+        sent.push(msg);
+      });
+      service.on('close', (code, reason) => {
+        closes.push({ code, reason });
+      });
+
+      // Act - the end is published mid-registration, then registration
+      // completes normally.
+      const pending = service.start();
+      bus.publish(SessionEndedChannel, {}, SESSION_UID);
+      resolveRegister({ unregister: vi.fn(), setMicrophoneActive: vi.fn() });
+      await pending;
+      service.onAuthAcknowledged();
+
+      // Assert
+      expect(sent).toEqual([{ type: 'sessionEnded' }]);
+      expect(closes).toEqual([{ code: 1000, reason: 'session-ended' }]);
     });
   });
 
@@ -387,6 +604,8 @@ describe('TranscriptionStreamService', () => {
       // Arrange
       const h = makeHarness('client');
       await h.service.start();
+      // The controller has sent authOk; the outbound gate is open.
+      h.service.onAuthAcknowledged();
 
       // Act
       h.bus.publish(
@@ -410,6 +629,8 @@ describe('TranscriptionStreamService', () => {
       // Arrange
       const h = makeHarness('client');
       await h.service.start();
+      // The controller has sent authOk; the outbound gate is open.
+      h.service.onAuthAcknowledged();
 
       // Act
       h.bus.publish(
@@ -431,6 +652,8 @@ describe('TranscriptionStreamService', () => {
       // Arrange
       const h = makeHarness('client');
       await h.service.start();
+      // The controller has sent authOk; the outbound gate is open.
+      h.service.onAuthAcknowledged();
 
       // Act
       h.bus.publish(
@@ -452,6 +675,8 @@ describe('TranscriptionStreamService', () => {
       // Arrange
       const h = makeHarness('client');
       await h.service.start();
+      // The controller has sent authOk; the outbound gate is open.
+      h.service.onAuthAcknowledged();
 
       // Act
       h.bus.publish(
@@ -475,6 +700,8 @@ describe('TranscriptionStreamService', () => {
       // Arrange
       const h = makeHarness('client');
       await h.service.start();
+      // The controller has sent authOk; the outbound gate is open.
+      h.service.onAuthAcknowledged();
 
       // Act
       h.bus.publish(SessionEndedChannel, {}, SESSION_UID);

--- a/apps/node-server/tests/unit/nginx-node-server-sticky.test.ts
+++ b/apps/node-server/tests/unit/nginx-node-server-sticky.test.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect } from 'vitest';
+
+import {
+  TRANSCRIPTION_STREAM_CLIENT_ROUTE,
+  TRANSCRIPTION_STREAM_SOURCE_ROUTE,
+} from '@scribear/node-server-schema';
+
+/**
+ * Guards the sticky-routing assumption this workspace is built on but cannot
+ * enforce from inside itself.
+ *
+ * `TranscriptionOrchestratorService`'s class doc states it outright: "Sticky
+ * URL routing pins all connections for a given sessionUid to one Node Server
+ * instance, so the singleton state for a session is always co-located with the
+ * source connections feeding it." That state - the EventBus, the upstream
+ * transcription socket, the pending-chunk map - is per-process. A viewer routed
+ * to a different instance than its source subscribes to a channel nothing
+ * publishes on and receives no transcripts: no error, no close, no banner, just
+ * an empty caption view.
+ *
+ * Nothing checked it. The `upstream node-server` block had no balancing
+ * directive at all, so stickiness held only because the service happens to run
+ * one replica; `docker compose up --scale node-server=2` would have broken
+ * captioning with nothing anywhere naming the cause.
+ *
+ * Same reasoning and same precedent as `nginx-status-not-public.test.ts`: the
+ * requirement belongs to this workspace, the config that satisfies it lives in
+ * `infra/`, and a comment is weaker than a failing test.
+ */
+const NGINX_CONF_PATH = fileURLToPath(
+  new URL('../../../../infra/scribear-nginx/nginx.conf', import.meta.url),
+);
+
+/** The `upstream node-server { ... }` block, exactly as nginx reads it. */
+function nodeServerUpstreamBlock(conf: string): string {
+  const start = conf.indexOf('upstream node-server {');
+  expect(
+    start,
+    'nginx.conf has no `upstream node-server { ... }` block.',
+  ).toBeGreaterThanOrEqual(0);
+  const end = conf.indexOf('\n    }', start);
+  expect(end).toBeGreaterThan(start);
+  return conf.slice(start, end);
+}
+
+describe('nginx sticky-routes node-server by session uid', (it) => {
+  it('balances the node-server upstream on the session-uid variable', () => {
+    // Arrange
+    const conf = readFileSync(NGINX_CONF_PATH, 'utf8');
+
+    // Act
+    const block = nodeServerUpstreamBlock(conf);
+
+    // Assert
+    expect(
+      block,
+      'The node-server upstream has no `hash` directive, so nginx will ' +
+        'round-robin. Every connection for a session must reach the same ' +
+        'instance: the orchestrator state is per-process, and a viewer on a ' +
+        'different instance than its source silently receives no transcripts.',
+    ).toContain('hash $node_server_session_uid');
+  });
+
+  it('does not use `consistent`, which this nginx silently ignores on a resolve upstream', () => {
+    // Arrange
+    const conf = readFileSync(NGINX_CONF_PATH, 'utf8');
+
+    // Act
+    const block = nodeServerUpstreamBlock(conf);
+
+    // Assert - measured against nginx:1.29.7-alpine3.23 with two backends
+    // behind one docker network alias. Requesting the same session uid
+    // repeatedly: `hash $key consistent;` returned B A B A B A - plain
+    // round-robin, the directive ignored - while `hash $key;` returned B B B B
+    // B B and held two uids on two different peers across several `valid=5s`
+    // re-resolutions. `nginx -t` passes on both and, at one replica, both
+    // behave identically, so nothing but this test would catch the swap.
+    //
+    // Ketama is the better algorithm on its merits (a peer joining remaps ~1/N
+    // of sessions rather than most of them), which is exactly why someone will
+    // eventually try to add it back. It does not work here. If you have a
+    // newer nginx where it does, re-run that measurement before changing this.
+    expect(
+      block,
+      '`consistent` is silently ignored when the upstream server is a ' +
+        '`resolve` name in this nginx build: the upstream falls back to ' +
+        'round-robin and stickiness is lost with no error and no log line.',
+    ).not.toContain('consistent');
+  });
+
+  it('keys the hash off the session uid segment of both stream routes', () => {
+    // Arrange - derived from the route definitions rather than hard-coded, so
+    // moving the routes fails this test instead of leaving the map matching a
+    // prefix that no longer exists.
+    const conf = readFileSync(NGINX_CONF_PATH, 'utf8');
+    const prefix = '/api/node-server/v1/transcription-stream/';
+    expect(TRANSCRIPTION_STREAM_SOURCE_ROUTE.url).toBe(
+      `${prefix}:sessionUid/source`,
+    );
+    expect(TRANSCRIPTION_STREAM_CLIENT_ROUTE.url).toBe(
+      `${prefix}:sessionUid/client`,
+    );
+
+    // Act
+    const mapStart = conf.indexOf('map $uri $node_server_session_uid {');
+    expect(
+      mapStart,
+      'nginx.conf defines no $node_server_session_uid map, so the `hash` ' +
+        'directive has nothing to hash on.',
+    ).toBeGreaterThanOrEqual(0);
+    const map = conf.slice(mapStart, conf.indexOf('\n    }', mapStart));
+
+    // Assert - the regex captures the segment straight after the shared
+    // prefix, which is the session uid on both routes.
+    expect(map).toContain(`~^${prefix}(?<sess_uid>[^/]+)`);
+    // `$uri`, not `$request_uri`: normalised, decoded and query-free, so a
+    // trailing `?x=1` cannot send a second connection for the same session to
+    // a different instance.
+    expect(map.startsWith('map $uri ')).toBe(true);
+  });
+});

--- a/apps/session-manager/src/app-config/app-config.ts
+++ b/apps/session-manager/src/app-config/app-config.ts
@@ -3,6 +3,7 @@ import { Type } from 'typebox';
 import type { Static } from 'typebox';
 
 import { LogLevel } from '@scribear/base-fastify-server';
+import { SHIPPED_TRANSCRIPTION_PROVIDER_IDS } from '@scribear/session-manager-schema';
 
 import type { DBClientConfig } from '#src/db/db-client.js';
 import { DEFAULT_DEMO_SESSION_UID } from '#src/server/features/demo-room/demo-room.constants.js';
@@ -82,6 +83,35 @@ const CONFIG_SCHEMA = Type.Object({
   // which is where a deployment that never provisioned a canary device already
   // was. Rotating it is a restart of both services.
   CANARY_DEVICE_SECRET: Type.String({ default: '' }),
+
+  // Comma-separated provider keys this deployment's transcription-service
+  // actually defines in its `provider_config.json`. A session, schedule or
+  // auto-session window created with anything else is rejected at 400.
+  //
+  // WHY A CONFIG VALUE AND NOT AN ENUM IN THE SCHEMA: `provider_config.json` is
+  // operator-editable deployment config. Baking the shipped four into the wire
+  // schema would reject a provider an operator legitimately added and accept
+  // one they removed - the schema would be asserting something it cannot know,
+  // the same mistake as pinning the Authorization header to a character class.
+  // The default is the shipped set, so a stock deployment needs nothing; a
+  // deployment that edits provider_config.json edits this alongside it.
+  //
+  // WHY NOT A LIVE LOOKUP: the authoritative list is behind
+  // transcription-service's `/providers/health`, which requires
+  // METRICS_API_KEY - a credential session-manager does not have and should not
+  // acquire, since it otherwise never talks to transcription-service at all.
+  // Making a create request depend on a second service being reachable would
+  // also mean a transcription-service outage blocks scheduling, which is worse
+  // than the problem being solved.
+  //
+  // Getting this list wrong is loud in both directions: too narrow and a create
+  // fails immediately with the accepted keys named in the message; too wide and
+  // we are back to today's behaviour, which the `invalid-request` disconnect
+  // reason now surfaces to the viewer anyway. Neither is silent.
+  TRANSCRIPTION_PROVIDER_IDS: Type.String({
+    minLength: 1,
+    default: SHIPPED_TRANSCRIPTION_PROVIDER_IDS.join(','),
+  }),
 });
 
 export interface BaseConfig {
@@ -107,6 +137,15 @@ export interface TestAudioRoomsConfig {
    * generator derives the same value from the same two inputs.
    */
   deviceSecret: string;
+}
+
+export interface ScheduleManagementConfig {
+  /**
+   * Provider keys accepted on session/schedule/window writes. Parsed from
+   * `TRANSCRIPTION_PROVIDER_IDS`; never empty (the env value has
+   * `minLength: 1` and a default).
+   */
+  transcriptionProviderIds: string[];
 }
 
 export interface CanaryRoomConfig {
@@ -186,6 +225,14 @@ export class AppConfig {
       // would only add a way to be half-configured.
       enabled: this._env.TEST_AUDIO_DEVICE_SECRET !== '',
       deviceSecret: this._env.TEST_AUDIO_DEVICE_SECRET,
+    };
+  }
+
+  get scheduleManagementConfig(): ScheduleManagementConfig {
+    return {
+      transcriptionProviderIds: this._env.TRANSCRIPTION_PROVIDER_IDS.split(',')
+        .map((id) => id.trim())
+        .filter((id) => id !== ''),
     };
   }
 

--- a/apps/session-manager/src/server/dependency-injection/app-dependencies.ts
+++ b/apps/session-manager/src/server/dependency-injection/app-dependencies.ts
@@ -8,6 +8,7 @@ import type {
   BaseConfig,
   CanaryRoomConfig,
   DemoRoomConfig,
+  ScheduleManagementConfig,
   TestAudioRoomsConfig,
 } from '#src/app-config/app-config.js';
 import type { DBClient, DBClientConfig } from '#src/db/db-client.js';
@@ -67,6 +68,7 @@ interface AppDependencies extends BaseDependencies {
   demoRoomConfig: DemoRoomConfig;
   testAudioRoomsConfig: TestAudioRoomsConfig;
   canaryRoomConfig: CanaryRoomConfig;
+  scheduleManagementConfig: ScheduleManagementConfig;
 
   // Database
   dbClient: DBClient;

--- a/apps/session-manager/src/server/dependency-injection/register-dependencies.ts
+++ b/apps/session-manager/src/server/dependency-injection/register-dependencies.ts
@@ -59,6 +59,7 @@ function registerDependencies(
     demoRoomConfig: asValue(config.demoRoomConfig),
     testAudioRoomsConfig: asValue(config.testAudioRoomsConfig),
     canaryRoomConfig: asValue(config.canaryRoomConfig),
+    scheduleManagementConfig: asValue(config.scheduleManagementConfig),
 
     // Database
     dbClient: asClass(DBClient, { lifetime: Lifetime.SINGLETON }),

--- a/apps/session-manager/src/server/features/schedule-management/schedule-management.controller.ts
+++ b/apps/session-manager/src/server/features/schedule-management/schedule-management.controller.ts
@@ -98,6 +98,8 @@ export class ScheduleManagementController {
       new Date(),
     );
 
+    if (result === 'UNKNOWN_TRANSCRIPTION_PROVIDER')
+      throw HttpError.badRequest(this._unknownProviderMessage());
     if (result === 'ROOM_NOT_FOUND')
       throw HttpError.notFound('ROOM_NOT_FOUND', 'Room not found.');
     if (result === 'CONFLICT')
@@ -168,6 +170,8 @@ export class ScheduleManagementController {
       new Date(),
     );
 
+    if (result === 'UNKNOWN_TRANSCRIPTION_PROVIDER')
+      throw HttpError.badRequest(this._unknownProviderMessage());
     if (result === 'NOT_FOUND')
       throw HttpError.notFound('SCHEDULE_NOT_FOUND', 'Schedule not found.');
     if (result === 'CONFLICT')
@@ -253,6 +257,8 @@ export class ScheduleManagementController {
       new Date(),
     );
 
+    if (result === 'UNKNOWN_TRANSCRIPTION_PROVIDER')
+      throw HttpError.badRequest(this._unknownProviderMessage());
     if (result === 'ROOM_NOT_FOUND')
       throw HttpError.notFound('ROOM_NOT_FOUND', 'Room not found.');
     if (result === 'CONFLICT')
@@ -314,6 +320,8 @@ export class ScheduleManagementController {
       new Date(),
     );
 
+    if (result === 'UNKNOWN_TRANSCRIPTION_PROVIDER')
+      throw HttpError.badRequest(this._unknownProviderMessage());
     if (result === 'NOT_FOUND')
       throw HttpError.notFound(
         'WINDOW_NOT_FOUND',
@@ -453,6 +461,8 @@ export class ScheduleManagementController {
       new Date(),
     );
 
+    if (result === 'UNKNOWN_TRANSCRIPTION_PROVIDER')
+      throw HttpError.badRequest(this._unknownProviderMessage());
     if (result === 'ROOM_NOT_FOUND')
       throw HttpError.notFound('ROOM_NOT_FOUND', 'Room not found.');
     if (result === 'ANOTHER_SESSION_ACTIVE')
@@ -718,6 +728,23 @@ export class ScheduleManagementController {
         this._mapSession(s),
       ),
     };
+  }
+
+  /**
+   * Rejection message for an unrecognized `transcriptionProviderId`.
+   *
+   * Names the accepted keys rather than just saying "invalid": the value comes
+   * from a free-text field in the admin console, the accepted set is deployment
+   * configuration the operator cannot see from the UI, and the alternative to
+   * telling them here is that they discover the typo when a room full of people
+   * gets a permanent "reconnecting" banner. Emitted as `400 VALIDATION_ERROR` -
+   * the same answer the request validator gives for any other malformed field,
+   * and already declared on every one of these routes, so nothing about the
+   * wire contract changes.
+   */
+  private _unknownProviderMessage(): string {
+    const known = this._scheduleService.transcriptionProviderIds.join(', ');
+    return `transcriptionProviderId is not a provider configured on this deployment. Configured providers: ${known}.`;
   }
 
   private _mapSchedule(s: Schedule) {

--- a/apps/session-manager/src/server/features/schedule-management/schedule-management.service.ts
+++ b/apps/session-manager/src/server/features/schedule-management/schedule-management.service.ts
@@ -220,17 +220,55 @@ export class ScheduleManagementService {
   private _dbClient: AppDependencies['dbClient'];
   private _repo: AppDependencies['scheduleManagementRepository'];
   private _eventBus: AppDependencies['eventBusService'];
+  /**
+   * Provider keys this deployment's transcription-service defines. See
+   * `TRANSCRIPTION_PROVIDER_IDS` in `app-config.ts` for why the accepted set is
+   * configuration rather than a schema enum or a live lookup.
+   */
+  private _transcriptionProviderIds: Set<string>;
 
   constructor(
     logger: AppDependencies['logger'],
     dbClient: AppDependencies['dbClient'],
     scheduleManagementRepository: AppDependencies['scheduleManagementRepository'],
     eventBusService: AppDependencies['eventBusService'],
+    scheduleManagementConfig: AppDependencies['scheduleManagementConfig'],
   ) {
     this._log = logger;
     this._dbClient = dbClient;
     this._repo = scheduleManagementRepository;
     this._eventBus = eventBusService;
+    this._transcriptionProviderIds = new Set(
+      scheduleManagementConfig.transcriptionProviderIds,
+    );
+  }
+
+  /**
+   * The provider keys this service accepts, in configured order. Exposed so the
+   * controller can name them in the rejection message - an operator who typed
+   * `whipser` should not have to go read the deployment's env to find out what
+   * was expected.
+   */
+  get transcriptionProviderIds(): string[] {
+    return [...this._transcriptionProviderIds];
+  }
+
+  /**
+   * Rejects a `transcriptionProviderId` the deployment has no provider for.
+   *
+   * Checked here, at write time, because the alternative is that it surfaces at
+   * *stream* time: transcription-service raises "Invalid Provider Key" and
+   * closes the upstream socket 1007, node-server retries a permanently
+   * unsatisfiable request forever, and every viewer of that room watches a
+   * banner promising a reconnection that cannot happen. The typo is made once,
+   * by an operator, at a keyboard - that is where it should be answered.
+   *
+   * `undefined` (an update that does not touch the field) passes: it cannot
+   * introduce a bad value.
+   */
+  private _isKnownTranscriptionProvider(id: string | undefined): boolean {
+    if (id === undefined) return true;
+    return this._transcriptionProviderIds.has(id);
   }
 
   /**
@@ -457,7 +495,11 @@ export class ScheduleManagementService {
     | 'INVALID_ACTIVE_END'
     | 'INVALID_LOCAL_TIMES'
     | 'INVALID_FREQUENCY_FIELDS'
+    | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
   > {
+    if (!this._isKnownTranscriptionProvider(data.transcriptionProviderId)) {
+      return 'UNKNOWN_TRANSCRIPTION_PROVIDER' as const;
+    }
     return this._runWithEvents(async (trx, collector) => {
       const room = await this._repo.lockRoom(trx, data.roomUid);
       if (!room) return 'ROOM_NOT_FOUND' as const;
@@ -549,7 +591,11 @@ export class ScheduleManagementService {
     | 'INVALID_ACTIVE_END'
     | 'INVALID_LOCAL_TIMES'
     | 'INVALID_FREQUENCY_FIELDS'
+    | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
   > {
+    if (!this._isKnownTranscriptionProvider(data.transcriptionProviderId)) {
+      return 'UNKNOWN_TRANSCRIPTION_PROVIDER' as const;
+    }
     return this._runWithEvents(async (trx, collector) => {
       const existing = await this._repo.findScheduleByUid(trx, uid);
       if (existing?.activeEnd !== null) {
@@ -615,8 +661,15 @@ export class ScheduleManagementService {
     data: CreateWindowInput,
     now: Date,
   ): Promise<
-    AutoSessionWindow | 'ROOM_NOT_FOUND' | 'CONFLICT' | 'INVALID_ACTIVE_END'
+    | AutoSessionWindow
+    | 'ROOM_NOT_FOUND'
+    | 'CONFLICT'
+    | 'INVALID_ACTIVE_END'
+    | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
   > {
+    if (!this._isKnownTranscriptionProvider(data.transcriptionProviderId)) {
+      return 'UNKNOWN_TRANSCRIPTION_PROVIDER' as const;
+    }
     return this._runWithEvents(async (trx, collector) => {
       const room = await this._repo.lockRoom(trx, data.roomUid);
       if (!room) return 'ROOM_NOT_FOUND' as const;
@@ -697,8 +750,15 @@ export class ScheduleManagementService {
     data: UpdateWindowInput,
     now: Date,
   ): Promise<
-    AutoSessionWindow | 'NOT_FOUND' | 'CONFLICT' | 'INVALID_ACTIVE_END'
+    | AutoSessionWindow
+    | 'NOT_FOUND'
+    | 'CONFLICT'
+    | 'INVALID_ACTIVE_END'
+    | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
   > {
+    if (!this._isKnownTranscriptionProvider(data.transcriptionProviderId)) {
+      return 'UNKNOWN_TRANSCRIPTION_PROVIDER' as const;
+    }
     return this._runWithEvents(async (trx, collector) => {
       const existing = await this._repo.findWindowByUid(trx, uid);
       if (existing?.activeEnd !== null) {
@@ -878,7 +938,15 @@ export class ScheduleManagementService {
   async createOnDemandSession(
     data: CreateOnDemandSessionInput,
     now: Date,
-  ): Promise<Session | 'ROOM_NOT_FOUND' | 'ANOTHER_SESSION_ACTIVE'> {
+  ): Promise<
+    | Session
+    | 'ROOM_NOT_FOUND'
+    | 'ANOTHER_SESSION_ACTIVE'
+    | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
+  > {
+    if (!this._isKnownTranscriptionProvider(data.transcriptionProviderId)) {
+      return 'UNKNOWN_TRANSCRIPTION_PROVIDER' as const;
+    }
     return this._runWithEvents(async (trx, collector) => {
       const room = await this._repo.lockRoom(trx, data.roomUid);
       if (!room) return 'ROOM_NOT_FOUND' as const;

--- a/apps/session-manager/src/server/features/session-auth/session-auth.repository.ts
+++ b/apps/session-manager/src/server/features/session-auth/session-auth.repository.ts
@@ -18,6 +18,11 @@ export interface JoinCode {
 /**
  * Subset of `sessions` columns relevant to authentication. Effective start/end
  * are precomputed to mirror the convention used in `schedule-management`.
+ *
+ * `canceledAt` is part of the auth-relevant set, not just calendar metadata: a
+ * canceled row keeps its effective window, so every "is this session live?"
+ * predicate that reads only start/end will happily authorize a session an
+ * operator has canceled once time catches up to its slot.
  */
 export interface SessionAuthRow {
   uid: string;
@@ -25,6 +30,7 @@ export interface SessionAuthRow {
   joinCodeScopes: SessionScope[];
   effectiveStart: Date;
   effectiveEnd: Date | null;
+  canceledAt: Date | null;
 }
 
 /** A persisted `session_refresh_tokens` row mapped to camelCase. */
@@ -107,6 +113,7 @@ export class SessionAuthRepository {
         'uid',
         'room_uid',
         'join_code_scopes',
+        'canceled_at',
         effectiveStart.as('effective_start'),
         effectiveEnd.as('effective_end'),
       ])
@@ -120,6 +127,7 @@ export class SessionAuthRepository {
       joinCodeScopes: parsePgEnumArray(row.join_code_scopes) as SessionScope[],
       effectiveStart: row.effective_start,
       effectiveEnd: row.effective_end,
+      canceledAt: row.canceled_at,
     };
   }
 

--- a/apps/session-manager/src/server/features/session-auth/session-auth.service.ts
+++ b/apps/session-manager/src/server/features/session-auth/session-auth.service.ts
@@ -322,6 +322,21 @@ export class SessionAuthService {
       joinCode,
     );
     if (!codeRow) return 'JOIN_CODE_NOT_FOUND' as const;
+    // A code is exchangeable only inside `[validStart, validEnd)` - the same
+    // window `fetchJoinCodes` and `_findOrMintCurrentJoinCode` use to decide
+    // which code is "current". Checking only `validEnd` made the handoff code
+    // that `fetchJoinCodes` pre-mints 60s before expiry (validStart ==
+    // current.validEnd) exchangeable the instant it was minted, stretching a
+    // code's usable life from the intended 5 minutes to nearly 10.
+    //
+    // Not-yet-valid answers 404 rather than 410: 410 GONE claims the code is
+    // permanently finished when it is about to work, and a distinct status
+    // would confirm an unused code to anyone guessing at the 8-character
+    // space. Nothing legitimate presents a future code - the kiosk QR renders
+    // only `current` - so this costs no working flow.
+    if (codeRow.validStart.getTime() > now.getTime()) {
+      return 'JOIN_CODE_NOT_FOUND' as const;
+    }
     if (codeRow.validEnd.getTime() <= now.getTime()) {
       return 'JOIN_CODE_EXPIRED' as const;
     }

--- a/apps/session-manager/src/server/features/session-auth/session-auth.service.ts
+++ b/apps/session-manager/src/server/features/session-auth/session-auth.service.ts
@@ -85,6 +85,13 @@ export class SessionAuthService {
       const session = await this._repo.findSessionForAuth(trx, sessionUid);
       if (!session) return 'SESSION_NOT_FOUND' as const;
 
+      // A canceled session is invisible to devices by construction:
+      // `my-schedule` filters `canceled_at`, so no device should ever be
+      // holding this uid. Report it as gone rather than adding a new error
+      // code to this route's published contract - and, more importantly,
+      // rather than minting a code that would exchange into a live token.
+      if (session.canceledAt !== null) return 'SESSION_NOT_FOUND' as const;
+
       const inRoom = await this._repo.isDeviceInRoom(
         trx,
         deviceUid,
@@ -482,7 +489,16 @@ export class SessionAuthService {
   }
 }
 
+/**
+ * Mirrors `schedule-management`'s `findActiveSession` predicate, including its
+ * `canceled_at IS NULL` clause. Canceling does not move a session's window -
+ * `cancel-session` only accepts *upcoming* occurrences, so time eventually
+ * catches up to every canceled row's slot - which means a start/end-only
+ * predicate starts reporting canceled sessions as live and mints tokens for
+ * them.
+ */
 function isSessionCurrentlyActive(session: SessionAuthRow, now: Date): boolean {
+  if (session.canceledAt !== null) return false;
   if (session.effectiveStart.getTime() > now.getTime()) return false;
   if (
     session.effectiveEnd !== null &&
@@ -493,7 +509,13 @@ function isSessionCurrentlyActive(session: SessionAuthRow, now: Date): boolean {
   return true;
 }
 
+/**
+ * Whether a session can never issue another token. Cancellation is terminal in
+ * the same way an elapsed end time is: an already-issued refresh token must
+ * stop working, not keep re-minting for the rest of the (canceled) window.
+ */
 function isSessionEnded(session: SessionAuthRow, now: Date): boolean {
+  if (session.canceledAt !== null) return true;
   return (
     session.effectiveEnd !== null &&
     session.effectiveEnd.getTime() <= now.getTime()

--- a/apps/session-manager/tests/integration/features/probes/probes.routes.test.ts
+++ b/apps/session-manager/tests/integration/features/probes/probes.routes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, inject } from 'vitest';
 
 import { LogLevel } from '@scribear/base-fastify-server';
+import { SHIPPED_TRANSCRIPTION_PROVIDER_IDS } from '@scribear/session-manager-schema';
 
 import type { AppConfig } from '#src/app-config/app-config.js';
 import createServer from '#src/server/create-server.js';
@@ -65,6 +66,9 @@ describe('Probes Routes', () => {
         },
         testAudioRoomsConfig: { enabled: false, deviceSecret: '' },
         canaryRoomConfig: { enabled: false, deviceSecret: '' },
+        scheduleManagementConfig: {
+          transcriptionProviderIds: [...SHIPPED_TRANSCRIPTION_PROVIDER_IDS],
+        },
       } as unknown as AppConfig;
       const { fastify } = await createServer(brokenConfig);
       await fastify.ready();

--- a/apps/session-manager/tests/integration/features/schedule-management/schedule-management.routes.test.ts
+++ b/apps/session-manager/tests/integration/features/schedule-management/schedule-management.routes.test.ts
@@ -164,6 +164,39 @@ describe('Schedule Management Routes', () => {
       expect(res.json<{ code: string }>().code).toBe('INVALID_ACTIVE_START');
     });
 
+    it('returns 400 naming the configured providers when the provider is unknown', async () => {
+      // Arrange - a typo in a free-text field. Left unchecked it surfaces at
+      // stream time as an upstream 1007 and a permanent "reconnecting" banner
+      // for every viewer of the room; answered here it costs one 400.
+      const { roomUid } = await setupRoom();
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/create-schedule`,
+        headers: { authorization: ADMIN_HEADER },
+        body: defaultScheduleBody(roomUid, {
+          transcriptionProviderId: 'whipser',
+        }),
+      });
+
+      // Assert - 400 VALIDATION_ERROR is already declared on this route via
+      // STANDARD_ERROR_REPLIES, so nothing about the contract changes. The
+      // message names the accepted keys: the operator cannot see the
+      // deployment's provider set from the console.
+      expect(res.statusCode).toBe(400);
+      const body = res.json<{ code: string; message: string }>();
+      expect(body.code).toBe('VALIDATION_ERROR');
+      expect(body.message).toContain('whisper');
+
+      // And nothing was written.
+      const schedules = await dbContext.db
+        .selectFrom('session_schedules')
+        .select('uid')
+        .execute();
+      expect(schedules).toHaveLength(0);
+    });
+
     it('returns 201 with the created schedule', async () => {
       // Arrange
       const { roomUid } = await setupRoom();
@@ -400,6 +433,30 @@ describe('Schedule Management Routes', () => {
       expect(res.statusCode).toBe(200);
       const body = res.json<{ uid: string; name: string }>();
       expect(body.name).toBe('Renamed');
+    });
+
+    it('returns 400 when the update names an unknown provider', async () => {
+      // Arrange
+      const { roomUid } = await setupRoom();
+      const create = await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/create-schedule`,
+        headers: { authorization: ADMIN_HEADER },
+        body: defaultScheduleBody(roomUid),
+      });
+      const { uid: scheduleUid } = create.json<{ uid: string }>();
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/update-schedule`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { scheduleUid, transcriptionProviderId: 'not-a-provider' },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(400);
+      expect(res.json<{ code: string }>().code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 422 when a past activeStart is supplied', async () => {
@@ -644,6 +701,31 @@ describe('Schedule Management Routes', () => {
       expect(body.roomUid).toBe(roomUid);
     });
 
+    it('returns 400 when the provider is unknown', async () => {
+      // Arrange - the window path matters as much as the session path: every
+      // AUTO session it materializes inherits this provider id.
+      const { roomUid } = await setupRoom();
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/create-auto-session-window`,
+        headers: { authorization: ADMIN_HEADER },
+        body: defaultWindowBody(roomUid, {
+          transcriptionProviderId: 'not-a-provider',
+        }),
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(400);
+      expect(res.json<{ code: string }>().code).toBe('VALIDATION_ERROR');
+      const windows = await dbContext.db
+        .selectFrom('auto_session_windows')
+        .select('uid')
+        .execute();
+      expect(windows).toHaveLength(0);
+    });
+
     it('returns 404 when the room does not exist', async () => {
       // Arrange / Act
       const res = await server.fastify.inject({
@@ -721,6 +803,30 @@ describe('Schedule Management Routes', () => {
   });
 
   describe('POST /update-auto-session-window', (it) => {
+    it('returns 400 when the update names an unknown provider', async () => {
+      // Arrange
+      const { roomUid } = await setupRoom();
+      const create = await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/create-auto-session-window`,
+        headers: { authorization: ADMIN_HEADER },
+        body: defaultWindowBody(roomUid),
+      });
+      const { uid: windowUid } = create.json<{ uid: string }>();
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/update-auto-session-window`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { windowUid, transcriptionProviderId: 'not-a-provider' },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(400);
+      expect(res.json<{ code: string }>().code).toBe('VALIDATION_ERROR');
+    });
+
     it('returns 200 with the new window, replacing the original', async () => {
       // Arrange
       const { roomUid } = await setupRoom();
@@ -1055,6 +1161,28 @@ describe('Schedule Management Routes', () => {
       // Assert
       expect(res.statusCode).toBe(201);
       expect(res.json<{ type: string }>().type).toBe('ON_DEMAND');
+    });
+
+    it('returns 400 when the provider is unknown, and creates nothing', async () => {
+      // Arrange
+      const { roomUid } = await setupRoom();
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/create-on-demand-session`,
+        headers: { authorization: ADMIN_HEADER },
+        body: makeBody(roomUid, { transcriptionProviderId: 'not-a-provider' }),
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(400);
+      expect(res.json<{ code: string }>().code).toBe('VALIDATION_ERROR');
+      const sessions = await dbContext.db
+        .selectFrom('sessions')
+        .select('uid')
+        .execute();
+      expect(sessions).toHaveLength(0);
     });
 
     it('returns 404 when the room does not exist', async () => {

--- a/apps/session-manager/tests/integration/features/schedule-management/schedule-management.service.test.ts
+++ b/apps/session-manager/tests/integration/features/schedule-management/schedule-management.service.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect } from 'vitest';
 
+import { SHIPPED_TRANSCRIPTION_PROVIDER_IDS } from '@scribear/session-manager-schema';
+
 import { ScheduleManagementRepository } from '#src/server/features/schedule-management/schedule-management.repository.js';
 import { ScheduleManagementService } from '#src/server/features/schedule-management/schedule-management.service.js';
 import { EventBusService } from '#src/server/shared/services/event-bus.service.js';
@@ -26,6 +28,7 @@ describe('ScheduleManagementService', () => {
       dbContext.dbClient,
       repository,
       new EventBusService(logger as never),
+      { transcriptionProviderIds: [...SHIPPED_TRANSCRIPTION_PROVIDER_IDS] },
     );
   });
 
@@ -123,6 +126,7 @@ describe('ScheduleManagementService', () => {
         | 'INVALID_ACTIVE_END'
         | 'INVALID_LOCAL_TIMES'
         | 'INVALID_FREQUENCY_FIELDS'
+        | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
       >;
       const sessions = await listSessionsForRoom(roomUid);
       const scheduled = sessions.filter((s) => s.type === 'SCHEDULED');
@@ -174,6 +178,7 @@ describe('ScheduleManagementService', () => {
         | 'INVALID_ACTIVE_END'
         | 'INVALID_LOCAL_TIMES'
         | 'INVALID_FREQUENCY_FIELDS'
+        | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
       >;
       expect(schedule.activeEnd).toEqual(activeEnd);
       const scheduled = (await listSessionsForRoom(roomUid)).filter(
@@ -458,6 +463,7 @@ describe('ScheduleManagementService', () => {
         | 'INVALID_ACTIVE_END'
         | 'INVALID_LOCAL_TIMES'
         | 'INVALID_FREQUENCY_FIELDS'
+        | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
       >;
 
       // Act
@@ -621,6 +627,7 @@ describe('ScheduleManagementService', () => {
         | 'INVALID_ACTIVE_END'
         | 'INVALID_LOCAL_TIMES'
         | 'INVALID_FREQUENCY_FIELDS'
+        | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
       >;
       expect(updated.uid).not.toBe(original.uid);
       expect(updated.name).toBe('Renamed');
@@ -775,6 +782,7 @@ describe('ScheduleManagementService', () => {
         | 'INVALID_ACTIVE_END'
         | 'INVALID_LOCAL_TIMES'
         | 'INVALID_FREQUENCY_FIELDS'
+        | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
       >;
       // Sanity: there's an upcoming auto session.
       const before = await listSessionsForRoom(roomUid);
@@ -1095,6 +1103,7 @@ describe('ScheduleManagementService', () => {
         | 'INVALID_ACTIVE_END'
         | 'INVALID_LOCAL_TIMES'
         | 'INVALID_FREQUENCY_FIELDS'
+        | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
       >;
       // Anchor preserved verbatim; the updated activeStart is the new one.
       expect(updated.anchorStart).toEqual(anchorDate);
@@ -1156,7 +1165,9 @@ describe('ScheduleManagementService', () => {
       expect(result).not.toBe('ANOTHER_SESSION_ACTIVE');
       const session = result as Exclude<
         typeof result,
-        'ROOM_NOT_FOUND' | 'ANOTHER_SESSION_ACTIVE'
+        | 'ROOM_NOT_FOUND'
+        | 'ANOTHER_SESSION_ACTIVE'
+        | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
       >;
       expect(session.scheduledEndTime).toEqual(nextStart);
     });
@@ -1183,7 +1194,9 @@ describe('ScheduleManagementService', () => {
       expect(result).not.toBe('ANOTHER_SESSION_ACTIVE');
       const session = result as Exclude<
         typeof result,
-        'ROOM_NOT_FOUND' | 'ANOTHER_SESSION_ACTIVE'
+        | 'ROOM_NOT_FOUND'
+        | 'ANOTHER_SESSION_ACTIVE'
+        | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
       >;
       expect(session.scheduledEndTime).toBeNull();
     });
@@ -2115,6 +2128,7 @@ describe('ScheduleManagementService', () => {
         | 'INVALID_ACTIVE_END'
         | 'INVALID_LOCAL_TIMES'
         | 'INVALID_FREQUENCY_FIELDS'
+        | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
       >;
 
       // Clear existing AUTO sessions and insert one that is currently running.
@@ -2648,6 +2662,7 @@ describe('ScheduleManagementService', () => {
           | 'INVALID_ACTIVE_END'
           | 'INVALID_LOCAL_TIMES'
           | 'INVALID_FREQUENCY_FIELDS'
+          | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
         >
       >;
     }
@@ -2859,6 +2874,7 @@ describe('ScheduleManagementService', () => {
         | 'INVALID_ACTIVE_END'
         | 'INVALID_LOCAL_TIMES'
         | 'INVALID_FREQUENCY_FIELDS'
+        | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
       >;
       expect(schedule.name).toBe('Biweekly B');
     });
@@ -2916,6 +2932,7 @@ describe('ScheduleManagementService', () => {
         | 'INVALID_ACTIVE_END'
         | 'INVALID_LOCAL_TIMES'
         | 'INVALID_FREQUENCY_FIELDS'
+        | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
       >;
       expect(schedule.name).toBe('Adjacent');
     });
@@ -3035,6 +3052,7 @@ describe('ScheduleManagementService', () => {
         | 'INVALID_ACTIVE_END'
         | 'INVALID_LOCAL_TIMES'
         | 'INVALID_FREQUENCY_FIELDS'
+        | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
       >;
       const before = (await listSessionsForRoom(roomUid)).filter(
         (s) => s.type === 'AUTO',

--- a/apps/session-manager/tests/integration/features/session-auth/session-auth.routes.test.ts
+++ b/apps/session-manager/tests/integration/features/session-auth/session-auth.routes.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect } from 'vitest';
 
+import type { SessionScope } from '@scribear/scribear-db';
+
 import createServer from '#src/server/create-server.js';
 import { useDb } from '#tests/utils/use-db.js';
 import {
@@ -166,6 +168,103 @@ describe('Session Auth Routes', () => {
     return { ...source, roomUid, sessionUid };
   }
 
+  /**
+   * Builds an in-room source device + a **SCHEDULED** session whose effective
+   * window covers now. `cancel-session` only accepts SCHEDULED occurrences, so
+   * this is the only shape that can reach the canceled-but-live state the auth
+   * paths have to defend against.
+   */
+  async function setupLiveScheduledSession(opts: CreateSessionOpts = {}) {
+    const source = await setupActivatedDevice('Source Device');
+    const roomUid = await createRoomWithSource(source.deviceUid);
+    const schedule = await dbContext.db
+      .insertInto('session_schedules')
+      .values({
+        room_uid: roomUid,
+        name: 'S',
+        active_start: new Date('2024-01-01T00:00:00Z'),
+        active_end: null,
+        anchor_start: new Date('2024-01-01T00:00:00Z'),
+        local_start_time: '09:00:00',
+        local_end_time: '10:00:00',
+        frequency: 'ONCE',
+        days_of_week: null,
+        transcription_provider_id: 'whisper',
+        transcription_stream_config: {},
+      })
+      .returning('uid')
+      .executeTakeFirstOrThrow();
+    const session = await dbContext.db
+      .insertInto('sessions')
+      .values({
+        room_uid: roomUid,
+        name: 'Scheduled',
+        type: 'SCHEDULED',
+        scheduled_session_uid: schedule.uid,
+        scheduled_start_time: new Date(Date.now() - 60 * 60 * 1000),
+        scheduled_end_time: new Date(Date.now() + 60 * 60 * 1000),
+        join_code_scopes: (opts.joinCodeScopes ?? [
+          'RECEIVE_TRANSCRIPTIONS',
+        ]) as SessionScope[],
+        transcription_provider_id: 'whisper',
+        transcription_stream_config: {},
+      })
+      .returning('uid')
+      .executeTakeFirstOrThrow();
+    return { ...source, roomUid, sessionUid: session.uid };
+  }
+
+  /**
+   * Cancels a currently-live SCHEDULED session through the real
+   * `cancel-session` endpoint, then restores its window.
+   *
+   * The detour exists because `assertCancelable` requires the occurrence to
+   * still be upcoming - which is exactly why the bug this guards is reachable:
+   * an operator cancels a future occurrence, time passes, and the row's
+   * effective window ends up covering now while `canceled_at` stays set. We
+   * push the window forward to satisfy the endpoint's precondition, cancel for
+   * real, then put the window back to simulate that passage of time. Nothing
+   * about the resulting row is synthesized by the test.
+   */
+  async function cancelLiveScheduledSession(sessionUid: string) {
+    const original = await dbContext.db
+      .selectFrom('sessions')
+      .select(['scheduled_start_time', 'scheduled_end_time'])
+      .where('uid', '=', sessionUid)
+      .executeTakeFirstOrThrow();
+
+    await dbContext.db
+      .updateTable('sessions')
+      .set({
+        scheduled_start_time: new Date(Date.now() + 60 * 60 * 1000),
+        scheduled_end_time: new Date(Date.now() + 2 * 60 * 60 * 1000),
+      })
+      .where('uid', '=', sessionUid)
+      .execute();
+
+    const res = await server.fastify.inject({
+      method: 'POST',
+      url: `${SCHEDULE_BASE}/cancel-session`,
+      headers: { authorization: ADMIN_HEADER },
+      body: { sessionUid },
+    });
+    // Asserted, not assumed: a fixture that quietly 422s would leave the row
+    // uncanceled and every test built on it would pass while proving nothing.
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ canceledAt: string | null }>().canceledAt).toEqual(
+      expect.any(String),
+    );
+
+    await dbContext.db
+      .updateTable('sessions')
+      .set({
+        scheduled_start_time: original.scheduled_start_time,
+        scheduled_end_time: original.scheduled_end_time,
+      })
+      .where('uid', '=', sessionUid)
+      .execute();
+  }
+
   describe('POST /fetch-join-code', (it) => {
     it('returns 401 when the device cookie is missing', async () => {
       // Arrange / Act
@@ -233,6 +332,32 @@ describe('Session Auth Routes', () => {
       // Assert
       expect(res.statusCode).toBe(409);
       expect(res.json<{ code: string }>().code).toBe('JOIN_CODE_SCOPES_EMPTY');
+    });
+
+    it('returns 404 for a canceled session whose window covers now', async () => {
+      // Arrange
+      const { token, sessionUid } = await setupLiveScheduledSession();
+      await cancelLiveScheduledSession(sessionUid);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/fetch-join-code`,
+        headers: { cookie: `DEVICE_TOKEN=${token}` },
+        body: { sessionUid },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(404);
+      expect(res.json<{ code: string }>().code).toBe('SESSION_NOT_FOUND');
+      // No code may be minted either: a code outlives this request and would
+      // still be exchangeable from anywhere.
+      const codes = await dbContext.db
+        .selectFrom('session_join_codes')
+        .select('join_code')
+        .where('session_uid', '=', sessionUid)
+        .execute();
+      expect(codes).toHaveLength(0);
     });
 
     it('returns 200 with a fresh current code on the first call', async () => {
@@ -489,6 +614,25 @@ describe('Session Auth Routes', () => {
       expect(res.json<{ status: string }>().status).toBe('not-active');
     });
 
+    it("returns status 'not-active' for a canceled session whose window covers now", async () => {
+      // Arrange
+      const { sessionUid } = await setupLiveScheduledSession();
+      await cancelLiveScheduledSession(sessionUid);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/admin-fetch-join-code`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { sessionUid },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(200);
+      expect(res.json<{ status: string }>().status).toBe('not-active');
+      expect(res.json<{ joinCode: string | null }>().joinCode).toBeNull();
+    });
+
     it("returns status 'ok' with a fresh code on the first call", async () => {
       // Arrange
       const { sessionUid } = await setupActiveSession();
@@ -735,6 +879,28 @@ describe('Session Auth Routes', () => {
         'SESSION_NOT_CURRENTLY_ACTIVE',
       );
     });
+
+    it('returns 409 for a canceled session whose window covers now', async () => {
+      // Arrange - the source kiosk still has this uid cached from before the
+      // cancellation; without the guard it re-arms itself with a SEND_AUDIO
+      // token and streams into a session nobody scheduled.
+      const { token, sessionUid } = await setupLiveScheduledSession();
+      await cancelLiveScheduledSession(sessionUid);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/exchange-device-token`,
+        headers: { cookie: `DEVICE_TOKEN=${token}` },
+        body: { sessionUid },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(409);
+      expect(res.json<{ code: string }>().code).toBe(
+        'SESSION_NOT_CURRENTLY_ACTIVE',
+      );
+    });
   });
 
   describe('POST /exchange-join-code', (it) => {
@@ -807,6 +973,34 @@ describe('Session Auth Routes', () => {
       expect(res.json<{ code: string }>().code).toBe(
         'SESSION_NOT_CURRENTLY_ACTIVE',
       );
+    });
+
+    it('returns 409 for a canceled session, and mints nothing', async () => {
+      // Arrange - the code was minted while the session was still live and is
+      // well inside its 5-minute TTL, so the code row alone cannot stop this.
+      const { token, sessionUid } = await setupLiveScheduledSession();
+      const joinCode = await fetchJoinCode(token, sessionUid);
+      await cancelLiveScheduledSession(sessionUid);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/exchange-join-code`,
+        body: { joinCode },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(409);
+      expect(res.json<{ code: string }>().code).toBe(
+        'SESSION_NOT_CURRENTLY_ACTIVE',
+      );
+      // A refresh token would outlive the request and keep re-minting.
+      const tokens = await dbContext.db
+        .selectFrom('session_refresh_tokens')
+        .select('uid')
+        .where('session_uid', '=', sessionUid)
+        .execute();
+      expect(tokens).toHaveLength(0);
     });
 
     it('returns 200 with a session token, refresh token, clientId, and scopes', async () => {
@@ -927,6 +1121,26 @@ describe('Session Auth Routes', () => {
       const { token, sessionUid } = await setupActiveSession();
       const refresh = await exchangeJoinCodeForRefresh(token, sessionUid);
       await endSessionEarly(sessionUid);
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/refresh-session-token`,
+        body: { sessionRefreshToken: refresh },
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(409);
+      expect(res.json<{ code: string }>().code).toBe('SESSION_ENDED');
+    });
+
+    it('returns 409 when the session has been canceled', async () => {
+      // Arrange - a viewer who joined before the cancellation holds a refresh
+      // token that outlives every short-lived session token; cancellation has
+      // to be terminal here or the viewer never actually loses access.
+      const { token, sessionUid } = await setupLiveScheduledSession();
+      const refresh = await exchangeJoinCodeForRefresh(token, sessionUid);
+      await cancelLiveScheduledSession(sessionUid);
 
       // Act
       const res = await server.fastify.inject({

--- a/apps/session-manager/tests/integration/features/session-auth/session-auth.routes.test.ts
+++ b/apps/session-manager/tests/integration/features/session-auth/session-auth.routes.test.ts
@@ -975,6 +975,68 @@ describe('Session Auth Routes', () => {
       );
     });
 
+    it('returns 404 for the pre-minted handoff code until its validStart arrives', async () => {
+      // Arrange - drive the real handoff: back-date the current code so we are
+      // inside the 60s handoff window, then re-fetch, which mints `next` with
+      // validStart == current.validEnd. That code is in the future.
+      const { token, sessionUid } = await setupActiveSession();
+      const current = await fetchJoinCode(token, sessionUid);
+      const now = Date.now();
+      await dbContext.db
+        .updateTable('session_join_codes')
+        .set({
+          valid_start: new Date(now - 4 * 60_000 - 30_000),
+          valid_end: new Date(now + 30_000),
+        })
+        .where('join_code', '=', current)
+        .execute();
+
+      const pairRes = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/fetch-join-code`,
+        headers: { cookie: `DEVICE_TOKEN=${token}` },
+        body: { sessionUid },
+      });
+      const next = pairRes.json<{
+        next: { joinCode: string; validStart: string } | null;
+      }>().next;
+      expect(next).not.toBeNull();
+      expect(Date.parse(next!.validStart)).toBeGreaterThan(Date.now());
+
+      // Act - the handoff code, presented early.
+      const early = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/exchange-join-code`,
+        body: { joinCode: next!.joinCode },
+      });
+
+      // Assert - not yet. Answering 404 rather than a distinct status also
+      // keeps the route from confirming an unused code to anyone guessing.
+      expect(early.statusCode).toBe(404);
+      expect(early.json<{ code: string }>().code).toBe('JOIN_CODE_NOT_FOUND');
+
+      // The current code is unaffected - the handoff still works.
+      const stillCurrent = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/exchange-join-code`,
+        body: { joinCode: current },
+      });
+      expect(stillCurrent.statusCode).toBe(200);
+
+      // And the handoff code becomes exchangeable the moment its window opens.
+      await dbContext.db
+        .updateTable('session_join_codes')
+        .set({ valid_start: new Date(Date.now() - 1000) })
+        .where('join_code', '=', next!.joinCode)
+        .execute();
+      const onTime = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/exchange-join-code`,
+        body: { joinCode: next!.joinCode },
+      });
+      expect(onTime.statusCode).toBe(200);
+    });
+
     it('returns 409 for a canceled session, and mints nothing', async () => {
       // Arrange - the code was minted while the session was still live and is
       // well inside its 5-minute TTL, so the code row alone cannot stop this.

--- a/apps/session-manager/tests/unit/features/schedule-management/schedule-management.service.test.ts
+++ b/apps/session-manager/tests/unit/features/schedule-management/schedule-management.service.test.ts
@@ -6,6 +6,7 @@ import type {
   ScheduleFrequency,
   SessionScope,
 } from '@scribear/scribear-db';
+import { SHIPPED_TRANSCRIPTION_PROVIDER_IDS } from '@scribear/session-manager-schema';
 
 import type {
   Schedule,
@@ -163,7 +164,9 @@ function createMockRepo(): MockRepo {
     insertWindow: vi.fn(),
     updateWindowActiveEnd: vi.fn().mockResolvedValue(true),
     deleteWindowHard: vi.fn().mockResolvedValue(true),
-    findLatestPastOrActiveSessionForSchedule: vi.fn().mockResolvedValue(undefined),
+    findLatestPastOrActiveSessionForSchedule: vi
+      .fn()
+      .mockResolvedValue(undefined),
     findActiveSession: vi.fn().mockResolvedValue(undefined),
     findActiveOnDemandSession: vi.fn().mockResolvedValue(undefined),
     findActiveAutoSession: vi.fn().mockResolvedValue(undefined),
@@ -209,6 +212,7 @@ describe('ScheduleManagementService', () => {
       mockDbClient as never,
       mockRepo as never,
       mockEventBus as never,
+      { transcriptionProviderIds: [...SHIPPED_TRANSCRIPTION_PROVIDER_IDS] },
     );
   });
 
@@ -255,7 +259,10 @@ describe('ScheduleManagementService', () => {
       });
 
       const result = await service.createSchedule(
-        makeCreateInput({ localStartTime: '09:00:00', localEndTime: '09:00:00' }),
+        makeCreateInput({
+          localStartTime: '09:00:00',
+          localEndTime: '09:00:00',
+        }),
         NOW,
       );
 
@@ -569,7 +576,9 @@ describe('ScheduleManagementService', () => {
         autoSessionEnabled: false,
       });
       mockRepo.findSchedulesOverlapping.mockResolvedValue([]);
-      mockRepo.insertSchedule.mockRejectedValue(new Error('DB connection lost'));
+      mockRepo.insertSchedule.mockRejectedValue(
+        new Error('DB connection lost'),
+      );
 
       await expect(
         service.createSchedule(makeCreateInput({ activeStart: FUTURE }), NOW),
@@ -729,6 +738,144 @@ describe('ScheduleManagementService', () => {
 
       expect(result).toBe('ANOTHER_SESSION_ACTIVE');
       expect(mockRepo.setSessionsConstraintsDeferred).not.toHaveBeenCalled();
+    });
+  });
+  // A transcriptionProviderId that no provider in the deployment's
+  // provider_config.json matches is invisible until stream time, where
+  // transcription-service raises "Invalid Provider Key", closes the upstream
+  // socket 1007, and node-server retries a permanently unsatisfiable request
+  // forever while every viewer sits on a reconnecting banner. Answered at the
+  // write, which is where an operator can still see it.
+  describe('transcriptionProviderId validation', (it) => {
+    const ROOM = { uid: 'room-1', timezone: 'UTC', autoSessionEnabled: false };
+
+    it('rejects an unknown provider on createSchedule, before touching the database', async () => {
+      mockRepo.lockRoom.mockResolvedValue(ROOM);
+
+      const result = await service.createSchedule(
+        {
+          roomUid: 'room-1',
+          name: 'Standup',
+          activeStart: FUTURE,
+          activeEnd: null,
+          localStartTime: '09:00:00',
+          localEndTime: '10:00:00',
+          frequency: 'WEEKLY',
+          daysOfWeek: ['MON'],
+          joinCodeScopes: [],
+          transcriptionProviderId: 'whipser',
+          transcriptionStreamConfig: {},
+        },
+        NOW,
+      );
+
+      expect(result).toBe('UNKNOWN_TRANSCRIPTION_PROVIDER');
+      expect(mockRepo.lockRoom).not.toHaveBeenCalled();
+      expect(mockRepo.insertSchedule).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown provider on updateSchedule', async () => {
+      mockRepo.lockRoom.mockResolvedValue(ROOM);
+      mockRepo.findScheduleByUid.mockResolvedValue(makeSchedule());
+
+      const result = await service.updateSchedule(
+        'sched-1',
+        { transcriptionProviderId: 'not-a-provider' },
+        NOW,
+      );
+
+      expect(result).toBe('UNKNOWN_TRANSCRIPTION_PROVIDER');
+      expect(mockRepo.insertSchedule).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown provider on createAutoSessionWindow', async () => {
+      mockRepo.lockRoom.mockResolvedValue(ROOM);
+
+      const result = await service.createAutoSessionWindow(
+        {
+          roomUid: 'room-1',
+          localStartTime: '09:00:00',
+          localEndTime: '17:00:00',
+          daysOfWeek: ['MON'],
+          activeStart: FUTURE,
+          activeEnd: null,
+          joinCodeScopes: [],
+          transcriptionProviderId: 'not-a-provider',
+          transcriptionStreamConfig: {},
+        },
+        NOW,
+      );
+
+      expect(result).toBe('UNKNOWN_TRANSCRIPTION_PROVIDER');
+      expect(mockRepo.insertWindow).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown provider on updateAutoSessionWindow', async () => {
+      mockRepo.lockRoom.mockResolvedValue(ROOM);
+
+      const result = await service.updateAutoSessionWindow(
+        'win-1',
+        { transcriptionProviderId: 'not-a-provider' },
+        NOW,
+      );
+
+      expect(result).toBe('UNKNOWN_TRANSCRIPTION_PROVIDER');
+      expect(mockRepo.insertWindow).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown provider on createOnDemandSession', async () => {
+      mockRepo.lockRoom.mockResolvedValue(ROOM);
+
+      const result = await service.createOnDemandSession(
+        {
+          roomUid: 'room-1',
+          name: 'Quick',
+          joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+          transcriptionProviderId: 'not-a-provider',
+          transcriptionStreamConfig: {},
+        },
+        NOW,
+      );
+
+      expect(result).toBe('UNKNOWN_TRANSCRIPTION_PROVIDER');
+      expect(mockRepo.insertSessions).not.toHaveBeenCalled();
+    });
+
+    it('accepts an update that does not mention the provider at all', async () => {
+      // `undefined` cannot introduce a bad value, so it must not be treated as
+      // one - otherwise every partial update of an unrelated field 400s.
+      mockRepo.lockRoom.mockResolvedValue(ROOM);
+      mockRepo.findWindowByUid.mockResolvedValue(undefined);
+
+      const result = await service.updateAutoSessionWindow(
+        'win-1',
+        { localStartTime: '10:00:00' },
+        NOW,
+      );
+
+      expect(result).not.toBe('UNKNOWN_TRANSCRIPTION_PROVIDER');
+    });
+
+    it('accepts every provider the deployment configured', async () => {
+      // Guards the parsing as much as the check: a list that arrived as one
+      // unsplit string would reject all four.
+      for (const providerId of SHIPPED_TRANSCRIPTION_PROVIDER_IDS) {
+        mockRepo.lockRoom.mockResolvedValue(undefined);
+
+        const result = await service.createOnDemandSession(
+          {
+            roomUid: 'room-1',
+            name: 'Quick',
+            joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+            transcriptionProviderId: providerId,
+            transcriptionStreamConfig: {},
+          },
+          NOW,
+        );
+
+        // Got past the provider gate and on to the room lookup.
+        expect(result).toBe('ROOM_NOT_FOUND');
+      }
     });
   });
 });

--- a/apps/session-manager/tests/unit/features/session-auth/session-auth.service.test.ts
+++ b/apps/session-manager/tests/unit/features/session-auth/session-auth.service.test.ts
@@ -14,6 +14,7 @@ const ACTIVE_SESSION = {
   joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS' as const],
   effectiveStart: new Date(NOW.getTime() - 60_000),
   effectiveEnd: new Date(NOW.getTime() + 60 * 60_000),
+  canceledAt: null,
 };
 
 const NOT_YET_STARTED_SESSION = {
@@ -24,6 +25,18 @@ const NOT_YET_STARTED_SESSION = {
 const ENDED_SESSION = {
   ...ACTIVE_SESSION,
   effectiveEnd: new Date(NOW.getTime() - 60_000),
+};
+
+/**
+ * A canceled session whose effective window still covers `now`. This is not a
+ * contrived state: `cancel-session` only accepts *upcoming* SCHEDULED
+ * occurrences, so every canceled row eventually has time catch up to its slot.
+ * `findActiveSession` and the `sessions_no_overlap` exclusion constraint both
+ * stop counting it at that point; every auth path must too.
+ */
+const CANCELED_SESSION = {
+  ...ACTIVE_SESSION,
+  canceledAt: new Date(NOW.getTime() - 30 * 60_000),
 };
 
 describe('SessionAuthService', () => {
@@ -125,6 +138,23 @@ describe('SessionAuthService', () => {
 
       // Assert
       expect(result).toBe('JOIN_CODE_SCOPES_EMPTY');
+    });
+
+    it("returns 'SESSION_NOT_FOUND' for a canceled session", async () => {
+      // Arrange - a canceled session is invisible to devices by design
+      // (`my-schedule` filters `canceled_at`), so the device-facing join-code
+      // endpoint must not confirm it exists either, let alone mint a code for
+      // it that would then exchange into a live token.
+      mockRepo.findSessionForAuth.mockResolvedValue(CANCELED_SESSION);
+      mockRepo.isDeviceInRoom.mockResolvedValue(true);
+      mockRepo.findActiveJoinCodes.mockResolvedValue([]);
+
+      // Act
+      const result = await service.fetchJoinCodes(DEVICE_UID, SESSION_UID, NOW);
+
+      // Assert
+      expect(result).toBe('SESSION_NOT_FOUND');
+      expect(mockRepo.insertJoinCode).not.toHaveBeenCalled();
     });
 
     it('generates a fresh code when none exist', async () => {
@@ -307,6 +337,20 @@ describe('SessionAuthService', () => {
       expect(result).toBe('SESSION_NOT_CURRENTLY_ACTIVE');
     });
 
+    it("returns 'SESSION_NOT_CURRENTLY_ACTIVE' for a canceled session", async () => {
+      // Arrange - the console must not offer an "open live captions" link for
+      // a session an operator has canceled.
+      mockRepo.findSessionForAuth.mockResolvedValue(CANCELED_SESSION);
+      mockRepo.findActiveJoinCodes.mockResolvedValue([]);
+
+      // Act
+      const result = await service.fetchJoinCodeForAdmin(SESSION_UID, NOW);
+
+      // Assert
+      expect(result).toBe('SESSION_NOT_CURRENTLY_ACTIVE');
+      expect(mockRepo.insertJoinCode).not.toHaveBeenCalled();
+    });
+
     it('mints a fresh code when none is active', async () => {
       // Arrange
       mockRepo.findSessionForAuth.mockResolvedValue(ACTIVE_SESSION);
@@ -413,6 +457,25 @@ describe('SessionAuthService', () => {
 
       // Assert
       expect(result).toBe('SESSION_NOT_CURRENTLY_ACTIVE');
+    });
+
+    it("returns 'SESSION_NOT_CURRENTLY_ACTIVE' for a canceled session", async () => {
+      // Arrange
+      mockRepo.findSessionForAuth.mockResolvedValue(CANCELED_SESSION);
+      mockRepo.isDeviceInRoom.mockResolvedValue(true);
+      mockRepo.isDeviceSourceForRoom.mockResolvedValue(true);
+      mockTokenService.sign.mockReturnValue('signed-token');
+
+      // Act
+      const result = await service.exchangeDeviceToken(
+        DEVICE_UID,
+        SESSION_UID,
+        NOW,
+      );
+
+      // Assert
+      expect(result).toBe('SESSION_NOT_CURRENTLY_ACTIVE');
+      expect(mockTokenService.sign).not.toHaveBeenCalled();
     });
 
     it('grants SEND_AUDIO + RECEIVE_TRANSCRIPTIONS to a source device', async () => {
@@ -536,6 +599,24 @@ describe('SessionAuthService', () => {
       expect(result).toBe('SESSION_NOT_CURRENTLY_ACTIVE');
     });
 
+    it("returns 'SESSION_NOT_CURRENTLY_ACTIVE' for a canceled session", async () => {
+      // Arrange - a code minted before the cancellation is still inside its
+      // 5-minute TTL, so the code row alone cannot stop this exchange.
+      mockRepo.findJoinCodeByCode.mockResolvedValue(VALID_CODE);
+      mockRepo.findSessionForAuth.mockResolvedValue(CANCELED_SESSION);
+      mockHashService.hash.mockResolvedValue('hash');
+      mockRepo.insertRefreshToken.mockResolvedValue({ uid: 'refresh-uid' });
+      mockTokenService.sign.mockReturnValue('signed-token');
+
+      // Act
+      const result = await service.exchangeJoinCode(VALID_CODE.joinCode, NOW);
+
+      // Assert
+      expect(result).toBe('SESSION_NOT_CURRENTLY_ACTIVE');
+      expect(mockRepo.insertRefreshToken).not.toHaveBeenCalled();
+      expect(mockTokenService.sign).not.toHaveBeenCalled();
+    });
+
     it('issues a session token, refresh token, and a fresh clientId', async () => {
       // Arrange
       mockRepo.findJoinCodeByCode.mockResolvedValue(VALID_CODE);
@@ -651,6 +732,30 @@ describe('SessionAuthService', () => {
 
       // Assert
       expect(result).toBe('SESSION_ENDED');
+    });
+
+    it("returns 'SESSION_ENDED' for a canceled session", async () => {
+      // Arrange - without this the refresh path re-mints indefinitely for a
+      // viewer who joined before the cancellation, which is the whole point of
+      // a long-lived refresh token.
+      mockRepo.findRefreshTokenByUid.mockResolvedValue({
+        uid: 'uid',
+        sessionUid: SESSION_UID,
+        clientId: 'client-1',
+        hash: 'stored-hash',
+        scopes: ['RECEIVE_TRANSCRIPTIONS'],
+        authMethod: 'JOIN_CODE',
+      });
+      mockHashService.verify.mockResolvedValue(true);
+      mockRepo.findSessionForAuth.mockResolvedValue(CANCELED_SESSION);
+      mockTokenService.sign.mockReturnValue('refreshed-token');
+
+      // Act
+      const result = await service.refreshSessionToken('uid:secret', NOW);
+
+      // Assert
+      expect(result).toBe('SESSION_ENDED');
+      expect(mockTokenService.sign).not.toHaveBeenCalled();
     });
 
     it('returns a new session token preserving the original scopes and clientId', async () => {

--- a/apps/session-manager/tests/unit/features/session-auth/session-auth.service.test.ts
+++ b/apps/session-manager/tests/unit/features/session-auth/session-auth.service.test.ts
@@ -575,6 +575,69 @@ describe('SessionAuthService', () => {
       expect(result).toBe('JOIN_CODE_EXPIRED');
     });
 
+    it("returns 'JOIN_CODE_NOT_FOUND' for a pre-minted handoff code that is not valid yet", async () => {
+      // Arrange - `fetchJoinCodes` mints the next code 60s before the current
+      // one expires, with validStart == current.validEnd. Without a
+      // valid_start check that code is exchangeable the instant it is minted,
+      // which stretches a code's usable life from the intended 5 minutes to
+      // nearly 10. The kiosk only ever renders `current`, so nothing legitimate
+      // presents a future code.
+      mockRepo.findJoinCodeByCode.mockResolvedValue({
+        ...VALID_CODE,
+        validStart: new Date(NOW.getTime() + 30_000),
+        validEnd: new Date(NOW.getTime() + 30_000 + 5 * 60_000),
+      });
+      mockRepo.findSessionForAuth.mockResolvedValue(ACTIVE_SESSION);
+      mockHashService.hash.mockResolvedValue('hash');
+      mockRepo.insertRefreshToken.mockResolvedValue({ uid: 'refresh-uid' });
+      mockTokenService.sign.mockReturnValue('signed-token');
+
+      // Act
+      const result = await service.exchangeJoinCode(VALID_CODE.joinCode, NOW);
+
+      // Assert
+      expect(result).toBe('JOIN_CODE_NOT_FOUND');
+      expect(mockRepo.insertRefreshToken).not.toHaveBeenCalled();
+    });
+
+    it("returns 'JOIN_CODE_NOT_FOUND' one millisecond before validStart", async () => {
+      // Arrange - boundary, closed side.
+      mockRepo.findJoinCodeByCode.mockResolvedValue({
+        ...VALID_CODE,
+        validStart: new Date(NOW.getTime() + 1),
+      });
+      mockRepo.findSessionForAuth.mockResolvedValue(ACTIVE_SESSION);
+
+      // Act
+      const result = await service.exchangeJoinCode(VALID_CODE.joinCode, NOW);
+
+      // Assert
+      expect(result).toBe('JOIN_CODE_NOT_FOUND');
+    });
+
+    it('exchanges a handoff code the instant validStart arrives', async () => {
+      // Arrange - boundary, open side. `validStart <= now` matches the
+      // predicate `fetchJoinCodes` and `_findOrMintCurrentJoinCode` already
+      // use, so a code becomes exchangeable exactly when it becomes "current".
+      // This is what keeps the QR handoff seamless.
+      mockRepo.findJoinCodeByCode.mockResolvedValue({
+        ...VALID_CODE,
+        validStart: NOW,
+        validEnd: new Date(NOW.getTime() + 5 * 60_000),
+      });
+      mockRepo.findSessionForAuth.mockResolvedValue(ACTIVE_SESSION);
+      mockHashService.hash.mockResolvedValue('hash');
+      mockRepo.insertRefreshToken.mockResolvedValue({ uid: 'refresh-uid' });
+      mockTokenService.sign.mockReturnValue('signed-token');
+
+      // Act
+      const result = await service.exchangeJoinCode(VALID_CODE.joinCode, NOW);
+
+      // Assert
+      if (typeof result === 'string') throw new Error('expected token result');
+      expect(result.sessionToken).toBe('signed-token');
+    });
+
     it("returns 'SESSION_NOT_CURRENTLY_ACTIVE' when the session has ended", async () => {
       // Arrange
       mockRepo.findJoinCodeByCode.mockResolvedValue(VALID_CODE);

--- a/apps/session-manager/tests/utils/use-server.ts
+++ b/apps/session-manager/tests/utils/use-server.ts
@@ -1,12 +1,14 @@
 import { afterAll, beforeAll, inject } from 'vitest';
 
 import { LogLevel } from '@scribear/base-fastify-server';
+import { SHIPPED_TRANSCRIPTION_PROVIDER_IDS } from '@scribear/session-manager-schema';
 
 import type {
   AppConfig,
   BaseConfig,
   CanaryRoomConfig,
   DemoRoomConfig,
+  ScheduleManagementConfig,
   TestAudioRoomsConfig,
 } from '#src/app-config/app-config.js';
 import type { DBClientConfig } from '#src/db/db-client.js';
@@ -43,6 +45,7 @@ export interface TestAppConfigOverrides {
   demoRoomConfig?: Partial<DemoRoomConfig>;
   testAudioRoomsConfig?: Partial<TestAudioRoomsConfig>;
   canaryRoomConfig?: Partial<CanaryRoomConfig>;
+  scheduleManagementConfig?: Partial<ScheduleManagementConfig>;
 }
 
 /**
@@ -119,6 +122,13 @@ export function buildTestAppConfig(
       enabled: false,
       deviceSecret: '',
       ...overrides.canaryRoomConfig,
+    },
+    // The shipped provider set, so fixtures using `whisper` behave as they do
+    // in a stock deployment. Suites that want to prove the rejection override
+    // this with a narrower list.
+    scheduleManagementConfig: {
+      transcriptionProviderIds: [...SHIPPED_TRANSCRIPTION_PROVIDER_IDS],
+      ...overrides.scheduleManagementConfig,
     },
   } as unknown as AppConfig;
 }

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -160,6 +160,37 @@ TRANSCRIPTION_AUDIO_SILENCE_THRESHOLD=0.01
 # admin-server reads the other. Uses REDIS_PASSWORD above:
 #   TRANSCRIPTION_REDIS_URL=redis://:CHANGEME@redis:6379
 TRANSCRIPTION_REDIS_URL=
+# Capacity estimator (admission control §3). transcription-service measures how
+# much of a worker one ASR session actually costs and derives a ceiling, N*, on
+# how many that worker could carry. That number is published on /metrics/status
+# and /providers/health and drawn as "estimated capacity" in the dashboard's
+# fleet view. It is OBSERVE-ONLY today: nothing is refused because of it, so
+# these three change what is reported, not who gets captions. All three default
+# to the shipped values, so leaving this whole block alone changes nothing.
+#
+# Fraction of a worker the ceiling aims to keep busy. Lower it if you want more
+# headroom in the reported number (a worker aiming at 0.85 busy is already close
+# to falling behind realtime); raise it towards 1.0 only if you are willing to
+# read a ceiling with no slack in it. Dimensionless and the same on every
+# device - the hardware-specific half is measured, not configured, so a CPU box
+# and a GPU box want the same value here.
+TRANSCRIPTION_TARGET_BUSY=0.85
+# Floor under the reported ceiling. Exists so one noisy or unlucky measurement
+# window can never report a worker's capacity as zero. Raise it only if you know
+# a worker genuinely carries more than one session on your hardware.
+TRANSCRIPTION_MIN_SESSIONS=1
+# Operator hard pin on a worker's session capacity. Empty (the default) leaves
+# the estimator auto-tuning. Set it and auto-tuning is off entirely: the
+# reported ceiling is exactly this number.
+#
+# It is the strongest of the three deliberately - it wins over
+# TRANSCRIPTION_MIN_SESSIONS above AND over warm-up, so it takes effect from the
+# very first request rather than after a measurement it has already overruled.
+# That is the point: it is a statement about the deployment, not an estimate,
+# and an operator who has measured their own box should not have to wait for the
+# service to agree. Use it when you know the answer for this hardware and want
+# the dashboard to say so; leave it empty otherwise.
+TRANSCRIPTION_MAX_SESSIONS=
 PROVIDER_CONFIG_PATH=./provider_config.json
 # Provider keys session-manager accepts when a session, schedule or
 # auto-session window is created or updated. MUST match the keys under

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -161,6 +161,14 @@ TRANSCRIPTION_AUDIO_SILENCE_THRESHOLD=0.01
 #   TRANSCRIPTION_REDIS_URL=redis://:CHANGEME@redis:6379
 TRANSCRIPTION_REDIS_URL=
 PROVIDER_CONFIG_PATH=./provider_config.json
+# Provider keys session-manager accepts when a session, schedule or
+# auto-session window is created or updated. MUST match the keys under
+# "providers" in the provider_config.json above - if you add or remove a
+# provider there, mirror it here. An id matching no provider is otherwise
+# invisible until stream time, where it closes the transcription socket 1007
+# and leaves every viewer of that room on a permanent "reconnecting" banner.
+# Empty/unset uses the set shipped in provider_config.template.json.
+TRANSCRIPTION_PROVIDER_IDS=debug,whisper,lumen_granite,crisper_whisper
 # Host directory bind-mounted at /models inside transcription-service, where
 # faster-whisper and silero-vad cache downloaded weights (via HF_HOME). Defaults
 # to ./models relative to compose.yml; created automatically on first download.

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,49 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — the capacity estimator's knobs are reachable from `.env` (`compose.yml` v9)
+
+**Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. **A
+stock deployment needs to do nothing** — all three new variables carry the
+values the service already used.
+
+Three new variables on `transcription-service`, all optional:
+
+| `.env` key | Default | What it does |
+| --- | --- | --- |
+| `TRANSCRIPTION_TARGET_BUSY` | `0.85` | Fraction of a worker the estimated ceiling aims to keep busy |
+| `TRANSCRIPTION_MIN_SESSIONS` | `1` | Floor under the estimated ceiling, so one bad window cannot report zero |
+| `TRANSCRIPTION_MAX_SESSIONS` | *(empty)* | Operator hard pin. Empty means auto-tune |
+
+transcription-service measures how much of a worker one ASR session actually
+costs and derives a ceiling — `estimatedCapacitySessions` on
+`/metrics/status` and `/providers/health`, drawn as "estimated capacity" in the
+dashboard's fleet view. **It is observe-only: nothing is refused because of it**,
+so these three change what is *reported*, never who gets captions.
+
+`TRANSCRIPTION_MAX_SESSIONS` is the strongest of the three on purpose. It wins
+over `TRANSCRIPTION_MIN_SESSIONS` *and* over warm-up, so it applies from the
+first request rather than after a measurement it has already overruled — it is a
+statement about your hardware, not an estimate. Set it if you have measured your
+box and want the dashboard to say so; leave it empty otherwise.
+
+### Why this is an upgrade note at all
+
+The service has read `TARGET_BUSY`, `MIN_SESSIONS` and `MAX_SESSIONS` from its
+environment since they were added, and its own config file says they are
+"reachable from `.env` on purpose". They were not: nothing passed them through
+`compose.yml`, so a compose operator had no way to set them short of editing the
+compose file — which is exactly the regret that variable was created to avoid,
+one indirection along. This closes it.
+
+Empty is read as "unset" for `TRANSCRIPTION_MAX_SESSIONS`, because compose has
+no way to omit an environment key. A value that is neither empty nor a number
+still stops the service at boot, deliberately: silently auto-tuning under a
+`MAX_SESSIONS` an operator believed was a hard pin is a misconfiguration with no
+symptom to find.
+
+---
+
 ## Unreleased — node-server is sticky-routed by session uid
 
 **Pull the new `scribear-nginx` image** (`docker compose pull scribear-nginx &&

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,46 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — session-manager validates `transcriptionProviderId` (`compose.yml` v8)
+
+**Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`.
+
+New variable: **`TRANSCRIPTION_PROVIDER_IDS`** on `session-manager`. It is a
+comma-separated list of the provider keys session-manager will accept when a
+session, schedule or auto-session window is created or updated, and it defaults
+to the set shipped in `provider_config.template.json`
+(`debug,whisper,lumen_granite,crisper_whisper`). **A stock deployment needs to
+do nothing.**
+
+**If you have edited `provider_config.json`** — added a provider, removed one,
+renamed a key — set `TRANSCRIPTION_PROVIDER_IDS` in `.env` to exactly the keys
+under its `"providers"` object. The two files now have to agree, and this is the
+one place that says so.
+
+### Why
+
+A `transcriptionProviderId` naming no configured provider used to be accepted
+silently and only fail when someone tried to use the room: transcription-service
+raises `Invalid Provider Key` and closes the socket with 1007, node-server
+retries a request that can never succeed, and every viewer sits on
+"Connection to the transcription service was lost. Reconnecting…" forever, with
+nothing anywhere naming the cause. The typo is made once, by an operator, at a
+keyboard — it is now answered there, with a `400` that lists the accepted keys.
+
+The list is deployment configuration rather than a fixed set in the API schema
+because `provider_config.json` is yours to edit: a hardcoded set would reject a
+provider you legitimately added and accept one you removed. It is not read live
+from transcription-service either — that endpoint needs `METRICS_API_KEY`, a
+credential session-manager does not have, and it would make scheduling fail
+whenever transcription-service is down.
+
+Getting the list wrong is loud either way: too narrow and a create fails
+immediately with the accepted keys in the message; too wide and you are back to
+the old behaviour, which the viewer now sees as a specific "misconfigured"
+message rather than an endless reconnect.
+
+---
+
 ## Unreleased — watchtower is gone; `deploy_latest.sh` replaces it (`compose.yml` v7)
 
 **Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. If

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,35 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — node-server is sticky-routed by session uid
+
+**Pull the new `scribear-nginx` image** (`docker compose pull scribear-nginx &&
+docker compose up -d`, or just run [`deploy_latest.sh`](deploy_latest.sh)). No
+`.env` or `compose.yml` change; the fix is inside the image.
+
+`upstream node-server` in `nginx.conf` now carries
+`hash $node_server_session_uid;`, keyed off the session uid in the WebSocket
+URL path. Before this, it had no balancing directive at all — nginx
+round-robined.
+
+That was survivable only because the service runs one replica.
+`docker compose up -d --scale node-server=2` would have broken live captioning
+in a way nothing reports: node-server's orchestrator state is per-process (the
+event bus, the upstream transcription socket), so a viewer routed to a
+different instance than its room's source subscribes to a channel nothing
+publishes on and receives no transcripts — no error, no close, no banner, just
+an empty caption view. **Scaling node-server past one replica is now
+supported**; before, it was not, and nothing said so.
+
+One caveat worth knowing before you scale: the hash is a plain modulo, not
+ketama. `consistent` is silently ignored by this nginx when the upstream server
+is a `resolve` name (measured — it falls back to round-robin, `nginx -t` passes
+either way), so it is deliberately not used. The practical consequence is that
+changing the replica count re-homes most sessions; do it when a brief
+reconnect is acceptable.
+
+---
+
 ## Unreleased — session-manager validates `transcriptionProviderId` (`compose.yml` v8)
 
 **Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`.

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -219,7 +219,7 @@ services:
       # Not `:?`-guarded, like DEPLOYMENT_ENV below and unlike the secrets: it
       # changes what is *reported*, never what runs, and must not be able to
       # stop a stack from starting.
-      COMPOSE_FILE_VERSION: "8"
+      COMPOSE_FILE_VERSION: "9"
       LOG_LEVEL: ${ADMIN_LOG_LEVEL:-info}
       ADMIN_API_KEY: ${SESSION_MANAGER_API_KEY}
       SESSION_MANAGER_BASE_URL: http://session-manager:80
@@ -449,6 +449,30 @@ services:
       # hostname, which compose sets to the container name, so scaling this
       # service gives each replica a distinct identity with no configuration.
       REDIS_URL: ${TRANSCRIPTION_REDIS_URL:-}
+      # Capacity estimator knobs. The estimator measures per-session ASR cost
+      # per worker and publishes a ceiling on /metrics/status and
+      # /providers/health, which the dashboard's fleet view draws; it is
+      # currently observe-only, so these change what is *reported*, not what is
+      # admitted. All three carry the shipped defaults, so leaving them unset
+      # changes nothing.
+      #
+      # They are here because this subsystem already shipped tuning knobs that
+      # only existed as compose-file edits and had to be rediscovered by every
+      # deployment; the service has read these from `.env` from the start, and
+      # this is the compose path that makes that true for an operator too.
+      #
+      # TARGET_BUSY is the headroom fraction the ceiling aims at, and is
+      # deliberately device-independent - the hardware-specific half
+      # (per-session cost) is measured, not configured. MIN_SESSIONS is the
+      # floor that stops a bad measurement taking a worker to zero.
+      # MAX_SESSIONS is the operator's hard pin: empty means auto-tune, and
+      # setting it disables auto-tuning entirely - it wins over the floor AND
+      # over warm-up, so it is the one value that is in effect from the first
+      # request. Empty is read as "unset" by the service, since compose has no
+      # way to omit a key.
+      TARGET_BUSY: ${TRANSCRIPTION_TARGET_BUSY:-0.85}
+      MIN_SESSIONS: ${TRANSCRIPTION_MIN_SESSIONS:-1}
+      MAX_SESSIONS: ${TRANSCRIPTION_MAX_SESSIONS:-}
       # Model download cache. faster-whisper pulls weights via huggingface_hub
       # and silero-vad via torch.hub; both honour HF_HOME (torch.hub falls back
       # to it when TORCH_HOME is unset), so one variable redirects both. The

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -126,6 +126,20 @@ services:
       # Unset seeds nothing and leaves the canary off, which is where a
       # deployment that never provisioned a canary device already was.
       CANARY_DEVICE_SECRET: ${MONITORING_CANARY_DEVICE_SECRET:-}
+      # Provider keys accepted on create/update of a session, schedule or
+      # auto-session window. MUST list exactly the keys under "providers" in the
+      # provider_config.json mounted into transcription-service below
+      # (PROVIDER_CONFIG_PATH) - if you edit that file, edit this alongside it.
+      #
+      # An id that matches no provider is otherwise invisible until stream time:
+      # transcription-service raises "Invalid Provider Key" and closes the
+      # socket 1007, node-server retries a request that can never succeed, and
+      # every viewer of the room sees only a reconnecting banner. Validating it
+      # here answers the typo at the console instead.
+      #
+      # The default is the set in provider_config.template.json, so a stock
+      # deployment needs nothing here.
+      TRANSCRIPTION_PROVIDER_IDS: ${TRANSCRIPTION_PROVIDER_IDS:-debug,whisper,lumen_granite,crisper_whisper}
     depends_on:
       scribear-db:
         condition: service_healthy
@@ -205,7 +219,7 @@ services:
       # Not `:?`-guarded, like DEPLOYMENT_ENV below and unlike the secrets: it
       # changes what is *reported*, never what runs, and must not be able to
       # stop a stack from starting.
-      COMPOSE_FILE_VERSION: "7"
+      COMPOSE_FILE_VERSION: "8"
       LOG_LEVEL: ${ADMIN_LOG_LEVEL:-info}
       ADMIN_API_KEY: ${SESSION_MANAGER_API_KEY}
       SESSION_MANAGER_BASE_URL: http://session-manager:80

--- a/infra/scribear-nginx/nginx.conf
+++ b/infra/scribear-nginx/nginx.conf
@@ -32,7 +32,53 @@ http {
     upstream admin-server      { zone admin-server       64k; server admin-server:80      resolve; keepalive 16; }
     # No keepalive: node-server's one location is a WebSocket upgrade, a
     # long-lived connection that was never a candidate for pooling anyway.
-    upstream node-server       { zone node-server        64k; server node-server:80       resolve; }
+    #
+    # STICKY BY SESSION UID, AND IT HAS TO BE. node-server's orchestrator state
+    # is per-process: the EventBus is in-process, and one session's upstream
+    # transcription connection lives on whichever instance the *source*
+    # connected to. A viewer that lands on a different instance subscribes to a
+    # channel nothing publishes on and silently receives no transcripts - no
+    # error, no banner, just an empty caption view. The orchestrator says so in
+    # its own class doc: "Sticky URL routing pins all connections for a given
+    # sessionUid to one Node Server instance."
+    #
+    # Round-robin (the default) satisfied that only by accident, because
+    # `node-server` resolves to exactly one address today. Scaling the service
+    # to two replicas is a one-word change in compose, and nothing about that
+    # change would look like it could break captioning.
+    #
+    # NOT `hash ... consistent`, AND THAT IS MEASURED, NOT PREFERRED. Ketama
+    # would be the better algorithm here - only ~1/N of sessions move when a
+    # peer joins or leaves, which `resolve` makes a runtime event rather than a
+    # restart - but `consistent` is silently ignored when the upstream's server
+    # is a `resolve` name, and the upstream falls back to round-robin.
+    #
+    # Measured against nginx:1.29.7-alpine3.23 (this image's base), two
+    # backends behind one docker network alias, requesting the same session uid
+    # repeatedly:
+    #
+    #   hash $node_server_session_uid consistent;  ->  B A B A B A B A ...
+    #   hash $node_server_session_uid;             ->  B B B B B B B B ...
+    #
+    # and, over 12s spanning several `valid=5s` re-resolutions, plain `hash`
+    # held two different uids on two different peers throughout. `nginx -t`
+    # passes on both, and with today's single replica both look identical -
+    # this is exactly the kind of guard that would have been merged green and
+    # done nothing.
+    # `apps/node-server/tests/unit/nginx-node-server-sticky.test.ts` pins the
+    # distinction so `consistent` cannot be "restored" as a tidy-up.
+    #
+    # The cost of plain modulo hashing is that changing the replica count
+    # remaps most sessions. That is acceptable: it happens on a deploy, when
+    # every connection is being re-established anyway, and both the source and
+    # its viewers rehash to the same new peer.
+    #
+    # See `$node_server_session_uid` below for the key.
+    upstream node-server {
+        zone node-server 64k;
+        hash $node_server_session_uid;
+        server node-server:80 resolve;
+    }
 
     # Shared settings
     sendfile            on;
@@ -43,6 +89,28 @@ http {
     map $http_upgrade $connection_upgrade {
         default upgrade;
         ''      close;
+    }
+
+    # Balancing key for the node-server upstream: the session uid out of the
+    # URL path. Both transcription-stream routes carry it in the same position -
+    # /api/node-server/v1/transcription-stream/<sessionUid>/source and
+    # .../client - which is exactly why it is in the path and not a query
+    # parameter (see the route description in
+    # libs/schemas/node-server-schema/.../transcription-stream.schema.ts: "The
+    # session UID is carried in the URL so the L7 proxy can sticky-route every
+    # connection for a session to the same Node Server instance").
+    #
+    # `$uri` rather than `$request_uri`: it is normalised and decoded and
+    # carries no query string, so `%2e%2e` games and a trailing `?foo` cannot
+    # change which peer a session hashes to.
+    #
+    # The fallback is `$remote_addr`, not the empty string. An empty key hashes
+    # every non-stream request to one peer, quietly concentrating the readiness
+    # probes and any future REST route on a single instance; `$remote_addr`
+    # spreads them, and none of those routes is stateful so any peer will do.
+    map $uri $node_server_session_uid {
+        default                                                       $remote_addr;
+        ~^/api/node-server/v1/transcription-stream/(?<sess_uid>[^/]+)  $sess_uid;
     }
 
     # Redirect HTTP to HTTPS

--- a/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
+++ b/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
@@ -214,6 +214,17 @@ export const STATUS_PROCESS_SCHEMA = Type.Object({
       description:
         'Source registrations that threw, closing the socket with 1011.',
     }),
+    // Optional for the same reason as `binaryBeforeAuthDropsTotal`: this
+    // record is republished to Redis and read back through a strict
+    // `Value.Check`, so a required field an older publisher omits would drop
+    // the whole snapshot and blank the node in the fleet view for the length
+    // of a rolling deploy.
+    endedSessionRegistrationsTotal: Type.Optional(
+      Type.Integer({
+        description:
+          'Source registrations refused because the session was already past its `effectiveEnd`. Not an error: the socket is closed 1000 with `sessionEnded` and no upstream is dialed. It is the only signal that a device is acting on a stale schedule - most often a kiosk whose `mySchedule` long-poll has been failing silently. Optional for backward-compat with publishers that predate it.',
+      }),
+    ),
     latencySamplesTotal: Type.Integer({
       description:
         'Latency samples published. The denominator for the two figures below.',

--- a/libs/schemas/node-server-schema/src/transcription-stream/routes/transcription-stream.schema.ts
+++ b/libs/schemas/node-server-schema/src/transcription-stream/routes/transcription-stream.schema.ts
@@ -35,16 +35,33 @@ export enum LatencyKind {
 
 /**
  * Distinguishes *why* `transcriptionServiceConnected` is `false`, when known.
+ *
  * `AT_CAPACITY` means the Transcription Service explicitly refused the
  * connection (WebSocket close 1013, "try again later") rather than the
  * connection dropping or the service crashing - see
  * `archived-plans/2026-07-27-02-PLAN-AdmissionControl.md` §4, "node-server must
- * distinguish 'service refused' from 'service crashed'". Mirrors the local
- * `TranscriptionServiceDisconnectReason` in node-server's
+ * distinguish 'service refused' from 'service crashed'".
+ *
+ * `INVALID_REQUEST` means the Transcription Service rejected what the Node
+ * Server sent as unacceptable (WebSocket close 1007, "invalid frame payload
+ * data"). The service closes 1007 for a `TranscriptionClientError` - in
+ * practice a session whose `transcriptionProviderId` is not a key in the
+ * deployment's `provider_config.json` ("Invalid Provider Key") - or for a
+ * message that fails its schema. Both are permanent: the Node Server's
+ * reconnect loop will re-send exactly the same request and be refused exactly
+ * the same way, forever. Distinguishing it is what lets a viewer be told the
+ * room is misconfigured instead of watching a "reconnecting" banner that will
+ * never resolve.
+ *
+ * The two are deliberately separate values: `AT_CAPACITY` clears on its own
+ * when load drops, `INVALID_REQUEST` never clears without an operator.
+ *
+ * Mirrors the local `TranscriptionServiceDisconnectReason` in node-server's
  * `session-status.events.ts`; keep both in sync.
  */
 export enum TranscriptionServiceDisconnectReason {
   AT_CAPACITY = 'at-capacity',
+  INVALID_REQUEST = 'invalid-request',
 }
 
 const TRANSCRIPTION_STREAM_SCHEMA = {
@@ -105,7 +122,7 @@ const TRANSCRIPTION_STREAM_SCHEMA = {
       transcriptionServiceDisconnectReason: Type.Optional(
         Type.Enum(TranscriptionServiceDisconnectReason, {
           description:
-            'Present only when transcriptionServiceConnected is false and the cause is known: today, "at-capacity" means the Transcription Service explicitly refused the connection (close 1013) rather than it dropping or crashing. Absent when connected, or when disconnected for an undistinguished reason, or when the publisher predates this field.',
+            'Present only when transcriptionServiceConnected is false and the cause is known. "at-capacity" means the Transcription Service explicitly refused the connection for load (close 1013) and will accept it again once load drops. "invalid-request" means the Transcription Service rejected the request as unacceptable (close 1007) - typically a transcriptionProviderId that is not configured on the deployment - which no amount of reconnecting will fix. Absent when connected, or when disconnected for an undistinguished reason, or when the publisher predates this field.',
         }),
       ),
     }),

--- a/libs/schemas/session-manager-schema/src/index.ts
+++ b/libs/schemas/session-manager-schema/src/index.ts
@@ -36,6 +36,7 @@ export * from './schedule-management/entities/session-schedule.schema.js';
 export * from './schedule-management/entities/session-type.schema.js';
 export * from './schedule-management/entities/session.schema.js';
 export * from './schedule-management/entities/auto-session-window.schema.js';
+export * from './schedule-management/entities/transcription-provider.schema.js';
 
 export * from './schedule-management/routes/my-schedule.schema.js';
 export * from './schedule-management/routes/list-schedules.schema.js';

--- a/libs/schemas/session-manager-schema/src/schedule-management/entities/auto-session-window.schema.ts
+++ b/libs/schemas/session-manager-schema/src/schedule-management/entities/auto-session-window.schema.ts
@@ -4,6 +4,7 @@ import { SESSION_SCOPE_SCHEMA } from '#src/shared/entities/session-scope.schema.
 
 import { DAY_OF_WEEK_SCHEMA } from './day-of-week.schema.js';
 import { LOCAL_TIME_SCHEMA } from './session-schedule.schema.js';
+import { TRANSCRIPTION_PROVIDER_ID_SCHEMA } from './transcription-provider.schema.js';
 
 /**
  * An auto-session window as returned by schedule-management read endpoints.
@@ -20,7 +21,7 @@ export const AUTO_SESSION_WINDOW_SCHEMA = Type.Object(
     daysOfWeek: Type.Array(DAY_OF_WEEK_SCHEMA),
 
     joinCodeScopes: Type.Array(SESSION_SCOPE_SCHEMA),
-    transcriptionProviderId: Type.String(),
+    transcriptionProviderId: TRANSCRIPTION_PROVIDER_ID_SCHEMA,
     transcriptionStreamConfig: Type.Unknown(),
 
     activeStart: Type.String({ format: 'date-time' }),

--- a/libs/schemas/session-manager-schema/src/schedule-management/entities/session-schedule.schema.ts
+++ b/libs/schemas/session-manager-schema/src/schedule-management/entities/session-schedule.schema.ts
@@ -4,6 +4,7 @@ import { SESSION_SCOPE_SCHEMA } from '#src/shared/entities/session-scope.schema.
 
 import { DAY_OF_WEEK_SCHEMA } from './day-of-week.schema.js';
 import { SCHEDULE_FREQUENCY_SCHEMA } from './schedule-frequency.schema.js';
+import { TRANSCRIPTION_PROVIDER_ID_SCHEMA } from './transcription-provider.schema.js';
 
 const LOCAL_TIME_SCHEMA = Type.String({
   maxLength: 8,
@@ -39,7 +40,10 @@ export const SESSION_SCHEDULE_SCHEMA = Type.Object(
     daysOfWeek: Type.Union([Type.Array(DAY_OF_WEEK_SCHEMA), Type.Null()]),
 
     joinCodeScopes: Type.Array(SESSION_SCOPE_SCHEMA),
-    transcriptionProviderId: Type.Union([Type.String(), Type.Null()]),
+    transcriptionProviderId: Type.Union([
+      TRANSCRIPTION_PROVIDER_ID_SCHEMA,
+      Type.Null(),
+    ]),
     transcriptionStreamConfig: Type.Union([Type.Unknown(), Type.Null()]),
 
     createdAt: Type.String({ format: 'date-time' }),

--- a/libs/schemas/session-manager-schema/src/schedule-management/entities/session.schema.ts
+++ b/libs/schemas/session-manager-schema/src/schedule-management/entities/session.schema.ts
@@ -3,6 +3,7 @@ import { type Static, Type } from 'typebox';
 import { SESSION_SCOPE_SCHEMA } from '#src/shared/entities/session-scope.schema.js';
 
 import { SESSION_TYPE_SCHEMA } from './session-type.schema.js';
+import { TRANSCRIPTION_PROVIDER_ID_SCHEMA } from './transcription-provider.schema.js';
 
 /**
  * A session as returned by schedule-management read endpoints. Includes
@@ -55,7 +56,7 @@ export const SESSION_SCHEMA = Type.Object(
     ]),
 
     joinCodeScopes: Type.Array(SESSION_SCOPE_SCHEMA),
-    transcriptionProviderId: Type.String(),
+    transcriptionProviderId: TRANSCRIPTION_PROVIDER_ID_SCHEMA,
     transcriptionStreamConfig: Type.Unknown(),
 
     sessionConfigVersion: Type.Integer({

--- a/libs/schemas/session-manager-schema/src/schedule-management/entities/transcription-provider.schema.ts
+++ b/libs/schemas/session-manager-schema/src/schedule-management/entities/transcription-provider.schema.ts
@@ -1,0 +1,42 @@
+import { Type } from 'typebox';
+
+/**
+ * Provider keys shipped in `deployment/provider_config.template.json`.
+ *
+ * This is a **default**, not the truth. The authoritative list is whatever the
+ * deployment's `provider_config.json` actually defines, and that file is
+ * operator-editable — a deployment can add a provider we have never heard of,
+ * or drop one of these. So this is not baked into the wire schema as an enum:
+ * a hardcoded union would reject a provider the operator legitimately
+ * configured and accept one they removed, which is the same class of mistake as
+ * pinning an `Authorization` header to a character class and guessing what an
+ * operator's secret manager emits.
+ *
+ * Instead session-manager validates against `TRANSCRIPTION_PROVIDER_IDS`, whose
+ * default is exactly this list. Exported here so both sides — the default and
+ * the OpenAPI documentation — come from one place.
+ */
+export const SHIPPED_TRANSCRIPTION_PROVIDER_IDS = [
+  'debug',
+  'whisper',
+  'lumen_granite',
+  'crisper_whisper',
+] as const;
+
+/**
+ * A transcription provider key. Stays `Type.String` on the wire — see
+ * {@link SHIPPED_TRANSCRIPTION_PROVIDER_IDS} for why the accepted set is not
+ * pinned here. Session Manager rejects a key outside its configured set with
+ * `400 VALIDATION_ERROR`, so an unknown provider fails at the point an operator
+ * can still see it, rather than at stream time where it closes the upstream
+ * socket 1007 and shows every viewer a "reconnecting" banner forever.
+ */
+export const TRANSCRIPTION_PROVIDER_ID_SCHEMA = Type.String({
+  minLength: 1,
+  description:
+    "Key of a provider defined in the deployment's transcription-service " +
+    'provider_config.json. Rejected with 400 VALIDATION_ERROR if it is not ' +
+    "one of the keys Session Manager is configured to accept (see the service's " +
+    'TRANSCRIPTION_PROVIDER_IDS).',
+  examples: [...SHIPPED_TRANSCRIPTION_PROVIDER_IDS],
+});

--- a/libs/schemas/session-manager-schema/src/schedule-management/routes/create-auto-session-window.schema.ts
+++ b/libs/schemas/session-manager-schema/src/schedule-management/routes/create-auto-session-window.schema.ts
@@ -18,6 +18,7 @@ import { SCHEDULE_MANAGEMENT_TAG } from '#src/tags.js';
 import { AUTO_SESSION_WINDOW_SCHEMA } from '../entities/auto-session-window.schema.js';
 import { DAY_OF_WEEK_SCHEMA } from '../entities/day-of-week.schema.js';
 import { LOCAL_TIME_SCHEMA } from '../entities/session-schedule.schema.js';
+import { TRANSCRIPTION_PROVIDER_ID_SCHEMA } from '../entities/transcription-provider.schema.js';
 
 const CREATE_AUTO_SESSION_WINDOW_SCHEMA = {
   description:
@@ -38,7 +39,7 @@ const CREATE_AUTO_SESSION_WINDOW_SCHEMA = {
     activeStart: Type.String({ format: 'date-time' }),
     activeEnd: Type.Union([Type.String({ format: 'date-time' }), Type.Null()]),
     joinCodeScopes: Type.Array(SESSION_SCOPE_SCHEMA),
-    transcriptionProviderId: Type.String(),
+    transcriptionProviderId: TRANSCRIPTION_PROVIDER_ID_SCHEMA,
     transcriptionStreamConfig: Type.Unknown(),
   }),
   response: {

--- a/libs/schemas/session-manager-schema/src/schedule-management/routes/create-on-demand-session.schema.ts
+++ b/libs/schemas/session-manager-schema/src/schedule-management/routes/create-on-demand-session.schema.ts
@@ -16,6 +16,7 @@ import {
 import { SCHEDULE_MANAGEMENT_TAG } from '#src/tags.js';
 
 import { SESSION_SCHEMA } from '../entities/session.schema.js';
+import { TRANSCRIPTION_PROVIDER_ID_SCHEMA } from '../entities/transcription-provider.schema.js';
 
 const CREATE_ON_DEMAND_SESSION_SCHEMA = {
   description:
@@ -29,7 +30,7 @@ const CREATE_ON_DEMAND_SESSION_SCHEMA = {
     roomUid: Type.String({ format: 'uuid' }),
     name: Type.String({ minLength: 1, maxLength: 256 }),
     joinCodeScopes: Type.Array(SESSION_SCOPE_SCHEMA),
-    transcriptionProviderId: Type.String(),
+    transcriptionProviderId: TRANSCRIPTION_PROVIDER_ID_SCHEMA,
     transcriptionStreamConfig: Type.Unknown(),
   }),
   response: {

--- a/libs/schemas/session-manager-schema/src/schedule-management/routes/create-schedule.schema.ts
+++ b/libs/schemas/session-manager-schema/src/schedule-management/routes/create-schedule.schema.ts
@@ -21,6 +21,7 @@ import {
   LOCAL_TIME_SCHEMA,
   SESSION_SCHEDULE_SCHEMA,
 } from '../entities/session-schedule.schema.js';
+import { TRANSCRIPTION_PROVIDER_ID_SCHEMA } from '../entities/transcription-provider.schema.js';
 
 const CREATE_SCHEDULE_SCHEMA = {
   description:
@@ -57,7 +58,7 @@ const CREATE_SCHEDULE_SCHEMA = {
       Type.Null(),
     ]),
     joinCodeScopes: Type.Array(SESSION_SCOPE_SCHEMA),
-    transcriptionProviderId: Type.String(),
+    transcriptionProviderId: TRANSCRIPTION_PROVIDER_ID_SCHEMA,
     transcriptionStreamConfig: Type.Unknown(),
   }),
   response: {

--- a/libs/schemas/session-manager-schema/src/schedule-management/routes/update-auto-session-window.schema.ts
+++ b/libs/schemas/session-manager-schema/src/schedule-management/routes/update-auto-session-window.schema.ts
@@ -18,6 +18,7 @@ import { SCHEDULE_MANAGEMENT_TAG } from '#src/tags.js';
 import { AUTO_SESSION_WINDOW_SCHEMA } from '../entities/auto-session-window.schema.js';
 import { DAY_OF_WEEK_SCHEMA } from '../entities/day-of-week.schema.js';
 import { LOCAL_TIME_SCHEMA } from '../entities/session-schedule.schema.js';
+import { TRANSCRIPTION_PROVIDER_ID_SCHEMA } from '../entities/transcription-provider.schema.js';
 
 const UPDATE_AUTO_SESSION_WINDOW_SCHEMA = {
   description:
@@ -39,7 +40,7 @@ const UPDATE_AUTO_SESSION_WINDOW_SCHEMA = {
       Type.Union([Type.String({ format: 'date-time' }), Type.Null()]),
     ),
     joinCodeScopes: Type.Optional(Type.Array(SESSION_SCOPE_SCHEMA)),
-    transcriptionProviderId: Type.Optional(Type.String()),
+    transcriptionProviderId: Type.Optional(TRANSCRIPTION_PROVIDER_ID_SCHEMA),
     transcriptionStreamConfig: Type.Optional(Type.Unknown()),
   }),
   response: {

--- a/libs/schemas/session-manager-schema/src/schedule-management/routes/update-schedule.schema.ts
+++ b/libs/schemas/session-manager-schema/src/schedule-management/routes/update-schedule.schema.ts
@@ -21,6 +21,7 @@ import {
   LOCAL_TIME_SCHEMA,
   SESSION_SCHEDULE_SCHEMA,
 } from '../entities/session-schedule.schema.js';
+import { TRANSCRIPTION_PROVIDER_ID_SCHEMA } from '../entities/transcription-provider.schema.js';
 
 const UPDATE_SCHEDULE_SCHEMA = {
   description:
@@ -47,7 +48,7 @@ const UPDATE_SCHEDULE_SCHEMA = {
       ]),
     ),
     joinCodeScopes: Type.Optional(Type.Array(SESSION_SCOPE_SCHEMA)),
-    transcriptionProviderId: Type.Optional(Type.String()),
+    transcriptionProviderId: Type.Optional(TRANSCRIPTION_PROVIDER_ID_SCHEMA),
     transcriptionStreamConfig: Type.Optional(Type.Unknown()),
   }),
   response: {

--- a/libs/ui/core-ui/src/components/connection-status-banner.tsx
+++ b/libs/ui/core-ui/src/components/connection-status-banner.tsx
@@ -2,6 +2,7 @@
 // glyph as `ErrorOutlineOutlined` (the bare `ErrorOutline` export was
 // dropped); its path is identical to the classic "error outline" icon.
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutlineOutlined';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import Box from '@mui/material/Box';
 import Slide from '@mui/material/Slide';
@@ -9,10 +10,15 @@ import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
 /**
- * Severity of a connection problem. Drives both the icon and the (fixed,
- * non-theme-relative) color pairing below.
+ * Severity of a connection problem. Drives the icon, the (fixed,
+ * non-theme-relative) color pairing below, and the live-region politeness.
+ *
+ * `'info'` is deliberately not a *problem*: it reports an expected, healthy
+ * waiting state (e.g. the room's microphone hasn't connected yet). Rendering
+ * that as a warning is what made every real room look broken, so it gets its
+ * own severity rather than borrowing `'warning'`.
  */
-export type ConnectionStatusSeverity = 'warning' | 'error';
+export type ConnectionStatusSeverity = 'info' | 'warning' | 'error';
 
 /**
  * Props for {@link ConnectionStatusBanner}.
@@ -44,18 +50,33 @@ export interface ConnectionStatusBannerProps {
  * imported from there to keep these leaf packages dependency-free of each
  * other — the formula is reproduced in this package's tests instead).
  *
- * Both pairs use white text/icon on a dark tint of the severity color:
+ * All three pairs use white text/icon on a dark tint of the severity color:
+ *  - info:    #0d3c61 background vs #ffffff text/icon → 11.44:1
  *  - warning: #5c3d00 background vs #ffffff text/icon → 9.89:1
  *  - error:   #5a1a1a background vs #ffffff text/icon → 13.15:1
- * Both comfortably clear SC 1.4.3 (text, >=4.5:1) and SC 1.4.11 (non-text /
+ * All comfortably clear SC 1.4.3 (text, >=4.5:1) and SC 1.4.11 (non-text /
  * icon, >=3:1).
  */
 const SEVERITY_COLORS: Record<
   ConnectionStatusSeverity,
   { background: string; foreground: string }
 > = {
+  info: { background: '#0d3c61', foreground: '#ffffff' }, // 11.44:1
   warning: { background: '#5c3d00', foreground: '#ffffff' }, // 9.89:1
   error: { background: '#5a1a1a', foreground: '#ffffff' }, // 13.15:1
+};
+
+/**
+ * Icon per severity. The shape (not just the color) is what distinguishes the
+ * three states for users who can't perceive the color difference. SC 1.4.1
+ */
+const SEVERITY_ICONS: Record<
+  ConnectionStatusSeverity,
+  typeof WarningAmberIcon
+> = {
+  info: InfoOutlinedIcon,
+  warning: WarningAmberIcon,
+  error: ErrorOutlineIcon,
 };
 
 // Slide duration; forced to 0 under prefers-reduced-motion below.
@@ -63,8 +84,8 @@ const SLIDE_DURATION_MS = 200;
 
 /**
  * Full-width status bar pinned to the bottom of the viewport, reporting the
- * app's connection to the transcription service (lost / retrying / at
- * capacity). Non-blocking: unlike {@link MainErrorFallback} this never moves
+ * app's connection to the transcription service (waiting / lost / retrying /
+ * at capacity). Non-blocking: unlike {@link MainErrorFallback} this never moves
  * focus, since the user's captioning session keeps running underneath it.
  *
  * Renders nothing when `open` is `false` — the subtree is unmounted, not
@@ -87,6 +108,7 @@ export const ConnectionStatusBanner = ({
   }
 
   const { background, foreground } = SEVERITY_COLORS[severity];
+  const SeverityIcon = SEVERITY_ICONS[severity];
 
   return (
     <Slide
@@ -97,12 +119,16 @@ export const ConnectionStatusBanner = ({
     >
       <Box
         // Time-sensitive: a captioning tool's user needs to know *now* that
-        // captions may have stopped, so this is `role="alert"` (implicit
-        // aria-live="assertive", no extra aria-live attribute needed) rather
-        // than the polite `role="status"` used elsewhere for non-urgent live
-        // regions. Non-blocking though — no focus move, unlike
-        // MainErrorFallback's full-page block. SC 4.1.3
-        role="alert"
+        // captions may have stopped, so `warning`/`error` are `role="alert"`
+        // (implicit aria-live="assertive", no extra aria-live attribute
+        // needed). `info` is not time-sensitive — nothing has broken and
+        // there is nothing for the user to do — so it takes the polite
+        // `role="status"` used elsewhere for non-urgent live regions;
+        // interrupting a screen-reader user to say "still waiting" is exactly
+        // the assertive-live-region misuse SC 4.1.3 warns about. Non-blocking
+        // in both cases — no focus move, unlike MainErrorFallback's full-page
+        // block. SC 4.1.3
+        role={severity === 'info' ? 'status' : 'alert'}
         sx={{
           position: 'fixed',
           bottom: 0,
@@ -121,17 +147,10 @@ export const ConnectionStatusBanner = ({
             is aria-hidden since the adjacent `message` text already carries
             the meaning for screen-reader users — never convey status by
             icon/color alone. SC 1.4.1 */}
-        {severity === 'warning' ? (
-          <WarningAmberIcon
-            aria-hidden="true"
-            sx={{ color: foreground, flexShrink: 0 }}
-          />
-        ) : (
-          <ErrorOutlineIcon
-            aria-hidden="true"
-            sx={{ color: foreground, flexShrink: 0 }}
-          />
-        )}
+        <SeverityIcon
+          aria-hidden="true"
+          sx={{ color: foreground, flexShrink: 0 }}
+        />
         <Typography sx={{ color: foreground }}>{message}</Typography>
       </Box>
     </Slide>

--- a/libs/ui/core-ui/tests/components/connection-status-banner.test.tsx
+++ b/libs/ui/core-ui/tests/components/connection-status-banner.test.tsx
@@ -34,6 +34,33 @@ describe('ConnectionStatusBanner', (it) => {
     );
   });
 
+  it('announces severity="info" politely via role=status, not role=alert', () => {
+    render(
+      <ConnectionStatusBanner
+        open
+        severity="info"
+        message="Waiting for the room's microphone to connect."
+      />,
+    );
+
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent(
+      "Waiting for the room's microphone to connect.",
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows an info icon for severity="info", hidden from assistive tech', () => {
+    render(<ConnectionStatusBanner open severity="info" message="Waiting…" />);
+
+    const icon = screen.getByTestId('InfoOutlinedIcon');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.queryByTestId('WarningAmberIcon')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('ErrorOutlineOutlinedIcon'),
+    ).not.toBeInTheDocument();
+  });
+
   it('shows a warning icon for severity="warning", hidden from assistive tech', () => {
     render(
       <ConnectionStatusBanner open severity="warning" message="Retrying…" />,
@@ -58,6 +85,17 @@ describe('ConnectionStatusBanner', (it) => {
     const icon = screen.getByTestId('ErrorOutlineOutlinedIcon');
     expect(icon).toHaveAttribute('aria-hidden', 'true');
     expect(screen.queryByTestId('WarningAmberIcon')).not.toBeInTheDocument();
+  });
+
+  it('has no axe violations when open (info)', async () => {
+    render(
+      <ConnectionStatusBanner
+        open
+        severity="info"
+        message="Waiting for the room's microphone to connect."
+      />,
+    );
+    expect(await axeViolations()).toEqual([]);
   });
 
   it('has no axe violations when open (warning)', async () => {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "a11y:axe:authed": "node tools/a11y/axe-scan-authed.mjs",
     "e2e:audio": "node tools/e2e-audio/kiosk-audio-e2e.mjs",
     "e2e:admin": "node tools/admin-scheduling-e2e/admin-scheduling-e2e.mjs",
+    "e2e:demo": "node tools/demo-e2e/demo-e2e.mjs",
     "asr:load": "node tools/asr-load/asr-load.mjs"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "e2e:admin": "node tools/admin-scheduling-e2e/admin-scheduling-e2e.mjs",
     "e2e:demo": "node tools/demo-e2e/demo-e2e.mjs",
     "e2e:browser-demo": "node tools/browser-demo-e2e/browser-demo-e2e.mjs",
+    "e2e:sessions": "node tools/session-corner-cases/session-corner-cases.mjs",
     "asr:load": "node tools/asr-load/asr-load.mjs"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "e2e:audio": "node tools/e2e-audio/kiosk-audio-e2e.mjs",
     "e2e:admin": "node tools/admin-scheduling-e2e/admin-scheduling-e2e.mjs",
     "e2e:demo": "node tools/demo-e2e/demo-e2e.mjs",
+    "e2e:browser-demo": "node tools/browser-demo-e2e/browser-demo-e2e.mjs",
     "asr:load": "node tools/asr-load/asr-load.mjs"
   },
   "engines": {

--- a/tools/browser-demo-e2e/README.md
+++ b/tools/browser-demo-e2e/README.md
@@ -1,0 +1,151 @@
+# Browser demo end-to-end check
+
+Drives the **entire** demo — operator, kiosk and audience member — through three
+real Chromium windows, and asserts what a human would actually see. It is the
+browser counterpart to `tools/demo-e2e`, which checks the same journey at the
+socket level and cannot see a single pixel.
+
+Every step that a person performs in the runbook is performed here by clicking
+the real control: logging into `/admin/`, **Register device**, **New room**,
+typing the activation code into the kiosk, **Start a session now**, **Open live
+captions**, and **End early**. Nothing is provisioned behind the UI's back.
+
+## Why
+
+The fixes this pins are _rendering and timing_ changes, and two of them are
+invisible to every other check in this repo.
+
+**The banner.** A healthy room that nobody is talking into yet used to render as
+_"Connection to the transcription service was lost. Reconnecting…"_ — a warning,
+coloured and announced as a fault, and it stayed up forever. That is why the
+demo "was always showing reconnecting" while the backend was entirely healthy,
+and why the hardcoded Alice room looked fine (its synthetic source hardcodes
+both status flags `true`). Unit tests pin the pure derivation function, but the
+thing that failed in the room was a rendered banner, so this asserts the
+rendered banner: the exact string, and `role="status"` rather than
+`role="alert"`.
+
+**The token-refresh timer.** `decodeSessionTokenExpiryMs` used to read the wrong
+segment of a ScribeAR session token (two segments, payload first — not a JWT),
+so it always returned `null` and the proactive refresh timer was **never armed**
+on any connection, ever (fixed in `8ff4582`). Session tokens live **5 minutes**.
+Any check shorter than that — which is every other check here — cannot tell the
+fixed build from the broken one. So this one holds a viewer open past the token
+lifetime with audio flowing and watches for a reconnect that must not happen.
+
+## Run
+
+```bash
+# Needs the stack up. Reads ADMIN_LOCAL_CREDENTIALS from deployment/.env.
+npm run e2e:browser-demo
+```
+
+```bash
+# Against a stack on a non-default origin, e.g. an isolated deployment:
+npm run e2e:browser-demo -- \
+  --base-url https://localhost:8443 \
+  --env-file ../deployment-iso/.env
+```
+
+Takes a little over **9 minutes** by default and that is deliberate: the
+long-lived window has to outlast a 5-minute token. Exits non-zero and names the
+failing assertion. `--json` emits the result, the artifacts (room/session uid,
+join URL) and the client's network counters as JSON.
+
+## What it checks
+
+| #   | Assertion                                   | What a failure means                                                                  |
+| --- | ------------------------------------------- | ------------------------------------------------------------------------------------- |
+| 1   | `ADMIN_LOGIN_VIA_UI`                        | the admin console's real login form is broken                                         |
+| 2   | `DEVICE_REGISTERED_VIA_UI`                  | the Register device dialog no longer shows the activation code                        |
+| 3   | `ROOM_CREATED_VIA_UI`                       | New room, or its async source-device picker, is broken                                |
+| 4   | `KIOSK_ACTIVATED_VIA_UI`                    | the kiosk's activation form does not bind a device                                    |
+| 5   | `SESSION_STARTED_VIA_UI`                    | "Start a session now" no longer lands on the session detail page                      |
+| 6   | `JOIN_URL_FROM_SESSION_PAGE`                | the lazy join-code mint is broken — no viewer can be invited                          |
+| 7   | `VIEWER_JOINED_VIA_URL`                     | the `#config=` handoff or the join-code exchange is broken                            |
+| 8   | **`IDLE_BANNER_IS_INFORMATIONAL`**          | **the idle room no longer reads "Waiting for the room's microphone to connect."**     |
+| 9   | **`IDLE_BANNER_NOT_A_FAULT`**               | **the idle banner says "reconnecting", or is `role="alert"` — the original demo bug** |
+| 10  | `BANNER_CLEARS_WHEN_AUDIO_FLOWS`            | the banner is sticky: it stays up after the room gets a microphone                    |
+| 11  | `TRANSCRIPT_RENDERED_IN_BROWSER`            | audio reached a provider but nothing reached `role="log"`                             |
+| 12  | **`LONG_LIVED_VIEWER_NEVER_RECONNECTS`**    | **the viewer opened a second socket — a reconnect, i.e. the dead-timer regression**   |
+| 13  | **`TOKEN_REFRESH_TIMER_ARMED`**             | **zero `refresh-session-token` calls in >5 min: the timer is not armed (`8ff4582`)**  |
+| 14  | `TRANSCRIPTS_STILL_FLOWING_AFTER_TOKEN_TTL` | captions died at the token boundary even without a visible reconnect                  |
+| 15  | `SESSION_END_RETURNS_VIEWER_TO_JOIN_PROMPT` | ending the session hangs the viewer instead of returning it to the join prompt        |
+
+8, 9, 12 and 13 are the reason this exists. The rest are there so that a failure
+in them is not misread as a failure in those four.
+
+## Screenshots
+
+Written to `--screenshot-dir` (default `~/app-screenshots`), prefixed with
+`--prefix` (default `browser-demo`):
+
+| File                                  | Shows                                                                 |
+| ------------------------------------- | --------------------------------------------------------------------- |
+| `-00-admin-session-detail.png`        | the operator's session page with the join code and live-captions link |
+| `-01-idle-waiting-for-microphone.png` | **the headline fix**: a blue, `info`-styled waiting banner            |
+| `-02-captions-flowing.png`            | captions on screen and **no banner at all**                           |
+| `-02b-kiosk-streaming.png`            | the kiosk that is producing that audio                                |
+| `-03-long-lived-viewer.png`           | the same viewer >6 minutes later, still captioning                    |
+| `-04-session-ended-join-prompt.png`   | the viewer back at the join prompt after End early                    |
+| `-zz-failure-*.png`                   | all three browsers, only written when a run fails                     |
+
+These are the deliverable a human reads. A passing exit code says the strings
+matched; the screenshot says the room looked right.
+
+## Options
+
+| Flag                   | Default             | Meaning                                                        |
+| ---------------------- | ------------------- | -------------------------------------------------------------- |
+| `--base-url`           | `https://localhost` | stack origin (self-signed certs are accepted)                  |
+| `--env-file`           | `deployment/.env`   | file holding `ADMIN_LOCAL_CREDENTIALS`                         |
+| `--username`           | from `--env-file`   | admin console user                                             |
+| `--password`           | from `--env-file`   | admin console password                                         |
+| `--screenshot-dir`     | `~/app-screenshots` | where the PNGs land                                            |
+| `--prefix`             | `browser-demo`      | screenshot filename prefix                                     |
+| `--warmup-seconds`     | `45`                | audio streamed before the long-lived window opens              |
+| `--long-lived-seconds` | `400`               | the long-lived window; **must exceed 300 s** or #13 is vacuous |
+| `--keep-room`          | off                 | skip the "Delete room" cleanup                                 |
+| `--headful`            | off                 | visible browsers, for debugging                                |
+| `--json`               | off                 | machine-readable result                                        |
+
+Chrome is auto-detected from `CHROME_PATH`, then `/usr/bin/google-chrome-stable`,
+`google-chrome`, `chromium-browser`, `chromium` — same as `tools/e2e-audio`.
+
+## Notes
+
+- **Three browsers, not three tabs.** They model three machines. The kiosk and
+  the client are served from the same origin, so one browser would have them
+  sharing `localStorage` and cookies — which is not how any of this is
+  deployed, and would let a kiosk bug hide behind client state.
+- **The kiosk is parked (`about:blank`) between activation and the session.**
+  It has to be: `sourceDeviceConnected` flips true when the kiosk opens its
+  source socket, which it does the instant a session goes active. A kiosk left
+  on the page would race the viewer and the idle banner would never be
+  observable. The device stays activated across the park — activation codes are
+  single-use, so re-activating is not an option.
+- **Navigate straight to the join URL.** Loading `/client/` and _then_ going to
+  `/client/#config=…` looks equivalent and is not: a fragment-only change is a
+  same-document navigation, the app never re-initializes, and the config
+  middleware — which runs once, on redux-remember rehydration — never sees the
+  code. The viewer silently sits on the join prompt.
+- **The microphone control is a toggle**, so the script clicks and then
+  _verifies_ binary frames are on the wire, rather than clicking a fixed number
+  of times.
+- **Audio** comes from Chrome's fake capture device fed by
+  `test_audio_files/speech/harvard_16k_mono.wav` (33 s, looped by Chrome), so a
+  ten-minute run needs no real microphone and stays deterministic.
+- **`…/transcription-stream/undefined/client`.** The client opens one socket
+  with a literal `undefined` session uid at startup, before it knows its
+  identity, and aborts it immediately. It is counted separately from real
+  sockets so it cannot be mistaken for a reconnect in assertion 12. It is
+  harmless but it is also noise in every browser console — worth removing.
+- **Ending a session returns the viewer to the join prompt without saying
+  why.** Assertion 15 passes (the viewer does not hang, which is what
+  `bc37f92`'s end-watch fixes), but the client renders no "this session has
+  ended" message — it just reopens the join dialog. The run records whatever
+  explanation _was_ shown in that check's detail, so a future fix has a
+  baseline. This is the same "cause, audience, next action" gap catalogued in
+  `2026-08-01-02-PLAN-VisibleErrors.md`.
+- **Cleanup deletes the room through the UI** ("Delete room" on the room detail
+  page), which cascades the session. `--keep-room` leaves it for inspection.

--- a/tools/browser-demo-e2e/browser-demo-e2e.mjs
+++ b/tools/browser-demo-e2e/browser-demo-e2e.mjs
@@ -1,0 +1,1032 @@
+/**
+ * Browser demo end-to-end check: drive the *whole* operator + viewer journey
+ * through real Chromium windows and assert what a human would see.
+ *
+ * Usage:
+ *   node tools/browser-demo-e2e/browser-demo-e2e.mjs [options]
+ *
+ * Options:
+ *   --base-url <url>       default https://localhost  (self-signed certs ok)
+ *   --username <u>         admin console user   (default: from --env-file)
+ *   --password <p>         admin console password
+ *   --env-file <path>      .env holding ADMIN_LOCAL_CREDENTIALS
+ *                          (default: deployment/.env)
+ *   --screenshot-dir <d>   default ~/app-screenshots
+ *   --prefix <name>        screenshot filename prefix (default browser-demo)
+ *   --warmup-seconds <n>   default 45. Audio streamed before the long-lived
+ *                          window starts, i.e. how long the "captions flowing"
+ *                          screenshot has to become interesting.
+ *   --long-lived-seconds <n>  default 400 (6m40s). MUST exceed the 300 s
+ *                          session-token lifetime or the token-refresh
+ *                          assertion is vacuous.
+ *   --keep-room            skip the "Delete room" cleanup at the end
+ *   --headful              run with a visible browser (debugging)
+ *   --json                 machine-readable result on stdout
+ *
+ * Why this exists
+ * ---------------
+ * The fixes on this branch (see 2026-08-01-01-PLAN-SessionChecks.md) are
+ * *rendering and timing* changes. Unit tests pin the pure derivation and a
+ * raw-socket harness (tools/demo-e2e) pins the protocol, but neither can see
+ * what the person in the lecture hall sees. Two of the fixes are only
+ * observable in a browser over real wall-clock time:
+ *
+ *   - the idle room banner. A healthy room with nobody talking yet used to
+ *     render as "Connection to the transcription service was lost.
+ *     Reconnecting…" — a warning, styled and announced as a fault. It must now
+ *     read "Waiting for the room's microphone to connect." as `role="status"`
+ *     (polite), never containing the word "reconnecting".
+ *   - the token-refresh timer (8ff4582). `decodeSessionTokenExpiryMs` used to
+ *     read the wrong segment of the two-segment session token, so the
+ *     proactive refresh timer was never armed. A viewer therefore only found
+ *     out its token had died when the socket did. A 5-minute token means the
+ *     bug is invisible to any check shorter than 5 minutes, which is every
+ *     other check in this repo.
+ *
+ * So this script keeps one viewer connected for >6 minutes with audio flowing
+ * and asserts it neither reconnects nor stops receiving transcripts, while a
+ * screenshot of each interesting moment lands in ~/app-screenshots for a human
+ * to confirm without re-running anything.
+ *
+ * Three separate Chromium instances, because they model three separate
+ * machines and must not share cookies or localStorage: the operator's admin
+ * console, the kiosk on the wall (fake audio capture device), and the
+ * audience member's phone.
+ *
+ * Requires a running stack. Chrome is auto-detected from CHROME_PATH, then the
+ * usual system locations — same as tools/e2e-audio.
+ */
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer-core';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+
+const CHROME_CANDIDATES = [
+  process.env.CHROME_PATH,
+  '/usr/bin/google-chrome-stable',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium-browser',
+  '/usr/bin/chromium',
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+].filter(Boolean);
+
+/** Speech fixture played into Chrome's fake microphone. Loops when exhausted. */
+const WAV = join(
+  REPO_ROOT,
+  'test_audio_files',
+  'speech',
+  'harvard_16k_mono.wav',
+);
+
+/** The exact string the idle-room fix must render. */
+const IDLE_BANNER = "Waiting for the room's microphone to connect.";
+
+/** Session tokens live 5 minutes; the client refreshes at 50% of remaining. */
+const SESSION_TOKEN_TTL_SECONDS = 300;
+
+function resolveChrome() {
+  for (const p of CHROME_CANDIDATES) if (existsSync(p)) return p;
+  throw new Error(
+    `No Chrome/Chromium found. Set CHROME_PATH. Tried: ${CHROME_CANDIDATES.join(', ')}`,
+  );
+}
+
+function parseArgs(argv) {
+  const a = {
+    baseUrl: 'https://localhost',
+    username: '',
+    password: '',
+    envFile: join(REPO_ROOT, 'deployment', '.env'),
+    screenshotDir: join(homedir(), 'app-screenshots'),
+    prefix: 'browser-demo',
+    warmupSeconds: 45,
+    longLivedSeconds: 400,
+    keepRoom: false,
+    headful: false,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const f = argv[i];
+    if (f === '--json') a.json = true;
+    else if (f === '--keep-room') a.keepRoom = true;
+    else if (f === '--headful') a.headful = true;
+    else if (f === '--base-url') a.baseUrl = argv[++i];
+    else if (f === '--username') a.username = argv[++i];
+    else if (f === '--password') a.password = argv[++i];
+    else if (f === '--env-file') a.envFile = argv[++i];
+    else if (f === '--screenshot-dir') a.screenshotDir = argv[++i];
+    else if (f === '--prefix') a.prefix = argv[++i];
+    else if (f === '--warmup-seconds') a.warmupSeconds = Number(argv[++i]);
+    else if (f === '--long-lived-seconds')
+      a.longLivedSeconds = Number(argv[++i]);
+    else throw new Error(`Unknown option: ${f}`);
+  }
+  return a;
+}
+
+/**
+ * Admin credentials from `ADMIN_LOCAL_CREDENTIALS` ("<user> <password>"), so
+ * the common case needs no flags. Deliberately a plain scan rather than a
+ * dotenv dependency — mirrors tools/e2e-audio's reasoning: one key is needed
+ * and the file's values are unquoted shell-hostile strings.
+ */
+function credsFromEnv(args) {
+  if (args.username && args.password) return args;
+  try {
+    const env = readFileSync(args.envFile, 'utf8');
+    const line = env
+      .split('\n')
+      .find((l) => l.startsWith('ADMIN_LOCAL_CREDENTIALS='));
+    if (line) {
+      const val = line.slice('ADMIN_LOCAL_CREDENTIALS='.length).trim();
+      const [user, ...rest] = val.split(/\s+/);
+      if (user && rest.length) {
+        return {
+          ...args,
+          username: args.username || user,
+          password: args.password || rest.join(' '),
+        };
+      }
+    }
+  } catch {
+    // optional; --username/--password still work
+  }
+  return args;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** A single assertion result. `id` names the fix or behaviour it pins. */
+function check(id, name, ok, detail = '') {
+  return { id, name, ok, detail };
+}
+
+/** Click the first visible control whose text or aria-label contains `needle`. */
+function clickByText(page, needle, scope = '') {
+  return page.evaluate(
+    (text, sel) => {
+      const root = sel ? document.querySelector(sel) : document;
+      if (!root) return false;
+      const els = [
+        ...root.querySelectorAll(
+          'button, [role="button"], a, li[role="option"]',
+        ),
+      ];
+      const hit = els.find(
+        (el) =>
+          (el.textContent ?? '').trim().toLowerCase().includes(text) ||
+          (el.getAttribute('aria-label') ?? '').toLowerCase().includes(text),
+      );
+      if (!hit) return false;
+      hit.click();
+      return true;
+    },
+    needle.toLowerCase(),
+    scope,
+  );
+}
+
+/** Poll `fn` until it returns truthy or `timeoutMs` elapses. */
+async function until(fn, timeoutMs, stepMs = 500) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() >= deadline) return null;
+    await sleep(stepMs);
+  }
+}
+
+/**
+ * Read the connection banner as assistive technology would: its ARIA role and
+ * its text. The banner is the only `position: fixed` live region either webapp
+ * renders, which is what distinguishes it from toasts and inline field errors.
+ *
+ * Returns `null` when no banner is shown — which is itself an assertion
+ * (captions flowing means no banner at all, not a quieter one).
+ */
+function readBanner(page) {
+  return page.evaluate(() => {
+    const nodes = [
+      ...document.querySelectorAll('[role="status"],[role="alert"]'),
+    ];
+    for (const n of nodes) {
+      const style = window.getComputedStyle(n);
+      const text = (n.innerText ?? '').trim();
+      if (style.position === 'fixed' && text.length > 0) {
+        return { role: n.getAttribute('role'), text };
+      }
+    }
+    return null;
+  });
+}
+
+/** Text inside the client's live-caption region (`role="log"`). */
+function readTranscript(page) {
+  return page.evaluate(() => {
+    const log = document.querySelector('[role="log"]');
+    return log ? (log.innerText ?? '').trim() : '';
+  });
+}
+
+async function shot(page, dir, prefix, name, log) {
+  const path = join(dir, `${prefix}-${name}.png`);
+  await page.screenshot({ path, fullPage: false });
+  log(`    screenshot -> ${path}`);
+  return path;
+}
+
+/**
+ * Instrument a page's network so the long-lived assertions have evidence
+ * rather than a vibe: how many viewer sockets were ever opened, when
+ * transcripts arrived, and whether the token-refresh call actually fired.
+ */
+async function instrumentClient(page) {
+  const state = {
+    socketsCreated: 0,
+    socketsClosed: 0,
+    // Sockets the app opens before it knows its own session uid, i.e.
+    // `.../transcription-stream/undefined/client`. Counted separately so they
+    // can't be mistaken for a reconnect: see the README's Notes.
+    undefinedSessionSockets: 0,
+    transcriptAtMs: [],
+    tokenRefreshes: 0,
+    consoleErrors: [],
+  };
+  const cdp = await page.createCDPSession();
+  await cdp.send('Network.enable');
+  // Navigations keep the target (and therefore this session) alive, but the
+  // client-webapp reloads itself once after consuming the #config fragment,
+  // so re-enable defensively rather than trust that.
+  page.on('framenavigated', (frame) => {
+    if (frame === page.mainFrame()) {
+      cdp.send('Network.enable').catch(() => {});
+    }
+  });
+  cdp.on('Network.webSocketCreated', (e) => {
+    if (!e.url.includes('/transcription-stream/')) return;
+    if (e.url.includes('/transcription-stream/undefined/')) {
+      state.undefinedSessionSockets++;
+      return;
+    }
+    state.socketsCreated++;
+  });
+  cdp.on('Network.webSocketClosed', () => {
+    state.socketsClosed++;
+  });
+  cdp.on('Network.webSocketFrameReceived', (e) => {
+    if (e.response.opcode !== 1) return;
+    if (e.response.payloadData.includes('"type":"transcript"')) {
+      state.transcriptAtMs.push(Date.now());
+    }
+  });
+  cdp.on('Network.requestWillBeSent', (e) => {
+    if (e.request.url.includes('refresh-session-token')) state.tokenRefreshes++;
+  });
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') state.consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', (err) => {
+    state.consoleErrors.push(String(err));
+  });
+  return state;
+}
+
+async function main() {
+  const args = credsFromEnv(parseArgs(process.argv.slice(2)));
+  const log = (...m) => {
+    if (!args.json) console.log(...m);
+  };
+  if (!args.username || !args.password) {
+    throw new Error(
+      `No admin credentials. Pass --username/--password or point --env-file at a file with ADMIN_LOCAL_CREDENTIALS (tried ${args.envFile}).`,
+    );
+  }
+  if (args.longLivedSeconds <= SESSION_TOKEN_TTL_SECONDS) {
+    log(
+      `!!! --long-lived-seconds ${args.longLivedSeconds} does not exceed the ` +
+        `${SESSION_TOKEN_TTL_SECONDS}s token lifetime; the refresh assertion will be vacuous.`,
+    );
+  }
+  mkdirSync(args.screenshotDir, { recursive: true });
+
+  const chrome = resolveChrome();
+  const results = [];
+  const screenshots = [];
+  const artifacts = {};
+  let admin, kiosk, client;
+  let adminPage, kioskPage, clientPage;
+  let clientNet = null;
+  let roomUid = null;
+
+  const launch = (extraArgs = []) =>
+    puppeteer.launch({
+      executablePath: chrome,
+      headless: !args.headful,
+      acceptInsecureCerts: true,
+      defaultViewport: { width: 1280, height: 800 },
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--ignore-certificate-errors',
+        ...extraArgs,
+      ],
+    });
+
+  try {
+    // =====================================================================
+    // Operator's browser: the real admin console, real login form.
+    // =====================================================================
+    admin = await launch();
+    adminPage = await admin.newPage();
+    adminPage.setDefaultTimeout(20_000);
+
+    log('--- [admin] logging in through the login form');
+    await adminPage.goto(`${args.baseUrl}/admin/`, {
+      waitUntil: 'networkidle2',
+    });
+    await adminPage.waitForSelector('input[autocomplete="username"]', {
+      visible: true,
+    });
+    await adminPage.type('input[autocomplete="username"]', args.username);
+    await adminPage.type('input[type="password"]', args.password);
+    await adminPage.click('button[type="submit"]');
+    const authed = await until(
+      () =>
+        adminPage.evaluate(
+          () => !document.querySelector('input[autocomplete="username"]'),
+        ),
+      20_000,
+    );
+    results.push(
+      check(
+        'ADMIN_LOGIN_VIA_UI',
+        'admin console login through the real form',
+        !!authed,
+        authed
+          ? 'Authenticated; login form gone.'
+          : 'Login form never cleared.',
+      ),
+    );
+    if (!authed) throw new Error('admin login failed');
+
+    const stamp = `bdemo-${process.pid}-${Math.floor(Date.now() / 1000)}`;
+    artifacts.stamp = stamp;
+
+    // ---- Register a device through the Devices page --------------------
+    log('--- [admin] Devices -> Register device');
+    await adminPage.goto(`${args.baseUrl}/admin/devices`, {
+      waitUntil: 'networkidle2',
+    });
+    if (!(await clickByText(adminPage, 'register device'))) {
+      throw new Error('no "Register device" button on /admin/devices');
+    }
+    await adminPage.waitForSelector('.MuiDialog-root input', { visible: true });
+    await adminPage.type('.MuiDialog-root input', `${stamp}-kiosk`);
+    await clickByText(adminPage, 'register device', '.MuiDialog-root');
+    // The dialog stays open showing the code so an operator can type it.
+    const activationCode = await until(
+      () =>
+        adminPage.evaluate(() => {
+          const dlg = document.querySelector('.MuiDialog-root');
+          if (!dlg) return null;
+          const m = /\b[A-Z0-9]{8}\b/.exec(dlg.innerText ?? '');
+          return m ? m[0] : null;
+        }),
+      20_000,
+    );
+    results.push(
+      check(
+        'DEVICE_REGISTERED_VIA_UI',
+        'device registered and activation code shown in the dialog',
+        activationCode !== null,
+        activationCode
+          ? `Activation code ${activationCode} read off the dialog (expires in 5 min).`
+          : 'The register dialog never showed an activation code.',
+      ),
+    );
+    if (!activationCode) throw new Error('no activation code');
+    artifacts.activationCode = activationCode;
+    await clickByText(adminPage, 'done', '.MuiDialog-root');
+    await sleep(500);
+
+    // ---- Create a room with that device as source ----------------------
+    log('--- [admin] Rooms -> New room');
+    await adminPage.goto(`${args.baseUrl}/admin/rooms`, {
+      waitUntil: 'networkidle2',
+    });
+    if (!(await clickByText(adminPage, 'new room'))) {
+      throw new Error('no "New room" button on /admin/rooms');
+    }
+    await adminPage.waitForSelector('.MuiDialog-root input', { visible: true });
+    await adminPage.type('.MuiDialog-root input', `${stamp}-room`);
+    // Source device is a MUI Select; open it and pick our freshly-made device
+    // by name (the list is loaded async, so wait for the option).
+    await adminPage.click(
+      '.MuiDialog-root [role="combobox"], .MuiDialog-root .MuiSelect-select',
+    );
+    const picked = await until(
+      () =>
+        clickByText(
+          adminPage,
+          `${stamp}-kiosk`,
+          '.MuiPopover-root, .MuiMenu-root',
+        ),
+      15_000,
+    );
+    if (!picked) throw new Error('device never appeared in the source picker');
+    await sleep(300);
+    await clickByText(adminPage, 'create', '.MuiDialog-root');
+    // Filter the list to our room and open it.
+    await adminPage.waitForSelector('input[type="text"]', { visible: true });
+    await adminPage.type('input[type="text"]', `${stamp}-room`);
+    const roomRow = await until(
+      () =>
+        adminPage.evaluate((needle) => {
+          const row = [...document.querySelectorAll('tbody tr')].find((r) =>
+            (r.innerText ?? '').includes(needle),
+          );
+          if (!row) return false;
+          row.click();
+          return true;
+        }, `${stamp}-room`),
+      20_000,
+    );
+    if (roomRow) {
+      await until(
+        () =>
+          adminPage.evaluate(() =>
+            /^\/admin\/rooms\/[0-9a-f-]{8,}/.test(window.location.pathname),
+          ),
+        15_000,
+      );
+      roomUid = await adminPage.evaluate(
+        () => window.location.pathname.split('/')[3] ?? null,
+      );
+    }
+    results.push(
+      check(
+        'ROOM_CREATED_VIA_UI',
+        'room created from the New room dialog with the device as source',
+        roomUid !== null,
+        roomUid
+          ? `Room ${roomUid} created and opened from the rooms table.`
+          : 'The new room never appeared in the rooms table.',
+      ),
+    );
+    if (!roomUid) throw new Error('room creation failed');
+    artifacts.roomUid = roomUid;
+
+    // =====================================================================
+    // Kiosk browser: activate the device through the real kiosk webapp.
+    // Fake audio capture device, microphone pre-granted.
+    // =====================================================================
+    log('--- [kiosk] activating the device in the real kiosk webapp');
+    kiosk = await launch([
+      '--use-fake-device-for-media-stream',
+      '--use-fake-ui-for-media-stream',
+      `--use-file-for-fake-audio-capture=${WAV}`,
+      '--autoplay-policy=no-user-gesture-required',
+    ]);
+    // Pre-grant the microphone. Without this the kiosk stops at INFO_PROMPT
+    // waiting for a second activation call, which reads as "connected but
+    // silent" — the same symptom as a genuine audio fault.
+    await kiosk
+      .defaultBrowserContext()
+      .overridePermissions(args.baseUrl, ['microphone']);
+    kioskPage = await kiosk.newPage();
+    kioskPage.setDefaultTimeout(20_000);
+    const kioskNet = {
+      sourceSocketOpen: false,
+      binaryFrames: 0,
+    };
+    const kioskCdp = await kioskPage.createCDPSession();
+    await kioskCdp.send('Network.enable');
+    kioskPage.on('framenavigated', (frame) => {
+      if (frame === kioskPage.mainFrame()) {
+        kioskCdp.send('Network.enable').catch(() => {});
+      }
+    });
+    kioskCdp.on('Network.webSocketCreated', (e) => {
+      if (e.url.includes('/transcription-stream/'))
+        kioskNet.sourceSocketOpen = true;
+    });
+    kioskCdp.on('Network.webSocketFrameSent', (e) => {
+      if (e.response.opcode === 2) kioskNet.binaryFrames++;
+    });
+
+    await kioskPage.goto(`${args.baseUrl}/kiosk/`, {
+      waitUntil: 'networkidle2',
+      timeout: 60_000,
+    });
+    const needsActivation = await until(
+      () =>
+        kioskPage.evaluate(() =>
+          document.body.innerText.includes('not registered'),
+        ),
+      20_000,
+    );
+    if (!needsActivation) {
+      throw new Error('kiosk did not offer the activation form');
+    }
+    await kioskPage.type('input', activationCode);
+    await clickByText(kioskPage, 'activate');
+    const activated = await until(
+      () =>
+        kioskPage.evaluate(
+          () => !document.body.innerText.includes('not registered'),
+        ),
+      30_000,
+    );
+    results.push(
+      check(
+        'KIOSK_ACTIVATED_VIA_UI',
+        'device activated by typing the code into the kiosk webapp',
+        !!activated,
+        activated
+          ? 'Kiosk left the activation form; device is bound to this browser.'
+          : 'Kiosk still shows the activation form.',
+      ),
+    );
+    if (!activated) throw new Error('kiosk activation failed');
+
+    // Park the kiosk. The whole point of the headline assertion is that the
+    // viewer is watching a room whose microphone has NOT connected yet, and
+    // the kiosk opens its source socket the moment a session goes active — so
+    // it must be off the page while the session starts. Cookies survive.
+    log('--- [kiosk] parking the kiosk so the room stays source-free');
+    await kioskPage.goto('about:blank');
+
+    // =====================================================================
+    // Start the session, then get the viewer URL off the session page.
+    // =====================================================================
+    log('--- [admin] Manage scheduling -> Start a session now');
+    await adminPage.goto(`${args.baseUrl}/admin/rooms/${roomUid}/scheduling`, {
+      waitUntil: 'networkidle2',
+    });
+    if (!(await clickByText(adminPage, 'start a session now'))) {
+      throw new Error('no "Start a session now" button on the scheduling page');
+    }
+    await adminPage.waitForSelector('.MuiDialog-root input', { visible: true });
+    await adminPage.type('.MuiDialog-root input', `${stamp}-session`);
+    await clickByText(adminPage, 'start session', '.MuiDialog-root');
+    // The dialog navigates to /admin/sessions/:uid on success.
+    const sessionUid = await until(
+      () =>
+        adminPage.evaluate(() => {
+          const m = /^\/admin\/sessions\/([0-9a-f-]{8,})/.exec(
+            window.location.pathname,
+          );
+          return m ? m[1] : null;
+        }),
+      30_000,
+    );
+    results.push(
+      check(
+        'SESSION_STARTED_VIA_UI',
+        'on-demand session started from the scheduling page',
+        sessionUid !== null,
+        sessionUid
+          ? `Session ${sessionUid}; the dialog navigated straight to its detail page.`
+          : 'Never landed on a session detail page.',
+      ),
+    );
+    if (!sessionUid) throw new Error('session creation failed');
+    artifacts.sessionUid = sessionUid;
+
+    // Join codes are minted lazily — this page (and the fleet panel) are the
+    // only things that mint one, which is exactly the step the demo runbook
+    // was missing.
+    log(
+      '--- [admin] reading the "Open live captions" link (mints a join code)',
+    );
+    const joinUrl = await until(
+      () =>
+        adminPage.evaluate(() => {
+          const a = [...document.querySelectorAll('a')].find((el) =>
+            /open live captions/i.test(el.textContent ?? ''),
+          );
+          return a ? a.getAttribute('href') : null;
+        }),
+      60_000,
+    );
+    results.push(
+      check(
+        'JOIN_URL_FROM_SESSION_PAGE',
+        '"Open live captions" offers a viewer URL (lazy join-code mint)',
+        joinUrl !== null,
+        joinUrl
+          ? `Viewer URL: ${joinUrl}`
+          : 'The session page never rendered a join link within 60s.',
+      ),
+    );
+    if (!joinUrl) throw new Error('no join URL');
+    artifacts.joinUrl = joinUrl;
+    screenshots.push(
+      await shot(
+        adminPage,
+        args.screenshotDir,
+        args.prefix,
+        '00-admin-session-detail',
+        log,
+      ),
+    );
+
+    // =====================================================================
+    // Viewer browser: join BEFORE the kiosk is anywhere near the room.
+    // =====================================================================
+    log('--- [client] opening the viewer URL');
+    client = await launch();
+    clientPage = await client.newPage();
+    clientPage.setDefaultTimeout(20_000);
+    // Instrument from about:blank and go straight to the join URL. Loading
+    // `/client/` first and *then* navigating to `/client/#config=…` looks
+    // equivalent but is not: a fragment-only change is a same-document
+    // navigation, the app never re-initializes, and the config middleware
+    // (which runs once, on redux-remember rehydration) never sees the code.
+    clientNet = await instrumentClient(clientPage);
+    await clientPage.goto(joinUrl, {
+      waitUntil: 'networkidle2',
+      timeout: 60_000,
+    });
+
+    // The app consumes the fragment, reloads once, then auto-joins; the Join
+    // Session dialog closes when the lifecycle reaches ACTIVE.
+    const joined = await until(
+      () =>
+        clientPage.evaluate(
+          () => !document.body.innerText.includes('Join Session'),
+        ),
+      60_000,
+    );
+    const joinDialogError = joined
+      ? null
+      : await clientPage.evaluate(() => {
+          const a = document.querySelector('.MuiDialog-root [role="alert"]');
+          return a ? (a.innerText ?? '').trim() : null;
+        });
+    results.push(
+      check(
+        'VIEWER_JOINED_VIA_URL',
+        'viewer joined from the admin-provided link with no typing',
+        !!joined,
+        joined
+          ? 'Join Session dialog closed; the client is ACTIVE.'
+          : `Join Session dialog never closed. Dialog error: ${joinDialogError ?? '(none rendered)'}`,
+      ),
+    );
+    if (!joined) throw new Error('viewer never joined');
+
+    // -------------------------------------------------------------------
+    // THE HEADLINE ASSERTION.
+    // A healthy room with nobody talking yet. Before this branch this state
+    // rendered "Connection to the transcription service was lost.
+    // Reconnecting…" as a role="alert" warning, and stayed up forever.
+    // -------------------------------------------------------------------
+    log('--- [client] reading the idle banner (source-free room)');
+    const idleBanner = await until(
+      () => readBanner(clientPage).then((b) => (b?.text ? b : null)),
+      30_000,
+    );
+    screenshots.push(
+      await shot(
+        clientPage,
+        args.screenshotDir,
+        args.prefix,
+        '01-idle-waiting-for-microphone',
+        log,
+      ),
+    );
+    const bannerText = idleBanner?.text ?? '(no banner)';
+    const bannerRole = idleBanner?.role ?? '(none)';
+    results.push(
+      check(
+        'IDLE_BANNER_IS_INFORMATIONAL',
+        'idle room reads "Waiting for the room\'s microphone to connect."',
+        idleBanner !== null && bannerText === IDLE_BANNER,
+        `role="${bannerRole}" text=${JSON.stringify(bannerText)}`,
+      ),
+    );
+    results.push(
+      check(
+        'IDLE_BANNER_NOT_A_FAULT',
+        'idle banner never says "reconnecting" and is polite, not assertive',
+        !/reconnect/i.test(bannerText) && bannerRole === 'status',
+        `role="${bannerRole}" (want "status"); "reconnect" present: ${/reconnect/i.test(bannerText)}`,
+      ),
+    );
+
+    // =====================================================================
+    // Bring the kiosk back and stream.
+    // =====================================================================
+    log('--- [kiosk] reopening the kiosk; it should find the live session');
+    await kioskPage.goto(`${args.baseUrl}/kiosk/`, {
+      waitUntil: 'networkidle2',
+      timeout: 60_000,
+    });
+    const sourceUp = await until(
+      () => kioskNet.sourceSocketOpen,
+      120_000,
+      1000,
+    );
+    if (!sourceUp) {
+      throw new Error(
+        'kiosk never opened a transcription-stream socket for the live session',
+      );
+    }
+    log('--- [kiosk] source socket open; enabling the microphone');
+    // The mic control is a toggle, so a fixed number of clicks is a coin flip.
+    // Click, then confirm audio is actually on the wire.
+    let streaming = false;
+    for (let attempt = 1; attempt <= 4 && !streaming; attempt++) {
+      const before = kioskNet.binaryFrames;
+      await clickByText(kioskPage, 'microphone');
+      await sleep(4000);
+      streaming = kioskNet.binaryFrames > before + 5;
+      log(
+        `    attempt ${attempt}: frames ${before} -> ${kioskNet.binaryFrames}`,
+      );
+    }
+    if (!streaming) {
+      throw new Error('microphone never started streaming from the kiosk');
+    }
+
+    log(`--- [client] streaming ${args.warmupSeconds}s; banner should clear`);
+    const bannerCleared = await until(
+      () => readBanner(clientPage).then((b) => b === null),
+      60_000,
+      1000,
+    );
+    results.push(
+      check(
+        'BANNER_CLEARS_WHEN_AUDIO_FLOWS',
+        'the waiting banner disappears once the room has a microphone',
+        !!bannerCleared,
+        bannerCleared
+          ? 'No banner rendered at all once the source connected.'
+          : `Banner still up: ${JSON.stringify(await readBanner(clientPage))}`,
+      ),
+    );
+
+    const transcriptText = await until(
+      () => readTranscript(clientPage).then((t) => (t.length > 0 ? t : null)),
+      args.warmupSeconds * 1000 + 60_000,
+      1000,
+    );
+    results.push(
+      check(
+        'TRANSCRIPT_RENDERED_IN_BROWSER',
+        "transcript text appears in the viewer's live-caption region",
+        transcriptText !== null,
+        transcriptText
+          ? `role="log" contains ${transcriptText.length} chars, e.g. ${JSON.stringify(transcriptText.slice(0, 80))}`
+          : 'The live-caption region stayed empty.',
+      ),
+    );
+    await sleep(Math.max(0, args.warmupSeconds * 1000 - 15_000));
+    screenshots.push(
+      await shot(
+        clientPage,
+        args.screenshotDir,
+        args.prefix,
+        '02-captions-flowing',
+        log,
+      ),
+    );
+    screenshots.push(
+      await shot(
+        kioskPage,
+        args.screenshotDir,
+        args.prefix,
+        '02b-kiosk-streaming',
+        log,
+      ),
+    );
+
+    // =====================================================================
+    // THE LONG-LIVED VIEWER. This is the assertion that only wall-clock time
+    // can make: the session token lives 5 minutes and, before 8ff4582, the
+    // refresh timer was never armed because the expiry was decoded from the
+    // wrong token segment.
+    // =====================================================================
+    const socketsAtStart = clientNet.socketsCreated;
+    const refreshesAtStart = clientNet.tokenRefreshes;
+    const windowStart = Date.now();
+    log(
+      `--- [client] holding the viewer for ${args.longLivedSeconds}s ` +
+        `(token TTL ${SESSION_TOKEN_TTL_SECONDS}s) with audio flowing`,
+    );
+    for (let elapsed = 0; elapsed < args.longLivedSeconds; ) {
+      const step = Math.min(30, args.longLivedSeconds - elapsed);
+      await sleep(step * 1000);
+      elapsed += step;
+      const banner = await readBanner(clientPage);
+      log(
+        `    t+${elapsed}s sockets=${clientNet.socketsCreated} ` +
+          `refreshes=${clientNet.tokenRefreshes} ` +
+          `transcripts=${clientNet.transcriptAtMs.length} ` +
+          `banner=${banner ? JSON.stringify(banner.text) : 'none'}`,
+      );
+    }
+    const windowEnd = Date.now();
+    screenshots.push(
+      await shot(
+        clientPage,
+        args.screenshotDir,
+        args.prefix,
+        '03-long-lived-viewer',
+        log,
+      ),
+    );
+
+    const extraSockets = clientNet.socketsCreated - socketsAtStart;
+    const refreshes = clientNet.tokenRefreshes - refreshesAtStart;
+    const recentTranscripts = clientNet.transcriptAtMs.filter(
+      (t) => t > windowEnd - 90_000,
+    ).length;
+    const finalBanner = await readBanner(clientPage);
+
+    results.push(
+      check(
+        'LONG_LIVED_VIEWER_NEVER_RECONNECTS',
+        `viewer survives ${Math.round((windowEnd - windowStart) / 1000)}s on one socket ` +
+          `(token TTL ${SESSION_TOKEN_TTL_SECONDS}s)`,
+        extraSockets === 0,
+        `${extraSockets} additional transcription-stream socket(s) opened during the window ` +
+          `(want 0; a reconnect loop is what the dead refresh timer used to cause).`,
+      ),
+    );
+    results.push(
+      check(
+        'TOKEN_REFRESH_TIMER_ARMED',
+        'the proactive session-token refresh actually fires (8ff4582)',
+        refreshes >= 1,
+        `${refreshes} refresh-session-token call(s) in the window. Before the fix the ` +
+          `timer was never armed and this would be 0.`,
+      ),
+    );
+    results.push(
+      check(
+        'TRANSCRIPTS_STILL_FLOWING_AFTER_TOKEN_TTL',
+        'transcripts keep arriving past the token lifetime',
+        recentTranscripts > 0 && finalBanner === null,
+        `${recentTranscripts} transcript frames in the last 90s; ` +
+          `banner=${finalBanner ? JSON.stringify(finalBanner.text) : 'none'}`,
+      ),
+    );
+
+    // =====================================================================
+    // End the session from the admin UI; the viewer should say so and go back
+    // to the join prompt rather than hang or reconnect-loop.
+    // =====================================================================
+    log('--- [admin] End early on the session detail page');
+    await adminPage.goto(`${args.baseUrl}/admin/sessions/${sessionUid}`, {
+      waitUntil: 'networkidle2',
+    });
+    const endClicked = await until(
+      () => clickByText(adminPage, 'end early'),
+      20_000,
+    );
+    if (!endClicked)
+      throw new Error('no "End early" button on the session page');
+    await adminPage.waitForSelector('.MuiDialog-root', { visible: true });
+    await clickByText(adminPage, 'end early', '.MuiDialog-root');
+
+    const backToJoin = await until(
+      () =>
+        clientPage.evaluate(() =>
+          document.body.innerText.includes('Join Session'),
+        ),
+      60_000,
+      1000,
+    );
+    screenshots.push(
+      await shot(
+        clientPage,
+        args.screenshotDir,
+        args.prefix,
+        '04-session-ended-join-prompt',
+        log,
+      ),
+    );
+    // What, if anything, the viewer is told about *why* the session ended.
+    // Recorded rather than asserted: the branch's fix is "don't hang", and
+    // node-server's end-watch (bc37f92) is what makes the prompt come back at
+    // all. Whether the client explains it is a separate, still-open finding —
+    // see the README.
+    const endExplanation = await clientPage.evaluate(() => {
+      const dlg = document.querySelector('.MuiDialog-root');
+      const alertEl = dlg?.querySelector('[role="alert"]');
+      const banner = [
+        ...document.querySelectorAll('[role="status"],[role="alert"]'),
+      ]
+        .filter((n) => window.getComputedStyle(n).position === 'fixed')
+        .map((n) => (n.innerText ?? '').trim())
+        .filter((t) => t.length > 0);
+      return {
+        dialogAlert: alertEl ? (alertEl.innerText ?? '').trim() : null,
+        fieldInErrorState: !!dlg?.querySelector('.Mui-error'),
+        banners: banner,
+      };
+    });
+    results.push(
+      check(
+        'SESSION_END_RETURNS_VIEWER_TO_JOIN_PROMPT',
+        'ending the session drops the viewer back to the join prompt',
+        !!backToJoin,
+        backToJoin
+          ? 'Join Session dialog reopened after the server closed the socket (1000). ' +
+              `Explanation shown to the viewer: ${JSON.stringify(endExplanation)}`
+          : 'The viewer never returned to the join prompt — it hung on the ended session.',
+      ),
+    );
+  } catch (err) {
+    results.push({
+      id: 'HARNESS_ERROR',
+      name: 'harness',
+      ok: false,
+      detail: err?.stack || String(err),
+    });
+    // A failure screenshot is worth more than the stack alone.
+    for (const [name, page] of [
+      ['zz-failure-client', clientPage],
+      ['zz-failure-admin', adminPage],
+      ['zz-failure-kiosk', kioskPage],
+    ]) {
+      if (!page) continue;
+      try {
+        screenshots.push(
+          await shot(page, args.screenshotDir, args.prefix, name, log),
+        );
+      } catch {
+        // page may already be gone
+      }
+    }
+  } finally {
+    if (adminPage && roomUid && !args.keepRoom) {
+      try {
+        await adminPage.goto(`${args.baseUrl}/admin/rooms/${roomUid}`, {
+          waitUntil: 'networkidle2',
+        });
+        await clickByText(adminPage, 'delete room');
+        await sleep(500);
+        await clickByText(adminPage, 'delete', '.MuiDialog-root');
+        await sleep(1500);
+        log(`--- [admin] deleted room ${roomUid}`);
+      } catch (e) {
+        log(`--- cleanup failed: ${e.message}`);
+      }
+    } else if (roomUid) {
+      log(`--- kept room ${roomUid} (--keep-room)`);
+    }
+    for (const b of [client, kiosk, admin]) {
+      if (b) await b.close().catch(() => {});
+    }
+  }
+
+  const failures = results.filter((r) => !r.ok);
+  const summary = {
+    ok: failures.length === 0,
+    total: results.length,
+    passed: results.length - failures.length,
+    failed: failures.length,
+    artifacts,
+    screenshots,
+    clientNetwork: clientNet
+      ? {
+          socketsCreated: clientNet.socketsCreated,
+          socketsClosed: clientNet.socketsClosed,
+          undefinedSessionSockets: clientNet.undefinedSessionSockets,
+          transcriptFrames: clientNet.transcriptAtMs.length,
+          tokenRefreshes: clientNet.tokenRefreshes,
+          consoleErrors: clientNet.consoleErrors.slice(0, 20),
+        }
+      : null,
+    results,
+  };
+
+  if (args.json) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    console.log('\n=== RESULT ===');
+    for (const r of results) {
+      console.log(`[${r.ok ? 'PASS' : 'FAIL'}] ${r.id}: ${r.name}`);
+      if (r.detail) console.log(`        ${r.detail}`);
+    }
+    console.log('\nScreenshots:');
+    for (const s of screenshots) console.log(`  ${s}`);
+    console.log(`\n${summary.passed}/${summary.total} checks passed.`);
+  }
+  process.exit(summary.ok ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(
+    err instanceof Error ? (err.stack ?? err.message) : String(err),
+  );
+  process.exit(2);
+});

--- a/tools/demo-e2e/README.md
+++ b/tools/demo-e2e/README.md
@@ -1,0 +1,182 @@
+# Two-room demo end-to-end check
+
+Provisions two **real** rooms against a running stack, streams real audio into
+each from a headless source device, and asserts that a real viewer socket — one
+that joined with a join code, exactly as a browser does — sees the room come out
+of idle and produce captions.
+
+Unlike `tools/e2e-audio` and `tools/admin-scheduling-e2e`, this drives no
+browser. It is the socket-level counterpart: everything a demo needs, minus the
+rendering. It also doubles as the provisioning script for a live demo — see
+`--hold`.
+
+## Why
+
+The demo this was written for failed with every real room stuck on
+_"Reconnecting…"_ while the backend was entirely healthy. The hardcoded Alice
+demo room worked, and every unit and integration test passed, so nothing pointed
+at the fault. The cause was that the **idle** state — `sourceDeviceConnected:
+false`, which is what a room looks like before anyone starts talking — was
+rendered as a lost connection, and the demo room was immune because its
+synthetic caption source hardcodes both status flags to `true`.
+
+Nothing in CI can see that, because seeing it requires a room somebody just
+created, a source that connects _after_ a viewer is already watching, and an
+observer of the `sessionStatus` sequence. That is what this is.
+
+So the assertions are about the **status transitions**, not only about
+transcript text:
+
+| #   | Assertion                                              | What a failure means                                                                                |
+| --- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| 1   | viewer gets `authOk`                                   | join-code exchange or the `/client` route is broken                                                 |
+| 2   | the first `sessionStatus` is idle (both flags `false`) | the seed state changed; the "not yet known" case is being conflated again                           |
+| 3   | `sourceDeviceConnected` goes `false` → `true`          | the headless source never registered                                                                |
+| 4   | `transcriptionServiceConnected` goes `false` → `true`  | node-server never reached a provider (or was refused — see capacity below)                          |
+| 5   | the source flag **led** the service flag               | node-server dials the upstream from `registerSource`; the reverse order means that contract changed |
+| 6   | a `transcript` arrives with non-empty `final.text`     | audio reached a provider but produced nothing                                                       |
+
+Room A exercises an **on-demand** session; room B exercises an **AUTO** session
+materialized from an auto-session window covering now. Both paths matter and
+they fail differently.
+
+## Run
+
+```bash
+# Needs the stack up, and a built repo (`npm run build`) — the source device is
+# the real @scribear/test-audio-source engine, not a copy of it.
+npm run e2e:demo
+```
+
+```bash
+node tools/demo-e2e/demo-e2e.mjs \
+  --base-url https://localhost \
+  --rooms 2 \
+  --stream-seconds 90 \
+  --json
+```
+
+Exits non-zero and names the failing assertion. Prints, per room, the room uid,
+session uid, join code and the full `/client/#config=…` URL — so a human can
+open the same rooms in a browser and watch the run they are asserting on.
+
+### Live demo mode
+
+```bash
+npm run e2e:demo -- --hold
+```
+
+Runs the assertions, then keeps both rooms alive with audio flowing and prints a
+**freshly minted join code and viewer URL** each time the previous one expires
+— join codes live five minutes. Ctrl-C prints the assertion report and stops the
+audio; the rooms are left in place.
+
+The refresh is keyed off each code's own `validEnd`, not a fixed interval, and
+that distinction is load-bearing: `admin-fetch-join-code` does not rotate on
+demand. It returns the code covering _now_ and mints a new one only once none is
+current. Polling it every four minutes reprints the _same_ code with a minute of
+life left and then goes quiet for another four — an operator following that
+output would be handing out links that die a minute later.
+
+## Options
+
+| Flag               | Default             | Meaning                                                                |
+| ------------------ | ------------------- | ---------------------------------------------------------------------- |
+| `--base-url`       | `https://localhost` | stack origin (self-signed certs accepted)                              |
+| `--rooms`          | `2`                 | how many rooms. A = on-demand, B = AUTO, the rest on-demand            |
+| `--stream-seconds` | `90`                | how long to wait for every assertion before declaring failure          |
+| `--hold`           | off                 | live-demo mode: never tear down, keep streaming, keep refreshing codes |
+| `--keep`           | off                 | run the assertions, then leave the rooms in place                      |
+| `--env-file`       | —                   | where to read `SESSION_MANAGER_API_KEY` / `ORIGIN` from                |
+| `--json`           | off                 | machine-readable result                                                |
+
+Keys default from `<repo>/deployment/.env`, then `<repo>/../deployment/.env`;
+`SESSION_MANAGER_API_KEY` in the process environment wins over both. The viewer
+URLs use `ORIGIN` from that file when present, so the printed links are the ones
+a browser on another machine can actually open.
+
+## Notes
+
+The non-obvious constraints this tool encodes, each of which cost real time to
+find:
+
+- **`test-audio-generator` cannot be pointed at rooms you create.** A device
+  token reaches only its own device's room, and the two synthetic devices are
+  pinned to `TEST-AUDIO-GOOD` / `TEST-AUDIO-FAULT` by reserved uid, with
+  `room-management` refusing to move them. That restriction is the safety
+  boundary for synthetic audio, not an oversight — so a demo harness has to
+  bring its own source. This one registers a throwaway device per room and
+  drives it with `@scribear/test-audio-source`, the same engine the canary and
+  those two devices run on.
+
+- **Join codes are minted lazily.** Creating a session does not create a code,
+  and the room detail page does not show one — only
+  `POST /session-auth/admin-fetch-join-code` (or an operator opening
+  `/admin/sessions/:uid`) mints one. This was the missing step in the demo
+  runbook: the operator had a live session and no way to get anyone into it.
+  Codes live 5 minutes and rotate.
+
+- **The viewer URL is a hash fragment, not a query parameter**, and the
+  trailing slash on `/client/` is load-bearing:
+  `{origin}/client/#config=<base64(JSON.stringify({clientSessionConfig:{joinCode}}))>`.
+  The app consumes the fragment and reloads once.
+
+- **Activation codes are single-use and expire in 5 minutes**, so
+  `register-device` and `activate-device` are adjacent calls here with nothing
+  between them. `activate-device` is unauthenticated — the activation code is
+  the credential — and it reveals the device secret exactly once, in a
+  `Set-Cookie` header rather than the response body.
+
+- **An AUTO window needs its `activeStart` backdated by more than "a bit".**
+  The materializer drops any occurrence whose _start_ precedes `activeStart`
+  (`inRange`, `schedule-materializer.ts`); only surviving occurrences are then
+  clipped to `now`. A window created at 16:39 UTC with `activeStart` one hour
+  earlier therefore loses today's 00:00 occurrence entirely and materializes
+  its first AUTO session **tomorrow**. This tool backdates a week. (Separately,
+  the admin console's window dialog forces `activeStart` into the future, so a
+  window created through the UI has the same problem for a different reason;
+  the API accepts a past start.)
+
+- **One source device per room, one room per device, one active session per
+  room** — enforced by DB triggers and an exclusion constraint. Each run
+  provisions a fresh device per room and deletes room-then-device on exit
+  (the room must go first: a device cannot be deleted while it is its room's
+  source).
+
+- **The viewer is a separate socket on the `/client` route.** A source token
+  also carries `RECEIVE_TRANSCRIPTIONS`, so it is tempting to read captions
+  back on the source socket — but that skips the fan-out path, and a pass would
+  then be a claim about a code path no real viewer takes.
+
+### Capacity
+
+`transcription-service` admits sessions against a per-worker estimate
+(`capacity_estimator.py`), and `provider_config.json` ships `num_workers: 1`.
+The estimate is **not** a fixed number: it starts low on a cold process and
+ratchets up as measured per-session cost comes in. It was `2` on this box during
+the investigation that prompted this tool, and `52` after a redeploy and warm-up
+— so `--rooms 2` is not inherently at the ceiling, and neither is `--rooms 3`.
+
+When admission _is_ refused, the failure is easy to misread as a generic
+connection fault: the transcription service closes **1013**, node-server
+publishes `sessionStatus` with `transcriptionServiceDisconnectReason:
+"at-capacity"`, and the viewer shows another reconnecting-flavoured banner. This
+tool watches for both and reports `capacityRefusal` separately from the ordinary
+assertions, with the ceiling named. Use `--rooms N` to probe it deliberately;
+`/providers/health` (needs `TRANSCRIPTION_METRICS_KEY`) reports the live
+`estimatedCapacitySessions`.
+
+### Known limitations
+
+- **`--hold` closes the harness's own viewer sockets** once the assertions have
+  passed. Their session tokens expire in 5 minutes and this tool implements no
+  refresh; the browser is the viewer for the rest of a held demo. The sources
+  _are_ refreshed — the streamer re-authenticates every 4 minutes, at the cost
+  of a sub-second gap in audio between segments.
+- The assertions stop as soon as every room has satisfied them, which is
+  typically 5–10 seconds in, so `framesSent` in the report is a few dozen rather
+  than a full `--stream-seconds` worth. `--hold` is the way to keep audio
+  running.
+- Rooms are only cleaned up by the process that created them. A run killed with
+  `SIGKILL` leaves a room and a device behind; they are named
+  `demo-<pid>-<epoch>-<label>` so they are easy to find and delete.

--- a/tools/demo-e2e/demo-e2e.mjs
+++ b/tools/demo-e2e/demo-e2e.mjs
@@ -1,0 +1,866 @@
+/**
+ * Two-room live demo harness: provisions real rooms, streams real audio into
+ * them from headless source devices, and asserts a real viewer sees captions.
+ *
+ * Usage:
+ *   node tools/demo-e2e/demo-e2e.mjs [options]
+ *
+ * Options:
+ *   --base-url <url>       default https://localhost (self-signed certs accepted)
+ *   --rooms <n>            default 2. Room A is on-demand, room B is an AUTO
+ *                          session from an auto-session window covering now;
+ *                          any further rooms are on-demand. Raise it to probe
+ *                          the transcription-service admission ceiling on
+ *                          purpose.
+ *   --stream-seconds <n>   default 90. How long to wait for every assertion in
+ *                          a room to be satisfied before calling it a failure.
+ *   --hold                 do not tear down. Keeps audio flowing and reprints a
+ *                          freshly minted join code / viewer URL before the old
+ *                          one expires, until Ctrl-C. This is the live-demo mode.
+ *   --keep                 run the assertions, then leave the rooms in place.
+ *   --env-file <path>      where to read SESSION_MANAGER_API_KEY / ORIGIN from.
+ *                          Defaults to <repo>/deployment/.env, then
+ *                          <repo>/../deployment/.env.
+ *   --json                 machine-readable result on stdout
+ *
+ * Why this exists: every part of this system has a test except the one thing a
+ * demo actually needs — a room somebody just created, with captions arriving in
+ * a browser. The demo that prompted this failed with a viewer stuck on
+ * "Reconnecting…" while the backend was entirely healthy, because the *idle*
+ * state (`sourceDeviceConnected: false`) was rendered as a fault. Nothing in CI
+ * could see that: it needs a real room, a real source, and a real viewer socket
+ * observing the transition out of idle.
+ *
+ * So the assertions here are deliberately about the `sessionStatus` sequence
+ * and not only about transcript text:
+ *
+ *   1. the viewer authenticates (`authOk`);
+ *   2. the first status is the idle one (both flags false) — the state that was
+ *      being mis-rendered;
+ *   3. `sourceDeviceConnected` goes false -> true, and only then does
+ *      `transcriptionServiceConnected` go false -> true. The order is pinned:
+ *      node-server dials the transcription service *from* `registerSource`, so
+ *      any build where the service flag leads the source flag has changed that
+ *      contract;
+ *   4. at least one `transcript` arrives with non-empty `final.text`.
+ *
+ * Requires a running stack and a built repo (`npm run build`) — the source
+ * device is `@scribear/test-audio-source`, the same engine the canary and the
+ * operator test-audio devices run on, rather than a second implementation of
+ * device auth, WAV chunking and SAFP framing that could drift from it.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  TRANSCRIPTION_STREAM_CLIENT_ROUTE,
+  TranscriptionServiceDisconnectReason,
+  TranscriptionStreamServerMessageType,
+} from '@scribear/node-server-schema';
+import { DEVICE_TOKEN_COOKIE_NAME } from '@scribear/session-manager-schema';
+import {
+  DeviceAuthClient,
+  GOOD_PARAM_DEFAULTS,
+  GoodEngine,
+  TestAudioStream,
+  connectStreamSocket,
+  createSeededRng,
+  decodeWav,
+  sliceIntoChunks,
+  waitForSocketOpen,
+} from '@scribear/test-audio-source';
+
+// The stack under test terminates TLS with a self-signed certificate, exactly
+// as the puppeteer-based harnesses assume (`acceptInsecureCerts`). Both `fetch`
+// and the global `WebSocket` honour this; neither opens a socket at import
+// time, so setting it here — after the hoisted imports — is early enough.
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+
+/** Speech fixture the synthetic sources loop. */
+const WAV = join(
+  REPO_ROOT,
+  'test_audio_files',
+  'speech',
+  'harvard_16k_mono.wav',
+);
+
+/** 100 ms matches the kiosk's `AUDIO_CHUNK_MS`, so frames look like a kiosk's. */
+const CHUNK_MS = 100;
+
+/**
+ * How long one streaming segment lasts before the source re-authenticates.
+ *
+ * A session token lives 5 minutes. The socket itself is only authenticated
+ * once, so an established stream outlives its token — but a *reconnect* after
+ * expiry would fail, which is precisely the state a long `--hold` demo would
+ * drift into. Re-running the streamer inside the token's lifetime mints a fresh
+ * one each cycle, at the cost of a sub-second gap in audio between segments.
+ */
+const SOURCE_SEGMENT_MS = 4 * 60 * 1000;
+
+/**
+ * How long after a join code's `validEnd` to ask for the next one.
+ *
+ * Deliberately keyed off the code's own expiry rather than a fixed interval,
+ * because `admin-fetch-join-code` does *not* rotate on demand: it returns the
+ * code covering `now` and mints a new one only once none is current
+ * (`_findOrMintCurrentJoinCode`). Polling it every four minutes therefore
+ * reprints the *same* code with 60 s of life left and then says nothing for
+ * another four minutes — an operator following the output would be handing out
+ * a link that dies a minute later.
+ */
+const JOIN_CODE_REFETCH_SLACK_MS = 2000;
+
+/** Every day, so the AUTO window covers "now" whatever day the demo runs on. */
+const ALL_DAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
+
+/**
+ * How far back the AUTO window's `activeStart` is placed.
+ *
+ * "In the past" is not enough, and getting this wrong costs an hour: the
+ * materializer drops any occurrence whose *start* precedes `activeStart`
+ * (`inRange` in `schedule-materializer.ts`), so a window created at 16:39 UTC
+ * with `activeStart` one hour earlier loses today's 00:00 occurrence entirely
+ * and the first AUTO session materialises tomorrow. The occurrence is clipped
+ * to `now` only once it has survived that test. A week back clears the
+ * day-boundary for any local start time in any timezone.
+ */
+const AUTO_WINDOW_BACKDATE_MS = 7 * 24 * 60 * 60 * 1000;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function parseArgs(argv) {
+  const args = {
+    baseUrl: 'https://localhost',
+    rooms: 2,
+    streamSeconds: 90,
+    hold: false,
+    keep: false,
+    envFile: '',
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === '--json') args.json = true;
+    else if (flag === '--hold') args.hold = true;
+    else if (flag === '--keep') args.keep = true;
+    else if (flag === '--base-url') args.baseUrl = argv[++i];
+    else if (flag === '--env-file') args.envFile = argv[++i];
+    else if (flag === '--rooms') args.rooms = Number(argv[++i]);
+    else if (flag === '--stream-seconds')
+      args.streamSeconds = Number(argv[++i]);
+    else throw new Error(`Unknown option ${flag}`);
+  }
+  if (!Number.isInteger(args.rooms) || args.rooms < 1) {
+    throw new Error('--rooms must be a positive integer');
+  }
+  return args;
+}
+
+/**
+ * Read the deployment env for the admin key and the public origin.
+ *
+ * A plain scan rather than a dotenv dependency, matching `tools/e2e-audio`. The
+ * default search order matters on a box where the *running* stack lives outside
+ * the repo: the checkout may have no `deployment/.env` at all, and the keys that
+ * work belong to whichever compose project is actually up.
+ */
+function loadDeploymentEnv(explicitPath) {
+  const candidates = [
+    explicitPath ? resolve(explicitPath) : null,
+    join(REPO_ROOT, 'deployment', '.env'),
+    join(REPO_ROOT, '..', 'deployment', '.env'),
+  ].filter(Boolean);
+
+  for (const path of candidates) {
+    if (!existsSync(path)) continue;
+    const env = {};
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      const match = /^\s*([A-Z0-9_]+)\s*=\s*(.*)$/.exec(line);
+      if (match) env[match[1]] = match[2].trim().replace(/^["']|["']$/g, '');
+    }
+    return { env, path };
+  }
+  throw new Error(
+    `No deployment .env found. Tried: ${candidates.join(', ')}. ` +
+      'Pass --env-file, or set SESSION_MANAGER_API_KEY in the environment.',
+  );
+}
+
+/** Thin session-manager client: admin-key calls plus the unauthenticated ones. */
+function createApi(baseUrl, adminKey) {
+  const root = `${baseUrl}/api/session-manager/v1`;
+
+  async function call(method, path, body, { auth }) {
+    const headers = { 'content-type': 'application/json' };
+    if (auth) headers.authorization = `Bearer ${adminKey}`;
+    const res = await fetch(`${root}/${path}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await res.text();
+    let parsed = null;
+    try {
+      parsed = text ? JSON.parse(text) : null;
+    } catch {
+      parsed = text;
+    }
+    if (!res.ok) {
+      const code = parsed?.code ? ` ${parsed.code}` : '';
+      const message = parsed?.message ? `: ${parsed.message}` : ` ${text}`;
+      throw new Error(
+        `${method} ${path} -> ${res.status}${code}${message.slice(0, 300)}`,
+      );
+    }
+    return { body: parsed, res };
+  }
+
+  return {
+    post: async (path, body) =>
+      (await call('POST', path, body, { auth: true })).body,
+    get: async (path) =>
+      (await call('GET', path, undefined, { auth: true })).body,
+    /** Routes that take no credential at all — the join code / activation code is the credential. */
+    postPublic: async (path, body) =>
+      await call('POST', path, body, { auth: false }),
+  };
+}
+
+/**
+ * Register a device and immediately activate it, returning its DEVICE_TOKEN.
+ *
+ * The two calls are adjacent on purpose: an activation code is single-use and
+ * expires 5 minutes after registration, so anything that separates them (a
+ * prompt, a slow room create) turns a rerun into a dead device.
+ *
+ * `activate-device` is the only place the 64-byte secret is ever revealed, and
+ * it is revealed in a `Set-Cookie` header rather than the body — which is why
+ * this reads `getSetCookie()` instead of the JSON.
+ */
+async function provisionDevice(api, name) {
+  const device = await api.post('device-management/register-device', { name });
+  const { res } = await api.postPublic('device-management/activate-device', {
+    activationCode: device.activationCode,
+  });
+
+  const cookies = res.headers.getSetCookie();
+  const prefix = `${DEVICE_TOKEN_COOKIE_NAME}=`;
+  const cookie = cookies.find((c) => c.startsWith(prefix));
+  if (!cookie) {
+    throw new Error(
+      `activate-device set no ${DEVICE_TOKEN_COOKIE_NAME} cookie (got: ${cookies.join(', ') || 'none'})`,
+    );
+  }
+  const value = decodeURIComponent(cookie.slice(prefix.length).split(';')[0]);
+  return { deviceUid: device.deviceUid, deviceToken: value };
+}
+
+/**
+ * Provision the device, room and session for one demo room.
+ *
+ * `record` is pushed to before each step that can fail, so a run that dies
+ * halfway still has enough in the caller's list for teardown to remove it.
+ */
+async function provisionRoom(api, { label, kind, stamp, log }, record) {
+  const name = `${stamp}-${label.toLowerCase()}`;
+  const room = {
+    label,
+    kind,
+    name,
+    device: null,
+    roomUid: null,
+    session: null,
+  };
+  record.push(room);
+
+  room.device = await provisionDevice(api, `${name}-src`);
+  log(
+    `--- [${label}] device ${room.device.deviceUid} registered and activated`,
+  );
+
+  const created = await api.post('room-management/create-room', {
+    name,
+    // UTC keeps the auto-session window's local times equal to wall-clock UTC,
+    // so "does the window contain now" needs no timezone arithmetic to reason
+    // about when a run fails.
+    timezone: 'UTC',
+    autoSessionEnabled: kind === 'auto',
+    sourceDeviceUids: [room.device.deviceUid],
+  });
+  room.roomUid = created.uid;
+  log(`--- [${label}] room ${room.roomUid} created (${kind})`);
+
+  if (kind === 'on-demand') {
+    room.session = await api.post(
+      'schedule-management/create-on-demand-session',
+      {
+        roomUid: room.roomUid,
+        name: `${name}-session`,
+        joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+        transcriptionProviderId: 'whisper',
+        transcriptionStreamConfig: {},
+      },
+    );
+  } else {
+    // A backdated `activeStart` is the whole trick: the admin dialog forces it
+    // into the future, so a window created through the UI may not materialise a
+    // slot until tomorrow. The API accepts a past start and reconciles a slot
+    // covering now immediately.
+    await api.post('schedule-management/create-auto-session-window', {
+      roomUid: room.roomUid,
+      localStartTime: '00:00',
+      localEndTime: '23:59',
+      daysOfWeek: ALL_DAYS,
+      activeStart: new Date(Date.now() - AUTO_WINDOW_BACKDATE_MS).toISOString(),
+      activeEnd: null,
+      joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+      transcriptionProviderId: 'whisper',
+      transcriptionStreamConfig: {},
+    });
+    room.session = await waitForActiveSession(api, room.roomUid, 30_000);
+  }
+  log(`--- [${label}] session ${room.session.uid} (${room.session.type})`);
+
+  return room;
+}
+
+/** Poll `get-active-session` until the reconciler has materialised a slot. */
+async function waitForActiveSession(api, roomUid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const session = await api.get(
+      `schedule-management/get-active-session/${roomUid}`,
+    );
+    if (session) return session;
+    if (Date.now() > deadline) {
+      throw new Error(
+        `No AUTO session materialised in room ${roomUid} within ${timeoutMs}ms. ` +
+          'Check that autoSessionEnabled is true and the window covers now.',
+      );
+    }
+    await sleep(1000);
+  }
+}
+
+/**
+ * Mint a join code for a session.
+ *
+ * Join codes are minted **lazily**: creating a session does not create one, and
+ * the room detail page does not show one. Nothing has a code until somebody
+ * reads it here (or opens `/admin/sessions/:uid`), which is the step that was
+ * missing from the demo runbook.
+ */
+async function fetchJoinCode(api, sessionUid) {
+  const result = await api.post('session-auth/admin-fetch-join-code', {
+    sessionUid,
+  });
+  if (result.status !== 'ok') {
+    throw new Error(
+      `admin-fetch-join-code returned "${result.status}" for ${sessionUid} ` +
+        '("not-active" = outside its effective window; "no-join-scopes" = the ' +
+        'session was created with an empty joinCodeScopes).',
+    );
+  }
+  return result;
+}
+
+/** The operator-facing link. A hash fragment, and the trailing slash matters. */
+function viewerUrl(origin, joinCode) {
+  const config = Buffer.from(
+    JSON.stringify({ clientSessionConfig: { joinCode } }),
+  ).toString('base64');
+  return `${origin}/client/#config=${config}`;
+}
+
+/**
+ * Open a viewer socket the way a browser viewer does: exchange the join code
+ * (unauthenticated — the code *is* the credential), then speak the client route.
+ *
+ * Deliberately not the source socket's own receive scope: a source token also
+ * carries `RECEIVE_TRANSCRIPTIONS`, but reading captions back on it would skip
+ * `/client` and the fan-out path, so a pass would be a claim about a code path
+ * no real viewer takes.
+ */
+async function openViewer(api, baseUrl, joinCode) {
+  const { body: exchanged } = await api.postPublic(
+    'session-auth/exchange-join-code',
+    { joinCode },
+  );
+
+  const observed = {
+    authOk: false,
+    statuses: [],
+    finals: [],
+    closes: [],
+    errors: [],
+    atCapacity: false,
+  };
+
+  const socket = connectStreamSocket(
+    baseUrl,
+    TRANSCRIPTION_STREAM_CLIENT_ROUTE,
+    exchanged.sessionUid,
+    exchanged.sessionToken,
+  );
+
+  // Registered synchronously, before the socket can have opened, so the
+  // very first `sessionStatus` — the idle one this harness exists to pin — is
+  // never missed.
+  socket.on('message', (msg) => {
+    if (msg.type === TranscriptionStreamServerMessageType.AUTH_OK) {
+      observed.authOk = true;
+    } else if (
+      msg.type === TranscriptionStreamServerMessageType.SESSION_STATUS
+    ) {
+      observed.statuses.push({
+        atMs: Date.now(),
+        source: msg.sourceDeviceConnected,
+        service: msg.transcriptionServiceConnected,
+        reason: msg.transcriptionServiceDisconnectReason ?? null,
+      });
+      if (
+        msg.transcriptionServiceDisconnectReason ===
+        TranscriptionServiceDisconnectReason.AT_CAPACITY
+      ) {
+        observed.atCapacity = true;
+      }
+    } else if (msg.type === TranscriptionStreamServerMessageType.TRANSCRIPT) {
+      const text = (msg.final?.text ?? []).join(' ').trim();
+      if (text) observed.finals.push(text);
+    }
+  });
+  socket.on('close', (code, reason) => {
+    observed.closes.push({ code, reason });
+    // 1013 is the transcription service refusing admission, relayed down.
+    if (code === 1013) observed.atCapacity = true;
+  });
+  socket.on('error', (err) => {
+    observed.errors.push(err instanceof Error ? err.message : String(err));
+  });
+
+  await waitForSocketOpen(socket, 15_000);
+  return { socket, observed, sessionUid: exchanged.sessionUid };
+}
+
+/** A logger shaped like `BaseLogger`, for the streaming engine's debug lines. */
+function quietLogger() {
+  const noop = () => {};
+  return {
+    trace: noop,
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+    fatal: noop,
+  };
+}
+
+/**
+ * Frames a source has put on the wire so far.
+ *
+ * Read live from the in-flight segment rather than only from finished ones:
+ * the assertions are evaluated while the stream is still running, so a
+ * segment-end-only total would report 0 on every passing run and be useless in
+ * the one case it matters — explaining a run with no transcript.
+ */
+function framesSent(state) {
+  return (
+    state.framesFromEndedSegments + (state.stream?.counters.framesSent ?? 0)
+  );
+}
+
+/**
+ * Drive a headless source into a room until `stopAtMs`, re-authenticating each
+ * segment. Never throws: the caller reports on the assertions either way, and
+ * an escaping error here would lose the viewer's evidence with it.
+ */
+async function runSource(room, chunks, baseUrl, stopAtMs, state) {
+  const auth = new DeviceAuthClient({
+    sessionManagerBaseUrl: baseUrl,
+    deviceToken: room.device.deviceToken,
+    timeoutMs: 10_000,
+  });
+  const engine = new GoodEngine(
+    GOOD_PARAM_DEFAULTS,
+    createSeededRng(room.roomUid.charCodeAt(0)),
+  );
+
+  let consecutiveErrors = 0;
+  while (!state.stopRequested && Date.now() < stopAtMs) {
+    const stream = new TestAudioStream(
+      { nodeServerBaseUrl: baseUrl, upstreamWaitMs: 20_000 },
+      auth,
+      engine,
+      quietLogger(),
+    );
+    state.stream = stream;
+    const deadline = Math.min(Date.now() + SOURCE_SEGMENT_MS, stopAtMs);
+    const result = await stream.run(chunks, deadline);
+    state.framesFromEndedSegments += stream.counters.framesSent;
+    // Cleared so the live read in `framesSent` cannot double-count a segment
+    // that has already been rolled into the total.
+    state.stream = null;
+
+    if (result.error === null) {
+      consecutiveErrors = 0;
+      continue;
+    }
+    state.errors.push(result.error);
+    if (++consecutiveErrors >= 3) {
+      state.gaveUp = true;
+      return;
+    }
+    await sleep(2000);
+  }
+}
+
+/** Turn a room's observations into named, ordered assertions. */
+function evaluate(room, observed, source) {
+  const checks = [];
+  const push = (name, ok, detail) => checks.push({ name, ok, detail });
+
+  push(
+    'viewer authenticated (authOk)',
+    observed.authOk,
+    observed.authOk
+      ? 'Join code exchanged and the client socket was accepted.'
+      : `No authOk. closes=${JSON.stringify(observed.closes)} errors=${observed.errors.join('; ')}`,
+  );
+
+  const first = observed.statuses[0] ?? null;
+  push(
+    'first sessionStatus is the idle state (both flags false)',
+    first !== null && first.source === false && first.service === false,
+    first === null
+      ? 'No sessionStatus was ever received.'
+      : `first status: sourceDeviceConnected=${first.source}, transcriptionServiceConnected=${first.service}`,
+  );
+
+  const sourceAt = observed.statuses.findIndex((s) => s.source === true);
+  const serviceAt = observed.statuses.findIndex((s) => s.service === true);
+  push(
+    'sourceDeviceConnected went false -> true',
+    sourceAt !== -1,
+    sourceAt !== -1
+      ? `at status #${sourceAt}`
+      : `never; the headless source never registered. source errors: ${source.errors.join('; ') || 'none'}`,
+  );
+  push(
+    'transcriptionServiceConnected went false -> true',
+    serviceAt !== -1,
+    serviceAt !== -1
+      ? `at status #${serviceAt}`
+      : observed.atCapacity
+        ? 'never — the transcription service refused admission (at-capacity).'
+        : 'never; node-server never established an upstream connection.',
+  );
+  push(
+    'the source flag led the service flag',
+    sourceAt !== -1 && serviceAt !== -1 && sourceAt <= serviceAt,
+    sourceAt === -1 || serviceAt === -1
+      ? 'not applicable — one of the transitions never happened.'
+      : `sourceDeviceConnected at #${sourceAt}, transcriptionServiceConnected at #${serviceAt}. ` +
+          'node-server dials the upstream from registerSource, so the reverse order means that contract changed.',
+  );
+
+  push(
+    'a transcript arrived with non-empty final text',
+    observed.finals.length > 0,
+    observed.finals.length > 0
+      ? `${observed.finals.length} final fragment(s); first: "${observed.finals[0].slice(0, 80)}"`
+      : `no final transcript in the run window (${framesSent(source)} audio frames were sent).`,
+  );
+
+  return checks;
+}
+
+function statusTrail(observed) {
+  return observed.statuses
+    .map(
+      (s) =>
+        `${s.source ? 'S' : '-'}${s.service ? 'T' : '-'}${s.reason ? `(${s.reason})` : ''}`,
+    )
+    .join(' ');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const log = (...m) => {
+    if (!args.json) console.log(...m);
+  };
+
+  const { env, path: envPath } = loadDeploymentEnv(args.envFile);
+  const adminKey =
+    process.env.SESSION_MANAGER_API_KEY || env.SESSION_MANAGER_API_KEY;
+  if (!adminKey) {
+    throw new Error(`${envPath} has no SESSION_MANAGER_API_KEY.`);
+  }
+  const origin = env.ORIGIN || args.baseUrl;
+  log(`--- keys from ${envPath}; origin ${origin}`);
+
+  const api = createApi(args.baseUrl, adminKey);
+  const wav = decodeWav(readFileSync(WAV));
+  const chunks = sliceIntoChunks(wav, CHUNK_MS);
+
+  const stamp = `demo-${process.pid}-${Math.floor(Date.now() / 1000)}`;
+  const plans = Array.from({ length: args.rooms }, (_, i) => ({
+    label: String.fromCharCode(65 + i),
+    // Room B is the AUTO one; the rest are on-demand, so `--rooms 3` probes the
+    // admission ceiling without inventing a third session kind.
+    kind: i === 1 ? 'auto' : 'on-demand',
+  }));
+
+  const rooms = [];
+  const viewers = [];
+  const sources = [];
+  let capacityRefusal = false;
+
+  try {
+    // ---- Provision every room before opening any socket, so all the
+    // operator-facing artifacts can be printed together and a human can be
+    // watching in a browser before audio starts. ----
+    for (const plan of plans) {
+      await provisionRoom(api, { ...plan, stamp, log }, rooms);
+    }
+
+    for (const room of rooms) {
+      const code = await fetchJoinCode(api, room.session.uid);
+      room.joinCode = code.joinCode;
+      room.joinCodeValidEnd = code.validEnd;
+      room.viewerUrl = viewerUrl(origin, code.joinCode);
+    }
+
+    if (!args.json) {
+      console.log('');
+      for (const room of rooms) {
+        console.log(`=== room ${room.label} (${room.kind}) ===`);
+        console.log(`  room     : ${room.roomUid}`);
+        console.log(`  device   : ${room.device.deviceUid}`);
+        console.log(`  session  : ${room.session.uid}`);
+        console.log(
+          `  joinCode : ${room.joinCode}  (valid until ${room.joinCodeValidEnd})`,
+        );
+        console.log(`  viewer   : ${room.viewerUrl}`);
+      }
+      console.log('');
+    }
+
+    // ---- Viewers first. The idle-state assertion only means something if the
+    // viewer is listening before any source exists. ----
+    for (const room of rooms) {
+      log(`--- [${room.label}] opening viewer socket`);
+      viewers.push(await openViewer(api, args.baseUrl, room.joinCode));
+    }
+
+    // ---- Then the sources. ----
+    const stopAtMs = args.hold
+      ? Date.now() + 24 * 60 * 60 * 1000
+      : Date.now() + args.streamSeconds * 1000 + 15_000;
+    for (const room of rooms) {
+      const state = {
+        stopRequested: false,
+        gaveUp: false,
+        framesFromEndedSegments: 0,
+        errors: [],
+        stream: null,
+      };
+      sources.push(state);
+      log(`--- [${room.label}] starting headless source`);
+      // The rejection handler is attached here rather than where `done` is
+      // awaited in `finally`: a throw before then would otherwise surface as an
+      // unhandled rejection warning instead of a named source error.
+      state.done = runSource(room, chunks, args.baseUrl, stopAtMs, state).catch(
+        (err) => {
+          state.errors.push(err instanceof Error ? err.message : String(err));
+          state.gaveUp = true;
+        },
+      );
+    }
+
+    // ---- Wait for every room to satisfy every assertion, or time out. ----
+    const deadline = Date.now() + args.streamSeconds * 1000;
+    log(`--- waiting up to ${args.streamSeconds}s for transcripts`);
+    for (;;) {
+      const done = rooms.every((_, i) => {
+        const o = viewers[i].observed;
+        return (
+          o.statuses.some((s) => s.source) &&
+          o.statuses.some((s) => s.service) &&
+          o.finals.length > 0
+        );
+      });
+      // Any source that has given up has already failed the run, so there is
+      // nothing left to wait out — stop and report rather than burn the window.
+      const stuck = sources.some((s) => s.gaveUp);
+      if (done || stuck || Date.now() > deadline) break;
+      await sleep(500);
+    }
+
+    for (let i = 0; i < rooms.length; i++) {
+      rooms[i].checks = evaluate(rooms[i], viewers[i].observed, sources[i]);
+      rooms[i].statusTrail = statusTrail(viewers[i].observed);
+      rooms[i].transcript = viewers[i].observed.finals.join(' ');
+      rooms[i].framesSent = framesSent(sources[i]);
+      rooms[i].sourceErrors = sources[i].errors;
+      if (viewers[i].observed.atCapacity) capacityRefusal = true;
+    }
+
+    // ---- Live-demo mode: stop asserting, keep the room usable. ----
+    if (args.hold) {
+      // The harness viewers are instruments, not part of the demo, and their
+      // session tokens expire in 5 minutes with no refresh path here. Close
+      // them and let the browser be the viewer.
+      for (const viewer of viewers) viewer.socket.terminate(1000, 'hold');
+      console.log('\n--- --hold: streaming continues. Ctrl-C to stop.\n');
+      let stopped = false;
+      process.on('SIGINT', () => {
+        stopped = true;
+      });
+      for (const room of rooms) {
+        room.nextCodeFetchAtMs =
+          Date.parse(room.joinCodeValidEnd) + JOIN_CODE_REFETCH_SLACK_MS;
+      }
+      while (!stopped) {
+        // Polled in short slices rather than one long sleep: registering a
+        // SIGINT handler suppresses Node's default exit, so a single multi-minute
+        // await would leave Ctrl-C looking ignored for minutes.
+        await sleep(250);
+        if (stopped) break;
+        for (const room of rooms) {
+          if (Date.now() < room.nextCodeFetchAtMs) continue;
+          try {
+            const code = await fetchJoinCode(api, room.session.uid);
+            room.nextCodeFetchAtMs =
+              Date.parse(code.validEnd) + JOIN_CODE_REFETCH_SLACK_MS;
+            if (code.joinCode === room.joinCode) continue;
+            room.joinCode = code.joinCode;
+            room.viewerUrl = viewerUrl(origin, code.joinCode);
+            console.log(
+              `[${new Date().toISOString()}] room ${room.label} joinCode ${code.joinCode} (until ${code.validEnd})`,
+            );
+            console.log(`  ${room.viewerUrl}`);
+          } catch (err) {
+            room.nextCodeFetchAtMs = Date.now() + 15_000;
+            console.log(
+              `[${new Date().toISOString()}] room ${room.label} join code refresh failed: ${err.message}`,
+            );
+          }
+        }
+      }
+    }
+  } finally {
+    for (const state of sources) state.stopRequested = true;
+    for (const state of sources) state.stream?.stop();
+    await Promise.allSettled(sources.map((s) => s.done));
+    for (const viewer of viewers) {
+      try {
+        viewer.socket.terminate(1000, 'demo-e2e-complete');
+      } catch {
+        // already gone
+      }
+    }
+
+    if (args.hold || args.keep) {
+      log(
+        `--- kept ${rooms.length} room(s): ${rooms.map((r) => r.roomUid).join(', ')}`,
+      );
+    } else {
+      for (const room of rooms) {
+        // Room first: it cascades sessions, windows and memberships, and a
+        // device cannot be deleted while it is still its room's source.
+        try {
+          if (room.roomUid) {
+            await api.post('room-management/delete-room', {
+              roomUid: room.roomUid,
+            });
+          }
+          if (room.device) {
+            await api.post('device-management/delete-device', {
+              deviceUid: room.device.deviceUid,
+            });
+          }
+          log(`--- [${room.label}] cleaned up`);
+        } catch (err) {
+          log(`--- [${room.label}] cleanup failed: ${err.message}`);
+        }
+      }
+    }
+  }
+
+  // ---- Report ----
+  const failures = [];
+  for (const room of rooms) {
+    for (const check of room.checks ?? []) {
+      if (!check.ok) failures.push(`room ${room.label}: ${check.name}`);
+    }
+  }
+  if (rooms.some((r) => !r.checks)) {
+    failures.push('the run ended before every room was evaluated');
+  }
+
+  const result = {
+    ok: failures.length === 0,
+    capacityRefusal,
+    rooms: rooms.map((r) => ({
+      label: r.label,
+      kind: r.kind,
+      roomUid: r.roomUid,
+      deviceUid: r.device?.deviceUid ?? null,
+      sessionUid: r.session?.uid ?? null,
+      joinCode: r.joinCode ?? null,
+      viewerUrl: r.viewerUrl ?? null,
+      framesSent: r.framesSent ?? 0,
+      statusTrail: r.statusTrail ?? '',
+      transcript: r.transcript ?? '',
+      sourceErrors: r.sourceErrors ?? [],
+      checks: r.checks ?? [],
+    })),
+    failures,
+  };
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log('\n=== RESULT ===');
+    for (const room of result.rooms) {
+      console.log(`\nroom ${room.label} (${room.kind}) — ${room.roomUid}`);
+      console.log(`  status trail : ${room.statusTrail || '(none)'}`);
+      console.log(`  frames sent  : ${room.framesSent}`);
+      if (room.transcript) {
+        console.log(`  transcript   : "${room.transcript.slice(0, 160)}"`);
+      }
+      for (const check of room.checks) {
+        console.log(`  [${check.ok ? 'PASS' : 'FAIL'}] ${check.name}`);
+        console.log(`         ${check.detail}`);
+      }
+    }
+    if (capacityRefusal) {
+      console.log(
+        '\nCAPACITY REFUSAL: the transcription service refused admission for at\n' +
+          'least one room (close 1013 / sessionStatus at-capacity). This is a\n' +
+          'deployment ceiling, not a defect in the session machinery. The shipped\n' +
+          'provider_config.json runs num_workers=1, and the per-worker admission\n' +
+          'estimate is dynamic: it starts low on a cold process and ratchets up as\n' +
+          'measured per-session cost arrives, so a run right after a restart can be\n' +
+          'refused where the same run minutes later is not. Read the live value from\n' +
+          "the service's /providers/health (needs TRANSCRIPTION_METRICS_KEY), then\n" +
+          're-run with fewer --rooms or raise the ceiling.',
+      );
+    }
+    console.log(result.ok ? '\nPASS' : `\nFAIL\n - ${failures.join('\n - ')}`);
+  }
+
+  process.exit(result.ok ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(
+    err instanceof Error ? (err.stack ?? err.message) : String(err),
+  );
+  process.exit(2);
+});

--- a/tools/session-corner-cases/README.md
+++ b/tools/session-corner-cases/README.md
@@ -219,7 +219,9 @@ console.
 
 ## What is checked
 
-`--list` prints the current set. As of this commit, 35 checks / ~150 assertions:
+`--list` prints the current set. As of this commit, **35 checks / 172
+assertions**, all green against `bc37f92`, of which 10 pin questionable
+behaviour (BUG-1 ×2, BUG-2 ×2, BUG-3 ×3, QUIRK-3 ×2, QUIRK-4 ×1).
 
 ### Session lifecycle
 

--- a/tools/session-corner-cases/README.md
+++ b/tools/session-corner-cases/README.md
@@ -1,0 +1,336 @@
+# Session, scheduling and calendar corner cases
+
+An adversarial regression suite for the session lifecycle, join-code auth, the
+auto-session/schedule calendar, and the room/device constraints that guard them.
+One node process, real HTTP and real WebSockets against a **running stack** — no
+mocks, no test containers, a real wall clock.
+
+Each check is named for the behaviour it pins; each assertion reports PASS/FAIL
+individually; the process exits non-zero if anything fails.
+
+## Why
+
+The session/schedule machinery is where this repo's shipped defects have
+clustered, and every one of them was invisible to the unit and integration
+suites:
+
+| commit    | defect                                                                        |
+| --------- | ----------------------------------------------------------------------------- |
+| `1bfbc60` | session tokens still issued for **canceled** sessions once their slot arrived |
+| `f7b26b6` | join codes exchangeable **before** `valid_start`, doubling a code's life      |
+| `16e07c9` | an unknown `transcriptionProviderId` accepted at write time                   |
+| `bc37f92` | a session with **no source attached** never told its viewers it had ended     |
+
+They needed a live room, a real clock, and an adversarial input to surface —
+`CONTRIBUTING.md`'s "a feature with a 'currently active' notion needs a fixture
+that is active now" is the same lesson. This suite is that fixture, generalised:
+every check provisions its own room, drives the real routes, and asserts on the
+real answer.
+
+## Run
+
+```bash
+# Needs the stack up and a built repo (`npm run build`) — the streaming check
+# uses the real @scribear/test-audio-source engine.
+npm run e2e:sessions
+```
+
+```bash
+node tools/session-corner-cases/session-corner-cases.mjs \
+  --base-url https://localhost:8443 \
+  --env-file ../deployment-iso/.env \
+  --quick        # skip the two wall-clock checks (~6 min of waiting)
+  --no-stream    # skip the one check that costs transcription capacity
+  --only cancel  # substring filter on the check name (repeatable)
+  --list         # print the check names and exit
+  --keep         # leave the provisioned rooms/devices in place
+  --json         # machine-readable result on stdout
+```
+
+`SESSION_MANAGER_API_KEY` is read from `--env-file`, else `deployment/.env`,
+else `../deployment/.env`, else the environment.
+
+A full run takes about **7 minutes**, almost all of it the two `slow` checks
+waiting on real join-code and session-start deadlines. `--quick --no-stream`
+runs in well under a minute and is the right default while iterating.
+
+Everything a run creates is named `scc-<pid>-<epoch>-*` and torn down in a
+`finally` block (rooms first — they cascade sessions, windows, schedules and
+memberships, and a device cannot be deleted while it is still its room's
+source). Any leftover with that prefix is an orphan from a killed run.
+
+### Reading the output
+
+| line                  | meaning                                                                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `[PASS]`              | the behaviour is what it should be.                                                                                                        |
+| `[PASS (pins BUG-n)]` | the behaviour is what it **currently is**, and that is wrong or surprising. See the table below. A _fix_ makes this line FAIL, on purpose. |
+| `[FAIL]`              | a regression.                                                                                                                              |
+
+Assertions that pin questionable behaviour pass deliberately. The alternative —
+asserting the desired behaviour and shipping a permanently red suite — makes a
+real regression indistinguishable from the known backlog, which is how a red
+suite stops being read. `tools/admin-scheduling-e2e` took the other route and
+has sat at 5/6 ever since.
+
+## Bugs this suite found
+
+### BUG-1 — an auto-session window with equal local times answers 500
+
+`create-auto-session-window` and `update-auto-session-window` have **no
+`localStartTime !== localEndTime` pre-check**. `_doCreateSchedule` has one
+(`INVALID_LOCAL_TIMES` → `400`, with a sentence naming the problem); the window
+path (`_doCreateWindow`) validates only `activeEnd`, so the
+`auto_session_windows_local_times_distinct` CHECK fires inside the transaction
+and the operator gets an opaque `500 INTERNAL_ERROR` for the same typo.
+
+Minimal reproduction:
+
+```bash
+curl -sk -X POST https://localhost:8443/api/session-manager/v1/schedule-management/create-auto-session-window \
+  -H "authorization: Bearer $SESSION_MANAGER_API_KEY" -H 'content-type: application/json' \
+  -d '{"roomUid":"<room>","localStartTime":"10:00","localEndTime":"10:00",
+       "daysOfWeek":["MON"],"activeStart":"2026-08-02T00:00:00Z","activeEnd":null,
+       "joinCodeScopes":["RECEIVE_TRANSCRIPTIONS"],"transcriptionProviderId":"whisper",
+       "transcriptionStreamConfig":{}}'
+# {"code":"INTERNAL_ERROR","message":"Server encountered an unexpected error..."}
+```
+
+session-manager logs the cause:
+
+```
+error: new row for relation "auto_session_windows" violates check constraint
+       "auto_session_windows_local_times_distinct"
+```
+
+The same request against `create-schedule` returns
+`400 "localStartTime and localEndTime must not be equal."`.
+
+Suggested fix: mirror the schedule path's check at the top of `_doCreateWindow`
+and add an `INVALID_LOCAL_TIMES` reply to the two window schemas. Pinned by
+`equal-local-start-and-end-times-are-refused-on-schedules-and-windows`.
+
+Not fixed here — the brief was to find and report, not to change behaviour.
+
+### BUG-2 — `activeEnd` inside an occurrence deletes the occurrence instead of clipping it
+
+`inRange` (`schedule-materializer.ts`) rejects an occurrence outright when
+`occ.endUtc > schedule.activeEnd`:
+
+```ts
+if (schedule.activeEnd && occ.endUtc > schedule.activeEnd) return false;
+```
+
+For the shape the admin console actually creates — a daily `00:00–23:59` window
+— that means **any** `activeEnd` before `23:59` removes the whole day, not the
+tail of it. Two operator-visible consequences, both reproduced by the suite:
+
+1. Creating "auto sessions every day, until 30 minutes from now" produces **no
+   auto session at all**, not a 30-minute one.
+2. Narrowing a **live** window (`update-auto-session-window` with an `activeEnd`
+   later today) **ends the AUTO session that is running right now**. The
+   reconciler finds no window occurrence covering the active session's start, so
+   it takes the `end_override = now` branch. An operator asking for "stop after
+   this afternoon" stops the room mid-lecture.
+
+Minimal reproduction: create an auto-enabled room, a `00:00–23:59` window
+backdated a week (so it covers now), confirm `get-active-session` returns an
+AUTO session, then
+
+```bash
+curl -sk -X POST .../schedule-management/update-auto-session-window \
+  -H "authorization: Bearer $KEY" -H 'content-type: application/json' \
+  -d '{"windowUid":"<w>","activeEnd":"<now+30min>"}'      # 200 OK
+curl -sk .../schedule-management/get-active-session/<room> -H "authorization: Bearer $KEY"
+# null
+```
+
+Whether clipping or dropping is _correct_ is a product decision — clipping is
+what the wording of the field implies and what the reconciler's own
+`materializeAutoSessions` does for blocker sessions — but silently ending a live
+session is not defensible either way. Pinned by
+`an-activeEnd-inside-an-occurrence-drops-the-occurrence-instead-of-clipping-it`.
+
+### BUG-3 — `add-device-to-room` silently demotes a room's source device
+
+`add-device-to-room` **publishes a `409 TOO_MANY_SOURCE_DEVICES` reply that
+nothing can produce**: that code is only ever returned by `createRoom`.
+`RoomManagementService.addDeviceToRoom` runs no "this room already has a source"
+check, and `RoomManagementRepository.addDeviceToRoom` clears `is_source` across
+the entire room before inserting when `asSource` is true. So the call succeeds
+with `204` and swaps the room's source out from under the operator.
+
+The victim keeps its room membership and its long-lived `DEVICE_TOKEN`, still
+sees the session through `my-schedule`, and still gets a session token — with
+`["RECEIVE_TRANSCRIPTIONS"]` instead of `["SEND_AUDIO","RECEIVE_TRANSCRIPTIONS"]`.
+That is a kiosk that starts, connects, shows a join code, and sends no audio,
+with nothing anywhere reporting a fault.
+
+This is precisely the harm `room-management.service.ts` already documents for
+the reserved rooms — "Promoting some other device to source silently demotes the
+synthetic source, which then still authenticates and still finds the session but
+is no longer granted SEND_AUDIO, so the operator sees a device that starts and
+sends nothing" — and guards `TEST_AUDIO_ROOM_NOT_ASSIGNABLE` /
+`CANARY_ROOM_NOT_ASSIGNABLE` against. Ordinary teaching rooms have no such
+guard.
+
+Minimal reproduction:
+
+```bash
+# room R with source device D1, live session S; D2 registered and activated, in no room
+curl -sk -X POST .../room-management/add-device-to-room -H "authorization: Bearer $KEY" \
+  -H 'content-type: application/json' \
+  -d '{"roomUid":"R","deviceUid":"D2","asSource":true}'          # 204
+
+curl -sk -X POST .../session-auth/exchange-device-token -H "cookie: DEVICE_TOKEN=<D1>" \
+  -H 'content-type: application/json' -d '{"sessionUid":"S"}'
+# 200 {"scopes":["RECEIVE_TRANSCRIPTIONS"]}      <- was ["SEND_AUDIO", ...]
+```
+
+Suggested fix: return the already-published `TOO_MANY_SOURCE_DEVICES` when
+`asSource` is true and the room has a source, and leave deliberate swaps to
+`set-source-device`. Pinned by `a-room-takes-exactly-one-source-device`.
+
+## Questionable-but-current behaviour also pinned
+
+These are not bugs so much as sharp edges. They are pinned so that changing them
+is a deliberate act.
+
+### QUIRK-3 — a window starting "now" produces nothing until tomorrow
+
+`inRange` also drops an occurrence whose **start** precedes `activeStart`. A
+daily `00:00–23:59` window created at 16:00 with `activeStart = now` loses
+today's occurrence (it started at 00:00) and first materializes at tomorrow's
+midnight. The admin dialog forces `activeStart` into the future, so an operator
+creating "auto sessions, every day, from now" gets nothing for the rest of the
+day and no explanation. `tools/demo-e2e` backdates `activeStart` a week for
+exactly this reason, with an hour of debugging recorded in its comments.
+
+Pinned by `an-auto-window-must-start-before-the-occurrence-to-cover-today`,
+which also asserts the backdated control case does work.
+
+### QUIRK-4 — a schedule beyond a ranged listing is invisible to that range
+
+A schedule starting 120 days out does not appear in a 90-day
+`list-schedules?from=&to=` query, and only an unbounded listing shows it. This
+is the session-manager half of `SCHEDULE_BEYOND_90_DAY_WINDOW_INVISIBLE`, which
+`tools/admin-scheduling-e2e` documents as an accepted limitation of the admin
+console.
+
+## What is checked
+
+`--list` prints the current set. As of this commit, 35 checks / ~150 assertions:
+
+### Session lifecycle
+
+- a second on-demand session in a live room is refused — including **five
+  simultaneous creates producing exactly one session**, which is what the
+  room-row lock in `createOnDemandSession` is for.
+- an on-demand session **preempts** the live AUTO one (`end_override = now`,
+  and the AUTO session really is over).
+- ending a session early tells a viewer **with no source attached** — the
+  `bc37f92` regression, asserted as `sessionEnded` **and** close 1000 within
+  15 s on a socket that joined with a real join code.
+- the same, **while a source is mid-stream** (`stream` tag), where the source's
+  `SessionState` owns the end timer instead. Reports SKIP rather than FAIL if
+  the transcription service refuses admission — that is a deployment ceiling,
+  not a session defect.
+- starting a session early moves `effectiveStart` and makes it joinable
+  (`not-active` → `ok`, and the room's source gets `SEND_AUDIO`).
+- **canceling is terminal once the slot arrives** (`slow`) — the `1bfbc60`
+  regression. Cancels a real occurrence while upcoming, waits for the wall clock
+  to enter its window, then asserts all four auth paths refuse it.
+- uncanceling restores an occurrence — **unless an AUTO session backfilled the
+  slot**, where it must be `409 SLOT_NO_LONGER_AVAILABLE` rather than a
+  corrupted schedule.
+- an ended session refuses its old join code (`409`), its refresh token
+  (`409 SESSION_ENDED`) and its device's token exchange.
+- the verb/type matrix: AUTO sessions refuse start/end/cancel; ON_DEMAND
+  sessions refuse cancel; ending twice is `422 SESSION_NOT_ACTIVE`.
+- an auto-enabled room survives two full create → preempt → end → backfill →
+  create cycles. This is the shape of the 500 that broke every on-demand session
+  in every auto-enabled room and survived 341 integration tests.
+
+### Join codes / auth
+
+- **a join code is exchangeable only inside `[validStart, validEnd)`** (`slow`)
+  — the `f7b26b6` regression, driven through the _real_ mint-next path: waits
+  into the 60 s handoff window, asserts the kiosk is handed a `next` code
+  starting exactly at `current.validEnd`, that exchanging it early is
+  `404 JOIN_CODE_NOT_FOUND`, that the old code is `410 JOIN_CODE_EXPIRED` once
+  it lapses, and that the handoff code then works.
+- unknown / malformed join codes and refresh tokens.
+- a session with empty `joinCodeScopes`: `no-join-scopes` on the admin route,
+  `409 JOIN_CODE_SCOPES_EMPTY` on the device route — but the source device can
+  still exchange its device token, because those scopes govern the anonymous
+  path only.
+- a device token only works for sessions in its own room (`403`).
+
+### Calendar / scheduling
+
+- a **midnight-wrapping** window materializes a session covering now that ends
+  the following day.
+- **spring-forward**: on the transition day a `02:00–02:59` and a `02:15–02:45`
+  schedule do **not** conflict, because both occurrences vanish into the DST
+  gap; `03:30`/`03:45` on that same day do conflict, and the identical `02:xx`
+  pair one week later does too. Three legs, so "no conflict" is a positive
+  statement rather than an artefact of a misbuilt fixture.
+- **fall-back**: ambiguous local times resolve to the **later, standard-time**
+  instant. Conflict detection alone cannot see this (local→UTC is strictly
+  increasing under either reading, so overlap decisions are identical) — the
+  check uses `inRange`'s `activeEnd` test as the discriminator instead: with
+  `activeEnd` placed _between_ the two candidate ends both occurrences are
+  dropped, and with it past the standard-time end they survive and conflict.
+- DST transition instants are **computed from the host ICU database**, not
+  hardcoded, so the checks keep working after the dates they were written
+  against have passed — a hardcoded `2027-03-14` becomes an
+  `INVALID_ACTIVE_START` the moment it is in the past.
+- overlapping windows conflict; abutting ones do not.
+- ONCE / WEEKLY / BIWEEKLY materialize, and the **BIWEEKLY parity anchor
+  survives an update** even when `activeStart` moves (`updateSchedule` closes
+  and re-inserts the row, so a dropped anchor would shift every future
+  occurrence by a week).
+- the horizons: 90-day ranged listing (QUIRK-4), 7-day materialization, and
+  `list-sessions` refusing a range over 31 days.
+- `activeEnd` mid-occurrence (BUG-2).
+- toggling `autoSessionEnabled` off ends the live AUTO session and back on
+  resumes from the untouched window.
+- deleting a window with a live AUTO session ends it (and is `404` the second
+  time); deleting a schedule takes its upcoming sessions with it.
+
+### Rooms / devices
+
+- exactly one source device per room (BUG-3).
+- a device cannot belong to two rooms.
+- a room's source device cannot be deleted or detached.
+- deleting a room with a live session cascades the session and kills its join
+  code.
+- the reserved demo / canary / test-audio uids are refused for assignment,
+  deletion and promotion. These guards run before any existence lookup, so the
+  assertions hold whether or not the seeders ran; the test-audio room is
+  discovered from `list-rooms` because it exists only when
+  `TEST_AUDIO_DEVICE_SECRET` is set.
+- an activation code is single-use and advertises a ~5 minute expiry.
+
+### Invalid input
+
+- an unknown `transcriptionProviderId` on **all five** write paths (`16e07c9`),
+  including that the message names the deployment's configured providers.
+- an invalid timezone (`422`), an empty one, and that the `Etc/UTC` alias
+  `Intl.supportedValuesOf` omits is still accepted.
+- equal local start/end times (BUG-1).
+- malformed vs unknown UUIDs, distinguished per resource.
+- `frequency`/`daysOfWeek` disagreement — including `daysOfWeek: []`, which the
+  DB CHECK cannot catch (`array_length()` is `NULL` for an empty array, so the
+  constraint passes) and the service therefore has to reject itself.
+
+## Known gaps
+
+- **Activation-code expiry** is asserted from the advertised `expiry` timestamp,
+  not by waiting five minutes for a code to lapse.
+- **Fall-back occurrence duration** is pinned indirectly, through `inRange`.
+  Observing the two-hour `00:30–01:30` occurrence directly would need the
+  transition inside the 7-day materialization horizon, which is true for a few
+  days a year.
+- The suite asserts **session-manager and node-server** behaviour. The admin
+  console's rendering of any of it is `tools/admin-scheduling-e2e`'s job.

--- a/tools/session-corner-cases/session-corner-cases.mjs
+++ b/tools/session-corner-cases/session-corner-cases.mjs
@@ -1,0 +1,2848 @@
+/**
+ * Adversarial corner-case regression suite for sessions, scheduling and the
+ * calendar.
+ *
+ * Usage:
+ *   node tools/session-corner-cases/session-corner-cases.mjs [options]
+ *
+ * Options:
+ *   --base-url <url>   default https://localhost (self-signed certs accepted)
+ *   --env-file <path>  where to read SESSION_MANAGER_API_KEY from. Defaults to
+ *                      <repo>/deployment/.env then <repo>/../deployment/.env.
+ *   --only <substr>    run only checks whose name contains <substr> (repeatable)
+ *   --list             print the check names and exit
+ *   --quick            skip the two wall-clock checks (~6 min of waiting)
+ *   --no-stream        skip the one check that streams audio
+ *   --keep             leave provisioned rooms/devices in place
+ *   --json             machine-readable result on stdout
+ *
+ * Why this exists, and why it is shaped like this:
+ *
+ * The session/schedule machinery is where this repo's shipped bugs have
+ * clustered - `1bfbc60` (tokens for canceled sessions), `f7b26b6` (join codes
+ * exchangeable before `valid_start`), `16e07c9` (unknown provider accepted at
+ * write time), `bc37f92` (source-free sessions never told viewers they ended).
+ * Every one of them was invisible to the unit and integration suites and needed
+ * a *live* room, a real clock, and an adversarial input to surface. That is what
+ * this is: one process, real HTTP and real WebSockets against a running stack,
+ * with each assertion named for the behaviour it pins.
+ *
+ * Three conventions matter when reading the output:
+ *
+ *   PASS            the behaviour is what it should be.
+ *   PASS (pins ...) the behaviour is what it *currently is*, and that is
+ *                   questionable or outright wrong. The assertion encodes the
+ *                   real behaviour deliberately, so the suite stays green and a
+ *                   *fix* fails here loudly and forces the assertion to be
+ *                   updated alongside it. Every one of these is listed in the
+ *                   README with its reproduction.
+ *   FAIL            a regression.
+ *
+ * The alternative - asserting the desired behaviour and shipping a permanently
+ * red suite - makes a real regression indistinguishable from the known
+ * backlog, which is how a red suite stops being read.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  TRANSCRIPTION_STREAM_CLIENT_ROUTE,
+  TranscriptionServiceDisconnectReason,
+  TranscriptionStreamServerMessageType,
+} from '@scribear/node-server-schema';
+import {
+  CANARY_DEVICE_UID,
+  CANARY_ROOM_UID,
+  DEMO_ROOM_UID,
+  DEMO_SOURCE_DEVICE_UID,
+  DEVICE_TOKEN_COOKIE_NAME,
+} from '@scribear/session-manager-schema';
+import {
+  DeviceAuthClient,
+  GOOD_PARAM_DEFAULTS,
+  GoodEngine,
+  TestAudioStream,
+  connectStreamSocket,
+  createSeededRng,
+  decodeWav,
+  sliceIntoChunks,
+  waitForSocketOpen,
+} from '@scribear/test-audio-source';
+
+// The stack under test terminates TLS with a self-signed certificate. Set here
+// rather than in the shell so a bare `npm run e2e:sessions` works; nothing has
+// opened a socket at this point.
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+
+const WAV = join(
+  REPO_ROOT,
+  'test_audio_files',
+  'speech',
+  'harvard_16k_mono.wav',
+);
+
+/** Matches the kiosk's `AUDIO_CHUNK_MS`, so frames look like a kiosk's. */
+const CHUNK_MS = 100;
+
+const ALL_DAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How far back an auto-session window's `activeStart` is placed when the check
+ * wants a session covering *now*.
+ *
+ * `inRange` in `schedule-materializer.ts` drops any occurrence whose *start*
+ * precedes `activeStart`, so a daily 00:00-23:59 window created at 16:00 with
+ * `activeStart = now` loses today's occurrence entirely and first materializes
+ * tomorrow. A week back clears the day boundary in any timezone. This is the
+ * behaviour `auto-window-activeStart-must-precede-...` pins on purpose.
+ */
+const BACKDATE_MS = 7 * DAY_MS;
+
+/** Provider key every deployment in this repo configures. */
+const PROVIDER = 'whisper';
+
+/** Session end must reach a viewer well inside this. */
+const SESSION_END_DEADLINE_MS = 15_000;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = {
+    baseUrl: 'https://localhost',
+    envFile: '',
+    only: [],
+    list: false,
+    quick: false,
+    stream: true,
+    keep: false,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === '--json') args.json = true;
+    else if (flag === '--list') args.list = true;
+    else if (flag === '--quick') args.quick = true;
+    else if (flag === '--no-stream') args.stream = false;
+    else if (flag === '--keep') args.keep = true;
+    else if (flag === '--base-url') args.baseUrl = argv[++i];
+    else if (flag === '--env-file') args.envFile = argv[++i];
+    else if (flag === '--only') args.only.push(argv[++i]);
+    else throw new Error(`Unknown option ${flag}`);
+  }
+  return args;
+}
+
+/**
+ * Read the deployment env for the admin key. A plain scan rather than a dotenv
+ * dependency, matching `tools/demo-e2e` and `tools/e2e-audio`. The search order
+ * matters on a box where the running stack lives outside the repo.
+ */
+function loadDeploymentEnv(explicitPath) {
+  const candidates = [
+    explicitPath ? resolve(explicitPath) : null,
+    join(REPO_ROOT, 'deployment', '.env'),
+    join(REPO_ROOT, '..', 'deployment', '.env'),
+  ].filter(Boolean);
+
+  for (const path of candidates) {
+    if (!existsSync(path)) continue;
+    const env = {};
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      const match = /^\s*([A-Z0-9_]+)\s*=\s*(.*)$/.exec(line);
+      if (match) env[match[1]] = match[2].trim().replace(/^["']|["']$/g, '');
+    }
+    return { env, path };
+  }
+  throw new Error(
+    `No deployment .env found. Tried: ${candidates.join(', ')}. ` +
+      'Pass --env-file, or set SESSION_MANAGER_API_KEY in the environment.',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// HTTP client
+// ---------------------------------------------------------------------------
+
+/**
+ * Session-manager client that never throws on a non-2xx: every check here is
+ * *about* the status code, so an exception would throw away the thing under
+ * test.
+ */
+function createApi(baseUrl, adminKey) {
+  const root = `${baseUrl}/api/session-manager/v1`;
+
+  async function req(method, path, { body, admin, deviceToken } = {}) {
+    const headers = { 'content-type': 'application/json' };
+    if (admin) headers.authorization = `Bearer ${adminKey}`;
+    if (deviceToken) {
+      headers.cookie = `${DEVICE_TOKEN_COOKIE_NAME}=${encodeURIComponent(deviceToken)}`;
+    }
+    const res = await fetch(`${root}/${path}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await res.text();
+    let parsed = null;
+    try {
+      parsed = text ? JSON.parse(text) : null;
+    } catch {
+      parsed = text;
+    }
+    return { status: res.status, body: parsed, headers: res.headers };
+  }
+
+  return {
+    /** Admin-key routes. */
+    post: (path, body) => req('POST', path, { body, admin: true }),
+    get: (path) => req('GET', path, { admin: true }),
+    /** Routes where a join code / activation code is itself the credential. */
+    anon: (path, body) => req('POST', path, { body }),
+    /** Device-token routes. */
+    device: (deviceToken, path, body) =>
+      req('POST', path, { body, deviceToken }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Assertion recorder
+// ---------------------------------------------------------------------------
+
+class Recorder {
+  constructor(checkName) {
+    this.checkName = checkName;
+    this.assertions = [];
+  }
+
+  /** A plain assertion: it passes when the behaviour is what it should be. */
+  ok(name, condition, detail) {
+    this.assertions.push({ name, ok: Boolean(condition), detail, pins: null });
+    return Boolean(condition);
+  }
+
+  /**
+   * An assertion that encodes the behaviour the stack *currently* has, where
+   * that behaviour is questionable or wrong. Passing means "still broken the
+   * same way"; failing means somebody changed it and must update this line.
+   */
+  pin(name, condition, detail, pins) {
+    this.assertions.push({ name, ok: Boolean(condition), detail, pins });
+    return Boolean(condition);
+  }
+
+  /** Convenience for the overwhelmingly common "status (and code) is X" shape. */
+  status(name, res, expectedStatus, expectedCode) {
+    const codeOk =
+      expectedCode === undefined || res.body?.code === expectedCode;
+    return this.ok(
+      name,
+      res.status === expectedStatus && codeOk,
+      `got ${res.status}${res.body?.code ? ` ${res.body.code}` : ''}` +
+        `, wanted ${expectedStatus}${expectedCode ? ` ${expectedCode}` : ''}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provisioning
+// ---------------------------------------------------------------------------
+
+/**
+ * Tracks everything a run created so teardown can remove it, and names it
+ * distinctively so an orphan left by a crashed run is identifiable at a glance.
+ */
+class Fixtures {
+  constructor(api, stamp) {
+    this.api = api;
+    this.stamp = stamp;
+    this.rooms = [];
+    this.devices = [];
+  }
+
+  name(label) {
+    return `${this.stamp}-${label}`;
+  }
+
+  /**
+   * Register a device and immediately activate it. The two calls are adjacent
+   * on purpose: an activation code is single-use and expires five minutes after
+   * registration, so anything that separates them turns a rerun into a dead
+   * device. The 64-byte secret is only ever revealed in a `Set-Cookie` header,
+   * which is why this reads `getSetCookie()` rather than the JSON body.
+   */
+  async device(label) {
+    const reg = await this.api.post('device-management/register-device', {
+      name: this.name(label),
+    });
+    if (reg.status !== 201 && reg.status !== 200) {
+      throw new Error(
+        `register-device -> ${reg.status} ${JSON.stringify(reg.body)}`,
+      );
+    }
+    this.devices.push(reg.body.deviceUid);
+
+    const act = await this.api.anon('device-management/activate-device', {
+      activationCode: reg.body.activationCode,
+    });
+    const prefix = `${DEVICE_TOKEN_COOKIE_NAME}=`;
+    const cookie = (act.headers.getSetCookie() ?? []).find((c) =>
+      c.startsWith(prefix),
+    );
+    if (!cookie) {
+      throw new Error(
+        `activate-device set no ${DEVICE_TOKEN_COOKIE_NAME} cookie (${act.status})`,
+      );
+    }
+    return {
+      deviceUid: reg.body.deviceUid,
+      activationCode: reg.body.activationCode,
+      expiry: reg.body.expiry,
+      deviceToken: decodeURIComponent(
+        cookie.slice(prefix.length).split(';')[0],
+      ),
+    };
+  }
+
+  /** A room with exactly one activated source device. */
+  async room(label, { timezone = 'UTC', auto = false } = {}) {
+    const device = await this.device(`${label}-src`);
+    const res = await this.api.post('room-management/create-room', {
+      name: this.name(label),
+      timezone,
+      autoSessionEnabled: auto,
+      sourceDeviceUids: [device.deviceUid],
+    });
+    if (res.status !== 201) {
+      throw new Error(
+        `create-room -> ${res.status} ${JSON.stringify(res.body)}`,
+      );
+    }
+    this.rooms.push(res.body.uid);
+    return { roomUid: res.body.uid, device, timezone };
+  }
+
+  onDemand(roomUid, name, overrides = {}) {
+    return this.api.post('schedule-management/create-on-demand-session', {
+      roomUid,
+      name: this.name(name),
+      joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+      transcriptionProviderId: PROVIDER,
+      transcriptionStreamConfig: {},
+      ...overrides,
+    });
+  }
+
+  /** A daily auto-session window covering the whole local day. */
+  window(roomUid, overrides = {}) {
+    return this.api.post('schedule-management/create-auto-session-window', {
+      roomUid,
+      localStartTime: '00:00',
+      localEndTime: '23:59',
+      daysOfWeek: ALL_DAYS,
+      activeStart: new Date(Date.now() - BACKDATE_MS).toISOString(),
+      activeEnd: null,
+      joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+      transcriptionProviderId: PROVIDER,
+      transcriptionStreamConfig: {},
+      ...overrides,
+    });
+  }
+
+  schedule(roomUid, overrides = {}) {
+    return this.api.post('schedule-management/create-schedule', {
+      roomUid,
+      name: this.name('sched'),
+      activeStart: new Date(Date.now() + 5_000).toISOString(),
+      activeEnd: null,
+      localStartTime: '09:00',
+      localEndTime: '10:00',
+      frequency: 'WEEKLY',
+      daysOfWeek: ALL_DAYS,
+      joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+      transcriptionProviderId: PROVIDER,
+      transcriptionStreamConfig: {},
+      ...overrides,
+    });
+  }
+
+  async activeSession(roomUid, timeoutMs = 10_000) {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const res = await this.api.get(
+        `schedule-management/get-active-session/${roomUid}`,
+      );
+      if (res.body) return res.body;
+      if (Date.now() > deadline) return null;
+      await sleep(400);
+    }
+  }
+
+  async listSessions(roomUid, fromMs = -60_000, toMs = DAY_MS) {
+    const from = new Date(Date.now() + fromMs).toISOString();
+    const to = new Date(Date.now() + toMs).toISOString();
+    const res = await this.api.get(
+      `schedule-management/list-sessions?roomUids=${roomUid}` +
+        `&from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`,
+    );
+    return res.body?.items ?? [];
+  }
+
+  async teardown(log) {
+    for (const roomUid of this.rooms) {
+      // Room first: it cascades sessions, windows, schedules and memberships,
+      // and a device cannot be deleted while it is still its room's source.
+      const res = await this.api.post('room-management/delete-room', {
+        roomUid,
+      });
+      if (res.status !== 204 && res.status !== 404) {
+        log(`  ! delete-room ${roomUid} -> ${res.status}`);
+      }
+    }
+    for (const deviceUid of this.devices) {
+      const res = await this.api.post('device-management/delete-device', {
+        deviceUid,
+      });
+      if (res.status !== 204 && res.status !== 404) {
+        log(`  ! delete-device ${deviceUid} -> ${res.status}`);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Time helpers
+// ---------------------------------------------------------------------------
+
+/** `HH:MM:SS` of a Date read in UTC - for rooms whose timezone is UTC. */
+function utcHms(date) {
+  const p = (n) => String(n).padStart(2, '0');
+  return `${p(date.getUTCHours())}:${p(date.getUTCMinutes())}:${p(date.getUTCSeconds())}`;
+}
+
+/** Zone offset in minutes at `date`, from the host ICU database. */
+function offsetMinutes(zone, date) {
+  const name = new Intl.DateTimeFormat('en-US', {
+    timeZone: zone,
+    timeZoneName: 'longOffset',
+  })
+    .formatToParts(date)
+    .find((p) => p.type === 'timeZoneName').value;
+  const m = /GMT([+-])(\d{2}):(\d{2})/.exec(name);
+  if (!m) return 0;
+  return (m[1] === '-' ? -1 : 1) * (Number(m[2]) * 60 + Number(m[3]));
+}
+
+/**
+ * The next `count` UTC instants at which `zone` changes offset, found by a
+ * six-hour scan with a binary search inside the bracketing step.
+ *
+ * Computed rather than hardcoded so the DST checks keep working after the dates
+ * they were written against have passed - a hardcoded 2027-03-14 becomes an
+ * `INVALID_ACTIVE_START` the moment it is in the past, which is exactly the
+ * kind of rot that makes a suite get deleted instead of fixed.
+ */
+function nextTransitions(zone, from, count) {
+  const found = [];
+  const step = 6 * 60 * 60 * 1000;
+  const limit = from.getTime() + 800 * DAY_MS;
+  let t = from.getTime();
+  let prev = offsetMinutes(zone, new Date(t));
+  while (t < limit && found.length < count) {
+    const next = t + step;
+    const off = offsetMinutes(zone, new Date(next));
+    if (off !== prev) {
+      let lo = t;
+      let hi = next;
+      while (hi - lo > 1000) {
+        const mid = Math.floor((lo + hi) / 2);
+        if (offsetMinutes(zone, new Date(mid)) === prev) lo = mid;
+        else hi = mid;
+      }
+      found.push({ at: new Date(hi), fromOffset: prev, toOffset: off });
+      prev = off;
+    }
+    t = next;
+  }
+  return found;
+}
+
+/** The three-letter `DayOfWeek` a UTC instant falls on in `zone`. */
+function localDayOfWeek(zone, date) {
+  return new Intl.DateTimeFormat('en-US', { timeZone: zone, weekday: 'short' })
+    .format(date)
+    .toUpperCase()
+    .slice(0, 3);
+}
+
+// ---------------------------------------------------------------------------
+// Socket helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Open a viewer socket exactly as a browser viewer does: exchange the join code
+ * (unauthenticated - the code *is* the credential), then speak the client
+ * route. Deliberately not the source token's own receive scope, which would
+ * skip `/client` and the fan-out path entirely.
+ */
+async function openViewer(api, baseUrl, joinCode) {
+  const exchanged = await api.anon('session-auth/exchange-join-code', {
+    joinCode,
+  });
+  if (exchanged.status !== 200) {
+    throw new Error(
+      `exchange-join-code -> ${exchanged.status} ${JSON.stringify(exchanged.body)}`,
+    );
+  }
+
+  const observed = {
+    authOk: false,
+    statuses: [],
+    ended: false,
+    endedAtMs: null,
+    closes: [],
+    atCapacity: false,
+  };
+
+  const socket = connectStreamSocket(
+    baseUrl,
+    TRANSCRIPTION_STREAM_CLIENT_ROUTE,
+    exchanged.body.sessionUid,
+    exchanged.body.sessionToken,
+  );
+
+  // Registered synchronously, before the socket can have opened, so no early
+  // message is missed.
+  socket.on('message', (msg) => {
+    if (msg.type === TranscriptionStreamServerMessageType.AUTH_OK) {
+      observed.authOk = true;
+    } else if (
+      msg.type === TranscriptionStreamServerMessageType.SESSION_STATUS
+    ) {
+      observed.statuses.push({
+        source: msg.sourceDeviceConnected,
+        service: msg.transcriptionServiceConnected,
+      });
+      if (
+        msg.transcriptionServiceDisconnectReason ===
+        TranscriptionServiceDisconnectReason.AT_CAPACITY
+      ) {
+        observed.atCapacity = true;
+      }
+    } else if (
+      msg.type === TranscriptionStreamServerMessageType.SESSION_ENDED
+    ) {
+      observed.ended = true;
+      observed.endedAtMs = Date.now();
+    }
+  });
+  socket.on('close', (code, reason) => {
+    observed.closes.push({ code, reason });
+    // 1013 is the transcription service refusing admission, relayed down.
+    if (code === 1013) observed.atCapacity = true;
+  });
+  socket.on('error', () => {
+    // Recorded through `closes`; an unhandled 'error' would kill the process.
+  });
+
+  await waitForSocketOpen(socket, 15_000);
+  return { socket, observed, exchanged: exchanged.body };
+}
+
+/** A logger shaped like `BaseLogger`, for the streaming engine's debug lines. */
+function quietLogger() {
+  const noop = () => {};
+  return {
+    trace: noop,
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+    fatal: noop,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Each entry pins one behaviour. `name` is the behaviour, not the mechanism, so
+ * a failure line reads as a statement about the product.
+ *
+ * `tags`:
+ *   'slow'   - waits on the wall clock; skipped by --quick.
+ *   'stream' - opens a source socket and costs transcription capacity;
+ *              skipped by --no-stream.
+ */
+const CHECKS = [
+  // -- session lifecycle ---------------------------------------------------
+  {
+    group: 'session lifecycle',
+    name: 'a-second-on-demand-session-in-a-live-room-is-refused',
+    async run(t, { fx }) {
+      const room = await fx.room('sec-od');
+      const first = await fx.onDemand(room.roomUid, 'first');
+      t.status('the first on-demand session is created', first, 201);
+
+      const second = await fx.onDemand(room.roomUid, 'second');
+      t.status(
+        'a second on-demand session is refused 409 ANOTHER_SESSION_ACTIVE',
+        second,
+        409,
+        'ANOTHER_SESSION_ACTIVE',
+      );
+
+      // The room row is locked for the whole transaction, so concurrency must
+      // not open a second door: five simultaneous creates must leave one
+      // session, not five. A lost race here would put two open-ended ON_DEMAND
+      // rows in one room, which the sessions_no_overlap constraint is supposed
+      // to make impossible.
+      const race = await fx.room('sec-od-race');
+      const results = await Promise.all(
+        Array.from({ length: 5 }, (_, i) =>
+          fx.onDemand(race.roomUid, `race-${i}`),
+        ),
+      );
+      const created = results.filter((r) => r.status === 201);
+      const refused = results.filter(
+        (r) => r.status === 409 && r.body?.code === 'ANOTHER_SESSION_ACTIVE',
+      );
+      t.ok(
+        'five simultaneous on-demand creates produce exactly one session',
+        created.length === 1 && refused.length === 4,
+        `statuses ${results.map((r) => r.status).join(',')}`,
+      );
+      const live = await fx.listSessions(race.roomUid);
+      t.ok(
+        'and the room holds exactly one session afterwards',
+        live.length === 1,
+        `${live.length} session(s): ${live.map((s) => s.name).join(', ')}`,
+      );
+    },
+  },
+
+  {
+    group: 'session lifecycle',
+    name: 'an-on-demand-session-preempts-the-live-auto-session',
+    async run(t, { fx, api }) {
+      const room = await fx.room('preempt', { auto: true });
+      await fx.window(room.roomUid);
+      const auto = await fx.activeSession(room.roomUid);
+      t.ok(
+        'a room with an auto window covering now has a live AUTO session',
+        auto?.type === 'AUTO',
+        `active session type ${auto?.type ?? 'none'}`,
+      );
+
+      const od = await fx.onDemand(room.roomUid, 'preemptor');
+      t.status(
+        'an on-demand session is accepted even though an AUTO one is live',
+        od,
+        201,
+      );
+
+      const after = await api.get(
+        `schedule-management/get-session/${auto.uid}`,
+      );
+      t.ok(
+        'the preempted AUTO session has end_override set',
+        after.body?.endOverride !== null &&
+          after.body?.effectiveEnd === after.body?.endOverride,
+        `endOverride=${after.body?.endOverride} effectiveEnd=${after.body?.effectiveEnd}`,
+      );
+      t.ok(
+        'the AUTO session really ended (its end is at or before now)',
+        Date.parse(after.body.effectiveEnd) <= Date.now(),
+        `effectiveEnd ${after.body.effectiveEnd} vs now ${new Date().toISOString()}`,
+      );
+
+      const live = await api.get(
+        `schedule-management/get-active-session/${room.roomUid}`,
+      );
+      t.ok(
+        'the on-demand session is now the room’s active session',
+        live.body?.uid === od.body.uid && live.body?.type === 'ON_DEMAND',
+        `active is ${live.body?.type} ${live.body?.uid}`,
+      );
+    },
+  },
+
+  {
+    group: 'session lifecycle',
+    name: 'ending-a-session-early-tells-a-viewer-with-no-source-attached',
+    async run(t, { fx, api, baseUrl }) {
+      // The regression bc37f92 fixed: registerSource was the only thing that
+      // ever armed the session-end timer, so a room whose viewers joined
+      // *without* a kiosk had nobody watching the clock and sat on stale
+      // captions for up to half a token lifetime.
+      const room = await fx.room('endwatch');
+      const session = await fx.onDemand(room.roomUid, 'endwatch');
+      const code = await api.post('session-auth/admin-fetch-join-code', {
+        sessionUid: session.body.uid,
+      });
+      t.ok(
+        'a live on-demand session mints a join code',
+        code.body?.status === 'ok',
+        `status ${code.body?.status}`,
+      );
+
+      const viewer = await openViewer(api, baseUrl, code.body.joinCode);
+      t.ok('the viewer socket authenticates', viewer.observed.authOk, '');
+      await sleep(1000);
+      t.ok(
+        'no source is attached (the first status has both flags false)',
+        viewer.observed.statuses[0]?.source === false &&
+          viewer.observed.statuses[0]?.service === false,
+        JSON.stringify(viewer.observed.statuses[0] ?? null),
+      );
+
+      const t0 = Date.now();
+      const ended = await api.post('schedule-management/end-session-early', {
+        sessionUid: session.body.uid,
+      });
+      t.status('end-session-early succeeds', ended, 200);
+
+      const deadline = Date.now() + SESSION_END_DEADLINE_MS;
+      while (
+        Date.now() < deadline &&
+        !(viewer.observed.ended && viewer.observed.closes.length > 0)
+      ) {
+        await sleep(100);
+      }
+      t.ok(
+        'the source-free viewer receives sessionEnded',
+        viewer.observed.ended,
+        viewer.observed.ended
+          ? `after ${viewer.observed.endedAtMs - t0}ms`
+          : `nothing within ${SESSION_END_DEADLINE_MS}ms`,
+      );
+      t.ok(
+        'and its socket is closed 1000',
+        viewer.observed.closes.some((c) => c.code === 1000),
+        JSON.stringify(viewer.observed.closes),
+      );
+      try {
+        viewer.socket.terminate(1000, 'check-complete');
+      } catch {
+        // already gone
+      }
+    },
+  },
+
+  {
+    group: 'session lifecycle',
+    tags: ['stream'],
+    name: 'ending-a-session-early-tells-a-viewer-while-a-source-is-streaming',
+    async run(t, { fx, api, baseUrl, chunks }) {
+      // The other half of bc37f92: with a live SessionState the *source* path
+      // owns the end timer, and the two owners must not cancel each other out.
+      const room = await fx.room('endstream');
+      const session = await fx.onDemand(room.roomUid, 'endstream');
+      const code = await api.post('session-auth/admin-fetch-join-code', {
+        sessionUid: session.body.uid,
+      });
+      const viewer = await openViewer(api, baseUrl, code.body.joinCode);
+
+      const auth = new DeviceAuthClient({
+        sessionManagerBaseUrl: baseUrl,
+        deviceToken: room.device.deviceToken,
+        timeoutMs: 10_000,
+      });
+      const stream = new TestAudioStream(
+        { nodeServerBaseUrl: baseUrl, upstreamWaitMs: 20_000 },
+        auth,
+        new GoodEngine(GOOD_PARAM_DEFAULTS, createSeededRng(7)),
+        quietLogger(),
+      );
+      const done = stream
+        .run(chunks, Date.now() + 30_000)
+        .catch((err) => ({ error: err }));
+
+      // Wait for the source to actually register, not a fixed sleep: the
+      // assertion is about ending a session mid-stream, so a run where the
+      // source never arrived would be asserting nothing.
+      const registerBy = Date.now() + 20_000;
+      while (
+        Date.now() < registerBy &&
+        !viewer.observed.statuses.some((s) => s.source) &&
+        !viewer.observed.atCapacity
+      ) {
+        await sleep(200);
+      }
+
+      if (viewer.observed.atCapacity) {
+        stream.stop();
+        await done;
+        try {
+          viewer.socket.terminate(1000, 'at-capacity');
+        } catch {
+          // already gone
+        }
+        return {
+          skipped:
+            'the transcription service refused admission (at-capacity). ' +
+            'This is a deployment ceiling, not a session-machinery defect; ' +
+            're-run later or with --no-stream.',
+        };
+      }
+
+      t.ok(
+        'the viewer sees the source connect',
+        viewer.observed.statuses.some((s) => s.source),
+        JSON.stringify(viewer.observed.statuses),
+      );
+
+      // Let real audio frames reach the wire before ending. "Mid-stream" has to
+      // mean mid-stream: registering and immediately ending would exercise the
+      // teardown path with an idle upstream, which is not the case that broke.
+      const streamBy = Date.now() + 5_000;
+      while (Date.now() < streamBy && stream.counters.framesSent < 20) {
+        await sleep(200);
+      }
+      t.ok(
+        'audio frames are actually on the wire when the session is ended',
+        stream.counters.framesSent > 0,
+        `${stream.counters.framesSent} frame(s) sent`,
+      );
+
+      const t0 = Date.now();
+      const ended = await api.post('schedule-management/end-session-early', {
+        sessionUid: session.body.uid,
+      });
+      t.status('end-session-early succeeds mid-stream', ended, 200);
+
+      const deadline = Date.now() + SESSION_END_DEADLINE_MS;
+      while (
+        Date.now() < deadline &&
+        !(viewer.observed.ended && viewer.observed.closes.length > 0)
+      ) {
+        await sleep(100);
+      }
+      t.ok(
+        'the viewer receives sessionEnded while a source is mid-stream',
+        viewer.observed.ended,
+        viewer.observed.ended
+          ? `after ${viewer.observed.endedAtMs - t0}ms`
+          : `nothing within ${SESSION_END_DEADLINE_MS}ms`,
+      );
+      t.ok(
+        'and its socket is closed 1000',
+        viewer.observed.closes.some((c) => c.code === 1000),
+        JSON.stringify(viewer.observed.closes),
+      );
+
+      stream.stop();
+      const result = await done;
+      const reconnect = await api.device(
+        room.device.deviceToken,
+        'session-auth/exchange-device-token',
+        { sessionUid: session.body.uid },
+      );
+      t.status(
+        'and the source cannot mint a fresh token to reconnect into the dead session',
+        reconnect,
+        409,
+        'SESSION_NOT_CURRENTLY_ACTIVE',
+      );
+      t.ok(
+        'the streaming run ends rather than hanging',
+        result !== undefined,
+        `frames sent ${stream.counters.framesSent}` +
+          (result?.error ? `, last error ${result.error}` : ''),
+      );
+      try {
+        viewer.socket.terminate(1000, 'check-complete');
+      } catch {
+        // already gone
+      }
+    },
+  },
+
+  {
+    group: 'session lifecycle',
+    name: 'starting-a-session-early-moves-its-effective-start-and-makes-it-joinable',
+    async run(t, { fx, api }) {
+      const room = await fx.room('startearly');
+      const startsAt = new Date(Date.now() + 120_000);
+      await fx.schedule(room.roomUid, {
+        frequency: 'ONCE',
+        daysOfWeek: null,
+        localStartTime: utcHms(startsAt),
+        localEndTime: utcHms(new Date(startsAt.getTime() + 10 * 60_000)),
+      });
+      const [session] = await fx.listSessions(room.roomUid);
+      t.ok(
+        'a ONCE schedule materializes exactly one upcoming session',
+        session?.type === 'SCHEDULED',
+        `${session?.type ?? 'none'} at ${session?.effectiveStart}`,
+      );
+
+      const before = await api.post('session-auth/admin-fetch-join-code', {
+        sessionUid: session.uid,
+      });
+      t.ok(
+        'an upcoming session cannot mint a join code yet',
+        before.body?.status === 'not-active',
+        `status ${before.body?.status}`,
+      );
+
+      const early = await api.post('schedule-management/start-session-early', {
+        sessionUid: session.uid,
+      });
+      t.status('start-session-early succeeds', early, 200);
+      t.ok(
+        'effectiveStart moves back to the start_override',
+        early.body?.startOverride !== null &&
+          early.body?.effectiveStart === early.body?.startOverride &&
+          Date.parse(early.body.effectiveStart) <
+            Date.parse(session.effectiveStart),
+        `${session.effectiveStart} -> ${early.body?.effectiveStart}`,
+      );
+
+      const after = await api.post('session-auth/admin-fetch-join-code', {
+        sessionUid: session.uid,
+      });
+      t.ok(
+        'the session becomes joinable immediately',
+        after.body?.status === 'ok' && typeof after.body?.joinCode === 'string',
+        `status ${after.body?.status}`,
+      );
+
+      const token = await api.device(
+        room.device.deviceToken,
+        'session-auth/exchange-device-token',
+        { sessionUid: session.uid },
+      );
+      t.ok(
+        'and the room’s source device gets SEND_AUDIO for it',
+        token.status === 200 && token.body?.scopes?.includes('SEND_AUDIO'),
+        `${token.status} scopes=${JSON.stringify(token.body?.scopes)}`,
+      );
+    },
+  },
+
+  {
+    group: 'session lifecycle',
+    tags: ['slow'],
+    name: 'canceling-a-session-is-terminal-once-its-slot-arrives',
+    async run(t, { fx, api }) {
+      // The regression 1bfbc60 fixed. cancel-session accepts only *upcoming*
+      // occurrences, so the interesting moment is the one time catches up to:
+      // a canceled row whose start/end window now contains `now`. Before the
+      // fix every session-auth predicate read start/end only and happily
+      // minted credentials - including SEND_AUDIO to the room's kiosk - for a
+      // session an operator had canceled.
+      const room = await fx.room('cancelterm');
+      const startsAt = new Date(Date.now() + 45_000);
+      await fx.schedule(room.roomUid, {
+        frequency: 'ONCE',
+        daysOfWeek: null,
+        localStartTime: utcHms(startsAt),
+        localEndTime: utcHms(new Date(startsAt.getTime() + 10 * 60_000)),
+      });
+      const [session] = await fx.listSessions(room.roomUid);
+      t.ok(
+        'the occurrence materialized',
+        session?.type === 'SCHEDULED',
+        `${session?.type ?? 'none'}`,
+      );
+
+      const canceled = await api.post('schedule-management/cancel-session', {
+        sessionUid: session.uid,
+      });
+      t.status(
+        'cancel-session succeeds while it is still upcoming',
+        canceled,
+        200,
+      );
+      t.ok(
+        'canceled_at is stamped',
+        canceled.body?.canceledAt !== null,
+        `${canceled.body?.canceledAt}`,
+      );
+
+      const waitMs = Date.parse(session.effectiveStart) - Date.now() + 3_000;
+      await sleep(Math.max(0, waitMs));
+      t.ok(
+        'the canceled slot is now in the past (its window contains now)',
+        Date.now() > Date.parse(session.effectiveStart),
+        `start ${session.effectiveStart}`,
+      );
+
+      const admin = await api.post('session-auth/admin-fetch-join-code', {
+        sessionUid: session.uid,
+      });
+      t.ok(
+        'admin-fetch-join-code reports not-active for a canceled session',
+        admin.body?.status === 'not-active',
+        `status ${admin.body?.status}`,
+      );
+
+      const deviceCode = await api.device(
+        room.device.deviceToken,
+        'session-auth/fetch-join-code',
+        { sessionUid: session.uid },
+      );
+      t.status(
+        'the device-facing join-code route reports a canceled session as gone',
+        deviceCode,
+        404,
+        'SESSION_NOT_FOUND',
+      );
+
+      const deviceToken = await api.device(
+        room.device.deviceToken,
+        'session-auth/exchange-device-token',
+        { sessionUid: session.uid },
+      );
+      t.status(
+        'exchange-device-token refuses a canceled session',
+        deviceToken,
+        409,
+        'SESSION_NOT_CURRENTLY_ACTIVE',
+      );
+
+      const live = await api.get(
+        `schedule-management/get-active-session/${room.roomUid}`,
+      );
+      t.ok(
+        'and the room reports no active session at all',
+        live.body === null,
+        JSON.stringify(live.body),
+      );
+    },
+  },
+
+  {
+    group: 'session lifecycle',
+    name: 'uncanceling-restores-an-occurrence-unless-an-auto-session-took-the-slot',
+    async run(t, { fx, api }) {
+      const plain = await fx.room('uncancel');
+      const startsAt = new Date(Date.now() + 180_000);
+      await fx.schedule(plain.roomUid, {
+        frequency: 'ONCE',
+        daysOfWeek: null,
+        localStartTime: utcHms(startsAt),
+        localEndTime: utcHms(new Date(startsAt.getTime() + 10 * 60_000)),
+      });
+      const [session] = await fx.listSessions(plain.roomUid);
+      await api.post('schedule-management/cancel-session', {
+        sessionUid: session.uid,
+      });
+      const restored = await api.post('schedule-management/uncancel-session', {
+        sessionUid: session.uid,
+      });
+      t.status('uncancel-session restores a free slot', restored, 200);
+      t.ok(
+        'and clears canceled_at',
+        restored.body?.canceledAt === null,
+        `${restored.body?.canceledAt}`,
+      );
+      const again = await api.post('schedule-management/uncancel-session', {
+        sessionUid: session.uid,
+      });
+      t.status(
+        'uncanceling a session that is not canceled is 422',
+        again,
+        422,
+        'SESSION_NOT_CANCELED',
+      );
+
+      // In an auto-enabled room the reconciler backfills the freed slot the
+      // instant it is freed, so the undo has nowhere to land.
+      const auto = await fx.room('uncancel-auto', { auto: true });
+      await fx.window(auto.roomUid);
+      await fx.schedule(auto.roomUid, {
+        frequency: 'ONCE',
+        daysOfWeek: null,
+        localStartTime: utcHms(startsAt),
+        localEndTime: utcHms(new Date(startsAt.getTime() + 10 * 60_000)),
+      });
+      const inAuto = (await fx.listSessions(auto.roomUid)).find(
+        (s) => s.type === 'SCHEDULED',
+      );
+      t.ok(
+        'the occurrence materializes between two AUTO sessions',
+        Boolean(inAuto),
+        `types: ${(await fx.listSessions(auto.roomUid)).map((s) => s.type).join(',')}`,
+      );
+      await api.post('schedule-management/cancel-session', {
+        sessionUid: inAuto.uid,
+      });
+      const merged = await fx.listSessions(auto.roomUid);
+      const covering = merged.find(
+        (s) =>
+          s.type === 'AUTO' &&
+          !s.canceledAt &&
+          Date.parse(s.effectiveStart) <= Date.parse(inAuto.effectiveStart) &&
+          Date.parse(s.effectiveEnd) >= Date.parse(inAuto.effectiveEnd),
+      );
+      t.ok(
+        'canceling it lets an AUTO session backfill the freed slot',
+        Boolean(covering),
+        `sessions now: ${merged
+          .map(
+            (s) =>
+              `${s.type}${s.canceledAt ? '(canceled)' : ''} ${s.effectiveStart}..${s.effectiveEnd}`,
+          )
+          .join(' | ')}`,
+      );
+      const blocked = await api.post('schedule-management/uncancel-session', {
+        sessionUid: inAuto.uid,
+      });
+      t.status(
+        'and the undo is refused because the slot is no longer free',
+        blocked,
+        409,
+        'SLOT_NO_LONGER_AVAILABLE',
+      );
+    },
+  },
+
+  {
+    group: 'session lifecycle',
+    name: 'an-ended-session-refuses-its-old-join-code-and-its-refresh-token',
+    async run(t, { fx, api }) {
+      const room = await fx.room('ended-auth');
+      const session = await fx.onDemand(room.roomUid, 'ended-auth');
+      const code = await api.post('session-auth/admin-fetch-join-code', {
+        sessionUid: session.body.uid,
+      });
+      const exchanged = await api.anon('session-auth/exchange-join-code', {
+        joinCode: code.body.joinCode,
+      });
+      t.status('a live session exchanges its join code', exchanged, 200);
+
+      const refreshedWhileLive = await api.anon(
+        'session-auth/refresh-session-token',
+        { sessionRefreshToken: exchanged.body.sessionRefreshToken },
+      );
+      t.status(
+        'and the refresh token works while it is live',
+        refreshedWhileLive,
+        200,
+      );
+
+      await api.post('schedule-management/end-session-early', {
+        sessionUid: session.body.uid,
+      });
+
+      const rejoin = await api.anon('session-auth/exchange-join-code', {
+        joinCode: code.body.joinCode,
+      });
+      t.status(
+        're-joining an ended session with the old code is 409 SESSION_NOT_CURRENTLY_ACTIVE',
+        rejoin,
+        409,
+        'SESSION_NOT_CURRENTLY_ACTIVE',
+      );
+
+      const refreshed = await api.anon('session-auth/refresh-session-token', {
+        sessionRefreshToken: exchanged.body.sessionRefreshToken,
+      });
+      t.status(
+        'and the refresh token stops minting across the session end',
+        refreshed,
+        409,
+        'SESSION_ENDED',
+      );
+
+      const deviceToken = await api.device(
+        room.device.deviceToken,
+        'session-auth/exchange-device-token',
+        { sessionUid: session.body.uid },
+      );
+      t.status(
+        'the source device is refused a token for the ended session too',
+        deviceToken,
+        409,
+        'SESSION_NOT_CURRENTLY_ACTIVE',
+      );
+    },
+  },
+
+  {
+    group: 'session lifecycle',
+    name: 'only-upcoming-scheduled-sessions-cancel-and-only-live-non-auto-ones-end',
+    async run(t, { fx, api }) {
+      const auto = await fx.room('verbs-auto', { auto: true });
+      await fx.window(auto.roomUid);
+      const live = await fx.activeSession(auto.roomUid);
+
+      const endAuto = await api.post('schedule-management/end-session-early', {
+        sessionUid: live.uid,
+      });
+      t.status(
+        'an AUTO session cannot be ended early',
+        endAuto,
+        422,
+        'SESSION_IS_AUTO',
+      );
+      const startAuto = await api.post(
+        'schedule-management/start-session-early',
+        { sessionUid: live.uid },
+      );
+      t.status(
+        'an AUTO session cannot be started early',
+        startAuto,
+        422,
+        'SESSION_IS_AUTO',
+      );
+      const cancelAuto = await api.post('schedule-management/cancel-session', {
+        sessionUid: live.uid,
+      });
+      t.status(
+        'an AUTO session cannot be canceled',
+        cancelAuto,
+        422,
+        'SESSION_NOT_SCHEDULED_TYPE',
+      );
+
+      const plain = await fx.room('verbs-od');
+      const od = await fx.onDemand(plain.roomUid, 'verbs');
+      const cancelOd = await api.post('schedule-management/cancel-session', {
+        sessionUid: od.body.uid,
+      });
+      t.status(
+        'an ON_DEMAND session cannot be canceled',
+        cancelOd,
+        422,
+        'SESSION_NOT_SCHEDULED_TYPE',
+      );
+      const first = await api.post('schedule-management/end-session-early', {
+        sessionUid: od.body.uid,
+      });
+      t.status('ending a live on-demand session succeeds', first, 200);
+      const second = await api.post('schedule-management/end-session-early', {
+        sessionUid: od.body.uid,
+      });
+      t.status(
+        'ending it a second time is 422 SESSION_NOT_ACTIVE',
+        second,
+        422,
+        'SESSION_NOT_ACTIVE',
+      );
+    },
+  },
+
+  {
+    group: 'session lifecycle',
+    name: 'an-auto-enabled-room-survives-repeated-on-demand-start-stop-churn',
+    async run(t, { fx, api }) {
+      // CONTRIBUTING's "a feature with a 'currently active' notion needs a
+      // fixture that is active now": a 500 that broke every on-demand session
+      // in every auto-enabled room survived 341 integration tests because no
+      // fixture was live. Two full cycles exercise create -> preempt ->
+      // end -> backfill -> create again, each of which reconciles AUTO rows
+      // against a deferred exclusion constraint.
+      const room = await fx.room('churn', { auto: true });
+      await fx.window(room.roomUid);
+      for (let cycle = 1; cycle <= 2; cycle++) {
+        const before = await fx.activeSession(room.roomUid);
+        t.ok(
+          `cycle ${cycle}: an AUTO session holds the room before the on-demand one`,
+          before?.type === 'AUTO',
+          `active ${before?.type ?? 'none'}`,
+        );
+        const od = await fx.onDemand(room.roomUid, `churn-${cycle}`);
+        t.status(
+          `cycle ${cycle}: creating an on-demand session in a live auto room succeeds`,
+          od,
+          201,
+        );
+        const ended = await api.post('schedule-management/end-session-early', {
+          sessionUid: od.body.uid,
+        });
+        t.status(`cycle ${cycle}: ending it succeeds`, ended, 200);
+        const after = await fx.activeSession(room.roomUid);
+        t.ok(
+          `cycle ${cycle}: an AUTO session backfills the freed time`,
+          after?.type === 'AUTO' && after.uid !== before.uid,
+          `active ${after?.type ?? 'none'}`,
+        );
+      }
+    },
+  },
+
+  // -- join codes and auth -------------------------------------------------
+  {
+    group: 'join codes / auth',
+    tags: ['slow'],
+    name: 'a-join-code-is-exchangeable-only-inside-its-validity-window',
+    async run(t, { fx, api }) {
+      // The regression f7b26b6 fixed. fetchJoinCodes pre-mints the *next* code
+      // 60s before the current one expires, with validStart == current.validEnd.
+      // Checking only validEnd made that future code exchangeable the instant it
+      // was minted, stretching a code's usable life from 5 minutes to nearly 10
+      // with two codes live through every rotation. Driving the real mint-next
+      // path is the point: a hand-written future code would not prove the kiosk
+      // handoff still works afterwards.
+      const room = await fx.room('joincode');
+      const session = await fx.onDemand(room.roomUid, 'joincode');
+      const minted = await api.post('session-auth/admin-fetch-join-code', {
+        sessionUid: session.body.uid,
+      });
+      t.ok(
+        'a live session mints a current join code',
+        minted.body?.status === 'ok',
+        `status ${minted.body?.status}`,
+      );
+      const current = minted.body.joinCode;
+      const validEnd = Date.parse(minted.body.validEnd);
+
+      const now = await api.anon('session-auth/exchange-join-code', {
+        joinCode: current,
+      });
+      t.status('the current code exchanges now', now, 200);
+
+      // Into the 60s handoff window, where fetchJoinCodes pre-mints `next`.
+      await sleep(Math.max(0, validEnd - Date.now() - 40_000));
+      const handoff = await api.device(
+        room.device.deviceToken,
+        'session-auth/fetch-join-code',
+        { sessionUid: session.body.uid },
+      );
+      t.ok(
+        'inside the handoff window the kiosk is handed the next code',
+        handoff.status === 200 &&
+          handoff.body?.current?.joinCode === current &&
+          typeof handoff.body?.next?.joinCode === 'string',
+        `current=${handoff.body?.current?.joinCode} next=${handoff.body?.next?.joinCode}`,
+      );
+      const next = handoff.body.next;
+      t.ok(
+        'and the next code starts exactly where the current one ends',
+        Date.parse(next.validStart) === validEnd,
+        `next.validStart=${next.validStart} current.validEnd=${minted.body.validEnd}`,
+      );
+
+      const early = await api.anon('session-auth/exchange-join-code', {
+        joinCode: next.joinCode,
+      });
+      t.status(
+        'a code before its valid_start is refused 404 JOIN_CODE_NOT_FOUND',
+        early,
+        404,
+        'JOIN_CODE_NOT_FOUND',
+      );
+
+      await sleep(Math.max(0, validEnd - Date.now() + 2_000));
+      const expired = await api.anon('session-auth/exchange-join-code', {
+        joinCode: current,
+      });
+      t.status(
+        'a code past its valid_end is refused 410 JOIN_CODE_EXPIRED',
+        expired,
+        410,
+        'JOIN_CODE_EXPIRED',
+      );
+
+      const handedOver = await api.anon('session-auth/exchange-join-code', {
+        joinCode: next.joinCode,
+      });
+      t.status(
+        'and the pre-minted handoff code works the moment the old one dies',
+        handedOver,
+        200,
+      );
+    },
+  },
+
+  {
+    group: 'join codes / auth',
+    name: 'an-unknown-or-malformed-join-code-is-rejected-without-leaking-anything',
+    async run(t, { api }) {
+      const unknown = await api.anon('session-auth/exchange-join-code', {
+        joinCode: 'ZZZZZZZZ',
+      });
+      t.status(
+        'a well-formed but nonexistent join code is 404 JOIN_CODE_NOT_FOUND',
+        unknown,
+        404,
+        'JOIN_CODE_NOT_FOUND',
+      );
+      const malformed = await api.anon('session-auth/exchange-join-code', {
+        joinCode: 'nope',
+      });
+      t.ok(
+        'a malformed join code is rejected 4xx by the schema',
+        malformed.status >= 400 && malformed.status < 500,
+        `${malformed.status} ${malformed.body?.code}`,
+      );
+      const badRefresh = await api.anon('session-auth/refresh-session-token', {
+        sessionRefreshToken: 'garbage-without-a-separator',
+      });
+      t.status(
+        'a malformed refresh token is 401 INVALID_REFRESH_TOKEN',
+        badRefresh,
+        401,
+        'INVALID_REFRESH_TOKEN',
+      );
+    },
+  },
+
+  {
+    group: 'join codes / auth',
+    name: 'a-session-with-no-join-code-scopes-cannot-mint-a-code',
+    async run(t, { fx, api }) {
+      const room = await fx.room('noscopes');
+      const session = await fx.onDemand(room.roomUid, 'noscopes', {
+        joinCodeScopes: [],
+      });
+      t.status('a session with empty joinCodeScopes is accepted', session, 201);
+
+      const admin = await api.post('session-auth/admin-fetch-join-code', {
+        sessionUid: session.body.uid,
+      });
+      t.ok(
+        'admin-fetch-join-code answers 200 with status no-join-scopes',
+        admin.status === 200 &&
+          admin.body?.status === 'no-join-scopes' &&
+          admin.body?.joinCode === null,
+        `${admin.status} ${JSON.stringify(admin.body)}`,
+      );
+
+      const device = await api.device(
+        room.device.deviceToken,
+        'session-auth/fetch-join-code',
+        { sessionUid: session.body.uid },
+      );
+      t.status(
+        'the device-facing route answers 409 JOIN_CODE_SCOPES_EMPTY',
+        device,
+        409,
+        'JOIN_CODE_SCOPES_EMPTY',
+      );
+
+      // The source device still gets its own token: joinCodeScopes govern the
+      // anonymous join path only, not device auth.
+      const token = await api.device(
+        room.device.deviceToken,
+        'session-auth/exchange-device-token',
+        { sessionUid: session.body.uid },
+      );
+      t.ok(
+        'but the room’s source device can still exchange its device token',
+        token.status === 200 && token.body?.scopes?.includes('SEND_AUDIO'),
+        `${token.status} ${JSON.stringify(token.body?.scopes)}`,
+      );
+    },
+  },
+
+  {
+    group: 'join codes / auth',
+    name: 'a-device-token-only-works-for-sessions-in-its-own-room',
+    async run(t, { fx, api }) {
+      const mine = await fx.room('scope-mine');
+      const theirs = await fx.room('scope-theirs');
+      const session = await fx.onDemand(mine.roomUid, 'scope');
+
+      const own = await api.device(
+        mine.device.deviceToken,
+        'session-auth/exchange-device-token',
+        { sessionUid: session.body.uid },
+      );
+      t.ok(
+        'the room’s own source device gets SEND_AUDIO',
+        own.status === 200 && own.body?.scopes?.includes('SEND_AUDIO'),
+        `${own.status} ${JSON.stringify(own.body?.scopes)}`,
+      );
+
+      const foreign = await api.device(
+        theirs.device.deviceToken,
+        'session-auth/exchange-device-token',
+        { sessionUid: session.body.uid },
+      );
+      t.status(
+        'a device from another room is refused 403',
+        foreign,
+        403,
+        'DEVICE_NOT_IN_SESSION_ROOM',
+      );
+      const foreignCode = await api.device(
+        theirs.device.deviceToken,
+        'session-auth/fetch-join-code',
+        { sessionUid: session.body.uid },
+      );
+      t.status(
+        'and cannot read its join codes either',
+        foreignCode,
+        403,
+        'DEVICE_NOT_IN_SESSION_ROOM',
+      );
+    },
+  },
+
+  // -- calendar / scheduling ----------------------------------------------
+  {
+    group: 'calendar / scheduling',
+    name: 'an-auto-window-wrapping-past-midnight-materializes-a-session-covering-now',
+    async run(t, { fx }) {
+      // localEndTime < localStartTime means each occurrence runs into the next
+      // day. Sized so the window is 23h long and unambiguously contains now,
+      // which no non-wrapping window with these two times could.
+      const start = new Date(Date.now() - 60 * 60 * 1000);
+      const end = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      const room = await fx.room('wrap', { auto: true });
+      const win = await fx.window(room.roomUid, {
+        localStartTime: utcHms(start).slice(0, 5),
+        localEndTime: utcHms(end).slice(0, 5),
+      });
+      t.status('a midnight-wrapping window is accepted', win, 201);
+
+      const live = await fx.activeSession(room.roomUid);
+      t.ok(
+        'it materializes an AUTO session covering now',
+        live?.type === 'AUTO',
+        `active ${live?.type ?? 'none'}`,
+      );
+      t.ok(
+        'whose effective end lands on the following day',
+        live !== null &&
+          Date.parse(live.effectiveEnd) > Date.now() &&
+          Date.parse(live.effectiveEnd) - Date.now() > 20 * 60 * 60 * 1000,
+        `end ${live?.effectiveEnd}`,
+      );
+    },
+  },
+
+  {
+    group: 'calendar / scheduling',
+    name: 'an-auto-window-must-start-before-the-occurrence-to-cover-today',
+    async run(t, { fx }) {
+      // `inRange` drops any occurrence whose *start* precedes `activeStart`,
+      // so a daily 00:00-23:59 window created at 16:00 with `activeStart = now`
+      // loses today's occurrence entirely and first materializes tomorrow. The
+      // admin dialog forces `activeStart` into the future, so an operator who
+      // creates "auto sessions, every day, from now" gets nothing until
+      // midnight. demo-e2e backdates a week for exactly this reason.
+      const today = await fx.room('as-today', { auto: true });
+      await fx.window(today.roomUid, {
+        activeStart: new Date().toISOString(),
+      });
+      const noneNow = await fx.activeSession(today.roomUid, 3_000);
+      t.pin(
+        'a window whose activeStart is "now" produces NO session covering now',
+        noneNow === null,
+        noneNow === null
+          ? 'no active session, as inRange drops the occurrence that started at 00:00'
+          : `unexpectedly active: ${noneNow.effectiveStart}`,
+        'QUIRK-3',
+      );
+      const upcoming = await fx.listSessions(
+        today.roomUid,
+        -60_000,
+        2 * DAY_MS,
+      );
+      t.pin(
+        'and the first AUTO session appears only on the next local day',
+        upcoming.length > 0 &&
+          Date.parse(upcoming[0].effectiveStart) > Date.now(),
+        upcoming.length
+          ? `first at ${upcoming[0].effectiveStart}`
+          : 'no sessions in the next two days',
+        'QUIRK-3',
+      );
+
+      const backdated = await fx.room('as-backdated', { auto: true });
+      await fx.window(backdated.roomUid);
+      const live = await fx.activeSession(backdated.roomUid);
+      t.ok(
+        'the same window backdated a week does cover now',
+        live?.type === 'AUTO',
+        `active ${live?.type ?? 'none'}`,
+      );
+    },
+  },
+
+  {
+    group: 'calendar / scheduling',
+    name: 'overlapping-auto-windows-in-one-room-are-refused',
+    async run(t, { fx }) {
+      const room = await fx.room('overlap', { auto: true });
+      const first = await fx.window(room.roomUid, {
+        localStartTime: '08:00',
+        localEndTime: '12:00',
+      });
+      t.status('the first window is accepted', first, 201);
+      const clash = await fx.window(room.roomUid, {
+        localStartTime: '10:00',
+        localEndTime: '14:00',
+      });
+      t.status(
+        'a window overlapping it is refused 409 CONFLICT',
+        clash,
+        409,
+        'CONFLICT',
+      );
+      const abutting = await fx.window(room.roomUid, {
+        localStartTime: '12:00',
+        localEndTime: '14:00',
+      });
+      t.status('a window that merely abuts it is accepted', abutting, 201);
+    },
+  },
+
+  {
+    group: 'calendar / scheduling',
+    name: 'a-spring-forward-gap-swallows-occurrences-that-fall-entirely-inside-it',
+    async run(t, { fx }) {
+      // America/Chicago springs forward at 02:00 local, so 02:00:00-02:59:59
+      // does not exist that day. `buildOccurrence` snaps both endpoints to the
+      // transition instant and returns null when they coincide, so an
+      // occurrence wholly inside the gap disappears. Observable through the
+      // conflict detector: two schedules that overlap on paper do not conflict
+      // on the gap day, because neither produces an occurrence.
+      const zone = 'America/Chicago';
+      const spring = nextTransitions(zone, new Date(), 4).find(
+        (x) => x.toOffset > x.fromOffset,
+      );
+      if (!spring) {
+        return { skipped: `no spring-forward transition found for ${zone}` };
+      }
+      const dow = localDayOfWeek(zone, new Date(spring.at.getTime() + 60_000));
+      const activeStart = new Date(spring.at.getTime() - 8 * 60 * 60 * 1000);
+      const activeEnd = new Date(spring.at.getTime() + 16 * 60 * 60 * 1000);
+      const pair = (roomUid, ls, le) => ({
+        frequency: 'WEEKLY',
+        daysOfWeek: [dow],
+        activeStart: activeStart.toISOString(),
+        activeEnd: activeEnd.toISOString(),
+        localStartTime: ls,
+        localEndTime: le,
+        roomUid,
+      });
+
+      const gap = await fx.room('dst-gap', { timezone: zone });
+      const g1 = await fx.schedule(
+        gap.roomUid,
+        pair(gap.roomUid, '02:00', '02:59'),
+      );
+      const g2 = await fx.schedule(
+        gap.roomUid,
+        pair(gap.roomUid, '02:15', '02:45'),
+      );
+      t.ok(
+        'a 02:00-02:59 schedule on the spring-forward day is accepted',
+        g1.status === 201,
+        `${g1.status} ${g1.body?.code ?? ''}`,
+      );
+      t.ok(
+        'and a 02:15-02:45 one does NOT conflict with it - both vanish into the gap',
+        g2.status === 201,
+        `${g2.status} ${g2.body?.code ?? ''} (transition at ${spring.at.toISOString()})`,
+      );
+
+      const same = await fx.room('dst-same-day', { timezone: zone });
+      const s1 = await fx.schedule(
+        same.roomUid,
+        pair(same.roomUid, '03:30', '04:30'),
+      );
+      const s2 = await fx.schedule(
+        same.roomUid,
+        pair(same.roomUid, '03:45', '04:15'),
+      );
+      t.ok(
+        'on that same day, times after the transition DO conflict',
+        s1.status === 201 && s2.status === 409 && s2.body?.code === 'CONFLICT',
+        `${s1.status}/${s2.status} ${s2.body?.code ?? ''}`,
+      );
+
+      const week = await fx.room('dst-next-week', { timezone: zone });
+      const later = (ls, le) => ({
+        ...pair(week.roomUid, ls, le),
+        activeStart: new Date(activeStart.getTime() + 7 * DAY_MS).toISOString(),
+        activeEnd: new Date(activeEnd.getTime() + 7 * DAY_MS).toISOString(),
+      });
+      const w1 = await fx.schedule(week.roomUid, later('02:00', '02:59'));
+      const w2 = await fx.schedule(week.roomUid, later('02:15', '02:45'));
+      t.ok(
+        'and the identical 02:xx pair one week later does conflict',
+        w1.status === 201 && w2.status === 409 && w2.body?.code === 'CONFLICT',
+        `${w1.status}/${w2.status} ${w2.body?.code ?? ''}`,
+      );
+    },
+  },
+
+  {
+    group: 'calendar / scheduling',
+    name: 'a-fall-back-ambiguous-local-time-resolves-to-the-standard-time-instant',
+    async run(t, { fx }) {
+      // At fall-back, local 01:00-01:59 happens twice. `localToUtc` picks the
+      // LATER (standard-time) instant, so an occurrence 00:30-01:30 runs two
+      // hours, not one.
+      //
+      // Conflict detection alone cannot see this: local -> UTC is strictly
+      // increasing under either reading, so overlap decisions are identical.
+      // What does distinguish them is `inRange`'s activeEnd test, which drops
+      // an occurrence whose end exceeds activeEnd. Put activeEnd *between* the
+      // two candidate ends and the occurrences survive only under the earlier
+      // (daylight) reading - so "no conflict" here is a positive statement
+      // that the later instant was chosen.
+      const zone = 'America/Chicago';
+      const fall = nextTransitions(zone, new Date(), 4).find(
+        (x) => x.toOffset < x.fromOffset,
+      );
+      if (!fall) {
+        return { skipped: `no fall-back transition found for ${zone}` };
+      }
+      const dow = localDayOfWeek(zone, new Date(fall.at.getTime() + 60_000));
+      const activeStart = new Date(fall.at.getTime() - 8 * 60 * 60 * 1000);
+      // 00:30 local is unambiguous (daylight); 01:30 local is ambiguous.
+      // daylight reading ends 30 min BEFORE the transition instant, standard
+      // reading 30 min after.
+      const between = new Date(fall.at.getTime());
+      const afterBoth = new Date(fall.at.getTime() + 90 * 60_000);
+      const pair = (roomUid, ls, le, activeEnd) => ({
+        roomUid,
+        frequency: 'WEEKLY',
+        daysOfWeek: [dow],
+        activeStart: activeStart.toISOString(),
+        activeEnd: activeEnd.toISOString(),
+        localStartTime: ls,
+        localEndTime: le,
+      });
+
+      const decisive = await fx.room('dst-fall', { timezone: zone });
+      const d1 = await fx.schedule(
+        decisive.roomUid,
+        pair(decisive.roomUid, '00:30', '01:30', between),
+      );
+      const d2 = await fx.schedule(
+        decisive.roomUid,
+        pair(decisive.roomUid, '00:45', '01:15', between),
+      );
+      t.ok(
+        'with activeEnd between the daylight and standard readings both occurrences vanish',
+        d1.status === 201 && d2.status === 201,
+        `${d1.status}/${d2.status} ${d2.body?.code ?? ''} ` +
+          `(transition at ${fall.at.toISOString()})`,
+      );
+
+      const control = await fx.room('dst-fall-ctl', { timezone: zone });
+      const c1 = await fx.schedule(
+        control.roomUid,
+        pair(control.roomUid, '00:30', '01:30', afterBoth),
+      );
+      const c2 = await fx.schedule(
+        control.roomUid,
+        pair(control.roomUid, '00:45', '01:15', afterBoth),
+      );
+      t.ok(
+        'with activeEnd past the standard reading they survive and conflict',
+        c1.status === 201 && c2.status === 409 && c2.body?.code === 'CONFLICT',
+        `${c1.status}/${c2.status} ${c2.body?.code ?? ''}`,
+      );
+    },
+  },
+
+  {
+    group: 'calendar / scheduling',
+    name: 'once-weekly-and-biweekly-schedules-materialize-and-the-biweekly-anchor-survives-an-update',
+    async run(t, { fx, api }) {
+      const once = await fx.room('freq-once');
+      const at = new Date(Date.now() + 5 * 60_000);
+      await fx.schedule(once.roomUid, {
+        frequency: 'ONCE',
+        daysOfWeek: null,
+        localStartTime: utcHms(at),
+        localEndTime: utcHms(new Date(at.getTime() + 60_000)),
+      });
+      const onceSessions = await fx.listSessions(
+        once.roomUid,
+        -60_000,
+        8 * DAY_MS,
+      );
+      t.ok(
+        'a ONCE schedule materializes exactly one occurrence',
+        onceSessions.length === 1,
+        `${onceSessions.length} session(s)`,
+      );
+
+      const weekly = await fx.room('freq-weekly');
+      await fx.schedule(weekly.roomUid, {
+        frequency: 'WEEKLY',
+        daysOfWeek: ALL_DAYS,
+        localStartTime: '09:00',
+        localEndTime: '10:00',
+      });
+      const weeklySessions = await fx.listSessions(
+        weekly.roomUid,
+        -60_000,
+        8 * DAY_MS,
+      );
+      t.ok(
+        'a daily WEEKLY schedule materializes one occurrence per day inside the 7-day horizon',
+        weeklySessions.length >= 6 && weeklySessions.length <= 8,
+        `${weeklySessions.length} session(s)`,
+      );
+
+      const biweekly = await fx.room('freq-biweekly');
+      const created = await fx.schedule(biweekly.roomUid, {
+        frequency: 'BIWEEKLY',
+        daysOfWeek: ALL_DAYS,
+        localStartTime: '09:00',
+        localEndTime: '10:00',
+      });
+      t.status('a BIWEEKLY schedule is accepted', created, 201);
+      t.ok(
+        'its anchor starts equal to its activeStart',
+        created.body?.anchorStart === created.body?.activeStart,
+        `anchor ${created.body?.anchorStart}`,
+      );
+
+      // updateSchedule closes the old row and inserts a new one; the anchor
+      // must be carried verbatim or the biweekly cadence silently shifts by a
+      // week for every future occurrence.
+      const updated = await api.post('schedule-management/update-schedule', {
+        scheduleUid: created.body.uid,
+        name: fx.name('freq-biweekly-renamed'),
+        activeStart: new Date(Date.now() + 20 * DAY_MS).toISOString(),
+      });
+      t.status('and it can be updated', updated, 200);
+      t.ok(
+        'the BIWEEKLY parity anchor survives the update unchanged',
+        updated.body?.anchorStart === created.body?.anchorStart,
+        `${created.body?.anchorStart} -> ${updated.body?.anchorStart}`,
+      );
+      t.ok(
+        'even though activeStart moved',
+        updated.body?.activeStart !== created.body?.activeStart,
+        `${created.body?.activeStart} -> ${updated.body?.activeStart}`,
+      );
+    },
+  },
+
+  {
+    group: 'calendar / scheduling',
+    name: 'schedules-and-sessions-outside-the-listing-and-materialization-horizons',
+    async run(t, { fx, api }) {
+      const room = await fx.room('horizon');
+      const far = new Date(Date.now() + 120 * DAY_MS);
+      const created = await fx.schedule(room.roomUid, {
+        activeStart: far.toISOString(),
+      });
+      t.status('a schedule starting 120 days out is accepted', created, 201);
+
+      const ranged = await api.get(
+        `schedule-management/list-schedules?roomUid=${room.roomUid}` +
+          `&from=${encodeURIComponent(new Date().toISOString())}` +
+          `&to=${encodeURIComponent(new Date(Date.now() + 90 * DAY_MS).toISOString())}`,
+      );
+      t.pin(
+        'but it is invisible to a 90-day ranged listing',
+        ranged.body?.items?.length === 0,
+        `${ranged.body?.items?.length} item(s) in the 90-day range`,
+        'QUIRK-4',
+      );
+      const unranged = await api.get(
+        `schedule-management/list-schedules?roomUid=${room.roomUid}`,
+      );
+      t.ok(
+        'and only an unbounded listing shows it',
+        unranged.body?.items?.length === 1,
+        `${unranged.body?.items?.length} item(s) unranged`,
+      );
+
+      const soon = await fx.room('horizon-7d');
+      await fx.schedule(soon.roomUid, {
+        activeStart: new Date(Date.now() + 10 * DAY_MS).toISOString(),
+      });
+      const sessions = await fx.listSessions(
+        soon.roomUid,
+        -60_000,
+        30 * DAY_MS,
+      );
+      t.ok(
+        'a schedule beyond the 7-day materialization horizon has no sessions yet',
+        sessions.length === 0,
+        `${sessions.length} session(s): ${sessions.map((s) => s.effectiveStart).join(', ')}`,
+      );
+
+      const tooWide = await api.get(
+        `schedule-management/list-sessions?roomUids=${soon.roomUid}` +
+          `&from=${encodeURIComponent(new Date().toISOString())}` +
+          `&to=${encodeURIComponent(new Date(Date.now() + 32 * DAY_MS).toISOString())}`,
+      );
+      t.status(
+        'list-sessions refuses a range longer than 31 days',
+        tooWide,
+        422,
+        'RANGE_TOO_LARGE',
+      );
+    },
+  },
+
+  {
+    group: 'calendar / scheduling',
+    name: 'an-activeEnd-inside-an-occurrence-drops-the-occurrence-instead-of-clipping-it',
+    async run(t, { fx, api }) {
+      // `inRange` rejects an occurrence whose end exceeds `activeEnd` rather
+      // than clipping it. For a daily 00:00-23:59 window that means setting
+      // activeEnd to any instant before 23:59 removes the whole day. An
+      // operator reading "auto sessions until 15:00" gets none at all - and,
+      // worse, narrowing a *live* window ends the session that is running now.
+      const fresh = await fx.room('clip-fresh', { auto: true });
+      await fx.window(fresh.roomUid, {
+        activeEnd: new Date(Date.now() + 30 * 60_000).toISOString(),
+      });
+      const none = await fx.activeSession(fresh.roomUid, 3_000);
+      t.pin(
+        'a window whose activeEnd lands mid-occurrence produces no session at all',
+        none === null,
+        none === null
+          ? 'no active session (the whole occurrence was dropped, not clipped to activeEnd)'
+          : `unexpectedly active until ${none.effectiveEnd}`,
+        'BUG-2',
+      );
+
+      const live = await fx.room('clip-live', { auto: true });
+      const win = await fx.window(live.roomUid);
+      const before = await fx.activeSession(live.roomUid);
+      t.ok(
+        'a live AUTO session exists before the window is narrowed',
+        before?.type === 'AUTO',
+        `active ${before?.type ?? 'none'}`,
+      );
+      const stopAt = new Date(Date.now() + 30 * 60_000);
+      const narrowed = await api.post(
+        'schedule-management/update-auto-session-window',
+        { windowUid: win.body.uid, activeEnd: stopAt.toISOString() },
+      );
+      t.status('narrowing the live window succeeds', narrowed, 200);
+      const after = await api.get(
+        `schedule-management/get-active-session/${live.roomUid}`,
+      );
+      t.pin(
+        'and it ends the running AUTO session NOW rather than at the new activeEnd',
+        after.body === null,
+        after.body === null
+          ? `no active session, though the operator asked for one until ${stopAt.toISOString()}`
+          : `still active until ${after.body.effectiveEnd}`,
+        'BUG-2',
+      );
+    },
+  },
+
+  {
+    group: 'calendar / scheduling',
+    name: 'turning-auto-sessions-off-ends-the-live-auto-session',
+    async run(t, { fx, api }) {
+      const room = await fx.room('toggle', { auto: true });
+      await fx.window(room.roomUid);
+      const live = await fx.activeSession(room.roomUid);
+      t.ok('an AUTO session is live', live?.type === 'AUTO', `${live?.type}`);
+
+      const off = await api.post(
+        'schedule-management/update-room-schedule-config',
+        { roomUid: room.roomUid, autoSessionEnabled: false },
+      );
+      t.status('autoSessionEnabled can be turned off', off, 200);
+      const after = await api.get(
+        `schedule-management/get-session/${live.uid}`,
+      );
+      t.ok(
+        'the live AUTO session is ended via end_override',
+        after.body?.endOverride !== null &&
+          Date.parse(after.body.effectiveEnd) <= Date.now(),
+        `endOverride ${after.body?.endOverride}`,
+      );
+      const none = await api.get(
+        `schedule-management/get-active-session/${room.roomUid}`,
+      );
+      t.ok(
+        'and the room has no active session',
+        none.body === null,
+        JSON.stringify(none.body),
+      );
+
+      const on = await api.post(
+        'schedule-management/update-room-schedule-config',
+        { roomUid: room.roomUid, autoSessionEnabled: true },
+      );
+      t.status('turning it back on succeeds', on, 200);
+      const resumed = await fx.activeSession(room.roomUid);
+      t.ok(
+        'and materialization resumes from the untouched window',
+        resumed?.type === 'AUTO' && resumed.uid !== live.uid,
+        `active ${resumed?.type ?? 'none'}`,
+      );
+    },
+  },
+
+  {
+    group: 'calendar / scheduling',
+    name: 'deleting-a-window-or-a-schedule-cleans-up-what-it-materialized',
+    async run(t, { fx, api }) {
+      const room = await fx.room('del-window', { auto: true });
+      const win = await fx.window(room.roomUid);
+      const live = await fx.activeSession(room.roomUid);
+      const deleted = await api.post(
+        'schedule-management/delete-auto-session-window',
+        { windowUid: win.body.uid },
+      );
+      t.status(
+        'deleting a window with a live AUTO session succeeds',
+        deleted,
+        204,
+      );
+      const ended = await api.get(
+        `schedule-management/get-session/${live.uid}`,
+      );
+      t.ok(
+        'the live AUTO session is ended, not orphaned',
+        ended.body?.endOverride !== null,
+        `endOverride ${ended.body?.endOverride}`,
+      );
+      const gone = await api.post(
+        'schedule-management/delete-auto-session-window',
+        { windowUid: win.body.uid },
+      );
+      t.status(
+        'deleting it again is 404 WINDOW_NOT_FOUND',
+        gone,
+        404,
+        'WINDOW_NOT_FOUND',
+      );
+
+      const sched = await fx.room('del-schedule');
+      const created = await fx.schedule(sched.roomUid, {
+        activeStart: new Date(Date.now() + 60_000).toISOString(),
+      });
+      const before = await fx.listSessions(sched.roomUid, -60_000, 8 * DAY_MS);
+      t.ok(
+        'a schedule materializes upcoming sessions',
+        before.length > 0,
+        `${before.length} session(s)`,
+      );
+      const removed = await api.post('schedule-management/delete-schedule', {
+        scheduleUid: created.body.uid,
+      });
+      t.status('deleting the schedule succeeds', removed, 204);
+      const after = await fx.listSessions(sched.roomUid, -60_000, 8 * DAY_MS);
+      t.ok(
+        'and its upcoming sessions go with it',
+        after.length === 0,
+        `${after.length} session(s) left`,
+      );
+    },
+  },
+
+  // -- rooms and devices ---------------------------------------------------
+  {
+    group: 'rooms / devices',
+    name: 'a-room-takes-exactly-one-source-device',
+    async run(t, { fx, api }) {
+      const a = await fx.device('two-src-a');
+      const b = await fx.device('two-src-b');
+      const both = await api.post('room-management/create-room', {
+        name: fx.name('two-src'),
+        timezone: 'UTC',
+        autoSessionEnabled: false,
+        sourceDeviceUids: [a.deviceUid, b.deviceUid],
+      });
+      t.status(
+        'creating a room with two source devices is refused',
+        both,
+        409,
+        'TOO_MANY_SOURCE_DEVICES',
+      );
+      const none = await api.post('room-management/create-room', {
+        name: fx.name('no-src'),
+        timezone: 'UTC',
+        autoSessionEnabled: false,
+        sourceDeviceUids: [],
+      });
+      t.ok(
+        'and creating one with no source device is refused too',
+        none.status >= 400 && none.status < 500,
+        `${none.status} ${none.body?.code}`,
+      );
+
+      // BUG-3. `add-device-to-room` publishes a 409 TOO_MANY_SOURCE_DEVICES
+      // reply that nothing can ever produce: only `createRoom` emits that code.
+      // The service runs no "this room already has a source" check, and the
+      // repository's `asSource` branch clears `is_source` across the whole room
+      // before inserting - so the call silently demotes the room's kiosk and
+      // answers 204.
+      const room = await fx.room('one-src');
+      const session = await fx.onDemand(room.roomUid, 'one-src');
+      const beforeScopes = await api.device(
+        room.device.deviceToken,
+        'session-auth/exchange-device-token',
+        { sessionUid: session.body.uid },
+      );
+      t.ok(
+        'the room’s source device has SEND_AUDIO before anything is added',
+        beforeScopes.body?.scopes?.includes('SEND_AUDIO'),
+        JSON.stringify(beforeScopes.body?.scopes),
+      );
+
+      const second = await api.post('room-management/add-device-to-room', {
+        roomUid: room.roomUid,
+        deviceUid: b.deviceUid,
+        asSource: true,
+      });
+      t.pin(
+        'adding a second device asSource is accepted (204) rather than refused',
+        second.status === 204,
+        `got ${second.status} ${second.body?.code ?? ''}; the route publishes a ` +
+          '409 TOO_MANY_SOURCE_DEVICES reply that only create-room can produce',
+        'BUG-3',
+      );
+
+      const afterScopes = await api.device(
+        room.device.deviceToken,
+        'session-auth/exchange-device-token',
+        { sessionUid: session.body.uid },
+      );
+      t.pin(
+        'and it silently demotes the original source, which keeps its token but loses SEND_AUDIO',
+        afterScopes.status === 200 &&
+          !afterScopes.body?.scopes?.includes('SEND_AUDIO'),
+        `original source scopes are now ${JSON.stringify(afterScopes.body?.scopes)} - ` +
+          'a kiosk that still authenticates, still finds the session, and sends nothing',
+        'BUG-3',
+      );
+      const promoted = await api.device(
+        b.deviceToken,
+        'session-auth/exchange-device-token',
+        { sessionUid: session.body.uid },
+      );
+      t.pin(
+        'while the newly added device now holds SEND_AUDIO',
+        promoted.body?.scopes?.includes('SEND_AUDIO'),
+        JSON.stringify(promoted.body?.scopes),
+        'BUG-3',
+      );
+    },
+  },
+
+  {
+    group: 'rooms / devices',
+    name: 'a-device-cannot-belong-to-two-rooms',
+    async run(t, { fx, api }) {
+      const a = await fx.room('two-rooms-a');
+      const b = await fx.room('two-rooms-b');
+      const asMember = await api.post('room-management/add-device-to-room', {
+        roomUid: b.roomUid,
+        deviceUid: a.device.deviceUid,
+        asSource: false,
+      });
+      t.status(
+        'adding a room’s device to a second room is refused',
+        asMember,
+        409,
+        'DEVICE_ALREADY_IN_ROOM',
+      );
+      const asSource = await api.post('room-management/add-device-to-room', {
+        roomUid: b.roomUid,
+        deviceUid: a.device.deviceUid,
+        asSource: true,
+      });
+      t.status(
+        'and so is adding it as that room’s source',
+        asSource,
+        409,
+        'DEVICE_ALREADY_IN_ROOM',
+      );
+    },
+  },
+
+  {
+    group: 'rooms / devices',
+    name: 'a-rooms-source-device-cannot-be-deleted-or-detached',
+    async run(t, { fx, api }) {
+      const room = await fx.room('src-lock');
+      const del = await api.post('device-management/delete-device', {
+        deviceUid: room.device.deviceUid,
+      });
+      t.status(
+        'deleting a room’s source device is refused',
+        del,
+        409,
+        'WOULD_LEAVE_ROOM_WITHOUT_SOURCE',
+      );
+      const detach = await api.post('room-management/remove-device-from-room', {
+        deviceUid: room.device.deviceUid,
+      });
+      t.status(
+        'and detaching it from its room is refused',
+        detach,
+        409,
+        'WOULD_LEAVE_ROOM_WITHOUT_SOURCE',
+      );
+    },
+  },
+
+  {
+    group: 'rooms / devices',
+    name: 'deleting-a-room-with-a-live-session-cascades-the-session',
+    async run(t, { fx, api }) {
+      const room = await fx.room('del-live');
+      const session = await fx.onDemand(room.roomUid, 'del-live');
+      const code = await api.post('session-auth/admin-fetch-join-code', {
+        sessionUid: session.body.uid,
+      });
+      t.ok('the session is live and joinable', code.body?.status === 'ok', '');
+
+      const deleted = await api.post('room-management/delete-room', {
+        roomUid: room.roomUid,
+      });
+      t.status('the room deletes despite the live session', deleted, 204);
+      fx.rooms = fx.rooms.filter((r) => r !== room.roomUid);
+
+      const gone = await api.get(
+        `schedule-management/get-session/${session.body.uid}`,
+      );
+      t.status('the session is gone with it', gone, 404, 'SESSION_NOT_FOUND');
+      const orphanCode = await api.anon('session-auth/exchange-join-code', {
+        joinCode: code.body.joinCode,
+      });
+      t.status(
+        'and its join code no longer exchanges',
+        orphanCode,
+        404,
+        'JOIN_CODE_NOT_FOUND',
+      );
+    },
+  },
+
+  {
+    group: 'rooms / devices',
+    name: 'reserved-demo-and-canary-uids-are-refused-for-assignment',
+    async run(t, { fx, api }) {
+      // These guards run before any existence lookup on purpose, so the answer
+      // does not depend on whether the seeder ran on this deployment.
+      const room = await fx.room('reserved');
+      const toDemo = await api.post('room-management/add-device-to-room', {
+        roomUid: DEMO_ROOM_UID,
+        deviceUid: room.device.deviceUid,
+        asSource: false,
+      });
+      t.status(
+        'a device cannot be added to the demo room',
+        toDemo,
+        409,
+        'DEMO_ROOM_NOT_ASSIGNABLE',
+      );
+      const toCanary = await api.post('room-management/add-device-to-room', {
+        roomUid: CANARY_ROOM_UID,
+        deviceUid: room.device.deviceUid,
+        asSource: false,
+      });
+      t.status(
+        'nor to the monitoring canary room',
+        toCanary,
+        409,
+        'CANARY_ROOM_NOT_ASSIGNABLE',
+      );
+      const demoSource = await api.post('room-management/create-room', {
+        name: fx.name('reserved-demo-src'),
+        timezone: 'UTC',
+        autoSessionEnabled: false,
+        sourceDeviceUids: [DEMO_SOURCE_DEVICE_UID],
+      });
+      t.status(
+        'the demo room’s placeholder source cannot become a real room’s source',
+        demoSource,
+        409,
+        'DEMO_SOURCE_DEVICE_NOT_ASSIGNABLE',
+      );
+      const canarySource = await api.post('room-management/create-room', {
+        name: fx.name('reserved-canary-src'),
+        timezone: 'UTC',
+        autoSessionEnabled: false,
+        sourceDeviceUids: [CANARY_DEVICE_UID],
+      });
+      t.status(
+        'nor can the canary device - the guard that keeps fixture speech out of a lecture',
+        canarySource,
+        409,
+        'CANARY_DEVICE_NOT_ASSIGNABLE',
+      );
+      const delDemo = await api.post('room-management/delete-room', {
+        roomUid: DEMO_ROOM_UID,
+      });
+      t.status(
+        'the demo room cannot be deleted',
+        delDemo,
+        409,
+        'DEMO_ROOM_NOT_DELETABLE',
+      );
+      const delDemoDevice = await api.post('device-management/delete-device', {
+        deviceUid: DEMO_SOURCE_DEVICE_UID,
+      });
+      t.status(
+        'and neither can its placeholder source device',
+        delDemoDevice,
+        409,
+        'DEMO_SOURCE_DEVICE_NOT_DELETABLE',
+      );
+
+      // The test-audio rooms are only seeded when TEST_AUDIO_DEVICE_SECRET is
+      // set, so they are discovered rather than assumed.
+      const rooms = await api.get('room-management/list-rooms?limit=100');
+      const testAudio = (rooms.body?.items ?? []).find((r) =>
+        r.name?.startsWith('TEST-AUDIO-'),
+      );
+      if (testAudio) {
+        const toTestAudio = await api.post(
+          'room-management/add-device-to-room',
+          {
+            roomUid: testAudio.uid,
+            deviceUid: room.device.deviceUid,
+            asSource: false,
+          },
+        );
+        t.status(
+          'a device cannot be added to a seeded test-audio room',
+          toTestAudio,
+          409,
+          'TEST_AUDIO_ROOM_NOT_ASSIGNABLE',
+        );
+      }
+    },
+  },
+
+  {
+    group: 'rooms / devices',
+    name: 'an-activation-code-is-single-use-and-advertises-a-five-minute-expiry',
+    async run(t, { fx, api }) {
+      const reg = await api.post('device-management/register-device', {
+        name: fx.name('activation'),
+      });
+      t.ok(
+        'register-device issues an activation code',
+        reg.status === 201,
+        `${reg.status}`,
+      );
+      fx.devices.push(reg.body.deviceUid);
+
+      const ttlMs = Date.parse(reg.body.expiry) - Date.now();
+      t.ok(
+        'the code advertises a ~5 minute expiry',
+        ttlMs > 4 * 60_000 && ttlMs <= 5 * 60_000 + 30_000,
+        `${Math.round(ttlMs / 1000)}s`,
+      );
+
+      const first = await api.anon('device-management/activate-device', {
+        activationCode: reg.body.activationCode,
+      });
+      t.ok(
+        'the first activation succeeds',
+        first.status === 200,
+        `${first.status}`,
+      );
+      const second = await api.anon('device-management/activate-device', {
+        activationCode: reg.body.activationCode,
+      });
+      t.status(
+        'the same code cannot be redeemed twice',
+        second,
+        404,
+        'ACTIVATION_CODE_NOT_FOUND',
+      );
+      const unknown = await api.anon('device-management/activate-device', {
+        activationCode: 'ZZZZZZZZ',
+      });
+      t.status(
+        'and an unknown code is 404',
+        unknown,
+        404,
+        'ACTIVATION_CODE_NOT_FOUND',
+      );
+    },
+  },
+
+  // -- invalid input -------------------------------------------------------
+  {
+    group: 'invalid input',
+    name: 'an-unknown-transcriptionProviderId-is-refused-on-every-write-path',
+    async run(t, { fx, api }) {
+      // 16e07c9. Answered at write time because the alternative surfaces at
+      // stream time: transcription-service closes the upstream 1007, node-server
+      // retries a permanently unsatisfiable request, and every viewer of that
+      // room watches a banner promising a reconnection that cannot happen.
+      const room = await fx.room('provider', { auto: true });
+      const typo = 'whipser';
+
+      const od = await fx.onDemand(room.roomUid, 'provider', {
+        transcriptionProviderId: typo,
+      });
+      t.status('create-on-demand-session refuses it', od, 400);
+      t.ok(
+        'and the message names the providers this deployment does have',
+        /Configured providers:/.test(od.body?.message ?? ''),
+        od.body?.message ?? '',
+      );
+
+      const sched = await fx.schedule(room.roomUid, {
+        transcriptionProviderId: typo,
+      });
+      t.status('create-schedule refuses it', sched, 400);
+
+      const win = await fx.window(room.roomUid, {
+        transcriptionProviderId: typo,
+      });
+      t.status('create-auto-session-window refuses it', win, 400);
+
+      const goodWindow = await fx.window(room.roomUid);
+      const updatedWindow = await api.post(
+        'schedule-management/update-auto-session-window',
+        { windowUid: goodWindow.body.uid, transcriptionProviderId: typo },
+      );
+      t.status('update-auto-session-window refuses it', updatedWindow, 400);
+
+      const goodSchedule = await fx.schedule(room.roomUid, {
+        localStartTime: '01:00',
+        localEndTime: '02:00',
+        activeStart: new Date(Date.now() + 60_000).toISOString(),
+      });
+      const updatedSchedule = await api.post(
+        'schedule-management/update-schedule',
+        { scheduleUid: goodSchedule.body.uid, transcriptionProviderId: typo },
+      );
+      t.status('update-schedule refuses it', updatedSchedule, 400);
+    },
+  },
+
+  {
+    group: 'invalid input',
+    name: 'an-invalid-timezone-is-refused',
+    async run(t, { fx, api }) {
+      const device = await fx.device('tz');
+      const bad = await api.post('room-management/create-room', {
+        name: fx.name('tz-bad'),
+        timezone: 'Mars/Olympus_Mons',
+        autoSessionEnabled: false,
+        sourceDeviceUids: [device.deviceUid],
+      });
+      t.status(
+        'a non-IANA timezone is refused 422 INVALID_TIMEZONE',
+        bad,
+        422,
+        'INVALID_TIMEZONE',
+      );
+      const empty = await api.post('room-management/create-room', {
+        name: fx.name('tz-empty'),
+        timezone: '',
+        autoSessionEnabled: false,
+        sourceDeviceUids: [device.deviceUid],
+      });
+      t.ok(
+        'and so is an empty one',
+        empty.status >= 400 && empty.status < 500,
+        `${empty.status} ${empty.body?.code}`,
+      );
+      const alias = await api.post('room-management/create-room', {
+        name: fx.name('tz-alias'),
+        timezone: 'Etc/UTC',
+        autoSessionEnabled: false,
+        sourceDeviceUids: [device.deviceUid],
+      });
+      t.ok(
+        'while an alias like Etc/UTC that Intl.supportedValuesOf omits is accepted',
+        alias.status === 201,
+        `${alias.status} ${alias.body?.code ?? ''}`,
+      );
+      if (alias.status === 201) fx.rooms.push(alias.body.uid);
+    },
+  },
+
+  {
+    group: 'invalid input',
+    name: 'equal-local-start-and-end-times-are-refused-on-schedules-and-windows',
+    async run(t, { fx, api }) {
+      const room = await fx.room('equal-times', { auto: true });
+
+      const schedule = await fx.schedule(room.roomUid, {
+        localStartTime: '10:00',
+        localEndTime: '10:00',
+      });
+      t.status(
+        'a schedule with localStartTime == localEndTime is refused 400',
+        schedule,
+        400,
+      );
+
+      // BUG-1: the window path has no equivalent pre-check, so the
+      // `auto_session_windows_local_times_distinct` CHECK fires and the
+      // operator gets a 500 for the same typo the schedule path answers with a
+      // sentence.
+      const window = await fx.window(room.roomUid, {
+        localStartTime: '10:00',
+        localEndTime: '10:00',
+      });
+      t.pin(
+        'an auto-session window with equal local times answers 500, not 400',
+        window.status === 500 && window.body?.code === 'INTERNAL_ERROR',
+        `got ${window.status} ${window.body?.code ?? ''} - the schedule path ` +
+          'validates this and returns 400; the window path lets the DB CHECK fire',
+        'BUG-1',
+      );
+
+      const good = await fx.window(room.roomUid, {
+        localStartTime: '08:00',
+        localEndTime: '09:00',
+      });
+      const narrowed = await api.post(
+        'schedule-management/update-auto-session-window',
+        { windowUid: good.body.uid, localEndTime: '08:00' },
+      );
+      t.pin(
+        'and so does updating an existing window to equal local times',
+        narrowed.status === 500 && narrowed.body?.code === 'INTERNAL_ERROR',
+        `got ${narrowed.status} ${narrowed.body?.code ?? ''}`,
+        'BUG-1',
+      );
+      const survived = await api.get(
+        `schedule-management/get-auto-session-window/${good.body.uid}`,
+      );
+      t.ok(
+        'the failed update at least rolls back and leaves the window intact',
+        survived.status === 200 &&
+          survived.body?.localEndTime?.startsWith('09:00') &&
+          survived.body?.activeEnd === null,
+        `${survived.status} localEndTime=${survived.body?.localEndTime} activeEnd=${survived.body?.activeEnd}`,
+      );
+    },
+  },
+
+  {
+    group: 'invalid input',
+    name: 'malformed-uuids-and-unknown-uids-are-rejected-distinctly',
+    async run(t, { api }) {
+      const absent = '00000000-0000-4000-8000-000000000000';
+      const malformed = await api.post(
+        'schedule-management/end-session-early',
+        {
+          sessionUid: 'not-a-uuid',
+        },
+      );
+      t.status(
+        'a malformed session uid is a 400 validation error',
+        malformed,
+        400,
+        'VALIDATION_ERROR',
+      );
+      const unknownSession = await api.post(
+        'schedule-management/end-session-early',
+        { sessionUid: absent },
+      );
+      t.status(
+        'a well-formed unknown session uid is 404 SESSION_NOT_FOUND',
+        unknownSession,
+        404,
+        'SESSION_NOT_FOUND',
+      );
+      const unknownRoom = await api.get(
+        `schedule-management/get-active-session/${absent}`,
+      );
+      t.status(
+        'an unknown room uid is 404 ROOM_NOT_FOUND, not a null active session',
+        unknownRoom,
+        404,
+        'ROOM_NOT_FOUND',
+      );
+      const unknownWindow = await api.post(
+        'schedule-management/delete-auto-session-window',
+        { windowUid: absent },
+      );
+      t.status(
+        'an unknown window uid is 404 WINDOW_NOT_FOUND',
+        unknownWindow,
+        404,
+        'WINDOW_NOT_FOUND',
+      );
+      const unknownSchedule = await api.get(
+        `schedule-management/get-schedule/${absent}`,
+      );
+      t.status(
+        'an unknown schedule uid is 404 SCHEDULE_NOT_FOUND',
+        unknownSchedule,
+        404,
+        'SCHEDULE_NOT_FOUND',
+      );
+    },
+  },
+
+  {
+    group: 'invalid input',
+    name: 'frequency-and-daysOfWeek-must-agree-and-active-ranges-must-be-ordered',
+    async run(t, { fx }) {
+      const room = await fx.room('freq-validation');
+
+      const onceWithDays = await fx.schedule(room.roomUid, {
+        frequency: 'ONCE',
+        daysOfWeek: ['MON'],
+      });
+      t.status(
+        'a ONCE schedule with daysOfWeek is refused 400',
+        onceWithDays,
+        400,
+      );
+
+      const weeklyWithNull = await fx.schedule(room.roomUid, {
+        frequency: 'WEEKLY',
+        daysOfWeek: null,
+      });
+      t.status(
+        'a WEEKLY schedule with null daysOfWeek is refused 400',
+        weeklyWithNull,
+        400,
+      );
+
+      // The DB CHECK uses array_length(), which is NULL for an empty array and
+      // therefore passes; the service has to catch [] itself.
+      const weeklyWithEmpty = await fx.schedule(room.roomUid, {
+        frequency: 'WEEKLY',
+        daysOfWeek: [],
+      });
+      t.status(
+        'a WEEKLY schedule with an EMPTY daysOfWeek is refused 400',
+        weeklyWithEmpty,
+        400,
+      );
+
+      const pastStart = await fx.schedule(room.roomUid, {
+        activeStart: new Date(Date.now() - 60_000).toISOString(),
+      });
+      t.status(
+        'a schedule whose activeStart is in the past is refused 422',
+        pastStart,
+        422,
+        'INVALID_ACTIVE_START',
+      );
+
+      const backwards = await fx.schedule(room.roomUid, {
+        activeStart: new Date(Date.now() + 2 * DAY_MS).toISOString(),
+        activeEnd: new Date(Date.now() + DAY_MS).toISOString(),
+      });
+      t.ok(
+        'a schedule whose activeEnd precedes activeStart is refused 4xx',
+        backwards.status >= 400 && backwards.status < 500,
+        `${backwards.status} ${backwards.body?.code ?? ''}`,
+      );
+
+      const auto = await fx.room('freq-validation-window', { auto: true });
+      const emptyDays = await fx.window(auto.roomUid, { daysOfWeek: [] });
+      t.status(
+        'an auto-session window with an empty daysOfWeek is refused 400 by the schema',
+        emptyDays,
+        400,
+        'VALIDATION_ERROR',
+      );
+      const windowBackwards = await fx.window(auto.roomUid, {
+        activeStart: new Date(Date.now() + 2 * DAY_MS).toISOString(),
+        activeEnd: new Date(Date.now() + DAY_MS).toISOString(),
+      });
+      t.status(
+        'and one whose activeEnd precedes activeStart is refused 422',
+        windowBackwards,
+        422,
+        'INVALID_ACTIVE_END',
+      );
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+function selectChecks(args) {
+  return CHECKS.filter((check) => {
+    if (args.only.length && !args.only.some((s) => check.name.includes(s))) {
+      return false;
+    }
+    return true;
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const log = (...m) => {
+    if (!args.json) console.log(...m);
+  };
+
+  if (args.list) {
+    for (const check of CHECKS) {
+      const tags = check.tags?.length ? ` [${check.tags.join(',')}]` : '';
+      console.log(`${check.group.padEnd(22)} ${check.name}${tags}`);
+    }
+    return 0;
+  }
+
+  const { env, path: envPath } = loadDeploymentEnv(args.envFile);
+  const adminKey =
+    process.env.SESSION_MANAGER_API_KEY || env.SESSION_MANAGER_API_KEY;
+  if (!adminKey) throw new Error(`${envPath} has no SESSION_MANAGER_API_KEY.`);
+  log(`--- keys from ${envPath}; base url ${args.baseUrl}`);
+
+  const api = createApi(args.baseUrl, adminKey);
+  const stamp = `scc-${process.pid}-${Math.floor(Date.now() / 1000)}`;
+  const fx = new Fixtures(api, stamp);
+  log(`--- fixtures named ${stamp}-*`);
+
+  let chunks = null;
+  const wantsStream =
+    args.stream && selectChecks(args).some((c) => c.tags?.includes('stream'));
+  if (wantsStream) {
+    chunks = sliceIntoChunks(decodeWav(readFileSync(WAV)), CHUNK_MS);
+  }
+
+  const ctx = { api, fx, baseUrl: args.baseUrl, chunks };
+  const results = [];
+
+  try {
+    for (const check of selectChecks(args)) {
+      if (check.tags?.includes('slow') && args.quick) {
+        results.push({ ...check, skipped: '--quick', assertions: [] });
+        log(`SKIP ${check.name} (--quick)`);
+        continue;
+      }
+      if (check.tags?.includes('stream') && !args.stream) {
+        results.push({ ...check, skipped: '--no-stream', assertions: [] });
+        log(`SKIP ${check.name} (--no-stream)`);
+        continue;
+      }
+
+      const t = new Recorder(check.name);
+      const startedAt = Date.now();
+      let error = null;
+      let skipped = null;
+      try {
+        const outcome = await check.run(t, ctx);
+        if (outcome?.skipped) skipped = outcome.skipped;
+      } catch (err) {
+        error = err instanceof Error ? (err.stack ?? err.message) : String(err);
+      }
+      const entry = {
+        group: check.group,
+        name: check.name,
+        tags: check.tags ?? [],
+        ms: Date.now() - startedAt,
+        assertions: t.assertions,
+        error,
+        skipped,
+      };
+      results.push(entry);
+
+      const failed = entry.assertions.filter((a) => !a.ok).length;
+      const verdict = error
+        ? 'ERROR'
+        : skipped
+          ? 'SKIP'
+          : failed
+            ? 'FAIL'
+            : 'PASS';
+      log(
+        `${verdict.padEnd(5)} ${check.name} ` +
+          `(${entry.assertions.length} assertions, ${Math.round(entry.ms / 1000)}s)`,
+      );
+      if (skipped) log(`      ${skipped}`);
+    }
+  } finally {
+    if (args.keep) {
+      log(
+        `--- --keep: left ${fx.rooms.length} room(s), ${fx.devices.length} device(s)`,
+      );
+    } else {
+      log('--- cleaning up');
+      await fx.teardown(log);
+    }
+  }
+
+  // ---- Report ----
+  const allAssertions = results.flatMap((r) =>
+    r.assertions.map((a) => ({ ...a, check: r.name })),
+  );
+  const failures = allAssertions.filter((a) => !a.ok);
+  const pinned = allAssertions.filter((a) => a.ok && a.pins);
+  const errored = results.filter((r) => r.error);
+  const ok = failures.length === 0 && errored.length === 0;
+
+  const result = {
+    ok,
+    stamp,
+    baseUrl: args.baseUrl,
+    counts: {
+      checks: results.length,
+      skipped: results.filter((r) => r.skipped).length,
+      assertions: allAssertions.length,
+      failed: failures.length,
+      pinsQuestionableBehaviour: pinned.length,
+      errored: errored.length,
+    },
+    checks: results,
+    failures: failures.map((f) => `${f.check}: ${f.name} (${f.detail})`),
+    questionable: pinned.map((p) => `${p.pins} ${p.check}: ${p.name}`),
+  };
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return ok ? 0 : 1;
+  }
+
+  console.log('\n=== RESULT ===');
+  let group = null;
+  for (const check of results) {
+    if (check.group !== group) {
+      group = check.group;
+      console.log(`\n-- ${group} --`);
+    }
+    if (check.skipped) {
+      console.log(`  SKIP  ${check.name}`);
+      console.log(`        ${check.skipped}`);
+      continue;
+    }
+    if (check.error) {
+      console.log(`  ERROR ${check.name}`);
+      console.log(`        ${check.error.split('\n')[0]}`);
+    }
+    for (const a of check.assertions) {
+      const label = a.ok ? (a.pins ? `PASS (pins ${a.pins})` : 'PASS') : 'FAIL';
+      console.log(`  [${label}] ${a.name}`);
+      if (!a.ok || a.pins) console.log(`         ${a.detail}`);
+    }
+  }
+
+  console.log(
+    `\n${result.counts.assertions} assertions in ${result.counts.checks} checks ` +
+      `(${result.counts.skipped} skipped); ${result.counts.failed} failed, ` +
+      `${result.counts.pinsQuestionableBehaviour} pin known-questionable behaviour.`,
+  );
+  if (pinned.length) {
+    console.log(
+      '\nAssertions marked "pins" encode behaviour that is currently wrong or\n' +
+        'surprising. They pass on purpose so a real regression stands out; each is\n' +
+        'documented in tools/session-corner-cases/README.md:',
+    );
+    for (const p of new Set(result.questionable)) console.log(`  - ${p}`);
+  }
+  if (errored.length) {
+    console.log('\nCHECKS THAT THREW:');
+    for (const e of errored) console.log(`  - ${e.name}: ${e.error}`);
+  }
+  console.log(ok ? '\nPASS' : `\nFAIL\n - ${result.failures.join('\n - ')}`);
+  return ok ? 0 : 1;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error(
+      err instanceof Error ? (err.stack ?? err.message) : String(err),
+    );
+    process.exit(2);
+  });

--- a/transcription_service/src/shared/config/config.py
+++ b/transcription_service/src/shared/config/config.py
@@ -60,12 +60,40 @@ class EnvSchema(BaseModel):
     # edits, never as `.env` values - `ALERT_RTF_P95` and its two siblings, a
     # number a CPU deployment must currently discover for itself and hand-set
     # with no `.env` path to do so. These three are the manual override the plan
-    # calls out by name, and are not repeating that mistake.
+    # calls out by name, and are not repeating that mistake. They are wired
+    # through `deployment/compose.yml` as `TRANSCRIPTION_TARGET_BUSY`,
+    # `TRANSCRIPTION_MIN_SESSIONS` and `TRANSCRIPTION_MAX_SESSIONS`, so a
+    # compose operator can actually reach them - which for a while they could
+    # not, the exact regret above one indirection along.
     TARGET_BUSY: float = 0.85
     MIN_SESSIONS: int = 1
     MAX_SESSIONS: int | None = None
 
     PROVIDER_CONFIG_PATH: str
+
+    @field_validator("MAX_SESSIONS", mode="before")
+    @classmethod
+    def _blank_max_sessions_means_no_pin(cls, value: Any) -> Any:
+        """
+        Reads an empty MAX_SESSIONS as "no operator pin", same as unset
+
+        Compose has no way to omit an environment key, so the
+        transcription-service block passes
+        `MAX_SESSIONS: ${TRANSCRIPTION_MAX_SESSIONS:-}` and every stock
+        deployment hands this an empty string. Without this, that empty string
+        fails `int | None` parsing at boot and the container refuses to start -
+        which would turn an optional tuning knob into a required one for
+        everybody who copied the shipped compose file, the loudest possible
+        version of a change that is supposed to be inert by default.
+
+        Only the empty case is special-cased: a typo'd `MAX_SESSIONS=lots`
+        still fails loudly, because silently auto-tuning under a value an
+        operator believed was a hard pin is precisely the misconfiguration
+        nobody would find.
+        """
+        if isinstance(value, str) and value.strip() == "":
+            return None
+        return value
 
     @field_validator("TRANSCRIPTION_HOST_ID")
     @classmethod

--- a/transcription_service/src/transcription_provider_interface/transcription_provider_interface.py
+++ b/transcription_service/src/transcription_provider_interface/transcription_provider_interface.py
@@ -130,7 +130,9 @@ class TranscriptionProviderInterface(ABC):
             logger      - Logger to attach to a refusal
 
         A session calls this itself, right after registering its job - not
-        the registry, and not at session construction. Registration is what
+        the registry, and not at session construction - and calls it through
+        `TranscriptionSessionInterface._admit_registered_job`, which owns the
+        deregistration a refusal has to undo. Registration is what
         makes a session a claim on worker capacity at all (an idle,
         audio-less connection that never registers a job never shows up in
         any worker's live_job_count), so there is nothing to decide before

--- a/transcription_service/src/transcription_provider_interface/transcription_provider_interface.py
+++ b/transcription_service/src/transcription_provider_interface/transcription_provider_interface.py
@@ -3,6 +3,7 @@ Defines TranscriptionProviderInterface API for transcription providers
 """
 
 from abc import ABC, abstractmethod
+from typing import Callable
 
 from src.shared.logger import Logger
 from src.shared.utils.worker_pool import WorkerPool
@@ -91,6 +92,54 @@ class TranscriptionProviderInterface(ABC):
     # immutable, so the first increment rebinds it as an instance attribute and
     # no state is ever shared between providers.
     _active_sessions: int = 0
+
+    # None until `bind_admission_check` wires one on, which
+    # TranscriptionProviderRegistry does right after constructing this
+    # provider. A provider built directly - every provider unit test does
+    # this - therefore admits unconditionally, the same fail-open default
+    # admission control has used from the start.
+    _admission_check: Callable[[int | None, Logger], None] | None = None
+
+    def bind_admission_check(
+        self, check: Callable[[int | None, Logger], None]
+    ) -> None:
+        """
+        Wires this provider to the registry's capacity gate
+
+        Args:
+            check   - Callable a session invokes the moment it discovers
+                        which worker (if any) its job landed on. Raises
+                        TranscriptionCapacityError if that worker has no
+                        room; a no-op call is always safe.
+
+        Called once, by TranscriptionProviderRegistry._load_providers,
+        immediately after construction - never by a session, and never
+        more than once per provider.
+        """
+        self._admission_check = check
+
+    def check_admission(self, worker_id: int | None, logger: Logger) -> None:
+        """
+        Asks the registry whether the given worker has room for one more
+        session, raising TranscriptionCapacityError if not
+
+        Args:
+            worker_id   - The worker a session's job just landed on, or None
+                            if this session's cost is not a capacity claim
+                            (see TranscriptionSessionInterface.admission_worker_id)
+            logger      - Logger to attach to a refusal
+
+        A session calls this itself, right after registering its job - not
+        the registry, and not at session construction. Registration is what
+        makes a session a claim on worker capacity at all (an idle,
+        audio-less connection that never registers a job never shows up in
+        any worker's live_job_count), so there is nothing to decide before
+        it happens, and deciding any later would let that session's job sit
+        on a worker it was never granted.
+        """
+        if self._admission_check is None:
+            return
+        self._admission_check(worker_id, logger)
 
     @property
     def job_period_ms(self) -> int | None:

--- a/transcription_service/src/transcription_provider_interface/transcription_session_interface.py
+++ b/transcription_service/src/transcription_provider_interface/transcription_session_interface.py
@@ -3,11 +3,18 @@ Defines TranscriptionSessionInterface API for transcription providers
 """
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
 
+from src.shared.logger import Logger
 from src.shared.utils.event_emitter import Event, EventEmitter
 
 from .transcription_client_error import TranscriptionClientError
 from .transcription_result import TranscriptionResult
+
+if TYPE_CHECKING:
+    # Import-cycle-free because it is type-checking only: the provider
+    # interface imports this module at runtime, not the other way round.
+    from .transcription_provider_interface import TranscriptionProviderInterface
 
 
 class TranscriptionSessionInterface(ABC, EventEmitter):
@@ -35,6 +42,60 @@ class TranscriptionSessionInterface(ABC, EventEmitter):
     # Part 2).
     session_uid: str | None = None
     room_uid: str | None = None
+
+    # The worker-pool JobHandle this session registered on its first audio
+    # chunk, or None while it has registered nothing. Declared here, not only
+    # in each implementation's __init__, because `_admit_registered_job` below
+    # owns the undo on a refusal and therefore has to be able to clear it.
+    # `Any` rather than `JobHandle[...]`: every provider parameterises the
+    # handle with its own data/result/config types, and the only thing this
+    # class ever does with it is `deregister()`.
+    _job: Any = None
+
+    def _admit_registered_job(
+        self, provider: "TranscriptionProviderInterface", logger: Logger
+    ) -> None:
+        """
+        Asks whether the worker this session's just-registered job landed on
+        has room for it, and undoes the registration if it does not
+
+        Args:
+            provider    - Provider this session belongs to; its
+                            `check_admission` carries the binding the registry
+                            attached at load time
+            logger      - Logger a refusal is attached to
+
+        Called from a session's `_ensure_job`, immediately after `register_job`
+        returns and before any data is queued to the job - so a refusal costs
+        the worker nothing beyond the registration undone here.
+
+        THE UNDO IS UNCONDITIONAL, AND SHARED ON PURPOSE. It used to be written
+        out inside `whisper_streaming_provider` alone, while `debug` and
+        `lumen_granite` called `check_admission` bare. That was safe only for
+        as long as neither of those two overrode `admission_worker_id` - an
+        invariant asserted in three docstrings and enforced by nothing.
+        Overriding that property is a one-line change in a provider with no
+        reason to know it would leak a job, and the leak is silent: the worker
+        keeps scheduling a job every period for a session no client ever
+        received, consuming exactly the capacity the refusal existed to
+        protect, and nothing ever calls `end_session` on a session the caller
+        never got back. So register/ask/undo is one thing all three sessions
+        call, rather than a shape each is trusted to reproduce.
+
+        Clearing `self._job` is what stops `admission_worker_id` continuing to
+        claim a worker this session was refused. Deregistration is idempotent
+        (`JobHandle.deregister`), so the `end_session` teardown that runs later
+        is unaffected either way.
+        """
+        if self._job is None:
+            return
+
+        try:
+            provider.check_admission(self.admission_worker_id, logger)
+        except BaseException:
+            self._job.deregister()
+            self._job = None
+            raise
 
     @property
     def admission_worker_id(self) -> int | None:

--- a/transcription_service/src/transcription_provider_interface/transcription_session_interface.py
+++ b/transcription_service/src/transcription_provider_interface/transcription_session_interface.py
@@ -40,26 +40,30 @@ class TranscriptionSessionInterface(ABC, EventEmitter):
     def admission_worker_id(self) -> int | None:
         """
         Gets the pool worker this session's compute landed on, or None if the
-        session is not subject to local worker-pool capacity admission
+        session is not subject to local worker-pool capacity admission, or if
+        it has not yet claimed a worker at all
 
         Which worker a session lands on is decided by live load balancing at
         `register_job` time (`WorkerPool._assign_process` picks the least
         utilized worker owning every required context tag), so it is not
-        knowable before the session is constructed. That is why admission
-        control registers first and asks afterwards, and why the answer has to
-        come off the session object: the registry that decides admission never
-        sees the JobHandle.
+        knowable before a job is registered. Registration itself is deferred
+        to the session's first real audio chunk (an idle, audio-less
+        connection registers no job and so is never a capacity claim on
+        anything), which is why this reads None right up until then even for
+        a provider that overrides it - and why the answer has to come off the
+        session object rather than be asked of the registry, which never sees
+        the JobHandle.
 
-        None is a positive statement, not a missing implementation. It means
-        "this session's cost is not a claim on a local worker's ASR throughput,
-        so the per-worker capacity estimate does not describe it" - the shape
-        `PLAN-AdmissionControl.md` §5 already uses for a remote provider's
-        capacity, which is reported as "not applicable" rather than as a
-        fabricated number. Defaulting to None is also the safe direction under
-        this plan's stated posture: a provider added later is admitted rather
-        than refused until someone deliberately opts it in, and an
-        over-admission is visible and self-corrects while a wrong refusal is
-        invisible to everyone including us.
+        None is also a positive statement once a job does exist, not only a
+        "not yet" state. It means "this session's cost is not a claim on a
+        local worker's ASR throughput, so the per-worker capacity estimate
+        does not describe it" - the shape `PLAN-AdmissionControl.md` §5 already
+        uses for a remote provider's capacity, which is reported as "not
+        applicable" rather than as a fabricated number. Defaulting to None is
+        also the safe direction under this plan's stated posture: a provider
+        added later is admitted rather than refused until someone deliberately
+        opts it in, and an over-admission is visible and self-corrects while a
+        wrong refusal is invisible to everyone including us.
 
         Concretely, of the three shipped providers only `whisper-streaming`
         overrides this. `lumen_granite` is a remote-API provider whose capacity

--- a/transcription_service/src/transcription_providers/debug_provider/debug_provider.py
+++ b/transcription_service/src/transcription_providers/debug_provider/debug_provider.py
@@ -2,6 +2,9 @@
 Defines DebugProvider that provides debugging information as "transcriptions"
 """
 
+# The provider/session wiring necessarily mirrors the other providers.
+# pylint: disable=duplicate-code
+
 from src.shared.logger import Logger
 from src.shared.utils.worker_pool import JobException, JobSuccess, WorkerPool
 from src.transcription_provider_interface import (
@@ -51,19 +54,10 @@ class DebugProvider(TranscriptionProviderInterface):
             self.session_uid = session_uid
             self.room_uid = room_uid
 
-            self._job = provider.worker_pool.register_job(
-                (),
-                DEBUG_JOB_PERIOD_MS,
-                DebugProviderJob(self._config),
-                provider.provider_key,
-                session_uid=self.session_uid,
-                room_uid=self.room_uid,
-            )
+            # Not registered here - see _ensure_job. An idle client that never
+            # sends audio must never take a worker's job slot.
+            self._job = None
 
-            self._job.on(self._job.JobResultEvent, self._handle_job_result)
-
-            # Last, so a registration that raises above never counts a session
-            # that did not open.
             provider.session_started()
 
         def _handle_job_result(
@@ -108,15 +102,46 @@ class DebugProvider(TranscriptionProviderInterface):
                 ),
             )
 
+        def _ensure_job(self) -> None:
+            """
+            Registers this session's worker-pool job on the first real audio
+            chunk, not at construction
+
+            Deferred so an idle client - configured but never streaming - never
+            takes a worker's job slot, and so never counts toward that
+            worker's live_job_count for capacity admission. `check_admission`
+            is called for uniformity with the other two providers' sessions,
+            not because it can refuse one here: this session never overrides
+            `admission_worker_id`, so the call is a guaranteed no-op (see
+            TranscriptionSessionInterface.admission_worker_id).
+            """
+            if self._job is not None:
+                return
+
+            self._job = self._provider.worker_pool.register_job(
+                (),
+                DEBUG_JOB_PERIOD_MS,
+                DebugProviderJob(self._config),
+                self._provider.provider_key,
+                session_uid=self.session_uid,
+                room_uid=self.room_uid,
+            )
+            self._job.on(self._job.JobResultEvent, self._handle_job_result)
+            self._provider.check_admission(
+                self.admission_worker_id, self._logger
+            )
+
         def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
             # Debug provider does not track chunk ids; the correlation id is
             # accepted for interface parity and ignored.
             del chunk_id
+            self._ensure_job()
             self._job.queue_data([chunk])
 
         def end_session(self):
             super().end_session()
-            self._job.deregister()
+            if self._job is not None:
+                self._job.deregister()
             self._provider.session_ended()
 
     def __init__(

--- a/transcription_service/src/transcription_providers/debug_provider/debug_provider.py
+++ b/transcription_service/src/transcription_providers/debug_provider/debug_provider.py
@@ -109,11 +109,15 @@ class DebugProvider(TranscriptionProviderInterface):
 
             Deferred so an idle client - configured but never streaming - never
             takes a worker's job slot, and so never counts toward that
-            worker's live_job_count for capacity admission. `check_admission`
-            is called for uniformity with the other two providers' sessions,
-            not because it can refuse one here: this session never overrides
-            `admission_worker_id`, so the call is a guaranteed no-op (see
-            TranscriptionSessionInterface.admission_worker_id).
+            worker's live_job_count for capacity admission.
+
+            `_admit_registered_job` is the same register/ask/undo the other two
+            providers' sessions run, called through the one implementation on
+            TranscriptionSessionInterface. Today it cannot refuse this session,
+            because this one does not override `admission_worker_id` - but that
+            is a property of this class right now, not a reason to write the
+            call differently here, and the shared helper means overriding that
+            property later cannot leak a registered job.
             """
             if self._job is not None:
                 return
@@ -127,9 +131,7 @@ class DebugProvider(TranscriptionProviderInterface):
                 room_uid=self.room_uid,
             )
             self._job.on(self._job.JobResultEvent, self._handle_job_result)
-            self._provider.check_admission(
-                self.admission_worker_id, self._logger
-            )
+            self._admit_registered_job(self._provider, self._logger)
 
         def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
             # Debug provider does not track chunk ids; the correlation id is

--- a/transcription_service/src/transcription_providers/lumen_granite_provider/lumen_granite_provider.py
+++ b/transcription_service/src/transcription_providers/lumen_granite_provider/lumen_granite_provider.py
@@ -67,18 +67,10 @@ class LumenGraniteProvider(TranscriptionProviderInterface):
             self.session_uid = session_uid
             self.room_uid = room_uid
 
-            self._job = provider.worker_pool.register_job(
-                (),  # no context - remote endpoint does the work
-                provider.config.job_period_ms,
-                LumenGraniteProviderJob(provider.config),
-                provider.provider_key,
-                session_uid=self.session_uid,
-                room_uid=self.room_uid,
-            )
-            self._job.on(self._job.JobResultEvent, self._handle_job_result)
+            # Not registered here - see _ensure_job. An idle client that never
+            # sends audio must never take a worker's job slot.
+            self._job = None
 
-            # Last, so a registration that raises above never counts a session
-            # that did not open.
             provider.session_started()
 
         def _handle_job_result(
@@ -90,14 +82,45 @@ class LumenGraniteProvider(TranscriptionProviderInterface):
 
             self.emit(self.TranscriptionResultEvent, result.value)
 
+        def _ensure_job(self) -> None:
+            """
+            Registers this session's worker-pool job on the first real audio
+            chunk, not at construction
+
+            Deferred so an idle client - configured but never streaming - never
+            takes a worker's job slot, and so never counts toward that
+            worker's live_job_count for capacity admission. `check_admission`
+            is called for uniformity with the other two providers' sessions,
+            not because it can refuse one here: this session never overrides
+            `admission_worker_id`, so the call is a guaranteed no-op (see
+            TranscriptionSessionInterface.admission_worker_id) - a remote
+            provider's capacity question is upstream rate limits and network
+            latency, explicitly out of scope per §5/§7.
+            """
+            if self._job is not None:
+                return
+
+            self._job = self._provider.worker_pool.register_job(
+                (),  # no context - remote endpoint does the work
+                self._provider.config.job_period_ms,
+                LumenGraniteProviderJob(self._provider.config),
+                self._provider.provider_key,
+                session_uid=self.session_uid,
+                room_uid=self.room_uid,
+            )
+            self._job.on(self._job.JobResultEvent, self._handle_job_result)
+            self._provider.check_admission(self.admission_worker_id, self._log)
+
         def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
+            self._ensure_job()
             self._job.queue_data(
                 [AudioChunkPayload(chunk_id=chunk_id, audio_bytes=chunk)]
             )
 
         def end_session(self):
             super().end_session()
-            self._job.deregister()
+            if self._job is not None:
+                self._job.deregister()
             self._provider.session_ended()
 
     def __init__(

--- a/transcription_service/src/transcription_providers/lumen_granite_provider/lumen_granite_provider.py
+++ b/transcription_service/src/transcription_providers/lumen_granite_provider/lumen_granite_provider.py
@@ -89,13 +89,17 @@ class LumenGraniteProvider(TranscriptionProviderInterface):
 
             Deferred so an idle client - configured but never streaming - never
             takes a worker's job slot, and so never counts toward that
-            worker's live_job_count for capacity admission. `check_admission`
-            is called for uniformity with the other two providers' sessions,
-            not because it can refuse one here: this session never overrides
-            `admission_worker_id`, so the call is a guaranteed no-op (see
-            TranscriptionSessionInterface.admission_worker_id) - a remote
+            worker's live_job_count for capacity admission.
+
+            `_admit_registered_job` is the same register/ask/undo the other two
+            providers' sessions run, called through the one implementation on
+            TranscriptionSessionInterface. Today it cannot refuse this session,
+            because this one does not override `admission_worker_id` - a remote
             provider's capacity question is upstream rate limits and network
-            latency, explicitly out of scope per §5/§7.
+            latency, explicitly out of scope per §5/§7. That is a property of
+            this class right now, not a reason to write the call differently
+            here, and the shared helper means opting in later cannot leak a
+            registered job.
             """
             if self._job is not None:
                 return
@@ -109,7 +113,7 @@ class LumenGraniteProvider(TranscriptionProviderInterface):
                 room_uid=self.room_uid,
             )
             self._job.on(self._job.JobResultEvent, self._handle_job_result)
-            self._provider.check_admission(self.admission_worker_id, self._log)
+            self._admit_registered_job(self._provider, self._log)
 
         def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
             self._ensure_job()

--- a/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_provider.py
+++ b/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_provider.py
@@ -133,12 +133,14 @@ class WhisperStreamingProvider(TranscriptionProviderInterface):
             Deferred so an idle client - configured but never streaming - never
             takes a worker's job slot, and so never counts toward that
             worker's live_job_count for capacity admission
-            (PLAN-AdmissionControl.md §4). `check_admission` is called
+            (PLAN-AdmissionControl.md §4). `_admit_registered_job` is called
             immediately after registering, before any data is queued to the
             job, so a refusal can undo the registration and raise before this
             chunk is ever processed - the same "build then undo" shape
             admission used at construction time, just relocated to where
-            registration itself now happens.
+            registration itself now happens. That undo lives on
+            TranscriptionSessionInterface rather than here, so all three
+            providers get it identically.
 
             A `register_job` that raises (context tags misconfigured, per
             `describe_health`'s "routed here dies at register_job") now
@@ -162,15 +164,7 @@ class WhisperStreamingProvider(TranscriptionProviderInterface):
                 room_uid=self.room_uid,
             )
             self._job.on(self._job.JobResultEvent, self._handle_job_result)
-
-            try:
-                self._provider.check_admission(
-                    self.admission_worker_id, self._log
-                )
-            except BaseException:
-                self._job.deregister()
-                self._job = None
-                raise
+            self._admit_registered_job(self._provider, self._log)
 
         def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
             self._ensure_job()

--- a/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_provider.py
+++ b/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_provider.py
@@ -2,6 +2,9 @@
 Defines FasterWhisperStreamingProvider
 """
 
+# The provider/session wiring necessarily mirrors the other providers.
+# pylint: disable=duplicate-code
+
 from dataclasses import asdict
 
 from src.shared.logger import Logger
@@ -68,28 +71,20 @@ class WhisperStreamingProvider(TranscriptionProviderInterface):
             self.session_uid = session_uid
             self.room_uid = room_uid
 
-            self._job = provider.worker_pool.register_job(
-                (
-                    self._provider.config.whisper_context_tag,
-                    self._provider.config.silero_context_tag,
-                ),
-                self._provider.config.job_period_ms,
-                WhisperStreamingProviderJob(self._provider.config),
-                self._provider.provider_key,
-                session_uid=self.session_uid,
-                room_uid=self.room_uid,
-            )
-            self._job.on(self._job.JobResultEvent, self._handle_job_result)
+            # Not registered here - see _ensure_job. An idle client that never
+            # sends audio must never take a worker's job slot, which is also
+            # why admission_worker_id below has to tolerate self._job being
+            # None.
+            self._job = None
 
-            # Last, so a registration that raises above never counts a session
-            # that did not open.
             self._provider.session_started()
 
         @property
         def admission_worker_id(self) -> int | None:
             """
             The worker this session's transcription job was actually assigned
-            to, read off the handle register_job returned
+            to, read off the handle register_job returned - or None if no job
+            has been registered yet
 
             Read from the JobHandle rather than recomputed, because the pool's
             choice is made from live utilization at registration time and any
@@ -97,8 +92,13 @@ class WhisperStreamingProvider(TranscriptionProviderInterface):
             already been made. This is the only shipped provider that overrides
             it: local ASR compute on a pool worker is exactly what the capacity
             estimator measures.
+
+            None before the first audio chunk is exactly the same "not a
+            capacity claim yet" statement the base class makes for a provider
+            excluded outright - see
+            TranscriptionSessionInterface.admission_worker_id.
             """
-            return self._job.worker_id
+            return self._job.worker_id if self._job is not None else None
 
         def _handle_job_result(
             self, result: JobSuccess[TranscriptionResult] | JobException
@@ -125,14 +125,63 @@ class WhisperStreamingProvider(TranscriptionProviderInterface):
             )
             self.emit(self.TranscriptionResultEvent, result.value)
 
+        def _ensure_job(self) -> None:
+            """
+            Registers this session's worker-pool job on the first real audio
+            chunk, not at construction
+
+            Deferred so an idle client - configured but never streaming - never
+            takes a worker's job slot, and so never counts toward that
+            worker's live_job_count for capacity admission
+            (PLAN-AdmissionControl.md §4). `check_admission` is called
+            immediately after registering, before any data is queued to the
+            job, so a refusal can undo the registration and raise before this
+            chunk is ever processed - the same "build then undo" shape
+            admission used at construction time, just relocated to where
+            registration itself now happens.
+
+            A `register_job` that raises (context tags misconfigured, per
+            `describe_health`'s "routed here dies at register_job") now
+            surfaces on the first audio chunk instead of at CONFIG time; the
+            readiness probe and per-provider health already report that
+            misconfiguration independently, so a client still finds out, just
+            not until it would have needed the worker anyway.
+            """
+            if self._job is not None:
+                return
+
+            self._job = self._provider.worker_pool.register_job(
+                (
+                    self._provider.config.whisper_context_tag,
+                    self._provider.config.silero_context_tag,
+                ),
+                self._provider.config.job_period_ms,
+                WhisperStreamingProviderJob(self._provider.config),
+                self._provider.provider_key,
+                session_uid=self.session_uid,
+                room_uid=self.room_uid,
+            )
+            self._job.on(self._job.JobResultEvent, self._handle_job_result)
+
+            try:
+                self._provider.check_admission(
+                    self.admission_worker_id, self._log
+                )
+            except BaseException:
+                self._job.deregister()
+                self._job = None
+                raise
+
         def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
+            self._ensure_job()
             self._job.queue_data(
                 [AudioChunkPayload(chunk_id=chunk_id, audio_bytes=chunk)]
             )
 
         def end_session(self):
             super().end_session()
-            self._job.deregister()
+            if self._job is not None:
+                self._job.deregister()
             self._provider.session_ended()
 
     def __init__(

--- a/transcription_service/src/webserver/create_webserver.py
+++ b/transcription_service/src/webserver/create_webserver.py
@@ -71,14 +71,8 @@ def create_webserver(config: Config, logger: Logger):
         metrics_registry.record_job_execution(observation)
         capacity_estimator.record(observation)
 
-    # Admission enforcement disabled for now: idle (audio-less) connections
-    # register a job and count toward a worker's live_job_count the same as
-    # an active one, so N can cross the ratcheted ceiling from connection
-    # count alone. `capacity_estimator` is still wired into `_observe_job`
-    # below and into /metrics/status + /providers/health, so estimation stays
-    # live in shadow mode - only the refusal in `create_session` is off.
     provider_registry = TranscriptionProviderRegistry(
-        config, logger, _observe_job, None, metrics_registry
+        config, logger, _observe_job, capacity_estimator, metrics_registry
     )
     # One join, two consumers: the /providers/health route below and the
     # telemetry publisher started in the lifespan hook.

--- a/transcription_service/src/webserver/create_webserver.py
+++ b/transcription_service/src/webserver/create_webserver.py
@@ -53,10 +53,10 @@ def create_webserver(config: Config, logger: Logger):
     metrics_registry = MetricsRegistry(process_identity=process_identity)
     # archived-plans/2026-07-27-02-PLAN-AdmissionControl.md §3/§4. Constructed
     # here, next to metrics_registry, because both are fed by the same
-    # job_observer below and
-    # both are threaded onward the same way - the estimator now reaching the
-    # provider registry (which enforces admission) as well as metrics_router
-    # (which reports its snapshot).
+    # job_observer below and both are threaded onward the same way - to
+    # metrics_router and ProviderHealthSnapshotService, which report its
+    # snapshot. It is deliberately NOT threaded into the provider registry;
+    # see the comment above that construction.
     capacity_estimator = CapacityEstimator(
         target_busy=config.target_busy,
         min_sessions=config.min_sessions,
@@ -67,13 +67,39 @@ def create_webserver(config: Config, logger: Logger):
         """
         Fans one completed job execution out to both consumers that need it:
         the metrics registry (what /metrics/status reports) and the capacity
-        estimator (what decides whether the next session is admitted).
+        estimator (whose ceiling both /metrics/status and /providers/health
+        publish).
         """
         metrics_registry.record_job_execution(observation)
         capacity_estimator.record(observation)
 
+    # SHADOW MODE: `None` where `capacity_estimator` would go, so the estimator
+    # observes and reports but nothing is ever refused. Deliberate, and the one
+    # thing that has to stay this way until a real deployment has been watched.
+    #
+    # Deferring job registration to a session's first audio chunk is
+    # unambiguously correct on its own - an idle, audio-less connection no
+    # longer takes a worker's job slot, which is what made refusals fire on
+    # connection count rather than on load. But that same fix *lowers* the
+    # measured ceiling, and by a lot. Idle registered jobs used to run an empty
+    # batch every period (`worker_process.py`'s scheduling loop), which added a
+    # distinct job_id to the estimator's window - inflating the `sessions`
+    # denominator of `cost_per_session = busy / sessions`
+    # (`capacity_estimator.py:_update_ratchet`) while contributing nothing to
+    # the numerator. A live box measured `estimatedCapacitySessions: 50` under
+    # that inflation. With it removed, a single whisper stream that keeps the
+    # one worker busy for half of each 5000 ms period gives b ~ 0.5 and
+    # therefore N* = 1.
+    #
+    # Turning enforcement on in the same change as the fix that moved the
+    # number would mean shipping a ceiling nobody has observed under real load.
+    # Wrong refusals are invisible to the user and unrecoverable for that
+    # session, so the order is: measure first (the estimate is published on
+    # /metrics/status and /providers/health, and drawn on the fleet dashboard),
+    # then decide. Passing `capacity_estimator` here is the whole of the
+    # switch - `_admits_worker` fails open on a `None` estimator by design.
     provider_registry = TranscriptionProviderRegistry(
-        config, logger, _observe_job, capacity_estimator, metrics_registry
+        config, logger, _observe_job, None, metrics_registry
     )
     # One join, two consumers: the /providers/health route below and the
     # telemetry publisher started in the lifespan hook.

--- a/transcription_service/src/webserver/features/transcription_stream/transcription_stream_controller.py
+++ b/transcription_service/src/webserver/features/transcription_stream/transcription_stream_controller.py
@@ -142,15 +142,16 @@ class TranscriptionStreamController(WebsocketHandler):
         TranscriptionStreamService once auth has completed and a config has
         not yet been received.
 
-        This is also the capacity-admission point (PLAN-AdmissionControl.md
-        §4): `service.start()` below reaches the registry, which registers the
-        session's job, checks the worker it actually landed on and raises
-        `TranscriptionCapacityError` if that worker is full. The refusal
-        propagates out of here to `_handle_error`, which maps it to a 1013
-        close. Deliberately not the WebSocket handshake, which is
-        unconditional before anything about the session is known, and
-        deliberately after auth, so an unauthenticated peer can neither
-        consume capacity nor learn anything about it.
+        Capacity admission (PLAN-AdmissionControl.md §4) no longer happens
+        here: a session's worker-pool job registers on its own first audio
+        chunk, not at construction, so there is nothing to ask about yet.
+        `TranscriptionCapacityError` instead surfaces from
+        `_handle_binary_message` below, and is mapped to a 1013 close by the
+        same `_handle_error` this method's own errors go through - deliberately
+        not the WebSocket handshake, which is unconditional before anything
+        about the session is known, and deliberately gated behind auth so an
+        unauthenticated peer can neither consume capacity nor learn anything
+        about it.
         """
         if not self._is_authenticated or self._service is not None:
             self.close(1008, "Unexpected Config Message")

--- a/transcription_service/src/webserver/features/transcription_stream/transcription_stream_service.py
+++ b/transcription_service/src/webserver/features/transcription_stream/transcription_stream_service.py
@@ -70,6 +70,14 @@ class TranscriptionStreamService(EventEmitter):
         self._room_uid = room_uid
         self._session: TranscriptionSessionInterface | None = None
         self._closed = False
+        # Separate from `_closed`: that flag also gates whether `close()` still
+        # has teardown to do, and a chunk error must not skip that teardown -
+        # `end_session()` is what balances the `session_started()` this
+        # session's constructor already ran, so skipping it would leak the
+        # provider's active-session count for good. This only stops
+        # `handle_audio_chunk` from re-entering a session that has already
+        # raised once.
+        self._audio_chunk_failed = False
 
     def start(self):
         """
@@ -78,12 +86,12 @@ class TranscriptionStreamService(EventEmitter):
         TranscriptionClientError if the provider key is unknown; callers
         should treat that as a protocol-level (1007) close.
 
-        Also raises TranscriptionCapacityError when the registry refuses the
-        session because the worker it was placed on is at capacity
-        (PLAN-AdmissionControl.md §4) - a 1013 close, not a 1007 one. Nothing
-        is wired up when that happens: the registry has already torn the
-        session back down, and the two `on()` calls below are never reached, so
-        this service holds no session and `close()` has nothing to undo.
+        Never raises TranscriptionCapacityError - that used to be decided
+        here, synchronously, but a session's job (and therefore the worker it
+        would occupy) is no longer registered at construction. It registers on
+        the session's own first `handle_audio_chunk`, which is also where a
+        capacity refusal now surfaces (PLAN-AdmissionControl.md §4; see
+        handle_audio_chunk below and TranscriptionSessionInterface for why).
         """
         self._session = self._provider_registry.create_session(
             self._provider_key,
@@ -104,10 +112,28 @@ class TranscriptionStreamService(EventEmitter):
         """
         Forward an audio chunk to the underlying session. No-op if the
         service has been closed.
+
+        A session's first chunk can be the one that registers its worker-pool
+        job and finds out - right then - that the worker is at capacity
+        (PLAN-AdmissionControl.md §4; job registration is deferred to first
+        audio, see TranscriptionSessionInterface). That raises
+        TranscriptionCapacityError out of this call, same as any other session
+        error, and this latches `_audio_chunk_failed` before re-raising: the
+        socket close that error triggers is asynchronous, so more chunks can
+        arrive before it lands, and without the latch each one would retry
+        registration against the same full worker and log another refusal for
+        a connection that is already on its way out. Deliberately not
+        `_closed` - `close()` still has to run its teardown once the socket
+        actually disconnects, whatever happened here.
         """
-        if self._closed or self._session is None:
+        if self._closed or self._session is None or self._audio_chunk_failed:
             return
-        self._session.handle_audio_chunk(chunk_id, chunk)
+        try:
+            self._session.handle_audio_chunk(chunk_id, chunk)
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            self._audio_chunk_failed = True
+            raise
 
     def close(self):
         """

--- a/transcription_service/src/webserver/shared/transcription_provider_registry/transcription_provider_registry.py
+++ b/transcription_service/src/webserver/shared/transcription_provider_registry/transcription_provider_registry.py
@@ -6,7 +6,7 @@ transcription providers configured for the service.
 # pylint: disable=import-outside-toplevel
 # Only import providers based on configuration
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable
 
 from src.shared.config import (
     Config,
@@ -243,6 +243,13 @@ class TranscriptionProviderRegistry:
                         provider_key,
                     )
 
+            # Bound per provider_key rather than shared, so a refusal is
+            # always counted and logged against the provider whose session
+            # actually triggered it, not whichever provider happened to be
+            # loaded last.
+            provider.bind_admission_check(
+                self._make_admission_check(provider_key)
+            )
             providers[provider_key] = provider
         return providers
 
@@ -357,88 +364,86 @@ class TranscriptionProviderRegistry:
 
         Raises:
             TranscriptionClientError if provider doesn't exist
-            TranscriptionCapacityError if the worker the session was placed on
-                has no capacity for it
 
-        ADMISSION IS DECIDED AFTER CONSTRUCTION, ON PURPOSE
-        (PLAN-AdmissionControl.md §4). `admit()` is a per-worker question, and
-        which worker a session lands on is chosen by live load balancing inside
-        `register_job` - so there is nothing to ask *about* until the session
-        has registered. Building the session first and tearing it back down is
-        therefore not a shortcut around a missing pre-check; it is the only
-        order in which the question is well posed.
+        NEVER RAISES TranscriptionCapacityError. That used to be decided here,
+        synchronously, because a session's job registered as part of its own
+        construction - so by the time this returned, it had already taken a
+        worker's job slot whether or not the caller ever sent it any audio.
+        That is exactly the failure this method used to cause: an idle,
+        audio-less connection occupied capacity identically to a real one, so
+        opening enough of them could refuse a genuinely busy worker's actual
+        next session, or - worse - refuse each other, entirely independent of
+        real transcription load.
 
-        `end_session()` is the undo, rather than a bespoke rollback path,
-        because it is already exactly the teardown a session that never carried
-        audio needs: it deregisters the job (so the worker's live_job_count
-        drops immediately, leaving no phantom) and decrements the provider's
-        active-session count that this constructor just incremented. A second
-        path would be a second thing to keep in step with it.
+        Registration is deferred to a session's own first `handle_audio_chunk`
+        (see each provider's `_ensure_job`), which is also now where admission
+        is decided - a session calls `provider.check_admission(...)` itself,
+        right after registering, via the callback `_make_admission_check`
+        binds onto its provider at load time. A refusal therefore surfaces
+        from `handle_audio_chunk`, not from here, and propagates out through
+        `TranscriptionStreamService.handle_audio_chunk` exactly like any other
+        session error - no special plumbing needed, since Python exceptions
+        already cross that boundary uncaught.
         """
         if provider_key not in self._providers:
             self._invalid_provider_key_rejects += 1
             raise TranscriptionClientError("Invalid Provider Key")
 
         provider = self._providers[provider_key]
-        session = provider.create_session(
+        return provider.create_session(
             session_config, session_uid, room_uid, logger
         )
 
-        if self._admits(session):
-            return session
-
-        session.end_session()
-        if self._metrics_registry is not None:
-            self._metrics_registry.record_capacity_refusal(provider_key)
-        logger.warning(
-            "Refused session: worker at capacity",
-            context={
-                "provider_key": provider_key,
-                "worker_id": session.admission_worker_id,
-            },
-        )
-        raise TranscriptionCapacityError(AT_CAPACITY_REASON)
-
-    def _admits(self, session: TranscriptionSessionInterface) -> bool:
+    def _make_admission_check(
+        self, provider_key: str
+    ) -> Callable[[int | None, Logger], None]:
         """
-        Whether a just-registered session may keep the worker slot it took
+        Builds the admission callback one provider is bound to at load time
 
         Args:
-            session - The session that has already registered its job
+            provider_key    - The provider this callback decides for, closed
+                                over so a refusal is always counted and logged
+                                against the provider whose session actually
+                                registered the job, not whichever provider
+                                `_load_providers` happened to construct last
 
         Returns:
-            True if the session should be allowed to proceed
+            A callable a session invokes with the worker its job just landed
+            on (or None - see TranscriptionSessionInterface.admission_worker_id).
+            Raises TranscriptionCapacityError if that worker has no room;
+            otherwise returns normally.
 
         Every gate here fails open, which is this plan's stated posture rather
         than laziness: an over-admission is visible, counted and self-corrects,
         while a wrong refusal is invisible and unrecoverable for that user.
-        Three of them are reached in normal operation:
+        Four of them are reached in normal operation:
 
-        1. No estimator configured - admission control is not wired up.
-        2. `admission_worker_id is None` - the session is not a claim on a local
-           worker's ASR throughput (`lumen_granite`, `debug`). See
-           TranscriptionSessionInterface.admission_worker_id for why that is a
-           statement rather than a gap.
+        1. `worker_id is None` - the session is not a claim on a local worker's
+           ASR throughput (`lumen_granite`, `debug`), or it has not yet
+           registered a job at all. See
+           TranscriptionSessionInterface.admission_worker_id for why both are
+           the same statement.
+        2. No estimator configured - admission control is not wired up.
         3. The pool reports no such worker. A worker that vanished between
            registration and this read is a pool fault, not a capacity fault,
            and refusing the user for it would misattribute the outage.
 
-        CONCURRENCY. This runs to completion between `register_job` and the
-        caller's next await point - register, read, decide and (if refused)
-        deregister are all synchronous, on the one event loop thread the pool's
-        registration bookkeeping also runs on. Two sessions arriving together
-        are therefore serialized, and each sees the other's registration
-        reflected in `live_job_count` only if that registration actually
-        happened first. There is no window in which both read a pre-registration
-        count and both get admitted, nor one in which both count the other and
-        both get refused.
+        CONCURRENCY. The session calls this synchronously, immediately after
+        `register_job` returns and before any `await` - register, read, decide
+        and (if refused) deregister all run on the one event loop thread the
+        pool's registration bookkeeping also runs on. Two sessions registering
+        together are therefore serialized, and each sees the other's
+        registration reflected in `live_job_count` only if that registration
+        actually happened first. There is no window in which both read a
+        pre-registration count and both get admitted, nor one in which both
+        count the other and both get refused.
 
         The `- 1` is what makes that true. `admit()` is specified as
         `N == 0 or N + 1 <= N*` where N is the count *before* placing the new
-        session, but by the time this runs the session is already registered and
-        the pool's `live_job_count` includes it. Passing that count raw would
-        ask whether an N+2nd session fits and would refuse the first session on
-        an idle worker, since N would never read as 0.
+        session, but by the time this runs the session is already registered
+        and the pool's `live_job_count` includes it. Passing that count raw
+        would ask whether an N+2nd session fits and would refuse the first
+        session on an idle worker, since N would never read as 0.
 
         TWO KNOWN LIMITATIONS, NAMED RATHER THAN GUARDED:
 
@@ -458,11 +463,36 @@ class TranscriptionProviderRegistry:
           §5's deferral of remote-provider capacity; it is not a claim that they
           cost a worker nothing.
         """
-        if self._capacity_estimator is None:
+
+        def _check(worker_id: int | None, logger: Logger) -> None:
+            if self._admits_worker(worker_id):
+                return
+
+            if self._metrics_registry is not None:
+                self._metrics_registry.record_capacity_refusal(provider_key)
+            logger.warning(
+                "Refused session: worker at capacity",
+                context={"provider_key": provider_key, "worker_id": worker_id},
+            )
+            raise TranscriptionCapacityError(AT_CAPACITY_REASON)
+
+        return _check
+
+    def _admits_worker(self, worker_id: int | None) -> bool:
+        """
+        Whether one more job may keep the worker slot it just took
+
+        Args:
+            worker_id   - The worker a session's job just registered onto, or
+                            None if this session's cost is not a capacity claim
+
+        Returns:
+            True if the session should be allowed to proceed
+        """
+        if worker_id is None:
             return True
 
-        worker_id = session.admission_worker_id
-        if worker_id is None:
+        if self._capacity_estimator is None:
             return True
 
         live_job_count = self._live_job_count(worker_id)

--- a/transcription_service/tests/integration/metrics/metrics_test.py
+++ b/transcription_service/tests/integration/metrics/metrics_test.py
@@ -4,6 +4,7 @@ Integration tests for the /metrics/status endpoint
 
 import asyncio
 import logging
+from os import path
 from unittest.mock import MagicMock
 
 import pytest
@@ -16,6 +17,7 @@ from src.shared.config import (
     TranscriptionProviderUID,
 )
 from src.shared.logger import ContextLogger, Logger
+from src.shared.utils.audio_frame_protocol import encode_audio_frame
 from src.transcription_providers.debug_provider.debug_provider import (
     DEBUG_JOB_PERIOD_MS,
 )
@@ -24,6 +26,18 @@ from src.webserver.create_webserver import create_webserver
 API_KEY = "TEST_KEY"
 METRICS_API_KEY = "TEST_METRICS_KEY"
 TIMEOUT_SEC = 1
+
+AUDIO_DIR = path.normpath(
+    path.join(
+        __file__,
+        "..",
+        "..",
+        "..",
+        "..",
+        "..",
+        "test_audio_files/musical_chords",
+    )
+)
 
 # Two real worker processes are spawned per test using these fixtures, which
 # is well past the global 1s pytest timeout.
@@ -256,10 +270,17 @@ async def test_records_a_real_job_execution(test_client: TestClient):
     in a spawned worker process, its result crosses the result queue, the
     worker pool hook folds it into the registry, and the endpoint reports it -
     labelled with the provider key the session was opened against.
+
+    Job registration is deferred to the session's first audio chunk (an idle
+    session never takes a worker's job slot at all), so one is sent here -
+    config alone no longer registers anything for the sleep below to catch a
+    pass of.
     """
     # Arrange
     headers = {"authorization": f"Bearer {METRICS_API_KEY}"}
     labels = {"provider_key": "debug"}
+    with open(path.join(AUDIO_DIR, "mono_f64le.wav"), "rb") as f:
+        chunk = f.read()
 
     # Act
     with test_client.websocket_connect(
@@ -269,9 +290,11 @@ async def test_records_a_real_job_execution(test_client: TestClient):
         websocket.send_json(
             {
                 "type": "config",
-                "config": {"sample_rate": 16000, "num_channels": 1},
+                # Matches mono_f64le.wav's actual sample rate.
+                "config": {"sample_rate": 48000, "num_channels": 1},
             }
         )
+        websocket.send_bytes(encode_audio_frame("chunk-1", chunk))
         # The debug job's period is 1000ms, so one full period plus slack
         await asyncio.sleep(1.5)
 

--- a/transcription_service/tests/integration/providers/providers_test.py
+++ b/transcription_service/tests/integration/providers/providers_test.py
@@ -3,6 +3,7 @@ Integration tests for the /providers/health endpoint
 """
 
 import logging
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -16,6 +17,7 @@ from src.shared.config import (
     TranscriptionProviderUID,
 )
 from src.shared.logger import ContextLogger, Logger
+from src.shared.utils.audio_frame_protocol import encode_audio_frame
 from src.webserver.create_webserver import create_webserver
 
 API_KEY = "TEST_KEY"
@@ -116,6 +118,31 @@ def _health(client: TestClient):
     )
     assert response.status_code == 200
     return response.json()
+
+
+def _health_once_active(client: TestClient, timeout_sec: float = 5.0):
+    """
+    Polls /providers/health until a worker reports an active job, or gives up
+
+    A synchronous TestClient send only guarantees a message has been handed to
+    the app's receive queue, not that the app has finished acting on it - job
+    registration happens moments later, on the app's own event loop thread. A
+    single immediate read would be racy; this polls briefly instead of relying
+    on a fixed sleep being long enough on a slower machine.
+
+    Args:
+        client       - Test client to read through
+        timeout_sec  - How long to keep polling before giving up and returning
+                        whatever the last read was
+    """
+    deadline = time.monotonic() + timeout_sec
+    body = _health(client)
+    while time.monotonic() < deadline:
+        if any(worker["activeJobs"] for worker in body["workers"]):
+            return body
+        time.sleep(0.05)
+        body = _health(client)
+    return body
 
 
 def test_rejects_request_with_no_credential(test_client: TestClient):
@@ -302,6 +329,14 @@ def test_reports_active_job_correlated_to_session_and_room_uid(
     worker holding its job - the correlation an operator needs to trace a
     saturated worker back to the session/room causing it (B1.7 follow-up,
     part 2 of 2)
+
+    Job registration is deferred to the session's first audio chunk (an idle
+    session never takes a worker's job slot at all), so one is sent here
+    before reading health - config alone no longer registers anything.
+    Registration itself is synchronous with handling that chunk (decoding it
+    is not), so the content does not need to be real audio here - only that
+    /providers/health, polled below, was not read before the server had a
+    chance to process the frame.
     """
     # Act
     with test_client.websocket_connect(
@@ -317,11 +352,12 @@ def test_reports_active_job_correlated_to_session_and_room_uid(
             }
         )
         # start_session() emits synchronously within config handling, so
-        # receiving it proves the session (and its job registration) exists
-        # server-side before the health read below.
+        # receiving it proves the session exists server-side before the audio
+        # chunk below registers its job.
         websocket.receive_json()
+        websocket.send_bytes(encode_audio_frame("chunk-1", b"not-real-audio"))
 
-        body = _health(test_client)
+        body = _health_once_active(test_client)
 
     # Assert
     active_jobs = [

--- a/transcription_service/tests/unit/shared/config/config_test.py
+++ b/transcription_service/tests/unit/shared/config/config_test.py
@@ -278,6 +278,71 @@ def test_config_loads_the_capacity_estimator_overrides_when_set(
     assert config.max_sessions == MAX_SESSIONS
 
 
+def test_config_reads_a_blank_max_sessions_as_no_pin(
+    clean_os_environ: None, tmp_path: Path
+):
+    # pylint: disable=unused-argument
+    # Need to include clean_os_environ so that fixture is created
+    """
+    Test an empty MAX_SESSIONS leaves the estimator auto-tuning
+
+    This is what every stock compose deployment sends. `compose.yml` cannot
+    omit an environment key, so it passes
+    `MAX_SESSIONS: ${TRANSCRIPTION_MAX_SESSIONS:-}` and an operator who never
+    sets the variable hands the service an empty string rather than nothing at
+    all. `int | None` refuses to parse that, so without the coercion the whole
+    container fails to boot - an optional tuning knob becoming a required one
+    for everyone who copied the shipped file.
+
+    The other two need no equivalent: they carry real literal defaults in
+    compose, so they are never blank.
+    """
+    # Arrange
+    transcription_config_path = tmp_path / "transcription_config.json"
+    transcription_config_path.write_text(VALID_PROVIDER_CONFIG_JSON)
+
+    dotenv_path = tmp_path / ".env"
+    dotenv_path.write_text(
+        valid_env(str(transcription_config_path)) + "MAX_SESSIONS=\n"
+    )
+
+    # Act
+    config = Config(dotenv_path=str(dotenv_path))
+
+    # Assert - identical to leaving the variable out entirely
+    assert config.max_sessions is None
+    assert config.target_busy == 0.85
+    assert config.min_sessions == 1
+
+
+def test_config_still_rejects_an_unparseable_max_sessions(
+    clean_os_environ: None, tmp_path: Path
+):
+    # pylint: disable=unused-argument
+    # Need to include clean_os_environ so that fixture is created
+    """
+    Test a non-numeric MAX_SESSIONS stops the process rather than being ignored
+
+    The blank coercion above is deliberately narrow. Falling back to
+    auto-tuning on any unparseable value would leave an operator who typed
+    `MAX_SESSIONS=lots` believing they had pinned the ceiling while the
+    estimator quietly went on measuring one - a misconfiguration with no
+    symptom to find.
+    """
+    # Arrange
+    transcription_config_path = tmp_path / "transcription_config.json"
+    transcription_config_path.write_text(VALID_PROVIDER_CONFIG_JSON)
+
+    dotenv_path = tmp_path / ".env"
+    dotenv_path.write_text(
+        valid_env(str(transcription_config_path)) + "MAX_SESSIONS=lots\n"
+    )
+
+    # Act / Assert
+    with pytest.raises(ValidationError):
+        Config(dotenv_path=str(dotenv_path))
+
+
 def test_config_rejects_a_host_id_that_could_forge_a_telemetry_key(
     clean_os_environ: None, tmp_path: Path
 ):

--- a/transcription_service/tests/unit/transcription_providers/admission_worker_id_test.py
+++ b/transcription_service/tests/unit/transcription_providers/admission_worker_id_test.py
@@ -15,6 +15,11 @@ does not describe it.
 Every session here is built over a mocked WorkerPool, so no model is loaded and
 no worker process is spawned; what is being pinned is which worker id each
 session reports, not what the pool does with it.
+
+Every test sends one audio chunk before asserting anything. Job registration -
+and therefore the worker placement `admission_worker_id` reports - is deferred
+to a session's first `handle_audio_chunk`, not its construction, so an idle
+session that never streams never takes a worker's job slot at all.
 """
 
 from unittest.mock import MagicMock
@@ -92,6 +97,7 @@ def test_whisper_session_reports_the_worker_its_job_landed_on(
     session = provider.create_session(
         "unused_config", "session-1", "room-1", mock_logger
     )
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     assert session.admission_worker_id == ASSIGNED_WORKER_ID
@@ -123,6 +129,7 @@ def test_lumen_granite_session_is_excluded_from_capacity_admission(
     session = provider.create_session(
         "unused_config", "session-1", "room-1", mock_logger
     )
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     assert session.admission_worker_id is None
@@ -151,6 +158,7 @@ def test_debug_session_is_excluded_from_capacity_admission(
     session = provider.create_session(
         DEBUG_SESSION_CONFIG, "session-1", "room-1", mock_logger
     )
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     assert session.admission_worker_id is None

--- a/transcription_service/tests/unit/transcription_providers/debug_provider/debug_provider_test.py
+++ b/transcription_service/tests/unit/transcription_providers/debug_provider/debug_provider_test.py
@@ -100,11 +100,20 @@ def test_debug_provider_registers_job_correlated_to_session_and_room_uid(
     worker snapshots - what makes /providers/health show it as an ActiveJob
 
     Registration is deferred to the first audio chunk (an idle session never
-    takes a worker's job slot), so this sends one before reading the snapshot.
+    takes a worker's job slot), so this sends one before reading the snapshot -
+    and reads the snapshot once beforehand, which is the actual invariant. The
+    equivalent of `register_job.assert_not_called()` for a real pool: without
+    it the test would pass just as happily if construction ALSO registered a
+    job, which is the entire behaviour being introduced.
     """
     # Arrange
     with open(path.join(AUDIO_DIR, "mono_f64le.wav"), "rb") as f:
         chunk = f.read()
+
+    # Assert - the fixture's session exists but has streamed nothing yet
+    (idle_snapshot,) = debug_provider_worker_pool.worker_snapshots()
+    assert idle_snapshot.active_jobs == ()
+    assert idle_snapshot.live_job_count == 0
 
     # Act
     debug_provider_session.handle_audio_chunk("chunk-1", chunk)

--- a/transcription_service/tests/unit/transcription_providers/debug_provider/debug_provider_test.py
+++ b/transcription_service/tests/unit/transcription_providers/debug_provider/debug_provider_test.py
@@ -98,8 +98,16 @@ def test_debug_provider_registers_job_correlated_to_session_and_room_uid(
     """
     Test the session's job is correlated to session_uid/room_uid in the pool's
     worker snapshots - what makes /providers/health show it as an ActiveJob
+
+    Registration is deferred to the first audio chunk (an idle session never
+    takes a worker's job slot), so this sends one before reading the snapshot.
     """
+    # Arrange
+    with open(path.join(AUDIO_DIR, "mono_f64le.wav"), "rb") as f:
+        chunk = f.read()
+
     # Act
+    debug_provider_session.handle_audio_chunk("chunk-1", chunk)
     (snapshot,) = debug_provider_worker_pool.worker_snapshots()
 
     # Assert
@@ -279,7 +287,10 @@ def test_debug_provider_reports_the_period_it_schedules():
     )
 
     # Act
-    provider.create_session(SESSION_CONFIG, None, None, MagicMock(spec=Logger))
+    session = provider.create_session(
+        SESSION_CONFIG, None, None, MagicMock(spec=Logger)
+    )
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     args, _ = mock_worker_pool.register_job.call_args

--- a/transcription_service/tests/unit/transcription_providers/lumen_granite_provider/lumen_granite_session_test.py
+++ b/transcription_service/tests/unit/transcription_providers/lumen_granite_provider/lumen_granite_session_test.py
@@ -87,9 +87,16 @@ def test_create_session_forwards_session_and_room_uid_to_register_job(
     """
     session_uid/room_uid reach worker_pool.register_job, which is what makes
     them show up as an ActiveJob on /providers/health
+
+    Registration is deferred to the first audio chunk (an idle session never
+    takes a worker's job slot), so this sends one before asserting on
+    register_job's call args.
     """
     # Act
-    provider.create_session("unused_config", "session-1", "room-1", mock_logger)
+    session = provider.create_session(
+        "unused_config", "session-1", "room-1", mock_logger
+    )
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     _, kwargs = mock_worker_pool.register_job.call_args
@@ -109,7 +116,8 @@ def test_reported_job_period_is_the_one_register_job_receives(
     reason the reported value is per provider rather than one number.
     """
     # Act
-    provider.create_session("unused_config", None, None, mock_logger)
+    session = provider.create_session("unused_config", None, None, mock_logger)
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     args, _ = mock_worker_pool.register_job.call_args

--- a/transcription_service/tests/unit/transcription_providers/lumen_granite_provider/lumen_granite_session_test.py
+++ b/transcription_service/tests/unit/transcription_providers/lumen_granite_provider/lumen_granite_session_test.py
@@ -90,15 +90,24 @@ def test_create_session_forwards_session_and_room_uid_to_register_job(
 
     Registration is deferred to the first audio chunk (an idle session never
     takes a worker's job slot), so this sends one before asserting on
-    register_job's call args.
+    register_job's call args - and asserts nothing was registered before it,
+    which is the actual invariant. Without that first assertion the test would
+    pass just as happily if construction ALSO registered a job, which is the
+    entire behaviour being introduced.
     """
     # Act
     session = provider.create_session(
         "unused_config", "session-1", "room-1", mock_logger
     )
+
+    # Assert - an idle session has taken no worker's job slot
+    mock_worker_pool.register_job.assert_not_called()
+
+    # Act
     session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
+    mock_worker_pool.register_job.assert_called_once()
     _, kwargs = mock_worker_pool.register_job.call_args
     assert kwargs["session_uid"] == "session-1"
     assert kwargs["room_uid"] == "room-1"

--- a/transcription_service/tests/unit/transcription_providers/whisper_streaming_provider/whisper_streaming_session_test.py
+++ b/transcription_service/tests/unit/transcription_providers/whisper_streaming_provider/whisper_streaming_session_test.py
@@ -1,7 +1,8 @@
 """
 Unit tests for WhisperStreamingProvider.create_session's session_uid/room_uid
 storage (Part 1 of the monitoring dashboard plan) and their forwarding to
-register_job, which is what surfaces them on /providers/health (Part 2).
+register_job, which is what surfaces them on /providers/health (Part 2), plus
+the capacity-refusal undo (PLAN-AdmissionControl.md §4).
 """
 
 from unittest.mock import MagicMock
@@ -10,6 +11,10 @@ import pytest
 
 from src.shared.logger import Logger
 from src.shared.utils.worker_pool import WorkerPool
+from src.transcription_provider_interface import (
+    AT_CAPACITY_REASON,
+    TranscriptionCapacityError,
+)
 from src.transcription_providers.whisper_streaming_provider import (
     WhisperStreamingProvider,
 )
@@ -92,9 +97,16 @@ def test_create_session_forwards_session_and_room_uid_to_register_job(
     """
     session_uid/room_uid reach worker_pool.register_job, which is what makes
     them show up as an ActiveJob on /providers/health
+
+    Registration is deferred to the first audio chunk (an idle session never
+    takes a worker's job slot), so this sends one before asserting on
+    register_job's call args.
     """
     # Act
-    provider.create_session("unused_config", "session-1", "room-1", mock_logger)
+    session = provider.create_session(
+        "unused_config", "session-1", "room-1", mock_logger
+    )
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     _, kwargs = mock_worker_pool.register_job.call_args
@@ -115,9 +127,44 @@ def test_reported_job_period_is_the_one_register_job_receives(
     register_job would reintroduce exactly that failure one layer down.
     """
     # Act
-    provider.create_session("unused_config", None, None, mock_logger)
+    session = provider.create_session("unused_config", None, None, mock_logger)
+    session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
     args, _ = mock_worker_pool.register_job.call_args
     assert provider.job_period_ms == PROVIDER_CONFIG["job_period_ms"]
     assert args[1] == provider.job_period_ms
+
+
+def test_capacity_refusal_deregisters_the_job_and_reraises(
+    provider: WhisperStreamingProvider,
+    mock_logger: MagicMock,
+    mock_worker_pool: MagicMock,
+):
+    """
+    A session refused on its first chunk must not leak the job it just
+    registered
+
+    `_ensure_job` registers before it can know whether the worker has room -
+    the pool only decides who owns a worker at `register_job` time - so a
+    refusal is always an undo, not a rejection that skips registering at all.
+    Left un-deregistered, the worker would keep scheduling a job every period
+    for a session no client is attached to, consuming the very capacity the
+    refusal exists to protect - invisibly, since nothing else would ever call
+    `end_session` on a session the caller never got back.
+    """
+
+    # Arrange
+    def _always_refuse(worker_id, logger):
+        raise TranscriptionCapacityError(AT_CAPACITY_REASON)
+
+    provider.bind_admission_check(_always_refuse)
+    session = provider.create_session("unused_config", None, None, mock_logger)
+    job_handle = mock_worker_pool.register_job.return_value
+
+    # Act / Assert
+    with pytest.raises(TranscriptionCapacityError):
+        session.handle_audio_chunk("chunk-1", b"audio")
+
+    job_handle.deregister.assert_called_once()
+    assert session.admission_worker_id is None

--- a/transcription_service/tests/unit/transcription_providers/whisper_streaming_provider/whisper_streaming_session_test.py
+++ b/transcription_service/tests/unit/transcription_providers/whisper_streaming_provider/whisper_streaming_session_test.py
@@ -100,15 +100,24 @@ def test_create_session_forwards_session_and_room_uid_to_register_job(
 
     Registration is deferred to the first audio chunk (an idle session never
     takes a worker's job slot), so this sends one before asserting on
-    register_job's call args.
+    register_job's call args - and asserts nothing was registered before it,
+    which is the actual invariant. Without that first assertion the test would
+    pass just as happily if construction ALSO registered a job, which is the
+    entire behaviour being introduced.
     """
     # Act
     session = provider.create_session(
         "unused_config", "session-1", "room-1", mock_logger
     )
+
+    # Assert - an idle session has taken no worker's job slot
+    mock_worker_pool.register_job.assert_not_called()
+
+    # Act
     session.handle_audio_chunk("chunk-1", b"audio")
 
     # Assert
+    mock_worker_pool.register_job.assert_called_once()
     _, kwargs = mock_worker_pool.register_job.call_args
     assert kwargs["session_uid"] == "session-1"
     assert kwargs["room_uid"] == "room-1"

--- a/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_controller_test.py
+++ b/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_controller_test.py
@@ -614,41 +614,66 @@ async def test_controller_closes_1013_for_a_capacity_refusal(
 
 
 @pytest.mark.asyncio
-async def test_capacity_refusal_during_config_reaches_the_error_handler(
+async def test_capacity_refusal_from_an_audio_chunk_reaches_the_error_handler(
     controller: TranscriptionStreamController,
     mock_auth_service: MagicMock,
     mock_provider_registry: MagicMock,
     mock_close_method: MagicMock,
 ):
     """
-    Test a refusal raised from the CONFIG step closes the socket with 1013
+    Test a refusal raised from an AUDIO frame closes the socket with 1013
 
     The end-to-end path through the controller, not just the mapping in
-    isolation: the registry refuses inside `create_session`, the error travels
-    out of `_config` through `WebsocketHandler`'s receive loop, and the socket
-    closes 1013. Worth pinning separately because the controller sets
-    `self._service` only after `start()` returns - a refusal must leave the
-    connection with no service attached and must NOT fall through to the
-    generic 1011 "Internal Server Error", which would tell an operator the
+    isolation: the session refuses inside `handle_audio_chunk`, the error
+    travels out of `_handle_binary_message` through `WebsocketHandler`'s
+    receive loop, and the socket closes 1013 rather than falling through to
+    the generic 1011 "Internal Server Error", which would tell an operator the
     service crashed.
+
+    This used to stub `create_session` raising instead. That path no longer
+    exists: a session's worker-pool job registers on its own first audio
+    chunk, so `create_session` has nothing to decide and its docstring now
+    says it NEVER RAISES TranscriptionCapacityError - a test asserting the
+    controller handles a refusal from there was pinning an impossibility.
+
+    The refusal is raised by the session directly rather than driven through
+    real admission, which is off in the shipped wiring (`create_webserver`
+    passes no estimator to the registry - shadow mode). What the controller
+    owes either way is the same: whatever surfaces a
+    `TranscriptionCapacityError` out of a binary frame closes 1013. Note the
+    service is still attached afterwards, unlike the old CONFIG-step case -
+    config succeeded, so `close()` has real teardown to do when the socket
+    goes.
     """
+
     # Arrange
+    class _RefusingSession(TranscriptionSessionInterface):
+        """A session whose first chunk discovers its worker has no room."""
+
+        def handle_audio_chunk(self, chunk_id: str, chunk: bytes):
+            raise TranscriptionCapacityError(AT_CAPACITY_REASON)
+
     mock_auth_service.is_authenticated.return_value = True
-    mock_provider_registry.create_session.side_effect = (
-        TranscriptionCapacityError(AT_CAPACITY_REASON)
-    )
+    mock_provider_registry.create_session.return_value = _RefusingSession()
     await controller._handle_text_message(VALID_AUTH_MESSAGE)
+    await controller._handle_text_message(VALID_CONFIG_MESSAGE)
 
     # Act - the same path receive_messages() takes when a handler raises
     try:
-        await controller._handle_text_message(VALID_CONFIG_MESSAGE)
+        await controller._handle_binary_message(AUDIO_FRAME)
         assert False
     except TranscriptionCapacityError as error:
         assert controller._handle_error(error) is True
 
     # Assert
     mock_close_method.assert_called_once_with(1013, AT_CAPACITY_REASON)
-    assert controller._service is None
+    assert controller._service is not None
+
+    # And the chunks that arrive before the close lands are swallowed, not
+    # re-raised - the service latches the failure, so one refusal produces one
+    # close rather than one per frame still in flight.
+    await controller._handle_binary_message(AUDIO_FRAME)
+    mock_close_method.assert_called_once_with(1013, AT_CAPACITY_REASON)
 
 
 @pytest.mark.asyncio

--- a/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_service_test.py
+++ b/transcription_service/tests/unit/webserver/features/transcription_stream/transcription_stream_service_test.py
@@ -181,6 +181,82 @@ def test_handle_audio_chunk_is_no_op_before_start(
     # Assert - no exception raised, no session call attempted (no session yet).
 
 
+def test_handle_audio_chunk_reraises_a_session_error(
+    service: TranscriptionStreamService, fake_session: FakeSession
+):
+    """
+    An error raised by the underlying session (e.g. TranscriptionCapacityError
+    on the first chunk that registers its job) propagates out of
+    handle_audio_chunk rather than being swallowed - the controller relies on
+    this to map it to the right close code.
+    """
+    # Arrange
+    service.start()
+    fake_session.handle_audio_chunk.side_effect = TranscriptionClientError(
+        "at capacity"
+    )
+
+    # Act / Assert
+    with pytest.raises(TranscriptionClientError):
+        service.handle_audio_chunk("chunk-1", b"\x01")
+
+
+def test_handle_audio_chunk_stops_retrying_after_a_session_error(
+    service: TranscriptionStreamService, fake_session: FakeSession
+):
+    """
+    Once a chunk has raised, later chunks are dropped instead of being
+    retried against the same session
+
+    A capacity refusal closes the socket asynchronously, so more chunks can
+    arrive before that close lands. Without this latch each one would retry
+    registration against the same full worker and log another refusal for a
+    connection that is already on its way out.
+    """
+    # Arrange
+    service.start()
+    fake_session.handle_audio_chunk.side_effect = TranscriptionClientError(
+        "at capacity"
+    )
+    with pytest.raises(TranscriptionClientError):
+        service.handle_audio_chunk("chunk-1", b"\x01")
+
+    # Act
+    fake_session.handle_audio_chunk.side_effect = None
+    service.handle_audio_chunk("chunk-2", b"\x02")
+
+    # Assert - the second chunk never reached the session
+    fake_session.handle_audio_chunk.assert_called_once_with("chunk-1", b"\x01")
+
+
+def test_close_still_ends_the_session_after_a_chunk_error(
+    service: TranscriptionStreamService, fake_session: FakeSession
+):
+    """
+    A session that raised out of handle_audio_chunk is still torn down by
+    close(), so its provider's active-session count is not leaked
+
+    The chunk-error latch is deliberately a separate flag from `_closed`:
+    `close()` checks `_closed` to decide whether it still has teardown to do,
+    and end_session() is what balances the session_started() its constructor
+    already ran. If a chunk error had set `_closed` instead, this would never
+    run and the provider would carry that session as active forever.
+    """
+    # Arrange
+    service.start()
+    fake_session.handle_audio_chunk.side_effect = TranscriptionClientError(
+        "at capacity"
+    )
+    with pytest.raises(TranscriptionClientError):
+        service.handle_audio_chunk("chunk-1", b"\x01")
+
+    # Act
+    service.close()
+
+    # Assert
+    fake_session.end_session.assert_called_once()
+
+
 def test_close_ends_underlying_session(
     service: TranscriptionStreamService, fake_session: FakeSession
 ):

--- a/transcription_service/tests/unit/webserver/shared/transcription_provider_registry/capacity_admission_test.py
+++ b/transcription_service/tests/unit/webserver/shared/transcription_provider_registry/capacity_admission_test.py
@@ -325,24 +325,36 @@ def test_refusal_increments_the_counter_under_its_provider_key(
     both end as a closed socket with no transcript, and only one of them means
     the deployment needs more capacity. Labelled by provider key because a host
     serving both a local model and a remote one needs to know which of the two
-    it has run out of - proven here by refusing on the first provider's
-    callback and confirming the second provider's counter is untouched.
+    it has run out of.
+
+    BOTH providers refuse here, deliberately. Refusing only on the first and
+    asserting the second's counter reads zero proves nothing at all - it is
+    trivially zero because the second provider's closure was never invoked, and
+    the test would pass unchanged if `_load_providers` had bound the *same*
+    key to both. Driving a refusal through each provider's own callback and
+    then reading two different counts is what actually pins the binding: a
+    shared key would put all four refusals on one label and leave the other at
+    zero.
     """
     # Arrange
     mock_worker_pool_instance.worker_snapshots.return_value = [
         worker_snapshot(PLACED_WORKER_ID, live_job_count=2)
     ]
     check = admission_check(mock_provider_instances[0])
+    other_check = admission_check(mock_provider_instances[1], provider_index=1)
 
     # Act
     for _ in range(3):
         with pytest.raises(TranscriptionCapacityError):
             check(PLACED_WORKER_ID, MagicMock(spec=Logger))
 
+    with pytest.raises(TranscriptionCapacityError):
+        other_check(PLACED_WORKER_ID, MagicMock(spec=Logger))
+
     # Assert
     counter = metrics_registry.sessions_refused_capacity_total
     assert counter.get({"provider_key": PROVIDER_KEY}) == 3
-    assert counter.get({"provider_key": OTHER_PROVIDER_KEY}) == 0
+    assert counter.get({"provider_key": OTHER_PROVIDER_KEY}) == 1
 
 
 def test_admitted_worker_is_not_counted_as_a_refusal(

--- a/transcription_service/tests/unit/webserver/shared/transcription_provider_registry/capacity_admission_test.py
+++ b/transcription_service/tests/unit/webserver/shared/transcription_provider_registry/capacity_admission_test.py
@@ -14,8 +14,22 @@ transcription host whose one worker is already carrying as many sessions as it
 can transcribe in realtime. Before this, the seventh room was accepted, every
 room degraded together, and nothing said no. The cost of getting this wrong in
 the other direction is a real user with no captions and no way to tell why -
-which is why every gate in `_admits` fails open, and why several of these tests
-pin the *admitting* path rather than the refusing one.
+which is why every gate here fails open, and why several of these tests pin
+the *admitting* path rather than the refusing one.
+
+WHAT MOVED. Admission used to be decided synchronously inside
+`create_session`, because a session's job registered as part of its own
+construction. Registration is now deferred to a session's own first
+`handle_audio_chunk` (an idle, audio-less connection must never take a worker's
+job slot), so `create_session` has nothing to decide any more - see
+`transcription_provider_registry_test.py` for its (unchanged) provider-loading
+and provider-key behaviour. What the registry still owns is the *decision
+itself*: a callable built by `_make_admission_check` and bound onto each
+provider at load time via `bind_admission_check`, which a session calls once
+it has registered and knows which worker (if any) it landed on. These tests
+exercise that callable directly, extracted from the mock provider's
+`bind_admission_check` call - `whisper_streaming_session_test.py` covers a real
+session actually calling it and undoing its own registration on a refusal.
 """
 
 from unittest.mock import MagicMock
@@ -43,7 +57,6 @@ from src.transcription_provider_interface import (
     TranscriptionCapacityError,
     TranscriptionClientError,
     TranscriptionProviderInterface,
-    TranscriptionSessionInterface,
 )
 from src.webserver.shared.metrics import MetricsRegistry
 from src.webserver.shared.transcription_provider_registry import (
@@ -54,7 +67,7 @@ NUM_WORKERS = 2
 PROVIDER_KEY = "asr_0"
 OTHER_PROVIDER_KEY = "asr_1"
 
-# The worker every test's session is placed on. Not 0, so a test that silently
+# The worker every test checks admission for. Not 0, so a test that silently
 # defaulted a worker id somewhere would fail rather than pass by coincidence.
 PLACED_WORKER_ID = 1
 
@@ -78,9 +91,8 @@ def pinned_estimator(max_sessions: int | None) -> CapacityEstimator:
 
     `max_sessions` wins over warm-up inside `_capacity`, so this reports a
     definite N* from the first call without any observations having to be fed
-    in. That keeps these tests about the registry's decision and teardown,
-    which is what they are for; how N* is arrived at is the estimator suite's
-    subject.
+    in. That keeps these tests about the registry's decision, which is what
+    they are for; how N* is arrived at is the estimator suite's subject.
     """
     return CapacityEstimator(
         target_busy=0.85, min_sessions=1, max_sessions=max_sessions
@@ -208,21 +220,6 @@ def metrics_registry():
     return MetricsRegistry()
 
 
-@pytest.fixture
-def mock_session(mock_provider_instances: list[MagicMock]):
-    """
-    The session the first provider hands back, reporting a real placement
-
-    `admission_worker_id` is set rather than left as a bare MagicMock attribute
-    because the whole decision keys on it, and a Mock is truthy - a test that
-    forgot to set it would exercise nothing and still pass.
-    """
-    session = MagicMock(spec=TranscriptionSessionInterface)
-    session.admission_worker_id = PLACED_WORKER_ID
-    mock_provider_instances[0].create_session.return_value = session
-    return session
-
-
 # pylint: disable=unused-argument
 def make_registry(
     config: Config,
@@ -258,20 +255,41 @@ def registry(
     )
 
 
-def test_session_is_refused_when_its_worker_is_already_full(
+def admission_check(provider_instance: MagicMock, provider_index: int = 0):
+    """
+    Gets the admission callable the registry bound onto a mock provider
+
+    Args:
+        provider_instance   - The mock provider whose binding to read
+        provider_index       - Unused, kept for call-site symmetry with the
+                                two-provider fixtures
+
+    A session calls this itself once it has registered a job and knows which
+    worker (if any) it landed on - see `check_admission` on
+    TranscriptionProviderInterface. Extracting it here is what lets these
+    tests exercise the registry's actual decision without standing up a real
+    session.
+    """
+    del provider_index
+    (check,), _ = provider_instance.bind_admission_check.call_args
+    return check
+
+
+def test_admission_check_raises_when_the_worker_is_already_full(
     registry: TranscriptionProviderRegistry,
     mock_worker_pool_instance: MagicMock,
-    mock_session: MagicMock,
+    mock_provider_instances: list[MagicMock],
 ):
     """
-    Test a session lands on a full worker and is refused with the capacity error
+    Test a session whose worker is already full is refused with the capacity
+    error
 
     The measured case: worker 1 is already carrying its one session, a second
-    room connects and the pool routes it there anyway (routing balances load,
+    room's session registers a job and lands there too (routing balances load,
     it does not enforce a ceiling). `live_job_count` is 2 because the new
     session has already registered by the time the check runs - that is the
-    whole point of the register-then-ask order, since the worker is only chosen
-    inside `register_job`.
+    whole point of the register-then-ask order, since the worker is only
+    chosen inside `register_job`.
 
     The type matters as much as the refusal. `TranscriptionCapacityError` is
     not a `TranscriptionClientError`, because that one closes 1007 and blames
@@ -282,60 +300,21 @@ def test_session_is_refused_when_its_worker_is_already_full(
     mock_worker_pool_instance.worker_snapshots.return_value = [
         worker_snapshot(PLACED_WORKER_ID, live_job_count=2)
     ]
+    check = admission_check(mock_provider_instances[0])
 
     # Act / Assert
     with pytest.raises(TranscriptionCapacityError) as refusal:
-        registry.create_session(
-            PROVIDER_KEY,
-            "config",
-            "session-1",
-            "room-1",
-            MagicMock(spec=Logger),
-        )
+        check(PLACED_WORKER_ID, MagicMock(spec=Logger))
 
     assert refusal.value.message == AT_CAPACITY_REASON
     assert not isinstance(refusal.value, TranscriptionClientError)
-
-
-def test_refused_session_is_torn_back_down(
-    registry: TranscriptionProviderRegistry,
-    mock_worker_pool_instance: MagicMock,
-    mock_session: MagicMock,
-):
-    """
-    Test a refused session's job registration does not leak
-
-    Admission has to register before it can ask which worker it got, so a
-    refusal is always an undo. If that undo is skipped the worker keeps a job
-    that will be scheduled every period for a session no client is attached to
-    - it would consume the very capacity the refusal exists to protect, and
-    would do it invisibly, since `/providers/health` would report a live job
-    with a session_uid that hung up.
-
-    `end_session()` is the undo: it deregisters the job (dropping the worker's
-    live_job_count immediately) and decrements the provider's active-session
-    count that the session's constructor just incremented.
-    """
-    # Arrange
-    mock_worker_pool_instance.worker_snapshots.return_value = [
-        worker_snapshot(PLACED_WORKER_ID, live_job_count=2)
-    ]
-
-    # Act
-    with pytest.raises(TranscriptionCapacityError):
-        registry.create_session(
-            PROVIDER_KEY, "config", None, None, MagicMock(spec=Logger)
-        )
-
-    # Assert
-    mock_session.end_session.assert_called_once()
 
 
 def test_refusal_increments_the_counter_under_its_provider_key(
     registry: TranscriptionProviderRegistry,
     mock_worker_pool_instance: MagicMock,
     metrics_registry: MetricsRegistry,
-    mock_session: MagicMock,
+    mock_provider_instances: list[MagicMock],
 ):
     """
     Test each refusal is counted against the provider it was refused for
@@ -344,19 +323,19 @@ def test_refusal_increments_the_counter_under_its_provider_key(
     both end as a closed socket with no transcript, and only one of them means
     the deployment needs more capacity. Labelled by provider key because a host
     serving both a local model and a remote one needs to know which of the two
-    it has run out of.
+    it has run out of - proven here by refusing on the first provider's
+    callback and confirming the second provider's counter is untouched.
     """
     # Arrange
     mock_worker_pool_instance.worker_snapshots.return_value = [
         worker_snapshot(PLACED_WORKER_ID, live_job_count=2)
     ]
+    check = admission_check(mock_provider_instances[0])
 
     # Act
     for _ in range(3):
         with pytest.raises(TranscriptionCapacityError):
-            registry.create_session(
-                PROVIDER_KEY, "config", None, None, MagicMock(spec=Logger)
-            )
+            check(PLACED_WORKER_ID, MagicMock(spec=Logger))
 
     # Assert
     counter = metrics_registry.sessions_refused_capacity_total
@@ -364,49 +343,38 @@ def test_refusal_increments_the_counter_under_its_provider_key(
     assert counter.get({"provider_key": OTHER_PROVIDER_KEY}) == 0
 
 
-def test_admitted_session_is_returned_untouched_and_uncounted(
+def test_admitted_worker_is_not_counted_as_a_refusal(
     registry: TranscriptionProviderRegistry,
     mock_worker_pool_instance: MagicMock,
     metrics_registry: MetricsRegistry,
-    mock_session: MagicMock,
     mock_provider_instances: list[MagicMock],
 ):
     """
-    Test an admitted session behaves exactly as it did before admission control
+    Test a worker under the ceiling admits and counts nothing
 
     The regression this guards is the one nobody would notice in a test that
     only exercised refusals: every session in every healthy deployment takes
-    this path, so "no observable difference" is the property that matters most.
-    The session object handed back is the provider's own, its teardown has not
-    been called, and no refusal was counted.
+    this path, so "no observable difference" is the property that matters
+    most.
 
     `live_job_count` is 1 - this session and nothing else - which is the
-    off-by-one that the `- 1` in `_admits` exists for. `admit()` is specified
-    over N *before* placement, so the count has to have the new session
-    subtracted back out; passing it raw would ask whether a second session fits
-    on a pinned-to-one worker and refuse the first client to ever connect.
+    off-by-one `_admits_worker`'s `- 1` exists for. `admit()` is specified over
+    N *before* placement, so the count has to have the new session subtracted
+    back out; passing it raw would ask whether a second session fits on a
+    pinned-to-one worker and refuse the first client to ever connect.
     """
     # Arrange
     mock_worker_pool_instance.worker_snapshots.return_value = [
         worker_snapshot(PLACED_WORKER_ID, live_job_count=1)
     ]
-    session_logger = MagicMock(spec=Logger)
+    check = admission_check(mock_provider_instances[0])
 
-    # Act
-    session = registry.create_session(
-        PROVIDER_KEY, "config", "session-1", "room-1", session_logger
-    )
-
-    # Assert
-    assert session is mock_session
-    mock_session.end_session.assert_not_called()
-    mock_provider_instances[0].create_session.assert_called_once_with(
-        "config", "session-1", "room-1", session_logger
-    )
+    # Act / Assert - does not raise
+    check(PLACED_WORKER_ID, MagicMock(spec=Logger))
     assert metrics_registry.sessions_refused_capacity_total.entries() == []
 
 
-def test_session_declaring_no_worker_is_never_checked(
+def test_worker_id_none_is_never_checked(
     mock_config: Config,
     mock_logger: Logger,
     mock_worker_pool_instance: MagicMock,
@@ -418,21 +386,22 @@ def test_session_declaring_no_worker_is_never_checked(
     mock_provider_import: MockType,
 ):
     """
-    Test a session reporting no admission worker skips the check entirely
+    Test worker_id=None is never even asked about the estimator
 
     This is how `lumen_granite` and `debug` are excluded (§5/§7 defer remote
     providers: their capacity question is upstream rate limits and latency, not
-    a local worker pool). Both register jobs with an empty context tag tuple,
-    so the worker they land on is whichever was least utilized rather than a
-    placement onto the model that would serve them - `admission_worker_id`
-    returning None is that statement, and the base
+    a local worker pool), and it is also the state before a session has
+    registered a job at all. Both register jobs with an empty context tag
+    tuple, so the worker they land on is whichever was least utilized rather
+    than a placement onto the model that would serve them -
+    `admission_worker_id` returning None is that statement, and the base
     TranscriptionSessionInterface returns None so a provider is excluded until
     it deliberately opts in.
 
     The estimator is pinned at zero, so it would refuse anything it was asked
     about. Asserting `admit` was never *called* rather than just that the
-    session came back proves the exclusion happens before the decision, not
-    that the decision happened to come out permissive.
+    check returned normally proves the exclusion happens before the decision,
+    not that the decision happened to come out permissive.
     """
     # Arrange
     estimator = pinned_estimator(0)
@@ -440,23 +409,15 @@ def test_session_declaring_no_worker_is_never_checked(
     registry = make_registry(
         mock_config, mock_logger, estimator, metrics_registry
     )
-
-    remote_session = MagicMock(spec=TranscriptionSessionInterface)
-    remote_session.admission_worker_id = None
-    mock_provider_instances[0].create_session.return_value = remote_session
+    del registry  # only constructed to drive _load_providers' binding
     mock_worker_pool_instance.worker_snapshots.return_value = [
         worker_snapshot(PLACED_WORKER_ID, live_job_count=99)
     ]
+    check = admission_check(mock_provider_instances[0])
 
-    # Act
-    session = registry.create_session(
-        PROVIDER_KEY, "config", None, None, MagicMock(spec=Logger)
-    )
-
-    # Assert
-    assert session is remote_session
+    # Act / Assert - does not raise
+    check(None, MagicMock(spec=Logger))
     admit.assert_not_called()
-    remote_session.end_session.assert_not_called()
     assert metrics_registry.sessions_refused_capacity_total.entries() == []
 
 
@@ -464,7 +425,7 @@ def test_admits_when_no_estimator_is_wired_up(
     mock_config: Config,
     mock_logger: Logger,
     mock_worker_pool_instance: MagicMock,
-    mock_session: MagicMock,
+    mock_provider_instances: list[MagicMock],
     mock_worker_pool_import: MagicMock,
     mock_context_import: MockType,
     mock_provider_import: MockType,
@@ -480,27 +441,24 @@ def test_admits_when_no_estimator_is_wired_up(
     """
     # Arrange
     registry = make_registry(mock_config, mock_logger, None, None)
+    del registry  # only constructed to drive _load_providers' binding
     mock_worker_pool_instance.worker_snapshots.return_value = [
         worker_snapshot(PLACED_WORKER_ID, live_job_count=50)
     ]
+    check = admission_check(mock_provider_instances[0])
 
-    # Act / Assert
-    assert (
-        registry.create_session(
-            PROVIDER_KEY, "config", None, None, MagicMock(spec=Logger)
-        )
-        is mock_session
-    )
+    # Act / Assert - does not raise
+    check(PLACED_WORKER_ID, MagicMock(spec=Logger))
 
 
 def test_admits_when_the_pool_reports_no_such_worker(
     registry: TranscriptionProviderRegistry,
     mock_worker_pool_instance: MagicMock,
     metrics_registry: MetricsRegistry,
-    mock_session: MagicMock,
+    mock_provider_instances: list[MagicMock],
 ):
     """
-    Test a session whose worker is missing from the pool snapshot is admitted
+    Test a worker missing from the pool snapshot is admitted
 
     Reachable if a worker dies between registration and this read. That is a
     pool fault, and refusing the user for it would report a crashed worker to
@@ -512,15 +470,47 @@ def test_admits_when_the_pool_reports_no_such_worker(
     mock_worker_pool_instance.worker_snapshots.return_value = [
         worker_snapshot(PLACED_WORKER_ID + 1, live_job_count=99)
     ]
+    check = admission_check(mock_provider_instances[0])
 
-    # Act / Assert
-    assert (
-        registry.create_session(
-            PROVIDER_KEY, "config", None, None, MagicMock(spec=Logger)
-        )
-        is mock_session
-    )
+    # Act / Assert - does not raise
+    check(PLACED_WORKER_ID, MagicMock(spec=Logger))
     assert metrics_registry.sessions_refused_capacity_total.entries() == []
+
+
+def test_create_session_never_raises_capacity_error(
+    registry: TranscriptionProviderRegistry,
+    mock_worker_pool_instance: MagicMock,
+    mock_provider_instances: list[MagicMock],
+):
+    """
+    Test create_session returns normally even when the worker it would use is
+    already full
+
+    The contract that changed: a session's job (and therefore its worker
+    placement) no longer registers as part of construction, so there is
+    nothing for `create_session` to ask about any more - see the module
+    docstring. Refusal now happens later, from the session's own first
+    `handle_audio_chunk`, which this mocked session never calls, so nothing
+    here can be refused - proving that the burden of asking has genuinely
+    moved off `create_session`, not just that this particular mock stayed
+    quiet.
+    """
+    # Arrange
+    mock_worker_pool_instance.worker_snapshots.return_value = [
+        worker_snapshot(PLACED_WORKER_ID, live_job_count=99)
+    ]
+    session_logger = MagicMock(spec=Logger)
+
+    # Act
+    session = registry.create_session(
+        PROVIDER_KEY, "config", "session-1", "room-1", session_logger
+    )
+
+    # Assert
+    assert session is mock_provider_instances[0].create_session.return_value
+    mock_provider_instances[0].create_session.assert_called_once_with(
+        "config", "session-1", "room-1", session_logger
+    )
 
 
 def test_unknown_provider_key_still_raises_the_client_error(
@@ -529,10 +519,11 @@ def test_unknown_provider_key_still_raises_the_client_error(
     """
     Test a typo'd provider key is still a 1007 client error, not a 1013
 
-    The two refusals now live in the same method and mean opposite things: one
-    says the caller asked for something that does not exist, the other says the
-    service cannot serve it right now. A client that retried the first forever
-    would never succeed; retrying the second is correct.
+    Unlike capacity, this refusal is still decided synchronously inside
+    `create_session` - a provider key either names a configured provider or it
+    does not, which is knowable immediately and has nothing to do with worker
+    load. A client that retried this forever would never succeed; retrying a
+    capacity refusal is correct.
     """
     # Act / Assert
     with pytest.raises(TranscriptionClientError) as error:


### PR DESCRIPTION
**Replaces #183, #184 and #185**, which are closed in favour of this one. All three were independent (zero file overlap) and are merged here in one branch off `staging`.

Investigation write-ups: `2026-08-01-01-PLAN-SessionChecks.md`, `2026-08-01-02-PLAN-VisibleErrors.md`, `2026-08-01-03-PLAN-EndedSessionSourceRace.md`, `DemoTestingWithCornerCases.md`.

## Why

A demo of the real system failed: the client "always showed reconnecting" while the hardcoded demo Alice room worked. Every unit test passed, so nothing in CI pointed at it.

The backend was fine. Rooms, on-demand and AUTO sessions, calendar materialization, timezone/DST math, join codes, device auth and the audio→transcript path were all verified working live. The failure was in how the frontend *described* a healthy state, plus latent faults that make a long session fall apart.

## The three root causes

1. **The idle state was rendered as "Reconnecting…".** With no kiosk streaming yet, node-server correctly reports `{transcriptionServiceConnected: false, sourceDeviceConnected: false}`. The banner turned that into *"Connection to the transcription service was lost. Reconnecting…"*, forever. `sourceDeviceConnected` reached Redux and was read by no component. The demo room was immune because it hardcodes both flags true — which is exactly why it looked healthy and every real room did not.
2. **The token-refresh timer was never armed.** `decodeJwtExpiryMs` read `parts[1]`, assuming a 3-segment JWT. A ScribeAR token has **two** segments with the payload at `parts[0]`, so it always returned `null` — no refresh timer, ever. A failed refresh then meant AUTH was never sent → 1008 `auth-timeout` → reconnect → and because the socket stayed open >1s the backoff *reset*, giving an unbounded ~1s hammer loop.
3. **A permanent 1008 retried forever** with no terminal state, indistinguishable from a flaky network.

## What's here

**Frontend** — idle rooms say *"Waiting for the room's microphone to connect."* (new `info` severity, `role="status"` not `role="alert"`; `sessionStatus` seeded `null` so "not yet known" ≠ "known bad"). Token expiry decoded correctly, refresh timer armed, bounded retry with a failure budget counted **across reconnects**. Terminal state for permanent/repeated 1008. `selectError` rendered. Resume-after-reload emits `sessionIdentity`.

**Backend correctness** — canceled sessions no longer issue tokens on any of the five auth paths (including `refresh-session-token`, where it matters most since a refresh token outlives every session token — an authorization gap). `exchange-join-code` enforces `valid_start`. Unknown `transcriptionProviderId` rejected at creation; upstream 1007 propagates a distinct `INVALID_REQUEST` reason. Viewers on a source-free session now learn it ended (ref-counted end-watch, no upstream dialed). A source landing on an already-ended session is told and closed, and no upstream is dialed for it.

**Infra** — nginx sticky-routes node-server by session uid. Note `hash … consistent` is **silently ignored** when the upstream is a `resolve` name, falling back to round-robin while `nginx -t` still passes; tests fail if it is reintroduced.

**Transcription (from #183, with one deliberate change)** — job registration deferred to the first audio chunk, so an idle audio-less connection no longer consumes worker capacity. The diagnosis and fix are #183's and they are correct.

**Admission enforcement stays OFF.** #183 also re-enabled it; this branch keeps `create_webserver.py` passing `None`. Reason: the same fix *lowers* the ceiling it would enforce. Idle registered jobs ran an empty batch every period (`worker_process.py:343-345`), inflating the `sessions` denominator in `cost_per_session = busy / sessions` while adding nothing to the numerator. A live box measured `estimatedCapacitySessions: 50` under that inflation; with it removed, one whisper stream keeping the single worker busy half of each 5000 ms period gives **`N* = 1`** — the second lecture hall refused. The estimator still observes and still reports through `/metrics/status` and `/providers/health`, so we can measure the true post-fix ceiling under real load and turn enforcement on with data instead of a guess.

**The capacity knobs are now reachable.** `TARGET_BUSY`, `MIN_SESSIONS` and `MAX_SESSIONS` were documented as `.env`-reachable but appeared in no deployment file — an operator could not set them. Added to `compose.yml` + `.env.example` (compose file version → 9). A blank `MAX_SESSIONS` is now read as "no pin"; without that, `${TRANSCRIPTION_MAX_SESSIONS:-}` sends `""`, pydantic rejects it for `int | None`, and every stock stack would fail to boot.

**Tooling** — three harnesses: `npm run e2e:demo` (two real rooms, on-demand + AUTO, asserting the `sourceDeviceConnected` → `transcriptionServiceConnected` ordering that is the regression test for cause #1), `npm run e2e:browser-demo` (real Chromium, admin UI → kiosk → viewer, including a >6-minute soak past the token TTL), and `npm run e2e:sessions` (35 checks / 172 assertions across session lifecycle, join-code auth, and the calendar — DST gaps, midnight wrap, biweekly parity, overlapping windows).

## Verification

Root `build` / `lint` / `test:unit` green; node-server integration 51/51; admin-server 191 unit + 109 integration; `transcription_service` 536 unit, 31 integration.

Verified against a locally-built stack running this exact code: `e2e:demo` 12/12, `e2e:browser-demo` 15/15 with the idle banner and captions confirmed by screenshot and the 6m40s soak showing 1 socket / 2 refreshes / 0 banners, `e2e:sessions` 172 assertions green.

## Known-questionable behaviour, pinned not fixed

`e2e:sessions` found three bugs, deliberately pinned so a fix turns them red: an auto-window with equal local times answers 500 (the schedule path answers 400); an `activeEnd` inside an occurrence drops the whole occurrence instead of clipping it, and narrowing a live window ends the running AUTO session immediately; and `add-device-to-room` with `asSource: true` returns 204 while silently demoting the room's existing source. Fixes are in progress on a follow-up branch.

## Follow-ups (not here)

- `kiosk-webapp` still carries the **identical** token-decode bug and dead `selectError` — on a device facing an audience. P0 in `2026-08-01-02-PLAN-VisibleErrors.md`.
- The client opens one `wss://…/transcription-stream/undefined/client` socket per page load; `start(stored)` does not validate the persisted identity.
- Ending a session tells the viewer nothing — the join dialog silently reopens.
