### PR TITLE
fix(session-manager): source-swap guard, window clipping, 400 for equal window times

### DIFF
--- a/.changeset/add-device-to-room-refuses-second-source.md
+++ b/.changeset/add-device-to-room-refuses-second-source.md
@@ -1,0 +1,42 @@
+---
+'@scribear/session-manager': patch
+'@scribear/session-manager-schema': patch
+'@scribear/admin-webapp': patch
+---
+
+Refuse `add-device-to-room` with `asSource` when the room already has a source,
+instead of silently demoting the incumbent.
+
+The route has always published a `409 TOO_MANY_SOURCE_DEVICES` reply that
+**nothing could produce** — only `createRoom` emitted that code.
+`addDeviceToRoom` ran no "this room already has a source" check, and the
+repository clears `is_source` across the whole room before inserting when
+`asSource` is true, so the call answered `204` and swapped the room's kiosk out
+from under the operator.
+
+The demoted device is not obviously broken, which is the problem. It keeps its
+room membership and its long-lived `DEVICE_TOKEN`, still sees the session through
+`my-schedule`, and still exchanges its token successfully — for
+`["RECEIVE_TRANSCRIPTIONS"]` instead of
+`["SEND_AUDIO","RECEIVE_TRANSCRIPTIONS"]`. That is a kiosk that starts, connects,
+displays a join code and sends no audio, with nothing anywhere reporting a fault.
+It is the exact harm `room-management.service.ts` already documents for the
+reserved test-audio and canary rooms and guards `TEST_AUDIO_ROOM_NOT_ASSIGNABLE`
+/ `CANARY_ROOM_NOT_ASSIGNABLE` against; ordinary teaching rooms had no guard at
+all.
+
+**No schema change**: the 409 was already declared, and now has a producer. The
+route description no longer claims that `asSource` replaces the existing source.
+
+**Replacing a source is still supported, as two deliberate calls.** Kiosk
+hardware breaks and gets swapped, so refusing outright would be worse than the
+bug. `set-source-device` is that flow and already exists: attach with
+`asSource: false`, then promote. The refusal's message names it.
+
+**Both admin-console callers now do that**, because both were always swaps: every
+room has a source device (`createRoom` requires one and the
+`room_devices_ensure_source` trigger keeps one), so the kiosk wizard's "add to an
+existing room" and the room detail page's "add as source device" could only ever
+have been replacing one. They attach then promote, and both labels now say that
+the room's current source is replaced — which the operator previously had no way
+to learn, from the UI or from the API.

--- a/.changeset/backup-service-hardening.md
+++ b/.changeset/backup-service-hardening.md
@@ -1,0 +1,37 @@
+---
+'@scribear/scribear-db': patch
+'@scribear/admin-server': minor
+---
+
+Hardens the Postgres backup service (`db-backup`) from a code review after it
+shipped:
+
+- Failed off-host pushes (scp/rsync) now retry every cycle until they
+  succeed, instead of silently leaving a permanent gap in the offsite backup
+  chain when the destination was unreachable for more than one cycle.
+- Every dump is checked with `pg_restore -l` immediately after `pg_dump`
+  exits 0 and discarded if it fails — `pg_dump` can exit 0 on an archive
+  nothing can actually read back.
+- `pg_dumpall --globals-only` now runs alongside the main dump, covering
+  roles that `pg_dump` alone never backed up.
+- New `BACKUP_ENABLED` (default `true`): set to `false` for a deployment on
+  managed Postgres with its own backups — `db-backup` idles instead of
+  dumping, and Deployment Check reports the choice explicitly (`backup-disabled`)
+  instead of `backup-none-found` forever.
+- New `BACKUP_ENCRYPTION_KEY` (empty/off by default): optional GPG AES256
+  symmetric encryption for every dump, at rest and offsite. `db-restore`
+  decrypts automatically when given a `.gpg` file and the same key.
+- `db-backup`'s healthcheck `start_period` is 30 minutes now, not 2 — long
+  enough for a large database's first `pg_dump` to finish before being read
+  as a failed container.
+- `BACKUP_INTERVAL_SECONDS`/`BACKUP_RETENTION_DAYS` are validated as positive
+  integers on startup rather than failing confusingly (a busy-loop on `0`, a
+  crash-loop on anything non-numeric).
+- Corrected a misleading comment claiming `pg_restore --clean --if-exists`
+  "overwrites" the target database — it drops and recreates only what the
+  dump itself contains.
+
+`COMPOSE_FILE_VERSION` 11 -> 12, `EXPECTED_COMPOSE_FILE_VERSION` follows, the
+drift guard's sha256 is re-pinned, and `deployment/UPGRADING.md` carries the
+note — including the RPO/WAL-archiving tradeoff and the offsite host's
+trust-on-first-connection behavior, both previously undocumented.

--- a/.changeset/clip-occurrences-to-active-range.md
+++ b/.changeset/clip-occurrences-to-active-range.md
@@ -1,0 +1,63 @@
+---
+'@scribear/session-manager': patch
+---
+
+Clip a schedule or window occurrence to its active range instead of dropping it.
+
+`inRange` rejected any occurrence that straddled either end of
+`[activeStart, activeEnd]`. That reads as the safe conservative choice and is
+not: the shape the admin console creates is a daily `00:00–23:59` window, so
+**every** occurrence straddles both ends of any active range that does not begin
+at midnight and finish at 23:59.
+
+Three operator-visible consequences, all reproduced against a running stack:
+
+- "Auto sessions every day, until 30 minutes from now" materialized **nothing** —
+  not a 30-minute session.
+- Narrowing a **live** window through `update-auto-session-window` returned 200
+  and then **ended the AUTO session that was running right then**: with no window
+  occurrence covering the active session's start, the reconciler took its
+  `end_override = now` branch. An operator asking to "stop after this afternoon"
+  stopped the room mid-lecture.
+- The mirror image at the other end: a window with `activeStart = now` produced
+  no session covering now, and the first appeared at the next local midnight.
+  This is why `tools/demo-e2e` backdates `activeStart` a week (an hour of
+  debugging is recorded in its comments) and why the admin dialog forces
+  `activeStart` into the future. Neither workaround is needed any more; the
+  `demo-e2e` backdate is now harmless rather than load-bearing and is left alone.
+
+Occurrences are now trimmed — `startUtc = max(startUtc, activeStart)`,
+`endUtc = min(endUtc, activeEnd)` — which is what the field names imply and what
+`materializeAutoSessions` already did when filling a window around a blocking
+session. The trim is arithmetic on absolute UTC instants, so a DST-adjusted
+occurrence keeps whichever instants `buildOccurrence` resolved; a fall-back
+occurrence clipped mid-way still lands on the standard-time instant.
+
+**A residue shorter than 60 s is dropped rather than materialized**, reusing the
+existing AUTO-slot floor (now `MIN_SESSION_DURATION_SECONDS`, exported from the
+materializer so there is one constant rather than two 60s).
+
+- It applies to **SCHEDULED occurrences too**, not only AUTO. They flow through
+  the same materializer, and SCHEDULED occurrences go straight to
+  `insertSessions` with no other length check — a zero-length residue would
+  violate `sessions_scheduled_end_after_start` and surface as a 500, which is
+  the failure mode this release is otherwise removing. AUTO occurrences pass
+  through `materializeAutoSessions`, which already applied the same floor to
+  every slot, so there the check is belt and braces.
+- It applies **only to a clipped residue**, never to an unclipped occurrence. A
+  30-second occurrence an operator typed out is a request; a 30-second tail left
+  by an `activeEnd` is an artefact, and one nothing can join — the join-code
+  handoff window is itself 60 s.
+
+Nothing downstream needed changing, and the knock-on paths are covered by tests:
+the window-overlap conflict check and `detectConflict` now compare the ranges
+that will actually be written rather than pre-trim ones; `reconcileAutoSessions`
+preserves the running AUTO row and moves its end instead of ending it; the
+deferred `sessions_no_overlap` exclusion constraint still holds for a clipped
+window abutting a SCHEDULED session inside it.
+
+`tools/session-corner-cases`'s fall-back DST check used the old drop behaviour as
+its discriminator between the daylight and standard readings of an ambiguous
+local time, and was rebuilt around clipping: both schedules now sit wholly inside
+the ambiguous hour, so `activeEnd` at the transition instant keeps them under one
+reading and clips them out of existence under the other.

--- a/.changeset/config-check-backup-status.md
+++ b/.changeset/config-check-backup-status.md
@@ -1,0 +1,19 @@
+---
+'@scribear/admin-server': minor
+---
+
+Deployment Check's Config Check page reports on `db-backup` (the Postgres
+backup service from compose.yml v10): whether an off-host copy is configured,
+whether a backup has completed at all yet, and whether the newest one has
+gone stale.
+
+`db-backup` has no HTTP surface to probe the way every other dependency on
+that page is probed — it is a cron loop, not a service — so admin-server
+reads the one channel that exists: a new read-only bind mount of the same
+directory `db-backup` writes its dumps to (`deployment/compose.yml`). The
+staleness threshold mirrors `infra/scribear-db/backup-healthcheck.sh`
+exactly, so this finding and that container's own health status agree.
+
+`COMPOSE_FILE_VERSION` 10 -> 11, `EXPECTED_COMPOSE_FILE_VERSION` follows, the
+drift guard's sha256 is re-pinned, and `deployment/UPGRADING.md` carries the
+note.

--- a/.changeset/postgres-backup-service.md
+++ b/.changeset/postgres-backup-service.md
@@ -1,0 +1,24 @@
+---
+'@scribear/scribear-db': minor
+'@scribear/admin-server': patch
+---
+
+Periodic Postgres backups ship with the stack, as a `db-backup` service
+reusing the `scribear-db` image rather than a host script and crontab an
+operator has to set up and keep in sync on every box separately.
+
+`db-backup` pg_dumps `DB_NAME` on a schedule (default every four hours),
+keeps a rolling local retention window, and can optionally push each dump
+off the host over scp or rsync-over-ssh. It reaches Postgres over the
+`backend` network with the same `DB_HOST`/`DB_USER`/`DB_PASSWORD` every other
+service in `deployment/compose.yml` already uses — no `docker exec`, no
+Docker socket. It does not use the `pg_cron` extension already loaded into
+the same image: `pg_cron` schedules SQL run *by* Postgres, and has no way to
+shell out to the external `pg_dump` client that actually produces a dump.
+
+A profile-gated `db-restore` service ships alongside it for restore drills
+and the real thing — never started by `up -d`.
+
+`COMPOSE_FILE_VERSION` 9 -> 10, `EXPECTED_COMPOSE_FILE_VERSION` follows, the
+drift guard's sha256 is re-pinned, and `deployment/UPGRADING.md` carries the
+note.

--- a/.changeset/window-equal-local-times-400.md
+++ b/.changeset/window-equal-local-times-400.md
@@ -1,0 +1,31 @@
+---
+'@scribear/session-manager': patch
+---
+
+Answer `400` instead of `500` when an auto-session window's `localStartTime`
+equals its `localEndTime`.
+
+`_doCreateSchedule` has validated this since it was written and returns
+`400 "localStartTime and localEndTime must not be equal."`. `_doCreateWindow`
+validated only `activeEnd`, so the identical typo reached the
+`auto_session_windows_local_times_distinct` CHECK inside the transaction and
+came back as an opaque `500 INTERNAL_ERROR` — on both
+`create-auto-session-window` and `update-auto-session-window`. Both window paths
+now mirror the schedule path exactly.
+
+**No schema change.** `400 VALIDATION_ERROR` is already declared on every route
+through `STANDARD_ERROR_REPLIES`, and that is all the schedule route ever
+declared for this: adding an `INVALID_LOCAL_TIMES` reply to the window schemas
+would have made the two paths _less_ consistent, not more.
+
+**The comparison is on time of day, not on the string.** `HH:MM` and `HH:MM:SS`
+are both accepted on the wire and the database stores either as `TIME`, so a row
+written as `08:00` reads back as `08:00:00`. An update merging a request's
+`08:00` against that stored value is exactly the collision the CHECK fires on,
+and `'08:00:00' === '08:00'` is false — so a literal mirror of the schedule
+path's `===` would have left the update route answering 500 for the case an
+operator is most likely to hit. The schedule path had the same hole one level
+deeper (its `===` caught the obvious typo first) and is fixed with it.
+
+Found by `tools/session-corner-cases`, which pinned the 500 and now asserts the
+400, including the `HH:MM` / `HH:MM:SS` form.

--- a/apps/admin-server/src/app-config/app-config.ts
+++ b/apps/admin-server/src/app-config/app-config.ts
@@ -6,6 +6,10 @@ import type { Static } from 'typebox';
 import { BUILD_INFO_PATH, LogLevel } from '@scribear/base-fastify-server';
 
 import type { AdminDbClientConfig } from '#src/db/admin-db-client.js';
+import {
+  BACKUP_DIRECTORY_PATH,
+  type BackupDirectoryConfig,
+} from '#src/server/features/config-check/backup-directory.service.js';
 import type { ConfigCheckConfig } from '#src/server/features/config-check/config-check.service.js';
 import type { DeploymentVersionsConfig } from '#src/server/features/deployment-versions/deployment-versions.service.js';
 import type { HealthCheckerConfig } from '#src/server/features/health/health.service.js';
@@ -106,6 +110,14 @@ const CONFIG_SCHEMA = Type.Object({
   // never stop the stack from starting.
   ADMIN_GRAFANA_BASE_URL: Type.String({ default: '' }),
   ADMIN_PROMETHEUS_BASE_URL: Type.String({ default: '' }),
+
+  // db-backup's own settings (deployment/compose.yml v10), passed through
+  // unchanged so Config Check can report on them directly rather than
+  // inferring them - the same "none" default as db-backup itself, so a
+  // deployment that has not touched either variable reports consistently
+  // with what is actually running.
+  BACKUP_OFFSITE_METHOD: Type.String({ default: 'none' }),
+  BACKUP_INTERVAL_SECONDS: Type.Integer({ minimum: 1, default: 14_400 }),
 
   // Operator test-audio devices (PLAN-TestAudioDevices §3). Empty base URL is
   // the default and means the feature is off: the panel reads
@@ -338,6 +350,8 @@ export class AppConfig {
       grafanaBaseUrl: this._env.ADMIN_GRAFANA_BASE_URL,
       prometheusBaseUrl: this._env.ADMIN_PROMETHEUS_BASE_URL,
       monitoringSidecarBaseUrl: this._env.MONITORING_SIDECAR_BASE_URL,
+      backupOffsiteMethod: this._env.BACKUP_OFFSITE_METHOD,
+      backupIntervalSeconds: this._env.BACKUP_INTERVAL_SECONDS,
       azureTenantId: this._env.AZURE_TENANT_ID,
       azureClientId: this._env.AZURE_CLIENT_ID,
       azureClientSecret: this._env.AZURE_CLIENT_SECRET,
@@ -346,6 +360,17 @@ export class AppConfig {
       // question an operator is waiting on, so one knob should bound both.
       upstreamTimeoutMs: this._env.HEALTH_CHECK_TIMEOUT_SEC * SECOND_MS,
     };
+  }
+
+  /**
+   * Fixed rather than driven by an environment variable: the container path
+   * is this image's own implementation detail, wired to db-backup's shared
+   * output only through `deployment/compose.yml`'s bind mount, which is free
+   * to change on either side without exposing a variable that would only
+   * ever be worth setting once.
+   */
+  get backupDirectoryConfig(): BackupDirectoryConfig {
+    return { path: BACKUP_DIRECTORY_PATH };
   }
 
   get sessionManagerGatewayConfig(): SessionManagerGatewayConfig {

--- a/apps/admin-server/src/app-config/app-config.ts
+++ b/apps/admin-server/src/app-config/app-config.ts
@@ -118,6 +118,7 @@ const CONFIG_SCHEMA = Type.Object({
   // with what is actually running.
   BACKUP_OFFSITE_METHOD: Type.String({ default: 'none' }),
   BACKUP_INTERVAL_SECONDS: Type.Integer({ minimum: 1, default: 14_400 }),
+  BACKUP_ENABLED: Type.Boolean({ default: true }),
 
   // Operator test-audio devices (PLAN-TestAudioDevices §3). Empty base URL is
   // the default and means the feature is off: the panel reads
@@ -352,6 +353,7 @@ export class AppConfig {
       monitoringSidecarBaseUrl: this._env.MONITORING_SIDECAR_BASE_URL,
       backupOffsiteMethod: this._env.BACKUP_OFFSITE_METHOD,
       backupIntervalSeconds: this._env.BACKUP_INTERVAL_SECONDS,
+      backupEnabled: this._env.BACKUP_ENABLED,
       azureTenantId: this._env.AZURE_TENANT_ID,
       azureClientId: this._env.AZURE_CLIENT_ID,
       azureClientSecret: this._env.AZURE_CLIENT_SECRET,

--- a/apps/admin-server/src/server/dependency-injection/app-dependencies.ts
+++ b/apps/admin-server/src/server/dependency-injection/app-dependencies.ts
@@ -10,6 +10,10 @@ import type {
 } from '#src/db/admin-db-client.js';
 import type { AuditController } from '#src/server/features/audit/audit.controller.js';
 import type { AuthController } from '#src/server/features/auth/auth.controller.js';
+import type {
+  BackupDirectoryConfig,
+  BackupDirectoryService,
+} from '#src/server/features/config-check/backup-directory.service.js';
 import type { ConfigCheckController } from '#src/server/features/config-check/config-check.controller.js';
 import type {
   ConfigCheckConfig,
@@ -104,6 +108,8 @@ interface AppDependencies extends BaseDependencies {
   configCheckConfig: ConfigCheckConfig;
   configCheckService: ConfigCheckService;
   configCheckController: ConfigCheckController;
+  backupDirectoryConfig: BackupDirectoryConfig;
+  backupDirectoryService: BackupDirectoryService;
 
   // Deployment versions
   deploymentVersionsConfig: DeploymentVersionsConfig;

--- a/apps/admin-server/src/server/dependency-injection/register-dependencies.ts
+++ b/apps/admin-server/src/server/dependency-injection/register-dependencies.ts
@@ -16,6 +16,7 @@ import {
 import { AdminDbClient } from '#src/db/admin-db-client.js';
 import { AuditController } from '#src/server/features/audit/audit.controller.js';
 import { AuthController } from '#src/server/features/auth/auth.controller.js';
+import { BackupDirectoryService } from '#src/server/features/config-check/backup-directory.service.js';
 import { ConfigCheckController } from '#src/server/features/config-check/config-check.controller.js';
 import { ConfigCheckService } from '#src/server/features/config-check/config-check.service.js';
 import { DemoRoomController } from '#src/server/features/demo-room/demo-room.controller.js';
@@ -106,8 +107,14 @@ function registerDependencies(
 
     // Config check. Depends on fleetTelemetryService and healthCheckerService
     // rather than re-probing: everything it needs about the backplane and the
-    // other containers is already observable through those two.
+    // other containers is already observable through those two. db-backup has
+    // no HTTP surface to probe the same way, so backupDirectoryService reads
+    // the bind mount they share instead.
     configCheckConfig: asValue(config.configCheckConfig),
+    backupDirectoryConfig: asValue(config.backupDirectoryConfig),
+    backupDirectoryService: asClass(BackupDirectoryService, {
+      lifetime: Lifetime.SINGLETON,
+    }),
     configCheckService: asClass(ConfigCheckService, {
       lifetime: Lifetime.SINGLETON,
     }),

--- a/apps/admin-server/src/server/features/config-check/backup-directory.service.ts
+++ b/apps/admin-server/src/server/features/config-check/backup-directory.service.ts
@@ -1,0 +1,62 @@
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+
+/**
+ * Where `db-backup`'s dumps land, read-only bind mount shared with
+ * `deployment/compose.yml`'s `db-backup`/`db-restore` services. The only
+ * channel Config Check has into that container's health: `db-backup` has no
+ * HTTP surface of its own, unlike every other dependency this check reads.
+ */
+export const BACKUP_DIRECTORY_PATH = '/backups';
+
+export interface BackupDirectoryConfig {
+  path: string;
+}
+
+/**
+ * Reads the age of the newest Postgres dump under the shared bind mount.
+ */
+export class BackupDirectoryService {
+  private _path: string;
+
+  constructor(backupDirectoryConfig: BackupDirectoryConfig) {
+    this._path = backupDirectoryConfig.path;
+  }
+
+  /**
+   * Milliseconds since the newest `*.dump` file was last written, or `null`
+   * when the directory cannot be read or holds none yet. Both read the same
+   * to a caller: this class has no way to distinguish "db-backup has not run
+   * yet" from "the bind mount is missing or empty" — `ConfigCheckService`
+   * phrases the resulting finding to cover both.
+   */
+  async newestDumpAgeMs(): Promise<number | null> {
+    let entries: string[];
+    try {
+      entries = await readdir(this._path);
+    } catch {
+      return null;
+    }
+
+    const dumps = entries.filter((name) => name.endsWith('.dump'));
+    if (dumps.length === 0) return null;
+
+    const mtimes = await Promise.all(
+      dumps.map(async (name) => {
+        try {
+          return (await stat(join(this._path, name))).mtimeMs;
+        } catch {
+          // Removed between the readdir and the stat - db-backup's own
+          // retention prune, most likely. Treated as absent rather than
+          // failing the whole check over one file.
+          return null;
+        }
+      }),
+    );
+
+    const known = mtimes.filter((m): m is number => m !== null);
+    if (known.length === 0) return null;
+
+    return Date.now() - Math.max(...known);
+  }
+}

--- a/apps/admin-server/src/server/features/config-check/config-check.service.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.service.ts
@@ -665,15 +665,21 @@ export class ConfigCheckService {
     const { environment, environmentSource, declaredButInvalid } =
       resolveEnvironment(this._config);
 
-    const [telemetry, services, database, monitoring, secretPlaceholders, backup] =
-      await Promise.all([
-        this._checkTelemetryBackplane(environment),
-        this._checkServiceReachability(environment),
-        this._checkDatabase(environment),
-        this._checkMonitoring(environment),
-        this._checkSecretPlaceholders(environment),
-        this._checkBackup(environment),
-      ]);
+    const [
+      telemetry,
+      services,
+      database,
+      monitoring,
+      secretPlaceholders,
+      backup,
+    ] = await Promise.all([
+      this._checkTelemetryBackplane(environment),
+      this._checkServiceReachability(environment),
+      this._checkDatabase(environment),
+      this._checkMonitoring(environment),
+      this._checkSecretPlaceholders(environment),
+      this._checkBackup(environment),
+    ]);
 
     const findings = [
       ...evaluateStaticChecks(this._config, environment, declaredButInvalid),
@@ -1039,7 +1045,11 @@ export class ConfigCheckService {
               'No action needed if another backup mechanism covers this database. Otherwise set BACKUP_ENABLED=true in deployment/.env.',
             docUrl: DOC.postgres,
           },
-          { development: 'advisory', staging: 'advisory', production: 'advisory' },
+          {
+            development: 'advisory',
+            staging: 'advisory',
+            production: 'advisory',
+          },
           env,
         ),
       ];
@@ -1060,7 +1070,11 @@ export class ConfigCheckService {
               'Set BACKUP_OFFSITE_METHOD to scp or rsync in deployment/.env — see deployment/UPGRADING.md.',
             docUrl: DOC.postgres,
           },
-          { development: 'advisory', staging: 'advisory', production: 'warning' },
+          {
+            development: 'advisory',
+            staging: 'advisory',
+            production: 'warning',
+          },
           env,
         ),
       );
@@ -1081,7 +1095,11 @@ export class ConfigCheckService {
               'Check `docker compose ps db-backup` and `docker compose logs db-backup`.',
             docUrl: DOC.postgres,
           },
-          { development: 'advisory', staging: 'warning', production: 'warning' },
+          {
+            development: 'advisory',
+            staging: 'warning',
+            production: 'warning',
+          },
           env,
         ),
       );
@@ -1102,7 +1120,11 @@ export class ConfigCheckService {
               "Check `docker compose logs db-backup` and db-backup's health status in `docker compose ps`.",
             docUrl: DOC.postgres,
           },
-          { development: 'warning', staging: 'critical', production: 'critical' },
+          {
+            development: 'warning',
+            staging: 'critical',
+            production: 'critical',
+          },
           env,
         ),
       );

--- a/apps/admin-server/src/server/features/config-check/config-check.service.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.service.ts
@@ -30,7 +30,8 @@ export type CheckCategory =
   | 'telemetry'
   | 'services'
   | 'environment'
-  | 'monitoring';
+  | 'monitoring'
+  | 'backups';
 
 /**
  * Severity of one finding in each environment.
@@ -180,6 +181,10 @@ export interface ConfigCheckConfig {
    * never needs to.
    */
   monitoringSidecarBaseUrl: string;
+  /** db-backup's own `BACKUP_OFFSITE_METHOD` — "none", "scp" or "rsync". */
+  backupOffsiteMethod: string;
+  /** db-backup's own `BACKUP_INTERVAL_SECONDS` — how stale is too stale. */
+  backupIntervalSeconds: number;
   azureTenantId: string;
   azureClientId: string;
   azureClientSecret: string;
@@ -636,6 +641,7 @@ export class ConfigCheckService {
   private _healthCheckerService: AppDependencies['healthCheckerService'];
   private _dbClient: AppDependencies['dbClient'];
   private _sessionManagerGatewayService: AppDependencies['sessionManagerGatewayService'];
+  private _backupDirectoryService: AppDependencies['backupDirectoryService'];
 
   constructor(
     configCheckConfig: ConfigCheckConfig,
@@ -643,25 +649,28 @@ export class ConfigCheckService {
     healthCheckerService: AppDependencies['healthCheckerService'],
     dbClient: AppDependencies['dbClient'],
     sessionManagerGatewayService: AppDependencies['sessionManagerGatewayService'],
+    backupDirectoryService: AppDependencies['backupDirectoryService'],
   ) {
     this._config = configCheckConfig;
     this._fleetTelemetryService = fleetTelemetryService;
     this._healthCheckerService = healthCheckerService;
     this._dbClient = dbClient;
     this._sessionManagerGatewayService = sessionManagerGatewayService;
+    this._backupDirectoryService = backupDirectoryService;
   }
 
   async check(): Promise<ConfigCheckReport> {
     const { environment, environmentSource, declaredButInvalid } =
       resolveEnvironment(this._config);
 
-    const [telemetry, services, database, monitoring, secretPlaceholders] =
+    const [telemetry, services, database, monitoring, secretPlaceholders, backup] =
       await Promise.all([
         this._checkTelemetryBackplane(environment),
         this._checkServiceReachability(environment),
         this._checkDatabase(environment),
         this._checkMonitoring(environment),
         this._checkSecretPlaceholders(environment),
+        this._checkBackup(environment),
       ]);
 
     const findings = [
@@ -671,6 +680,7 @@ export class ConfigCheckService {
       ...services,
       ...monitoring,
       ...secretPlaceholders,
+      ...backup,
     ];
 
     const summary: Record<CheckSeverity, number> = {
@@ -974,6 +984,98 @@ export class ConfigCheckService {
             staging: 'critical',
             production: 'critical',
           },
+          env,
+        ),
+      );
+    }
+
+    return findings;
+  }
+
+  /**
+   * Is `db-backup` (deployment/compose.yml v10) actually completing, and is a
+   * copy leaving this host.
+   *
+   * `db-backup` has no HTTP surface to probe like every other dependency
+   * above — it is a cron loop, not a service — so this reads the one channel
+   * that exists: the bind-mounted directory both containers share.
+   * `backupDirectoryService` reports the newest `*.dump` file's age, or
+   * `null` when none exists yet. Both "db-backup has never run" and "the bind
+   * mount is missing" read as `null` to that class, and are reported the same
+   * way here — an operator's next step (check the container) is the same
+   * either way.
+   *
+   * The staleness threshold — `backupIntervalSeconds` plus an hour of grace —
+   * mirrors `infra/scribear-db/backup-healthcheck.sh` exactly, so this
+   * finding and that container's `docker compose ps` health status agree.
+   *
+   * Off-host copy is checked directly rather than inferred, unlike most of
+   * this page: `BACKUP_OFFSITE_METHOD` is admin-server's own environment
+   * variable (passed through unchanged, never a secret), not another
+   * service's. `none` is reported as advisory/warning rather than left
+   * silent, the same "worth a nudge, not a defect" treatment
+   * `monitoring-not-configured` gets — a deployment that has never lost a
+   * host has not yet learned why this matters.
+   */
+  private async _checkBackup(env: DeploymentEnv): Promise<ConfigFinding[]> {
+    const findings: ConfigFinding[] = [];
+
+    if (this._config.backupOffsiteMethod === 'none') {
+      findings.push(
+        finding(
+          {
+            id: 'backup-offsite-not-configured',
+            category: 'backups',
+            title: 'Off-host backup copy is not configured',
+            detail:
+              'BACKUP_OFFSITE_METHOD is "none", so Postgres backups are kept only on this host and do not survive losing it.',
+            remediation:
+              'Set BACKUP_OFFSITE_METHOD to scp or rsync in deployment/.env — see deployment/UPGRADING.md.',
+            docUrl: DOC.postgres,
+          },
+          { development: 'advisory', staging: 'advisory', production: 'warning' },
+          env,
+        ),
+      );
+    }
+
+    const ageMs = await this._backupDirectoryService.newestDumpAgeMs();
+
+    if (ageMs === null) {
+      findings.push(
+        finding(
+          {
+            id: 'backup-none-found',
+            category: 'backups',
+            title: 'No Postgres backup has completed yet',
+            detail:
+              'No .dump file was found under the backup directory. Expected for the first BACKUP_INTERVAL_SECONDS after this stack was brought up; otherwise db-backup may not be running, or its backup volume may not be mounted the same way here.',
+            remediation:
+              'Check `docker compose ps db-backup` and `docker compose logs db-backup`.',
+            docUrl: DOC.postgres,
+          },
+          { development: 'advisory', staging: 'warning', production: 'warning' },
+          env,
+        ),
+      );
+      return findings;
+    }
+
+    const maxAgeMs = (this._config.backupIntervalSeconds + 3600) * 1000;
+    if (ageMs > maxAgeMs) {
+      const ageHours = Math.round(ageMs / (60 * 60 * 1000));
+      findings.push(
+        finding(
+          {
+            id: 'backup-stale',
+            category: 'backups',
+            title: 'Postgres backups have stopped completing',
+            detail: `The newest backup is ${String(ageHours)}h old, older than the configured BACKUP_INTERVAL_SECONDS (${String(this._config.backupIntervalSeconds)}s) plus an hour of grace. db-backup may be failing silently.`,
+            remediation:
+              "Check `docker compose logs db-backup` and db-backup's health status in `docker compose ps`.",
+            docUrl: DOC.postgres,
+          },
+          { development: 'warning', staging: 'critical', production: 'critical' },
           env,
         ),
       );

--- a/apps/admin-server/src/server/features/config-check/config-check.service.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.service.ts
@@ -185,6 +185,8 @@ export interface ConfigCheckConfig {
   backupOffsiteMethod: string;
   /** db-backup's own `BACKUP_INTERVAL_SECONDS` — how stale is too stale. */
   backupIntervalSeconds: number;
+  /** db-backup's own `BACKUP_ENABLED` — false means deliberately idling. */
+  backupEnabled: boolean;
   azureTenantId: string;
   azureClientId: string;
   azureClientSecret: string;
@@ -1016,8 +1018,33 @@ export class ConfigCheckService {
    * silent, the same "worth a nudge, not a defect" treatment
    * `monitoring-not-configured` gets — a deployment that has never lost a
    * host has not yet learned why this matters.
+   *
+   * `backupEnabled: false` short-circuits everything else below: a
+   * deployment on managed Postgres (RDS and similar) that has deliberately
+   * turned db-backup off is not missing a backup, and reporting
+   * `backup-none-found` at it forever would be exactly the false alarm this
+   * variable exists to prevent.
    */
   private async _checkBackup(env: DeploymentEnv): Promise<ConfigFinding[]> {
+    if (!this._config.backupEnabled) {
+      return [
+        finding(
+          {
+            id: 'backup-disabled',
+            category: 'backups',
+            title: 'Automated Postgres backups are disabled',
+            detail:
+              'BACKUP_ENABLED is false, so db-backup is idling rather than dumping. Expected for a deployment on managed Postgres with its own backup mechanism.',
+            remediation:
+              'No action needed if another backup mechanism covers this database. Otherwise set BACKUP_ENABLED=true in deployment/.env.',
+            docUrl: DOC.postgres,
+          },
+          { development: 'advisory', staging: 'advisory', production: 'advisory' },
+          env,
+        ),
+      ];
+    }
+
     const findings: ConfigFinding[] = [];
 
     if (this._config.backupOffsiteMethod === 'none') {

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
@@ -50,7 +50,7 @@ export interface ContainerVersion {
  * version.test.ts` fails if the two ever disagree, or if that file changes
  * without someone having made that call.
  */
-export const EXPECTED_COMPOSE_FILE_VERSION = 11;
+export const EXPECTED_COMPOSE_FILE_VERSION = 12;
 
 /**
  * How the running `compose.yml` compares to the one this image was built for.

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
@@ -50,7 +50,7 @@ export interface ContainerVersion {
  * version.test.ts` fails if the two ever disagree, or if that file changes
  * without someone having made that call.
  */
-export const EXPECTED_COMPOSE_FILE_VERSION = 10;
+export const EXPECTED_COMPOSE_FILE_VERSION = 11;
 
 /**
  * How the running `compose.yml` compares to the one this image was built for.

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
@@ -50,7 +50,7 @@ export interface ContainerVersion {
  * version.test.ts` fails if the two ever disagree, or if that file changes
  * without someone having made that call.
  */
-export const EXPECTED_COMPOSE_FILE_VERSION = 9;
+export const EXPECTED_COMPOSE_FILE_VERSION = 10;
 
 /**
  * How the running `compose.yml` compares to the one this image was built for.

--- a/apps/admin-server/tests/integration/config-check.routes.test.ts
+++ b/apps/admin-server/tests/integration/config-check.routes.test.ts
@@ -99,14 +99,17 @@ describe('Config check route', () => {
       expect(body.data.environmentSource).toBe('explicit');
     });
 
-    // Three findings, and all are properties of this fixture rather than of
+    // Five findings, and all are properties of this fixture rather than of
     // the configuration: telemetry is switched off above, the monitoring
-    // profile's base URLs are unset by default (`buildTestAppConfig`), and the
+    // profile's base URLs are unset by default (`buildTestAppConfig`), the
     // test database is a plain Postgres carrying only admin-server's own audit
     // tables — the shared schema `infra/scribear-db` owns has deliberately
     // never been migrated here, since applying it would mean building that
-    // image (pg_cron, pg_trgm) to test a route that has nothing to do with it.
-    it('reports the telemetry and monitoring advisories and the unmigrated shared schema', async () => {
+    // image (pg_cron, pg_trgm) to test a route that has nothing to do with it
+    // — and no db-backup runs in this test environment either, so its bind
+    // mount points nowhere (`buildTestAppConfig`) and neither backup finding
+    // has anything real to read.
+    it('reports the telemetry, monitoring and backup advisories and the unmigrated shared schema', async () => {
       const res = await server.fastify.inject({
         method: 'GET',
         url: URL,
@@ -119,6 +122,8 @@ describe('Config check route', () => {
         'fleet-telemetry-disabled',
         'schema-never-migrated',
         'monitoring-not-configured',
+        'backup-offsite-not-configured',
+        'backup-none-found',
       ]);
     });
 

--- a/apps/admin-server/tests/unit/features/config-check/backup-directory.service.test.ts
+++ b/apps/admin-server/tests/unit/features/config-check/backup-directory.service.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect } from 'vitest';
+
+import { BackupDirectoryService } from '#src/server/features/config-check/backup-directory.service.js';
+
+describe('BackupDirectoryService', (it) => {
+  let dir = '';
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'backup-directory-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('reports null when the directory does not exist', async () => {
+    const service = new BackupDirectoryService({
+      path: join(dir, 'does-not-exist'),
+    });
+
+    expect(await service.newestDumpAgeMs()).toBeNull();
+  });
+
+  it('reports null when the directory holds no .dump files', async () => {
+    await writeFile(join(dir, 'notes.txt'), 'not a dump');
+    const service = new BackupDirectoryService({ path: dir });
+
+    expect(await service.newestDumpAgeMs()).toBeNull();
+  });
+
+  it('reports the age of a dump that just landed as close to zero', async () => {
+    await writeFile(join(dir, 'scribear-db-20260802T040000Z.dump'), 'x');
+    const service = new BackupDirectoryService({ path: dir });
+
+    const age = await service.newestDumpAgeMs();
+
+    expect(age).not.toBeNull();
+    // Not `>= 0`: the filesystem's mtime clock and `Date.now()` are not
+    // guaranteed to agree to sub-millisecond precision, so a dump written
+    // moments ago can read as a hair negative. The real invariant is "small",
+    // not "non-negative" - staleness is judged in hours, not milliseconds.
+    expect(age as number).toBeGreaterThanOrEqual(-1000);
+    expect(age as number).toBeLessThan(5000);
+  });
+
+  it('reports the newest of several dumps, not the oldest', async () => {
+    const now = new Date();
+    const anHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+    const aWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+    await writeFile(join(dir, 'old.dump'), 'x');
+    await utimes(join(dir, 'old.dump'), aWeekAgo, aWeekAgo);
+    await writeFile(join(dir, 'recent.dump'), 'x');
+    await utimes(join(dir, 'recent.dump'), anHourAgo, anHourAgo);
+
+    const service = new BackupDirectoryService({ path: dir });
+    const age = await service.newestDumpAgeMs();
+
+    // ~1h, not ~1 week - the newest file's age, comfortably inside a margin
+    // for however long the test itself takes to run.
+    expect(age as number).toBeGreaterThan(59 * 60 * 1000);
+    expect(age as number).toBeLessThan(61 * 60 * 1000);
+  });
+
+  it('ignores files that are not .dump', async () => {
+    await writeFile(join(dir, 'readme.txt'), 'x');
+    await writeFile(join(dir, 'scribear-db-20260802T040000Z.dump'), 'x');
+
+    const service = new BackupDirectoryService({ path: dir });
+
+    expect(await service.newestDumpAgeMs()).not.toBeNull();
+  });
+});

--- a/apps/admin-server/tests/unit/features/config-check/backup-directory.service.test.ts
+++ b/apps/admin-server/tests/unit/features/config-check/backup-directory.service.test.ts
@@ -1,7 +1,6 @@
 import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-
 import { afterEach, beforeEach, describe, expect } from 'vitest';
 
 import { BackupDirectoryService } from '#src/server/features/config-check/backup-directory.service.js';
@@ -43,8 +42,8 @@ describe('BackupDirectoryService', (it) => {
     // guaranteed to agree to sub-millisecond precision, so a dump written
     // moments ago can read as a hair negative. The real invariant is "small",
     // not "non-negative" - staleness is judged in hours, not milliseconds.
-    expect(age as number).toBeGreaterThanOrEqual(-1000);
-    expect(age as number).toBeLessThan(5000);
+    expect(age!).toBeGreaterThanOrEqual(-1000);
+    expect(age!).toBeLessThan(5000);
   });
 
   it('reports the newest of several dumps, not the oldest', async () => {
@@ -62,8 +61,8 @@ describe('BackupDirectoryService', (it) => {
 
     // ~1h, not ~1 week - the newest file's age, comfortably inside a margin
     // for however long the test itself takes to run.
-    expect(age as number).toBeGreaterThan(59 * 60 * 1000);
-    expect(age as number).toBeLessThan(61 * 60 * 1000);
+    expect(age!).toBeGreaterThan(59 * 60 * 1000);
+    expect(age!).toBeLessThan(61 * 60 * 1000);
   });
 
   it('ignores files that are not .dump', async () => {

--- a/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
+++ b/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
@@ -46,6 +46,7 @@ const CLEAN: ConfigCheckConfig = {
   // turns it on with its own overrides.
   backupOffsiteMethod: 'none',
   backupIntervalSeconds: 14_400,
+  backupEnabled: true,
   azureTenantId: 'tenant-1',
   azureClientId: 'client-1',
   azureClientSecret: '0b4e8d2a7f16c395',
@@ -1183,7 +1184,27 @@ describe('the monitoring probes', () => {
   });
 });
 
-describe('the backup service (compose.yml v11)', (it) => {
+describe('the backup service (compose.yml v12)', (it) => {
+  describe('BACKUP_ENABLED=false', (it) => {
+    it('reports one advisory finding instead of any freshness or offsite finding', async () => {
+      const found = await backupFindings(
+        { backupEnabled: false, backupOffsiteMethod: 'none' },
+        { newestDumpAgeMs: () => Promise.resolve(null) },
+      );
+
+      expect(found.map((f) => f.id)).toEqual(['backup-disabled']);
+      expect(found[0]?.severity).toBe('advisory');
+      expect(found[0]?.productionSeverity).toBe('advisory');
+    });
+
+    it('never asks the backup directory anything', async () => {
+      const newestDumpAgeMs = vi.fn(() => Promise.resolve(0));
+      await backupIds({ backupEnabled: false }, { newestDumpAgeMs });
+
+      expect(newestDumpAgeMs).not.toHaveBeenCalled();
+    });
+  });
+
   describe('off-host copy', (it) => {
     it('is only advisory in development, warning in production', async () => {
       const found = await backupFindings({ backupOffsiteMethod: 'none' });

--- a/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
+++ b/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
@@ -41,6 +41,11 @@ const CLEAN: ConfigCheckConfig = {
   grafanaBaseUrl: '',
   prometheusBaseUrl: '',
   monitoringSidecarBaseUrl: SIDECAR_TEST_URL,
+  // Off ("none") by default, like a deployment that never turns on the
+  // monitoring profile above - `the backup service` describe block below
+  // turns it on with its own overrides.
+  backupOffsiteMethod: 'none',
+  backupIntervalSeconds: 14_400,
   azureTenantId: 'tenant-1',
   azureClientId: 'client-1',
   azureClientSecret: '0b4e8d2a7f16c395',
@@ -94,6 +99,14 @@ const REACHABLE_DB: DbClientLike = {
 };
 
 /**
+ * A backup directory with a dump that just landed - so `_checkBackup`'s
+ * freshness findings (`backup-none-found`/`backup-stale`) stay quiet in every
+ * helper below except `backupService`, which cares about them directly and
+ * overrides this.
+ */
+const FRESH_BACKUP = { newestDumpAgeMs: () => Promise.resolve(0) };
+
+/**
  * A `ConfigCheckService` whose only live dependency is the database: fleet
  * telemetry is off, every probed service answers, and session-manager reports the
  * same schema version this build expects, so the findings from `check()` are
@@ -114,6 +127,7 @@ function dbService(
     { check: () => Promise.resolve([]) } as unknown as Args[2],
     dbClient as unknown as Args[3],
     gateway(reportedLatest) as unknown as Args[4],
+    FRESH_BACKUP as unknown as Args[5],
   );
 }
 
@@ -163,6 +177,7 @@ function healthService(components: HealthComponentLike[]): ConfigCheckService {
     { check: () => Promise.resolve(components) } as unknown as Args[2],
     REACHABLE_DB as unknown as Args[3],
     gateway(LATEST_MIGRATION) as unknown as Args[4],
+    FRESH_BACKUP as unknown as Args[5],
   );
 }
 
@@ -279,6 +294,7 @@ function monitoringService(
     { check: () => Promise.resolve([]) } as unknown as Args[2],
     REACHABLE_DB as unknown as Args[3],
     gateway(LATEST_MIGRATION) as unknown as Args[4],
+    FRESH_BACKUP as unknown as Args[5],
   );
 }
 
@@ -287,6 +303,47 @@ async function monitoringIds(
 ): Promise<string[]> {
   const report = await monitoringService(overrides).check();
   return report.findings.map((f) => f.id);
+}
+
+/** What `backupDirectoryService.newestDumpAgeMs()` returns. */
+interface BackupDirectoryLike {
+  newestDumpAgeMs: () => Promise<number | null>;
+}
+
+/**
+ * A `ConfigCheckService` with every other dependency healthy, so `check()`'s
+ * `backup-*` findings are exactly what `_checkBackup` made of `overrides` and
+ * `backupDirectory`.
+ */
+function backupService(
+  overrides: Partial<ConfigCheckConfig> = {},
+  backupDirectory: BackupDirectoryLike = FRESH_BACKUP,
+): ConfigCheckService {
+  type Args = ConstructorParameters<typeof ConfigCheckService>;
+  return new ConfigCheckService(
+    { ...CLEAN, ...overrides },
+    { enabled: false } as unknown as Args[1],
+    { check: () => Promise.resolve([]) } as unknown as Args[2],
+    REACHABLE_DB as unknown as Args[3],
+    gateway(LATEST_MIGRATION) as unknown as Args[4],
+    backupDirectory as unknown as Args[5],
+  );
+}
+
+async function backupIds(
+  overrides: Partial<ConfigCheckConfig> = {},
+  backupDirectory?: BackupDirectoryLike,
+): Promise<string[]> {
+  const report = await backupService(overrides, backupDirectory).check();
+  return report.findings.map((f) => f.id);
+}
+
+async function backupFindings(
+  overrides: Partial<ConfigCheckConfig> = {},
+  backupDirectory?: BackupDirectoryLike,
+) {
+  const report = await backupService(overrides, backupDirectory).check();
+  return report.findings.filter((f) => f.category === 'backups');
 }
 
 describe('resolveEnvironment', () => {
@@ -1123,6 +1180,96 @@ describe('the monitoring probes', () => {
         false,
       );
     });
+  });
+});
+
+describe('the backup service (compose.yml v11)', (it) => {
+  describe('off-host copy', (it) => {
+    it('is only advisory in development, warning in production', async () => {
+      const found = await backupFindings({ backupOffsiteMethod: 'none' });
+      const offsite = found.find(
+        (f) => f.id === 'backup-offsite-not-configured',
+      );
+
+      expect(offsite).toBeTruthy();
+      expect(offsite?.productionSeverity).toBe('warning');
+    });
+
+    it('reports nothing when scp or rsync is configured', async () => {
+      const scp = await backupIds({ backupOffsiteMethod: 'scp' });
+      const rsync = await backupIds({ backupOffsiteMethod: 'rsync' });
+
+      expect(scp).not.toContain('backup-offsite-not-configured');
+      expect(rsync).not.toContain('backup-offsite-not-configured');
+    });
+  });
+
+  describe('freshness', (it) => {
+    it('reports nothing when a backup just landed', async () => {
+      const found = await backupIds(
+        { backupOffsiteMethod: 'scp' },
+        { newestDumpAgeMs: () => Promise.resolve(0) },
+      );
+
+      expect(found.filter((id) => id.startsWith('backup-'))).toEqual([]);
+    });
+
+    it('flags none found without also calling it stale', async () => {
+      const found = await backupIds(
+        { backupOffsiteMethod: 'scp' },
+        { newestDumpAgeMs: () => Promise.resolve(null) },
+      );
+
+      expect(found).toContain('backup-none-found');
+      expect(found).not.toContain('backup-stale');
+    });
+
+    it('accepts a backup within the interval plus an hour of grace', async () => {
+      const found = await backupIds(
+        { backupOffsiteMethod: 'scp', backupIntervalSeconds: 14_400 },
+        // Interval + grace exactly: still fresh, since the threshold is
+        // exclusive - one tick later is what "stale" tests.
+        { newestDumpAgeMs: () => Promise.resolve((14_400 + 3600) * 1000) },
+      );
+
+      expect(found).not.toContain('backup-stale');
+    });
+
+    it('flags a backup older than the interval plus an hour of grace as critical in staging/production', async () => {
+      const found = await backupFindings(
+        { backupOffsiteMethod: 'scp', backupIntervalSeconds: 14_400 },
+        { newestDumpAgeMs: () => Promise.resolve((14_400 + 3600) * 1000 + 1) },
+      );
+      const stale = found.find((f) => f.id === 'backup-stale');
+
+      expect(stale?.severity).toBe('critical');
+      expect(stale?.detail).toContain('14400s');
+    });
+
+    it('is only a warning in development', async () => {
+      const found = await backupFindings(
+        {
+          backupOffsiteMethod: 'scp',
+          isDevelopment: true,
+          declaredEnv: 'development',
+        },
+        { newestDumpAgeMs: () => Promise.resolve(999_999_999) },
+      );
+      const stale = found.find((f) => f.id === 'backup-stale');
+
+      expect(stale?.severity).toBe('warning');
+      expect(stale?.productionSeverity).toBe('critical');
+    });
+  });
+
+  it('never names db-backup findings outside the backups category', async () => {
+    const found = await backupFindings(
+      { backupOffsiteMethod: 'none' },
+      { newestDumpAgeMs: () => Promise.resolve(null) },
+    );
+
+    expect(found.length).toBeGreaterThan(0);
+    for (const f of found) expect(f.category).toBe('backups');
   });
 });
 

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  '48fb8bb10beb70b0be5a97beb18cbd3e2b65af5d4dc96f65257ef9668ea960ee';
+  '9f6210678f668139110c88dc88efc827ab1137830acf67d2b438f15d9c20b48d';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  '9f6210678f668139110c88dc88efc827ab1137830acf67d2b438f15d9c20b48d';
+  '9021034c7195193ec91956cff25d10b936cbc7e380d387824b7e99f14c9928c4';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  '9021034c7195193ec91956cff25d10b936cbc7e380d387824b7e99f14c9928c4';
+  '3f17fa29b049183cdb4cf17e331fb1af0b382952228504228eeff8781be7f541';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/apps/admin-server/tests/utils/use-server.ts
+++ b/apps/admin-server/tests/utils/use-server.ts
@@ -195,6 +195,7 @@ export function buildTestAppConfig(
       // explicitly.
       backupOffsiteMethod: 'none',
       backupIntervalSeconds: 14_400,
+      backupEnabled: true,
       ...overrides.configCheckConfig,
     },
     // No real db-backup runs in this test environment, so this deliberately

--- a/apps/admin-server/tests/utils/use-server.ts
+++ b/apps/admin-server/tests/utils/use-server.ts
@@ -36,6 +36,7 @@ export interface TestAppConfigOverrides {
   fleetTelemetryConfig?: Partial<AppConfig['fleetTelemetryConfig']>;
   testAudioConfig?: Partial<AppConfig['testAudioConfig']>;
   configCheckConfig?: Partial<AppConfig['configCheckConfig']>;
+  backupDirectoryConfig?: Partial<AppConfig['backupDirectoryConfig']>;
   cookieSecret?: string;
 }
 
@@ -188,7 +189,20 @@ export function buildTestAppConfig(
       // stubbed, so a real timeout would only ever be hit by a test that
       // meant to hit it.
       upstreamTimeoutMs: 500,
+      // Off ("none") by default, like the monitoring profile above - most
+      // deployments have not set this either. Tests that care about
+      // `_checkBackup`'s freshness findings pass `backupDirectoryConfig`
+      // explicitly.
+      backupOffsiteMethod: 'none',
+      backupIntervalSeconds: 14_400,
       ...overrides.configCheckConfig,
+    },
+    // No real db-backup runs in this test environment, so this deliberately
+    // points nowhere - `backup-none-found` is as true here as
+    // `schema-never-migrated` above, for the same reason.
+    backupDirectoryConfig: {
+      path: '/nonexistent-in-tests',
+      ...overrides.backupDirectoryConfig,
     },
     cookieSecret: overrides.cookieSecret ?? TEST_COOKIE_SECRET,
   } as unknown as AppConfig;

--- a/apps/admin-webapp/src/features/kiosk-setup/kiosk-wizard-page.tsx
+++ b/apps/admin-webapp/src/features/kiosk-setup/kiosk-wizard-page.tsx
@@ -193,7 +193,7 @@ const RoomStep = ({
         <FormControlLabel
           value="existing"
           control={<Radio />}
-          label="Add to an existing room"
+          label="Add to an existing room (replaces its source device)"
         />
       </RadioGroup>
       {roomChoice === 'new' ? (
@@ -477,8 +477,17 @@ export const KioskWizardPage = () => {
     if (deviceUid === null || selectedRoomUid === '') return;
     setRoomSubmitting(true);
     setRoomMisconfigured(false);
+    // Attach, then promote as a separate call. `add-device-to-room` refuses
+    // `asSource` when the room already has a source (409
+    // TOO_MANY_SOURCE_DEVICES) so that a swap is never a side effect of
+    // attaching a device - and every room has a source, so the wizard's
+    // "add to an existing room" is always a swap. `set-source-device` is the
+    // deliberate form of it.
     adminApi
-      .addDeviceToRoom({ roomUid: selectedRoomUid, deviceUid, asSource: true })
+      .addDeviceToRoom({ roomUid: selectedRoomUid, deviceUid, asSource: false })
+      .then(() =>
+        adminApi.setSourceDevice({ roomUid: selectedRoomUid, deviceUid }),
+      )
       .then(() => {
         setRoomUid(selectedRoomUid);
         showSuccess('Device added to room.');

--- a/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
+++ b/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
@@ -186,8 +186,17 @@ const AddDeviceDialog = ({
   const handleSubmit = () => {
     setSubmitting(true);
     setMisconfigured(false);
+    // Attach, then promote as a separate call. `add-device-to-room` refuses
+    // `asSource` when the room already has a source (409
+    // TOO_MANY_SOURCE_DEVICES) precisely so that replacing a source is never a
+    // side effect of attaching a device; `set-source-device` is the deliberate
+    // swap, and every room has a source, so that is the only path that works
+    // here.
     adminApi
-      .addDeviceToRoom({ roomUid, deviceUid, asSource })
+      .addDeviceToRoom({ roomUid, deviceUid, asSource: false })
+      .then(() =>
+        asSource ? adminApi.setSourceDevice({ roomUid, deviceUid }) : null,
+      )
       .then(() => {
         showSuccess('Device added to room.');
         onAdded();
@@ -260,7 +269,7 @@ const AddDeviceDialog = ({
               }}
             />
           }
-          label="Add as source device"
+          label="Add as source device (replaces the room's current source)"
           sx={{ mt: 1 }}
         />
       </DialogContent>

--- a/apps/admin-webapp/src/features/scheduling/auto-window-dialog.tsx
+++ b/apps/admin-webapp/src/features/scheduling/auto-window-dialog.tsx
@@ -8,7 +8,6 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 
 import type { AutoSessionWindow } from '@scribear/session-manager-schema';
@@ -23,7 +22,11 @@ import { adminApi } from '#src/lib/admin-api';
 import { isApiErrorCode } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
 
-import { JsonConfigField, MultiSelectField } from './scheduling-form-fields';
+import {
+  JsonConfigField,
+  LocalTimeRangeFields,
+  MultiSelectField,
+} from './scheduling-form-fields';
 import {
   DAYS_OF_WEEK,
   SCOPES,
@@ -63,6 +66,10 @@ function windowToFormState(w: AutoSessionWindow): AutoWindowFormState {
 
 export interface AutoWindowDialogProps {
   roomUid: string;
+  /** Room name, shown alongside its timezone on the local-time fields. */
+  roomName: string;
+  /** The room's IANA zone — the clock the local start/end times are read in. */
+  roomTimezone: string;
   window: AutoSessionWindow | null;
   onClose: () => void;
   onSaved: () => void;
@@ -70,6 +77,8 @@ export interface AutoWindowDialogProps {
 
 export const AutoWindowDialog = ({
   roomUid,
+  roomName,
+  roomTimezone,
   window: autoWindow,
   onClose,
   onSaved,
@@ -209,30 +218,18 @@ export const AutoWindowDialog = ({
             server&apos;s ADMIN_API_KEY.
           </Alert>
         )}
-        <Stack direction="row" spacing={2}>
-          <TextField
-            label="Local start time"
-            type="time"
-            value={form.localStartTime}
-            onChange={(e) => {
-              setForm((f) => ({ ...f, localStartTime: e.target.value }));
-            }}
-            margin="normal"
-            fullWidth
-            slotProps={{ inputLabel: { shrink: true } }}
-          />
-          <TextField
-            label="Local end time"
-            type="time"
-            value={form.localEndTime}
-            onChange={(e) => {
-              setForm((f) => ({ ...f, localEndTime: e.target.value }));
-            }}
-            margin="normal"
-            fullWidth
-            slotProps={{ inputLabel: { shrink: true } }}
-          />
-        </Stack>
+        <LocalTimeRangeFields
+          startTime={form.localStartTime}
+          endTime={form.localEndTime}
+          onStartChange={(v) => {
+            setForm((f) => ({ ...f, localStartTime: v }));
+          }}
+          onEndChange={(v) => {
+            setForm((f) => ({ ...f, localEndTime: v }));
+          }}
+          roomName={roomName}
+          roomTimezone={roomTimezone}
+        />
         <MultiSelectField
           label="Days of week"
           options={DAYS_OF_WEEK}

--- a/apps/admin-webapp/src/features/scheduling/auto-window-dialog.tsx
+++ b/apps/admin-webapp/src/features/scheduling/auto-window-dialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
 import Dialog from '@mui/material/Dialog';
@@ -9,6 +10,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 
 import type { AutoSessionWindow } from '@scribear/session-manager-schema';
 
@@ -70,6 +72,13 @@ export interface AutoWindowDialogProps {
   roomName: string;
   /** The room's IANA zone — the clock the local start/end times are read in. */
   roomTimezone: string;
+  /**
+   * The room's auto-session master switch. A window on a room with this off is
+   * stored and listed but produces no sessions at all (the reconciler reads
+   * zero windows), so the dialog has to say which of the two states the room
+   * is in — and offer to flip it — rather than saving in silence.
+   */
+  autoSessionEnabled: boolean;
   window: AutoSessionWindow | null;
   onClose: () => void;
   onSaved: () => void;
@@ -79,6 +88,7 @@ export const AutoWindowDialog = ({
   roomUid,
   roomName,
   roomTimezone,
+  autoSessionEnabled,
   window: autoWindow,
   onClose,
   onSaved,
@@ -98,6 +108,12 @@ export const AutoWindowDialog = ({
           transcriptionProviderId: 'whisper',
           transcriptionStreamConfig: '{}',
         },
+  );
+  // Seeded from the room, same as the kiosk wizard's schedule step: when the
+  // master switch is off the offer to turn it on is pre-accepted, since a
+  // window saved without it does nothing.
+  const [enableAutoSessions, setEnableAutoSessions] = useState(
+    () => !autoSessionEnabled,
   );
   const [jsonError, setJsonError] = useState<string | null>(null);
   const [daysError, setDaysError] = useState(false);
@@ -143,6 +159,8 @@ export const AutoWindowDialog = ({
     setSubmitting(true);
     setMisconfigured(false);
 
+    const creating = autoWindow === null;
+    let saved: Promise<AutoSessionWindow>;
     if (autoWindow === null) {
       const body: CreateAutoWindowBody = {
         roomUid,
@@ -155,22 +173,7 @@ export const AutoWindowDialog = ({
         transcriptionProviderId: form.transcriptionProviderId,
         transcriptionStreamConfig,
       };
-      adminApi
-        .createAutoWindow(body)
-        .then(() => {
-          showSuccess('Auto-session window created.');
-          onSaved();
-        })
-        .catch((err: unknown) => {
-          if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
-            setMisconfigured(true);
-          } else {
-            showError(errorMessage(err, 'Failed to create window.'));
-          }
-        })
-        .finally(() => {
-          setSubmitting(false);
-        });
+      saved = adminApi.createAutoWindow(body);
     } else {
       const body: UpdateAutoWindowBody = {
         windowUid: autoWindow.uid,
@@ -185,23 +188,53 @@ export const AutoWindowDialog = ({
           transcriptionStreamConfig,
         }),
       };
-      adminApi
-        .updateAutoWindow(body)
-        .then(() => {
-          showSuccess('Auto-session window updated.');
-          onSaved();
-        })
-        .catch((err: unknown) => {
-          if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
-            setMisconfigured(true);
-          } else {
-            showError(errorMessage(err, 'Failed to update window.'));
-          }
-        })
-        .finally(() => {
-          setSubmitting(false);
-        });
+      saved = adminApi.updateAutoWindow(body);
     }
+    const alsoEnable = enableAutoSessions && !autoSessionEnabled;
+
+    saved
+      .then(() => {
+        if (!alsoEnable) return null;
+        // The master switch is what actually makes the window produce
+        // sessions, so a failure here is reported on its own.
+        return adminApi
+          .updateRoomScheduleConfig({ roomUid, autoSessionEnabled: true })
+          .then(() => null)
+          .catch((err: unknown) => {
+            showError(
+              errorMessage(
+                err,
+                'Window saved, but auto-sessions could not be enabled for the room.',
+              ),
+            );
+            return null;
+          });
+      })
+      .then(() => {
+        showSuccess(
+          creating
+            ? 'Auto-session window created.'
+            : 'Auto-session window updated.',
+        );
+        onSaved();
+      })
+      .catch((err: unknown) => {
+        if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
+          setMisconfigured(true);
+        } else {
+          showError(
+            errorMessage(
+              err,
+              creating
+                ? 'Failed to create window.'
+                : 'Failed to update window.',
+            ),
+          );
+        }
+      })
+      .finally(() => {
+        setSubmitting(false);
+      });
   };
 
   return (
@@ -303,6 +336,41 @@ export const AutoWindowDialog = ({
           }}
           error={jsonError}
         />
+        {autoSessionEnabled ? (
+          <Alert severity="success" sx={{ mt: 2 }}>
+            Auto-sessions are enabled for this room, so this window takes effect
+            as soon as you save.
+          </Alert>
+        ) : (
+          <Box sx={{ mt: 2 }}>
+            <Alert severity="warning">
+              Auto-sessions are turned off for this room, so this window will
+              not produce any sessions until they are turned on.
+            </Alert>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={enableAutoSessions}
+                  onChange={(e) => {
+                    setEnableAutoSessions(e.target.checked);
+                  }}
+                />
+              }
+              label="Enable auto-sessions for this room"
+            />
+            <Typography
+              variant="caption"
+              sx={{
+                display: 'block',
+                color: 'text.secondary',
+              }}
+            >
+              {enableAutoSessions
+                ? "This room's master switch is off. Saving will turn it on."
+                : 'Leaving this off saves the window but produces no sessions until the master switch is turned on from this page.'}
+            </Typography>
+          </Box>
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} disabled={submitting}>

--- a/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
+++ b/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
@@ -752,6 +752,8 @@ export const RoomSchedulingPage = () => {
       {scheduleDialogOpen && (
         <ScheduleDialog
           roomUid={room.uid}
+          roomName={room.name}
+          roomTimezone={room.timezone}
           schedule={editingSchedule}
           onClose={() => {
             setScheduleDialogOpen(false);
@@ -765,6 +767,8 @@ export const RoomSchedulingPage = () => {
       {windowDialogOpen && (
         <AutoWindowDialog
           roomUid={room.uid}
+          roomName={room.name}
+          roomTimezone={room.timezone}
           window={editingWindow}
           onClose={() => {
             setWindowDialogOpen(false);

--- a/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
+++ b/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
@@ -48,11 +48,18 @@ import { AutoWindowDialog } from './auto-window-dialog';
 import { OnDemandDialog } from './on-demand-dialog';
 import { ScheduleDialog } from './schedule-dialog';
 
+// Forward bound for the Sessions table only. Schedules and auto-session
+// windows are listed with no upper bound (see the listSchedules/
+// listAutoWindows calls below) so a far-future one is never hidden from the
+// page that manages it (QUIRK-4) — only materialized *sessions* are worth
+// capping, since those can accumulate without limit over time.
 const RANGE_DAYS = 90;
-// How far back the scheduling page looks. The session listing uses an overlap
-// predicate, so a session that started before page-load (e.g. an active
-// on-demand session) still appears. The schedule/window listing filters on
-// `active_start <= to`, so this primarily governs sessions.
+// How far back the scheduling page looks, for all three tables. The session
+// listing uses an overlap predicate, so a session that started before
+// page-load (e.g. an active on-demand session) still appears. The
+// schedule/window listing filters on `active_end IS NULL OR active_end >=
+// from`, so this excludes only schedules/windows that were already over a
+// week ago.
 const LOOKBACK_DAYS = 7;
 // The scheduling page has no server-push; poll the session list so a session
 // created or started elsewhere (e.g. by the auto-session reconciler, or by
@@ -125,8 +132,11 @@ export const RoomSchedulingPage = () => {
     () =>
       roomUid === undefined
         ? Promise.resolve([])
-        : adminApi
-            .listSchedules({ roomUid, from: rangeFrom, to: rangeTo })
+        : // No `to`: this table manages every schedule the room has, however
+          // far out it starts, not just the ones landing in the Sessions
+          // table's occurrence window below (QUIRK-4).
+          adminApi
+            .listSchedules({ roomUid, from: rangeFrom })
             .then((res) => res.items),
     [roomUid],
   );
@@ -141,8 +151,9 @@ export const RoomSchedulingPage = () => {
     () =>
       roomUid === undefined
         ? Promise.resolve([])
-        : adminApi
-            .listAutoWindows({ roomUid, from: rangeFrom, to: rangeTo })
+        : // No `to`, same reasoning as listSchedules above.
+          adminApi
+            .listAutoWindows({ roomUid, from: rangeFrom })
             .then((res) => res.items),
     [roomUid],
   );
@@ -408,10 +419,10 @@ export const RoomSchedulingPage = () => {
               color: 'text.secondary',
             }}
           >
-            Showing occurrences between{' '}
-            {formatInTimeZone(rangeFrom, room.timezone)} and{' '}
-            {formatInTimeZone(rangeTo, room.timezone)} (last {LOOKBACK_DAYS}{' '}
-            days and next {RANGE_DAYS} days).
+            Every schedule active since{' '}
+            {formatInTimeZone(rangeFrom, room.timezone)} (last {LOOKBACK_DAYS}{' '}
+            days), with no upper bound — including ones starting further out
+            than the Sessions table below shows.
           </Typography>
         </Box>
         <Button
@@ -453,7 +464,7 @@ export const RoomSchedulingPage = () => {
                       color: 'text.secondary',
                     }}
                   >
-                    No schedules in this range.
+                    No schedules for this room.
                   </Typography>
                 </TableCell>
               </TableRow>
@@ -528,10 +539,9 @@ export const RoomSchedulingPage = () => {
               color: 'text.secondary',
             }}
           >
-            Showing occurrences between{' '}
-            {formatInTimeZone(rangeFrom, room.timezone)} and{' '}
-            {formatInTimeZone(rangeTo, room.timezone)} (last {LOOKBACK_DAYS}{' '}
-            days and next {RANGE_DAYS} days).
+            Every auto-session window active since{' '}
+            {formatInTimeZone(rangeFrom, room.timezone)} (last {LOOKBACK_DAYS}{' '}
+            days), with no upper bound.
           </Typography>
         </Box>
         <Button
@@ -574,7 +584,7 @@ export const RoomSchedulingPage = () => {
                       color: 'text.secondary',
                     }}
                   >
-                    No auto-session windows in this range.
+                    No auto-session windows for this room.
                   </Typography>
                 </TableCell>
               </TableRow>

--- a/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
+++ b/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
@@ -555,6 +555,16 @@ export const RoomSchedulingPage = () => {
           New window
         </Button>
       </Box>
+      {/* A window on a room whose master switch is off is stored, listed, and
+          completely inert — the reconciler reads zero windows. Without this the
+          table below looks entirely healthy while producing nothing. */}
+      {!room.autoSessionEnabled && windows.length > 0 && (
+        <Alert severity="warning" sx={{ mb: 1 }}>
+          These windows are not producing sessions — auto-sessions are disabled
+          for this room. Turn on the Auto-sessions switch above to start
+          producing sessions.
+        </Alert>
+      )}
       <TableContainer component={Paper} sx={{ mb: 3 }}>
         <Table>
           <TableHead>
@@ -769,6 +779,7 @@ export const RoomSchedulingPage = () => {
           roomUid={room.uid}
           roomName={room.name}
           roomTimezone={room.timezone}
+          autoSessionEnabled={room.autoSessionEnabled}
           window={editingWindow}
           onClose={() => {
             setWindowDialogOpen(false);
@@ -776,6 +787,9 @@ export const RoomSchedulingPage = () => {
           onSaved={() => {
             setWindowDialogOpen(false);
             reloadWindows();
+            // The dialog can flip the room's auto-session master switch as
+            // part of its save, so the switch above has to be re-read.
+            reloadRoom();
           }}
         />
       )}

--- a/apps/admin-webapp/src/features/scheduling/schedule-dialog.tsx
+++ b/apps/admin-webapp/src/features/scheduling/schedule-dialog.tsx
@@ -13,7 +13,6 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import type { SelectChangeEvent } from '@mui/material/Select';
-import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 
 import type { SessionSchedule } from '@scribear/session-manager-schema';
@@ -29,7 +28,11 @@ import { adminApi } from '#src/lib/admin-api';
 import { isApiErrorCode } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
 
-import { JsonConfigField, MultiSelectField } from './scheduling-form-fields';
+import {
+  JsonConfigField,
+  LocalTimeRangeFields,
+  MultiSelectField,
+} from './scheduling-form-fields';
 import {
   DAYS_OF_WEEK,
   SCOPES,
@@ -80,6 +83,10 @@ function scheduleToFormState(schedule: SessionSchedule): ScheduleFormState {
 
 export interface ScheduleDialogProps {
   roomUid: string;
+  /** Room name, shown alongside its timezone on the local-time fields. */
+  roomName: string;
+  /** The room's IANA zone — the clock the local start/end times are read in. */
+  roomTimezone: string;
   schedule: SessionSchedule | null;
   onClose: () => void;
   onSaved: () => void;
@@ -87,6 +94,8 @@ export interface ScheduleDialogProps {
 
 export const ScheduleDialog = ({
   roomUid,
+  roomName,
+  roomTimezone,
   schedule,
   onClose,
   onSaved,
@@ -277,30 +286,18 @@ export const ScheduleDialog = ({
               : ''
           }
         />
-        <Stack direction="row" spacing={2}>
-          <TextField
-            label="Local start time"
-            type="time"
-            value={form.localStartTime}
-            onChange={(e) => {
-              setForm((f) => ({ ...f, localStartTime: e.target.value }));
-            }}
-            margin="normal"
-            fullWidth
-            slotProps={{ inputLabel: { shrink: true } }}
-          />
-          <TextField
-            label="Local end time"
-            type="time"
-            value={form.localEndTime}
-            onChange={(e) => {
-              setForm((f) => ({ ...f, localEndTime: e.target.value }));
-            }}
-            margin="normal"
-            fullWidth
-            slotProps={{ inputLabel: { shrink: true } }}
-          />
-        </Stack>
+        <LocalTimeRangeFields
+          startTime={form.localStartTime}
+          endTime={form.localEndTime}
+          onStartChange={(v) => {
+            setForm((f) => ({ ...f, localStartTime: v }));
+          }}
+          onEndChange={(v) => {
+            setForm((f) => ({ ...f, localEndTime: v }));
+          }}
+          roomName={roomName}
+          roomTimezone={roomTimezone}
+        />
         <TextField
           label="Active start"
           type="datetime-local"

--- a/apps/admin-webapp/src/features/scheduling/scheduling-form-fields.tsx
+++ b/apps/admin-webapp/src/features/scheduling/scheduling-form-fields.tsx
@@ -1,3 +1,4 @@
+import Box from '@mui/material/Box';
 import Checkbox from '@mui/material/Checkbox';
 import FormControl from '@mui/material/FormControl';
 import FormHelperText from '@mui/material/FormHelperText';
@@ -6,6 +7,7 @@ import ListItemText from '@mui/material/ListItemText';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import type { SelectChangeEvent } from '@mui/material/Select';
+import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 
 interface MultiSelectFieldProps<T extends string> {
@@ -57,6 +59,77 @@ export function MultiSelectField<T extends string>({
     </FormControl>
   );
 }
+
+interface LocalTimeRangeFieldsProps {
+  startTime: string;
+  endTime: string;
+  onStartChange: (value: string) => void;
+  onEndChange: (value: string) => void;
+  /** Room these times belong to, named in the caption. */
+  roomName: string;
+  /** The room's IANA zone — the clock these two fields are read against. */
+  roomTimezone: string;
+}
+
+/**
+ * The "Local start/end time" pair, with the clock it is read against spelled
+ * out.
+ *
+ * These are wall-clock strings the server resolves in the *room's* timezone,
+ * while "Active start"/"Active end" in the same dialogs are read in the
+ * browser's. Two clocks in one form: for an operator scheduling a room in
+ * another timezone, a mismatch produces no error at any layer — every value is
+ * individually valid — just a window at the wrong hour. So the room's zone is
+ * named here the same way "Active start"'s helper text names the browser's.
+ */
+export const LocalTimeRangeFields = ({
+  startTime,
+  endTime,
+  onStartChange,
+  onEndChange,
+  roomName,
+  roomTimezone,
+}: LocalTimeRangeFieldsProps) => {
+  const helperId = 'local-time-range-helper';
+  return (
+    <Box>
+      <Stack direction="row" spacing={2}>
+        <TextField
+          label="Local start time"
+          type="time"
+          value={startTime}
+          onChange={(e) => {
+            onStartChange(e.target.value);
+          }}
+          margin="normal"
+          fullWidth
+          slotProps={{
+            inputLabel: { shrink: true },
+            htmlInput: { 'aria-describedby': helperId },
+          }}
+        />
+        <TextField
+          label="Local end time"
+          type="time"
+          value={endTime}
+          onChange={(e) => {
+            onEndChange(e.target.value);
+          }}
+          margin="normal"
+          fullWidth
+          slotProps={{
+            inputLabel: { shrink: true },
+            htmlInput: { 'aria-describedby': helperId },
+          }}
+        />
+      </Stack>
+      <FormHelperText id={helperId} sx={{ mx: 1.75 }}>
+        Interpreted in {roomName}&apos;s timezone ({roomTimezone}), not your
+        browser&apos;s.
+      </FormHelperText>
+    </Box>
+  );
+};
 
 /** JSON textarea for `transcriptionStreamConfig`. Parsing happens on submit. */
 interface JsonConfigFieldProps {

--- a/apps/admin-webapp/src/features/sessions/room-calendar-page.tsx
+++ b/apps/admin-webapp/src/features/sessions/room-calendar-page.tsx
@@ -399,6 +399,8 @@ export const RoomCalendarPage = () => {
       {scheduleDialogOpen && (
         <ScheduleDialog
           roomUid={room.uid}
+          roomName={room.name}
+          roomTimezone={room.timezone}
           schedule={null}
           onClose={() => {
             setScheduleDialogOpen(false);
@@ -412,6 +414,8 @@ export const RoomCalendarPage = () => {
       {windowDialogOpen && (
         <AutoWindowDialog
           roomUid={room.uid}
+          roomName={room.name}
+          roomTimezone={room.timezone}
           window={null}
           onClose={() => {
             setWindowDialogOpen(false);

--- a/apps/admin-webapp/src/features/sessions/room-calendar-page.tsx
+++ b/apps/admin-webapp/src/features/sessions/room-calendar-page.tsx
@@ -416,6 +416,7 @@ export const RoomCalendarPage = () => {
           roomUid={room.uid}
           roomName={room.name}
           roomTimezone={room.timezone}
+          autoSessionEnabled={room.autoSessionEnabled}
           window={null}
           onClose={() => {
             setWindowDialogOpen(false);

--- a/apps/admin-webapp/tests/features/kiosk-setup/kiosk-wizard-page.test.tsx
+++ b/apps/admin-webapp/tests/features/kiosk-setup/kiosk-wizard-page.test.tsx
@@ -17,6 +17,7 @@ vi.mock('#src/lib/admin-api', () => ({
     listRooms: vi.fn(),
     createRoom: vi.fn(),
     addDeviceToRoom: vi.fn(),
+    setSourceDevice: vi.fn(),
     getDevice: vi.fn(),
   },
 }));
@@ -177,7 +178,11 @@ describe('KioskWizardPage', () => {
         ],
         nextCursor: null,
       });
+      // Attaching and promoting are two calls: `add-device-to-room` refuses
+      // `asSource` on a room that already has a source, so the wizard adds the
+      // kiosk as a member and then promotes it with `set-source-device`.
       vi.mocked(adminApi.addDeviceToRoom).mockResolvedValue(null);
+      vi.mocked(adminApi.setSourceDevice).mockResolvedValue(null);
       renderWithProviders(<KioskWizardPage />);
       await registerDevice(user);
       await clickNext(user);

--- a/apps/admin-webapp/tests/features/scheduling/room-scheduling-page.test.tsx
+++ b/apps/admin-webapp/tests/features/scheduling/room-scheduling-page.test.tsx
@@ -9,6 +9,7 @@ import { ApiError } from '#src/lib/api-error';
 
 import { renderWithProviders } from '../../utils/render-with-providers';
 import {
+  buildRoom,
   buildRoomDetail,
   buildSchedule,
   buildSession,
@@ -48,6 +49,14 @@ function mockDefaultLoad(
   vi.mocked(adminApi.listSchedules).mockResolvedValue({ items: schedules });
   vi.mocked(adminApi.listAutoWindows).mockResolvedValue({ items: windows });
   vi.mocked(adminApi.listSessions).mockResolvedValue({ items: [] });
+  // The window dialog chains this after a save whenever the room's
+  // auto-session master switch is off and the operator leaves the
+  // "Enable auto-sessions for this room" box ticked (its default), which the
+  // fixture room is. Resolved by default so tests that are not about the
+  // master switch do not have to know about it.
+  vi.mocked(adminApi.updateRoomScheduleConfig).mockResolvedValue(
+    buildRoom({ ...roomOverrides, autoSessionEnabled: true }),
+  );
 }
 
 async function waitForLoad() {
@@ -282,6 +291,166 @@ describe('RoomSchedulingPage', () => {
         transcriptionProviderId: 'whisper',
         transcriptionStreamConfig: {},
       });
+    });
+  });
+
+  // A window on a room whose auto-session master switch is off is stored,
+  // listed and completely inert — the reconciler reads zero windows — so both
+  // the dialog and the page have to say so. Ported from the kiosk wizard's
+  // schedule step, which already got this right.
+  describe('auto-session master switch', (it) => {
+    /** Opens "New window" and fills the two fields Save validates. */
+    async function openNewWindow(autoSessionEnabled: boolean) {
+      mockDefaultLoad({ roomOverrides: { autoSessionEnabled } });
+      renderPage();
+      await waitForLoad();
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: /new window/i }));
+      await screen.findByLabelText('Local start time');
+      await toggleMultiSelectOption(user, 'Days of week', 'MON');
+      fireEvent.change(screen.getByLabelText('Active start'), {
+        target: { value: '2030-01-01T09:00' },
+      });
+      vi.mocked(adminApi.createAutoWindow).mockResolvedValue(buildWindow());
+      return user;
+    }
+
+    it('warns and offers a pre-ticked checkbox when the switch is off, then enables it after the save', async () => {
+      // Arrange
+      const user = await openNewWindow(false);
+
+      // Assert: both halves of the signal are up before the operator saves.
+      expect(
+        screen.getByText(/auto-sessions are turned off for this room/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('checkbox', {
+          name: /enable auto-sessions for this room/i,
+        }),
+      ).toBeChecked();
+
+      // Act
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      await waitFor(() => {
+        expect(adminApi.createAutoWindow).toHaveBeenCalledTimes(1);
+        expect(adminApi.updateRoomScheduleConfig).toHaveBeenCalledTimes(1);
+      });
+      expect(adminApi.updateRoomScheduleConfig).toHaveBeenCalledWith({
+        roomUid: ROOM_UID,
+        autoSessionEnabled: true,
+      });
+      // The switch is what makes the window live, so it must be flipped only
+      // once the window it is being flipped for actually exists.
+      const windowOrder = vi.mocked(adminApi.createAutoWindow).mock
+        .invocationCallOrder[0]!;
+      const configOrder = vi.mocked(adminApi.updateRoomScheduleConfig).mock
+        .invocationCallOrder[0]!;
+      expect(windowOrder).toBeLessThan(configOrder);
+    });
+
+    it('reassures instead of warning, and leaves the switch alone, when it is already on', async () => {
+      // Arrange
+      const user = await openNewWindow(true);
+
+      // Assert
+      expect(
+        screen.getByText(/auto-sessions are enabled for this room/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/auto-sessions are turned off for this room/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('checkbox', {
+          name: /enable auto-sessions for this room/i,
+        }),
+      ).not.toBeInTheDocument();
+
+      // Act
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      await waitFor(() => {
+        expect(adminApi.createAutoWindow).toHaveBeenCalledTimes(1);
+      });
+      expect(adminApi.updateRoomScheduleConfig).not.toHaveBeenCalled();
+    });
+
+    it('leaves the switch alone when the operator unticks the checkbox', async () => {
+      // Arrange
+      const user = await openNewWindow(false);
+
+      // Act
+      await user.click(
+        screen.getByRole('checkbox', {
+          name: /enable auto-sessions for this room/i,
+        }),
+      );
+
+      // Assert: the caption swaps to spell out what unticking costs.
+      expect(
+        screen.getByText(
+          /leaving this off saves the window but produces no sessions/i,
+        ),
+      ).toBeInTheDocument();
+
+      // Act
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      await waitFor(() => {
+        expect(adminApi.createAutoWindow).toHaveBeenCalledTimes(1);
+      });
+      expect(adminApi.updateRoomScheduleConfig).not.toHaveBeenCalled();
+    });
+
+    it('banners the windows table when the switch is off and windows exist', async () => {
+      // Arrange
+      mockDefaultLoad({
+        windows: [buildWindow()],
+        roomOverrides: { autoSessionEnabled: false },
+      });
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        screen.getByText(/these windows are not producing sessions/i),
+      ).toBeInTheDocument();
+    });
+
+    it('does not banner an empty windows table', async () => {
+      // Arrange: nothing listed yet — there is no dead window to warn about.
+      mockDefaultLoad({ roomOverrides: { autoSessionEnabled: false } });
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        screen.queryByText(/these windows are not producing sessions/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not banner windows on a room whose switch is on', async () => {
+      // Arrange
+      mockDefaultLoad({
+        windows: [buildWindow()],
+        roomOverrides: { autoSessionEnabled: true },
+      });
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(
+        screen.queryByText(/these windows are not producing sessions/i),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/apps/admin-webapp/tests/features/scheduling/room-scheduling-page.test.tsx
+++ b/apps/admin-webapp/tests/features/scheduling/room-scheduling-page.test.tsx
@@ -285,6 +285,86 @@ describe('RoomSchedulingPage', () => {
     });
   });
 
+  // The two clocks a scheduling dialog uses at once: "Local start/end time"
+  // is resolved server-side in the *room's* zone, "Active start" client-side
+  // in the browser's. Both are labeled so an operator administering a room in
+  // another timezone can see which is which — a mismatch is otherwise silent,
+  // since every value is individually valid.
+  describe('local-time fields name the room timezone', (it) => {
+    it('labels the window dialog with the room name and IANA zone', async () => {
+      // Arrange
+      mockDefaultLoad({
+        roomOverrides: { name: 'Siebel 1404', timezone: 'Europe/London' },
+      });
+      renderPage();
+      await waitForLoad();
+      const user = userEvent.setup();
+
+      // Act
+      await user.click(screen.getByRole('button', { name: /new window/i }));
+      await screen.findByLabelText('Local start time');
+
+      // Assert
+      expect(
+        screen.getByText(
+          "Interpreted in Siebel 1404's timezone (Europe/London), not your browser's.",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Must be in the future. Interpreted in your browser's local time zone.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('labels the schedule dialog with the room name and IANA zone', async () => {
+      // Arrange
+      mockDefaultLoad({
+        roomOverrides: { name: 'Siebel 1404', timezone: 'Europe/London' },
+      });
+      renderPage();
+      await waitForLoad();
+      const user = userEvent.setup();
+
+      // Act
+      await user.click(screen.getByRole('button', { name: /new schedule/i }));
+      await screen.findByLabelText('Local start time');
+
+      // Assert
+      expect(
+        screen.getByText(
+          "Interpreted in Siebel 1404's timezone (Europe/London), not your browser's.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('points both local-time inputs at that caption for screen readers', async () => {
+      // Arrange
+      mockDefaultLoad({
+        roomOverrides: { name: 'Siebel 1404', timezone: 'Europe/London' },
+      });
+      renderPage();
+      await waitForLoad();
+      const user = userEvent.setup();
+
+      // Act
+      await user.click(screen.getByRole('button', { name: /new window/i }));
+      const start = await screen.findByLabelText('Local start time');
+
+      // Assert
+      const helperId = start.getAttribute('aria-describedby');
+      expect(helperId).not.toBeNull();
+      expect(
+        screen
+          .getByLabelText('Local end time')
+          .getAttribute('aria-describedby'),
+      ).toBe(helperId);
+      expect(document.getElementById(helperId ?? '')).toHaveTextContent(
+        "Interpreted in Siebel 1404's timezone (Europe/London), not your browser's.",
+      );
+    });
+  });
+
   describe('BACKEND_MISCONFIGURATION handling', (it) => {
     it('shows the in-dialog alert instead of a toast when updating a schedule hits BACKEND_MISCONFIGURATION', async () => {
       // Arrange

--- a/apps/client-webapp/src/features/session-provider/components/join-session-modal.tsx
+++ b/apps/client-webapp/src/features/session-provider/components/join-session-modal.tsx
@@ -13,12 +13,25 @@ import { useAppDispatch, useAppSelector } from '#src/store/use-redux';
 import {
   ClientLifecycle,
   JoinError,
+  JoinNotice,
 } from '../services/client-session-service-status';
 import {
   joinSession,
   selectJoinError,
+  selectJoinNotice,
   selectLifecycle,
 } from '../stores/client-session-service-slice';
+
+/**
+ * Why the dialog is open, when nothing failed. Rendered above the join field
+ * as `info`: expected, no fault, nothing red. Before this existed a session
+ * ending normally simply made the captions disappear behind a blank join
+ * prompt, which is exactly what a crash looks like.
+ */
+const JOIN_NOTICE_MESSAGES: Record<JoinNotice, string> = {
+  [JoinNotice.SESSION_ENDED]:
+    'This session has ended. Enter a new join code to watch another session.',
+};
 
 const JOIN_ERROR_MESSAGES: Record<JoinError, string> = {
   [JoinError.NETWORK_ERROR]:
@@ -40,9 +53,11 @@ export const JoinSessionModal = () => {
   const dispatch = useAppDispatch();
   const lifecycle = useAppSelector(selectLifecycle);
   const joinError = useAppSelector(selectJoinError);
+  const joinNotice = useAppSelector(selectJoinNotice);
   const [joinCode, setJoinCode] = useState('');
   const titleId = useId();
   const errorId = useId();
+  const noticeId = useId();
 
   const isOpen = lifecycle === ClientLifecycle.IDLE;
 
@@ -54,9 +69,20 @@ export const JoinSessionModal = () => {
   };
 
   return (
-    <Dialog open={isOpen} aria-labelledby={titleId}>
+    <Dialog
+      open={isOpen}
+      aria-labelledby={titleId}
+      // Describes the dialog, so the reason it appeared is announced with the
+      // title on open rather than only if the user happens to navigate to it.
+      aria-describedby={joinNotice !== null ? noticeId : undefined}
+    >
       <DialogTitle id={titleId}>Join Session</DialogTitle>
       <DialogContent>
+        {joinNotice !== null && (
+          <Alert id={noticeId} severity="info" sx={{ mt: 1 }}>
+            {JOIN_NOTICE_MESSAGES[joinNotice]}
+          </Alert>
+        )}
         <Box component="form" onSubmit={handleSubmit} sx={{ pt: 1 }}>
           <TextField
             autoFocus

--- a/apps/client-webapp/src/features/session-provider/services/client-session-service-status.ts
+++ b/apps/client-webapp/src/features/session-provider/services/client-session-service-status.ts
@@ -34,6 +34,23 @@ export enum SessionConnectionStatus {
 }
 
 /**
+ * Why the join dialog is being shown, when the reason is *not* a failure.
+ * Sits alongside {@link JoinError} on the same dialog and is deliberately
+ * separate from it: these are expected outcomes, rendered as `info` per the
+ * severity convention (`info` = expected, no action; `warning` = degraded,
+ * retrying; `error` = terminal, action required), so they must not paint the
+ * join field red or read as something the user did wrong.
+ *
+ * It exists because a session ending normally used to be indistinguishable
+ * from a crash: node-server closes the viewer's socket 1000, the client drops
+ * back to `IDLE`, and the join dialog reopened completely blank - the
+ * captions simply vanished with no explanation anywhere on screen.
+ */
+export enum JoinNotice {
+  SESSION_ENDED = 'SESSION_ENDED',
+}
+
+/**
  * Outcome of the most recent join-code submission. Surfaces a specific
  * failure mode to the UI without polluting the lifecycle state machine -
  * `JOIN_ERROR` lives alongside `IDLE`, not as its own lifecycle phase.

--- a/apps/client-webapp/src/features/session-provider/services/client-session-service.ts
+++ b/apps/client-webapp/src/features/session-provider/services/client-session-service.ts
@@ -22,6 +22,7 @@ import type {
 import {
   ClientLifecycle,
   JoinError,
+  JoinNotice,
   SessionConnectionStatus,
 } from './client-session-service-status';
 
@@ -73,6 +74,12 @@ interface ClientSessionServiceEvents {
   transcript: (event: TranscriptEvent) => void;
   latency: (sample: LatencySample) => void;
   joinError: (error: JoinError | null) => void;
+  /**
+   * Why the join dialog is being shown, when the reason is not a failure, or
+   * `null` to clear. Today the only value is "the session ended normally";
+   * without it that case reopened the join dialog with nothing on it at all.
+   */
+  joinNotice: (notice: JoinNotice | null) => void;
   /**
    * Why this session is unrecoverable, or `null` to clear. Deliberately
    * narrow: it used to also carry transient blips ("Network error -
@@ -316,6 +323,9 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
     this._identity = null;
     this.emit('sessionIdentity', null);
     this.emit('joinError', null);
+    // A "the previous session ended" notice explains the dialog the user is
+    // looking at; the moment they act on it, it is stale.
+    this.emit('joinNotice', null);
 
     const [response, error] =
       await this._sessionManagerClient.sessionAuth.exchangeJoinCode({
@@ -359,11 +369,28 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
   /**
    * Disconnect from the current session and reset to {@link ClientLifecycle.IDLE}.
    * Persisted identity is cleared so a page reload won't try to resume.
+   *
+   * This is the *user-initiated* leave (the Leave button, and the internal
+   * paths where there is nothing to explain), so it carries no notice: the
+   * user knows why the join dialog is back. Ending because the session itself
+   * ended goes through {@link _endSession} with a {@link JoinNotice} instead.
    */
   leaveSession(): void {
+    this._endSession(null);
+  }
+
+  /**
+   * Return to {@link ClientLifecycle.IDLE}, optionally telling the user why.
+   * `notice` is emitted before the lifecycle change so the join dialog opens
+   * with its explanation already in the store rather than blank for a frame.
+   * Passing `null` also *clears* any stale notice, which is what makes a
+   * subsequent user-initiated leave not still claim the session ended.
+   */
+  private _endSession(notice: JoinNotice | null): void {
     this._teardownActiveSession();
     this._identity = null;
     this.emit('sessionIdentity', null);
+    this.emit('joinNotice', notice);
     this._enterIdle();
   }
 
@@ -458,9 +485,13 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
     socket.on('close', (code, reason) => {
       if (epoch !== this._epoch) return;
       // 1000 = normal close (sessionEnded message received) - session is
-      // over and the persisted identity should be cleared.
+      // over and the persisted identity should be cleared. This is the one
+      // close code that is *expected*, so it is also the one the user must be
+      // told about explicitly: everything else on screen is about to be
+      // replaced by the join dialog, and without the notice that dialog
+      // reopens blank and a normal end is indistinguishable from a crash.
       if (code === 1000) {
-        this.leaveSession();
+        this._endSession(JoinNotice.SESSION_ENDED);
         return;
       }
       // 1008 = auth failure. The cached session token was rejected; drop it
@@ -613,12 +644,20 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
       case 200:
         this._refreshFailures = 0;
         return response.data.sessionToken;
-      // 401 INVALID_REFRESH_TOKEN or 409 SESSION_ENDED: refresh token is no
-      // longer usable. Drop the stored identity and return to IDLE so the
-      // user can join a new session.
+      // 401 INVALID_REFRESH_TOKEN: refresh token is no longer usable. Drop
+      // the stored identity and return to IDLE so the user can join a new
+      // session. Nothing specific to say - the cause is a credential the user
+      // never saw - so this keeps the bare join dialog it always had.
       case 401:
-      case 409:
         this.leaveSession();
+        return null;
+      // 409 SESSION_ENDED: session-manager saying the same thing the 1000
+      // close says, over the other channel (this path is how a viewer whose
+      // socket died first learns of it). Same event, so the same notice -
+      // otherwise which of the two channels noticed first would decide
+      // whether the user gets an explanation.
+      case 409:
+        this._endSession(JoinNotice.SESSION_ENDED);
         return null;
       default:
         this._refreshFailures++;

--- a/apps/client-webapp/src/features/session-provider/stores/client-session-service-middleware.ts
+++ b/apps/client-webapp/src/features/session-provider/stores/client-session-service-middleware.ts
@@ -26,6 +26,7 @@ import {
   setConnectionStatus,
   setError,
   setJoinError,
+  setJoinNotice,
   setLifecycle,
   setSessionStatus,
 } from './client-session-service-slice';
@@ -82,6 +83,9 @@ export const createClientSessionServiceMiddleware =
     });
     service.on('joinError', (joinError) => {
       store.dispatch(setJoinError(joinError));
+    });
+    service.on('joinNotice', (joinNotice) => {
+      store.dispatch(setJoinNotice(joinNotice));
     });
     service.on('error', (message) => {
       store.dispatch(setError(message));

--- a/apps/client-webapp/src/features/session-provider/stores/client-session-service-slice.ts
+++ b/apps/client-webapp/src/features/session-provider/stores/client-session-service-slice.ts
@@ -10,6 +10,7 @@ import type { SessionStatusSnapshot } from '../services/client-session-service';
 import {
   ClientLifecycle,
   type JoinError,
+  type JoinNotice,
   SessionConnectionStatus,
 } from '../services/client-session-service-status';
 
@@ -36,6 +37,13 @@ export interface ClientSessionServiceSliceState {
   } | null;
   joinError: JoinError | null;
   /**
+   * Why the join dialog is open when nothing went wrong (today: the session
+   * ended), or `null`. Rendered by `JoinSessionModal` as an `info` alert,
+   * alongside - and deliberately not merged into - `joinError`, which is what
+   * turns the join field red.
+   */
+  joinNotice: JoinNotice | null;
+  /**
    * Why the current session is unrecoverable, or `null`. Rendered by
    * `selectConnectionBanner`'s terminal branch - its only consumer, and the
    * only reason to write anything here. It used to also collect transient
@@ -48,6 +56,7 @@ const initialState: ClientSessionServiceSliceState = {
   lifecycle: ClientLifecycle.INITIALIZING,
   session: null,
   joinError: null,
+  joinNotice: null,
   error: null,
 };
 
@@ -57,6 +66,8 @@ export const selectSession = (state: RootState) =>
   state.clientSessionService.session;
 export const selectJoinError = (state: RootState) =>
   state.clientSessionService.joinError;
+export const selectJoinNotice = (state: RootState) =>
+  state.clientSessionService.joinNotice;
 export const selectError = (state: RootState) =>
   state.clientSessionService.error;
 
@@ -98,6 +109,9 @@ export const clientSessionServiceSlice = createSlice({
     setJoinError: (state, action: PayloadAction<JoinError | null>) => {
       state.joinError = action.payload;
     },
+    setJoinNotice: (state, action: PayloadAction<JoinNotice | null>) => {
+      state.joinNotice = action.payload;
+    },
     setError: (state, action: PayloadAction<string | null>) => {
       state.error = action.payload;
     },
@@ -112,6 +126,7 @@ export const {
   setConnectionStatus,
   setSessionStatus,
   setJoinError,
+  setJoinNotice,
   setError,
 } = clientSessionServiceSlice.actions;
 

--- a/apps/client-webapp/tests/features/session-provider/components/join-session-modal.test.tsx
+++ b/apps/client-webapp/tests/features/session-provider/components/join-session-modal.test.tsx
@@ -1,0 +1,99 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { describe, expect, it } from 'vitest';
+
+import { JoinSessionModal } from '#src/features/session-provider/components/join-session-modal';
+import {
+  ClientLifecycle,
+  JoinError,
+  JoinNotice,
+} from '#src/features/session-provider/services/client-session-service-status';
+import {
+  setJoinError,
+  setJoinNotice,
+  setLifecycle,
+} from '#src/features/session-provider/stores/client-session-service-slice';
+import { rootReducer } from '#src/store/store';
+
+/**
+ * Render the dialog over a real store, in `IDLE` (the only lifecycle that
+ * opens it), with whatever join error/notice the case is about. No service
+ * middleware: this is about what the dialog says, not how the state got there.
+ */
+function renderIdleDialog(options: {
+  joinNotice?: JoinNotice;
+  joinError?: JoinError;
+}) {
+  const store = configureStore({ reducer: rootReducer });
+  store.dispatch(setLifecycle(ClientLifecycle.IDLE));
+  if (options.joinNotice !== undefined) {
+    store.dispatch(setJoinNotice(options.joinNotice));
+  }
+  if (options.joinError !== undefined) {
+    store.dispatch(setJoinError(options.joinError));
+  }
+  render(
+    <Provider store={store}>
+      <JoinSessionModal />
+    </Provider>,
+  );
+}
+
+describe('JoinSessionModal', () => {
+  it('explains a session that ended, rather than reopening blank', () => {
+    renderIdleDialog({ joinNotice: JoinNotice.SESSION_ENDED });
+
+    // The whole point of the notice: a viewer whose captions just vanished
+    // must be able to read why on the dialog that replaced them.
+    expect(screen.getByText(/This session has ended\./)).toBeInTheDocument();
+  });
+
+  it('states it informationally, not as something the viewer broke', () => {
+    renderIdleDialog({ joinNotice: JoinNotice.SESSION_ENDED });
+
+    // `info` = expected, no action - a session ending on schedule is not a
+    // fault, and must not paint the join field red.
+    const alerts = screen.getAllByRole('alert');
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.className).toContain('MuiAlert-colorInfo');
+    expect(alerts[0]?.className).not.toContain('MuiAlert-colorError');
+    expect(screen.getByLabelText('Join Code')).not.toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+
+  it('describes the dialog with the notice, so it is announced on open', () => {
+    renderIdleDialog({ joinNotice: JoinNotice.SESSION_ENDED });
+
+    const dialog = screen.getByRole('dialog');
+    const describedBy = dialog.getAttribute('aria-describedby');
+    expect(describedBy).not.toBeNull();
+    expect(document.getElementById(describedBy ?? '')).toHaveTextContent(
+      /This session has ended\./,
+    );
+  });
+
+  it('shows nothing extra when the dialog opens for any other reason', () => {
+    renderIdleDialog({});
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('leaves a failed join attempt reading as an error', () => {
+    renderIdleDialog({ joinError: JoinError.JOIN_CODE_NOT_FOUND });
+
+    // Unchanged behaviour: the notice is a separate, additive surface and
+    // must not have softened or displaced the existing failure messaging.
+    const alerts = screen.getAllByRole('alert');
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toHaveTextContent('Invalid join code. Please try again.');
+    expect(alerts[0]?.className).toContain('MuiAlert-colorError');
+    expect(screen.getByLabelText('Join Code')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+});

--- a/apps/client-webapp/tests/features/session-provider/services/client-session-service.test.ts
+++ b/apps/client-webapp/tests/features/session-provider/services/client-session-service.test.ts
@@ -17,7 +17,11 @@ import type {
   SessionIdentity,
   SessionStatusSnapshot,
 } from '#src/features/session-provider/services/client-session-service';
-import { SessionConnectionStatus } from '#src/features/session-provider/services/client-session-service-status';
+import {
+  ClientLifecycle,
+  JoinNotice,
+  SessionConnectionStatus,
+} from '#src/features/session-provider/services/client-session-service-status';
 
 vi.mock('@scribear/node-server-client', async (importOriginal) => {
   const actual =
@@ -385,6 +389,132 @@ describe('ClientSessionService terminal states', () => {
     expect(statuses).not.toContain(SessionConnectionStatus.TERMINAL);
     expect(authenticatedTokens()).toEqual([token]);
     vi.useRealTimers();
+  });
+});
+
+describe('ClientSessionService normal session end', () => {
+  function trackEnd(service: ClientSessionService) {
+    const notices: (JoinNotice | null)[] = [];
+    const lifecycles: ClientLifecycle[] = [];
+    service.on('joinNotice', (notice) => notices.push(notice));
+    service.on('lifecycleChange', (lifecycle) => lifecycles.push(lifecycle));
+    return { notices, lifecycles };
+  }
+
+  it('tells the user the session ended when the socket closes 1000', () => {
+    const service = new ClientSessionService();
+    const { notices, lifecycles } = trackEnd(service);
+
+    service.start(IDENTITY);
+    fakeSocket.emit('close', 1000, '', 1000);
+
+    // The join dialog is about to reopen over a suddenly-empty caption pane.
+    // Without this it reopened blank, and a session ending exactly as
+    // intended was indistinguishable from the app breaking.
+    expect(notices).toEqual([JoinNotice.SESSION_ENDED]);
+    expect(lifecycles.at(-1)).toBe(ClientLifecycle.IDLE);
+  });
+
+  it('emits the notice before dropping to IDLE, so the dialog is never blank', () => {
+    const service = new ClientSessionService();
+    const order: string[] = [];
+    service.on('joinNotice', () => order.push('notice'));
+    service.on('lifecycleChange', (lifecycle) => {
+      if (lifecycle === ClientLifecycle.IDLE) order.push('idle');
+    });
+
+    service.start(IDENTITY);
+    fakeSocket.emit('close', 1000, '', 1000);
+
+    expect(order).toEqual(['notice', 'idle']);
+  });
+
+  it('says nothing when the user leaves the session themselves', () => {
+    const service = new ClientSessionService();
+    const { notices, lifecycles } = trackEnd(service);
+
+    service.start(IDENTITY);
+    service.leaveSession();
+
+    // The user pressed Leave; "This session has ended." would be a lie about
+    // who ended it. The explicit `null` also clears any earlier notice.
+    expect(notices).toEqual([null]);
+    expect(lifecycles.at(-1)).toBe(ClientLifecycle.IDLE);
+  });
+
+  it('does not claim the session ended for any other close code', () => {
+    const service = new ClientSessionService();
+    const { notices } = trackEnd(service);
+
+    service.start(IDENTITY);
+    // Abnormal (1006), server error (1011), restarting (1012) and auth
+    // (1008) all keep their existing behaviour: the transport retries, and
+    // the connection banner - not the join dialog - does the explaining.
+    fakeSocket.emit('close', 1006, '', 1000);
+    fakeSocket.emit('close', 1011, '', 1000);
+    fakeSocket.emit('close', 1012, '', 1000);
+    fakeSocket.emit('close', 1008, 'token-expired', 1000);
+
+    expect(notices).toEqual([]);
+  });
+
+  it('does not claim the session ended when a 1008 turns terminal', () => {
+    const service = new ClientSessionService();
+    const { notices } = trackEnd(service);
+
+    service.start(IDENTITY);
+    fakeSocket.emit('close', 1008, 'missing-scope', 1000);
+
+    // Terminal states explain themselves through `error` and the banner's
+    // terminal branch; the session did not "end", the client gave up on it.
+    expect(notices).toEqual([]);
+  });
+
+  it('clears the notice as soon as the user submits another join code', async () => {
+    exchangeJoinCode.mockResolvedValue(joinOk('payload.signature'));
+    const service = new ClientSessionService();
+    const { notices } = trackEnd(service);
+
+    service.start(IDENTITY);
+    fakeSocket.emit('close', 1000, '', 1000);
+    await service.joinSession('JOINCODE');
+
+    expect(notices).toEqual([JoinNotice.SESSION_ENDED, null]);
+  });
+
+  it('reports a 409 SESSION_ENDED refresh the same way as the 1000 close', async () => {
+    refreshSessionToken.mockResolvedValue([
+      { status: 409, data: { code: 'SESSION_ENDED' } },
+      null,
+    ]);
+    const service = new ClientSessionService();
+    const { notices } = trackEnd(service);
+
+    service.start(IDENTITY);
+    fakeSocket.emit('open');
+
+    // Same event as the 1000 close, learned over the other channel - which of
+    // the two noticed first must not decide whether the user is told.
+    await vi.waitFor(() => {
+      expect(notices).toEqual([JoinNotice.SESSION_ENDED]);
+    });
+  });
+
+  it('stays silent on a 401 refresh, which is not the session ending', async () => {
+    refreshSessionToken.mockResolvedValue([
+      { status: 401, data: { code: 'INVALID_REFRESH_TOKEN' } },
+      null,
+    ]);
+    const service = new ClientSessionService();
+    const { notices, lifecycles } = trackEnd(service);
+
+    service.start(IDENTITY);
+    fakeSocket.emit('open');
+
+    await vi.waitFor(() => {
+      expect(lifecycles.at(-1)).toBe(ClientLifecycle.IDLE);
+    });
+    expect(notices).toEqual([null]);
   });
 });
 

--- a/apps/client-webapp/tests/features/session-provider/stores/client-session-service-slice.test.ts
+++ b/apps/client-webapp/tests/features/session-provider/stores/client-session-service-slice.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import { SessionConnectionStatus } from '#src/features/session-provider/services/client-session-service-status';
+import {
+  ClientLifecycle,
+  JoinNotice,
+  SessionConnectionStatus,
+} from '#src/features/session-provider/services/client-session-service-status';
 import {
   clientSessionServiceReducer,
   setActiveSession,
+  setJoinNotice,
+  setLifecycle,
   setSessionStatus,
 } from '#src/features/session-provider/stores/client-session-service-slice';
 
@@ -42,6 +48,39 @@ describe('clientSessionServiceSlice', () => {
       transcriptionServiceConnected: false,
       sourceDeviceConnected: false,
     });
+  });
+
+  it('keeps the join notice across the drop to IDLE that reopens the dialog', () => {
+    const ended = clientSessionServiceReducer(
+      undefined,
+      setJoinNotice(JoinNotice.SESSION_ENDED),
+    );
+    const state = clientSessionServiceReducer(
+      ended,
+      setLifecycle(ClientLifecycle.IDLE),
+    );
+
+    // `setLifecycle` deliberately drops `session`; if it dropped the notice
+    // too, the explanation would die one action before the dialog that has to
+    // render it opens.
+    expect(state.joinNotice).toBe(JoinNotice.SESSION_ENDED);
+    expect(state.session).toBeNull();
+  });
+
+  it('starts with no join notice and clears it on setJoinNotice(null)', () => {
+    const initial = clientSessionServiceReducer(
+      undefined,
+      setLifecycle(ClientLifecycle.INITIALIZING),
+    );
+    expect(initial.joinNotice).toBeNull();
+
+    const ended = clientSessionServiceReducer(
+      initial,
+      setJoinNotice(JoinNotice.SESSION_ENDED),
+    );
+    expect(
+      clientSessionServiceReducer(ended, setJoinNotice(null)).joinNotice,
+    ).toBeNull();
   });
 
   it('clears the session on setActiveSession(null)', () => {

--- a/apps/kiosk-webapp/package.json
+++ b/apps/kiosk-webapp/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@eslint-react/eslint-plugin": "5.18.0",
     "eslint-plugin-react-hooks": "7.1.1",
-    "eslint-plugin-react-refresh": "0.5.3"
+    "eslint-plugin-react-refresh": "0.5.3",
+    "jsdom": "29.1.1"
   }
 }

--- a/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service-status.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service-status.ts
@@ -18,9 +18,25 @@ export enum KioskLifecycle {
 /**
  * Sub-status of a session connection while the kiosk is `ACTIVE`. Drives the
  * connection indicator in the UI; not used outside `ACTIVE`.
+ *
+ * `TERMINAL` is the modeled unrecoverable state: the kiosk has stopped
+ * retrying and will not reconnect to this session on its own. It exists
+ * because without it a permanent fault (a token minted without `SEND_AUDIO`,
+ * a device assigned to the wrong room, a schema drift after a partial deploy)
+ * is indistinguishable from a flaky network forever - the kiosk drops to
+ * `IDLE`, the panel says "Inactive, waiting for a session to start." while a
+ * session is in fact running, schedule sync rediscovers the same session,
+ * and the cycle repeats unbounded with nothing on screen naming the cause.
+ *
+ * The kiosk stays in {@link KioskLifecycle.ACTIVE} while `TERMINAL`, so the
+ * captions already on the wall survive, the session name and join code stay
+ * on the panel, and the banner can say what happened and who has to fix it.
+ * Terminal is scoped to one session: the next session (or the current one
+ * disappearing from the schedule) clears it and starts fresh.
  */
 export enum SessionConnectionStatus {
   CONNECTING = 'CONNECTING',
   CONNECTED = 'CONNECTED',
   DISCONNECTED = 'DISCONNECTED',
+  TERMINAL = 'TERMINAL',
 }

--- a/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
@@ -90,6 +90,20 @@ export interface SessionStatusSnapshot {
 }
 
 /**
+ * A user-visible failure, carrying the severity it should be reported with.
+ *
+ * The severity is decided here rather than in the store because only this
+ * service knows whether it is still retrying: `'warning'` means degraded but
+ * retrying (no action yet), `'error'` means nothing is retrying and a human
+ * has to do something. Conflating the two is what let a permanently-rejected
+ * kiosk read the same as a five-second network blip.
+ */
+export interface KioskFault {
+  severity: 'warning' | 'error';
+  message: string;
+}
+
+/**
  * Events emitted by {@link KioskService} for the Redux middleware to consume.
  * One emit per state transition or external observation; selectors elsewhere
  * map these into the UX store.
@@ -107,7 +121,20 @@ interface KioskServiceEvents {
     codes: { current: JoinCodeEntry; next: JoinCodeEntry | null } | null,
   ) => void;
   registrationError: (message: string | null) => void;
-  error: (message: string | null) => void;
+  /**
+   * Why the kiosk is degraded or stuck, or `null` to clear. Every value
+   * emitted here reaches the wall, via the connection banner - this used to
+   * be written to Redux and read by nothing, so `'Failed to fetch device
+   * info.'` and `'Session stream protocol mismatch.'` were computed,
+   * dispatched, stored, and never rendered.
+   */
+  error: (fault: KioskFault | null) => void;
+  /**
+   * Health of the schedule long-poll, which is a separate failure domain from
+   * the session socket: it can be dead for hours while the panel calmly reads
+   * "Inactive, waiting for a session to start." and no session ever starts.
+   */
+  scheduleSyncError: (fault: KioskFault | null) => void;
 }
 
 /**
@@ -157,11 +184,73 @@ const TIME_SYNC_INTERVAL_MS = 15_000;
 const DEVICE_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
 /**
+ * Bounded retry budget for `exchange-device-token`, counted per session
+ * rather than per attempt: a failed token fetch used to drop the kiosk to
+ * `IDLE`, where schedule sync immediately rediscovered the same still-active
+ * session and tried again, forever, with the panel reading "Inactive,
+ * waiting for a session to start." the whole time. Counting across those
+ * cycles is what makes the loop converge, and exhausting the budget is
+ * terminal and visible.
+ */
+const MAX_TOKEN_FETCH_FAILURES = 5;
+const TOKEN_FETCH_RETRY_BASE_MS = 500;
+const TOKEN_FETCH_RETRY_MAX_MS = 5_000;
+
+/**
+ * How many consecutive 1008 closes to tolerate before declaring the session
+ * terminal, when the close reason isn't one we recognise as permanent. A
+ * merely-stale token also closes 1008 and is genuinely fixed by the refetch
+ * on the next attempt, so a couple of retries are worth having; an unbounded
+ * number is what turned a permanently-bad credential into a silent
+ * ACTIVE-IDLE loop on a wall-mounted display.
+ */
+const MAX_CONSECUTIVE_AUTH_FAILURES = 3;
+
+/**
+ * Close reasons node-server sends with 1008 (see
+ * `transcription-stream.auth.ts` / `.controller.ts`) that can never succeed
+ * on a retry: the token was minted for a different session, or without the
+ * scope this role needs, or this device's role is not allowed to send audio
+ * at all. Reconnecting with a freshly-minted token reproduces all three
+ * exactly, because they are properties of the device's configuration rather
+ * than of the credential.
+ *
+ * The reason string does reach the browser - node-server passes it to
+ * `socket.close(code, reason)`, so it rides in the close frame - but an empty
+ * or unfamiliar reason is not treated as recoverable either:
+ * {@link MAX_CONSECUTIVE_AUTH_FAILURES} bounds the unrecognised case
+ * independently.
+ */
+const PERMANENT_AUTH_CLOSE_REASONS = new Set([
+  'missing-scope',
+  'session-mismatch',
+  'binary-not-allowed-for-role',
+]);
+
+/**
+ * How many consecutive schedule long-poll failures to absorb before saying so
+ * on screen. The poll's own backoff is 1s/2s/4s..., so three failures is
+ * roughly seven seconds of genuine outage - long enough not to flag a single
+ * blip, short enough that "the schedule is not updating" is on the wall
+ * within one lecture-hall attention span rather than never.
+ */
+const SCHEDULE_SYNC_DEGRADED_AFTER = 3;
+
+/**
  * Compute a uniform jitter offset in `[-jitter * base, +jitter * base]`.
  */
 function jitter(baseMs: number, fraction: number): number {
   const span = baseMs * fraction;
   return (Math.random() * 2 - 1) * span;
+}
+
+/**
+ * Resolve after `ms`, so an async retry loop can back off without owning a
+ * timer handle. Teardown is detected by the session-identity check that
+ * follows every await, not by cancelling this.
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**
@@ -210,6 +299,61 @@ function decodeSessionTokenExpiryMs(token: string): number | null {
     return payload.exp * 1000;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Outcome of one `exchange-device-token` call. A failure always carries the
+ * reason it failed and whether retrying could ever help - the previous
+ * `string | null` return threw both away, which is why session-manager being
+ * down, a 429 from a room full of devices, a 500, and a revoked device cookie
+ * were indistinguishable to everyone including the operator.
+ */
+type TokenFetchResult =
+  | { token: string }
+  | { token: null; permanent: boolean; message: string };
+
+/**
+ * Turn a declared non-200 from `exchange-device-token` into a cause, an
+ * audience, and a next action. `permanent` is the load-bearing part: it
+ * decides whether the kiosk keeps retrying (and says "retrying") or stops and
+ * asks for a human, and the two statuses that are permanent here are both
+ * device *configuration* problems that no amount of reconnecting can resolve.
+ */
+function describeTokenFetchFailure(status: number): {
+  permanent: boolean;
+  message: string;
+} {
+  switch (status) {
+    case 401:
+      return {
+        permanent: true,
+        message:
+          "This kiosk's registration is no longer valid, so it cannot join the session running in this room. Re-activate the device from the admin console.",
+      };
+    case 403:
+      return {
+        permanent: true,
+        message:
+          "This kiosk is not assigned to the room running this session, so it cannot join it. An administrator needs to check the device's room assignment.",
+      };
+    case 404:
+      return {
+        permanent: false,
+        message:
+          'This session no longer exists. Waiting for the schedule to catch up…',
+      };
+    case 409:
+      return {
+        permanent: false,
+        message:
+          'This session is not currently active. Waiting for the schedule to catch up…',
+      };
+    default:
+      return {
+        permanent: false,
+        message: `The session service could not issue credentials (HTTP ${status.toString()}). Retrying…`,
+      };
   }
 }
 
@@ -285,6 +429,27 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
   private _joinCodeRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   private _clockSync = new ClockSync();
   private _timeSyncTimer: ReturnType<typeof setInterval> | null = null;
+
+  /**
+   * Consecutive-failure budgets for the current session. Deliberately *not*
+   * reset by `_teardownActiveSession`, because the kiosk's own recovery path
+   * for both failures is ACTIVE -> IDLE -> (schedule sync) -> ACTIVE: a
+   * per-attempt counter would be refilled by the very loop it exists to
+   * bound. They are keyed to the session uid instead, so a genuinely new
+   * session starts with a full budget - see {@link _resetFailureBudget}.
+   */
+  private _failureBudgetSessionUid: string | null = null;
+  private _tokenFetchFailures = 0;
+  private _authFailures = 0;
+
+  /** Consecutive schedule long-poll failures since the last good response. */
+  private _schedulePollFailures = 0;
+
+  /**
+   * Set once the current session has been declared unrecoverable, to keep the
+   * transition one-way until the session is torn down.
+   */
+  private _terminal = false;
 
   constructor(microphoneService: MicrophoneService) {
     super();
@@ -396,20 +561,34 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
       await this._sessionManagerClient.deviceManagement.getMyDevice({});
 
     if (error instanceof NetworkError) {
+      this.emit('error', {
+        severity: 'warning',
+        message: 'Cannot reach the ScribeAR server. Retrying…',
+      });
       this._scheduleInitRetry();
       return;
     }
     if (error instanceof UnexpectedResponseError) {
-      this.emit('error', 'Failed to fetch device info.');
+      this.emit('error', {
+        severity: 'warning',
+        message: `Failed to fetch device info (HTTP ${error.status.toString()}). Retrying…`,
+      });
       this._scheduleInitRetry();
       return;
     }
     if (response === null) {
+      this.emit('error', {
+        severity: 'warning',
+        message: 'Failed to fetch device info. Retrying…',
+      });
       this._scheduleInitRetry();
       return;
     }
 
     if (response.status === 401) {
+      // Not an error to report: the activation form this drops to is itself
+      // the explanation, and it says what to do next.
+      this.emit('error', null);
       this._device = null;
       this.emit('deviceInfo', null);
       this._setLifecycle(KioskLifecycle.UNREGISTERED);
@@ -420,10 +599,21 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
     // keeps both happy and treats other declared error bodies as a retry.
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (response.status !== 200) {
-      this.emit('error', 'Failed to fetch device info.');
+      // No HTTP status in the message: the narrowing collapse noted above
+      // leaves `response.status` with no usable type here. The two device
+      // failures an operator has to tell apart - unreachable and
+      // rejected-with-a-status - are already distinguished by the two
+      // branches above.
+      this.emit('error', {
+        severity: 'warning',
+        message: 'Failed to fetch device info. Retrying…',
+      });
       this._scheduleInitRetry();
       return;
     }
+
+    // Whatever the last attempt complained about is now stale.
+    this.emit('error', null);
 
     const { uid, name, roomUid, isSource } = response.data;
     if (roomUid === null || isSource === null) {
@@ -541,6 +731,11 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
 
   private async _enterIdle(): Promise<void> {
     this._teardownActiveSession();
+    // Every fault this service reports is scoped to a session or to
+    // initialization; arriving at IDLE means the session that carried the
+    // explanation is gone, so leaving its message up would be describing
+    // something that is no longer happening.
+    this.emit('error', null);
     this._setLifecycle(KioskLifecycle.IDLE);
 
     await this._fetchRoomInfo();
@@ -566,22 +761,53 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
 
   private _startSchedulePoll(): void {
     this._schedulePoll?.close();
+    this._schedulePollFailures = 0;
+    this.emit('scheduleSyncError', null);
 
     const poll = this._sessionManagerClient.scheduleManagement.mySchedule({});
     this._schedulePoll = poll;
 
     poll.on('data', (payload) => {
+      this._schedulePollFailures = 0;
+      this.emit('scheduleSyncError', null);
       // Refresh server-clock offset on every successful response so timer
       // computations track server time, not the device's clock.
       this._serverClockOffsetMs = Date.parse(payload.serverTime) - Date.now();
       this.emit('scheduleUpdated', payload.sessions);
       this._syncSchedule(payload.sessions);
     });
-    poll.on('error', () => {
-      // Backoff is handled inside the long-poll client; nothing to do here.
+    poll.on('error', (err) => {
+      // Retry and backoff are the long-poll client's job, so there is nothing
+      // to *do* here - but there is something to say. Swallowing this
+      // entirely meant schedule sync could be dead for hours behind
+      // "Inactive, waiting for a session to start.", which is the same
+      // sentence a healthy kiosk shows between lectures.
+      this._schedulePollFailures++;
+      if (this._schedulePollFailures < SCHEDULE_SYNC_DEGRADED_AFTER) return;
+      this.emit('scheduleSyncError', {
+        severity: 'warning',
+        message: this._scheduleSyncMessage(err),
+      });
     });
 
     poll.start();
+  }
+
+  /**
+   * Name the schedule-sync failure specifically enough to be actionable:
+   * unreachable (check the network/deployment) reads differently from a
+   * server that is answering with a 500 (check session-manager).
+   */
+  private _scheduleSyncMessage(err: Error): string {
+    const consequence =
+      'Scheduled sessions may not start or end on time on this kiosk.';
+    if (err instanceof NetworkError) {
+      return `Cannot reach the ScribeAR schedule service. ${consequence}`;
+    }
+    if (err instanceof UnexpectedResponseError) {
+      return `The schedule service is failing (HTTP ${err.status.toString()}). ${consequence}`;
+    }
+    return `Schedule updates have stopped arriving. ${consequence}`;
   }
 
   /**
@@ -689,23 +915,23 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
 
   private async _enterActive(session: Session): Promise<void> {
     this._teardownActiveSession();
+    this._resetFailureBudget(session.uid);
     this._activeSession = session;
     this._setLifecycle(KioskLifecycle.ACTIVE);
     this.emit('activeSession', { sessionUid: session.uid, name: session.name });
     this.emit('connectionStatus', SessionConnectionStatus.CONNECTING);
 
-    const token = await this._fetchSessionToken(session.uid);
+    const token = await this._acquireSessionToken(session);
     // A newer _enterActive / _enterIdle may have superseded this session while
     // the token request was in flight. If so, that flow now owns the socket
     // and token state - bail before clobbering it (and leaking a socket).
     if (this._activeSession !== session) return;
-    if (token === null) {
-      this.emit('connectionStatus', SessionConnectionStatus.DISCONNECTED);
-      // Fall back to IDLE; the schedule poll will re-trigger if the session
-      // is still active on the next cycle.
-      void this._enterIdle();
-      return;
-    }
+    // No token means `_acquireSessionToken` has already reported why and, if
+    // it gave up, entered TERMINAL. Do not open a socket: doing so used to
+    // reach OPEN with nothing to authenticate with, so the banner closed and
+    // the room read as connected for the five seconds until node-server's
+    // auth watchdog closed it - then did the whole thing again.
+    if (token === null) return;
     this._sessionToken = token;
 
     const isSource = this._device?.isSource === true;
@@ -720,15 +946,109 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
     }
   }
 
-  private async _fetchSessionToken(sessionUid: string): Promise<string | null> {
+  /**
+   * Reset the per-session failure budgets, but only when this really is a
+   * different session. `_enterActive` runs again for the *same* session every
+   * time schedule sync rediscovers it after a drop to IDLE, which is exactly
+   * the loop the budgets bound - refilling them there would make them
+   * unbounded again.
+   */
+  private _resetFailureBudget(sessionUid: string): void {
+    if (this._failureBudgetSessionUid === sessionUid) return;
+    this._failureBudgetSessionUid = sessionUid;
+    this._tokenFetchFailures = 0;
+    this._authFailures = 0;
+  }
+
+  /**
+   * Obtain a session token for `session`, retrying transient failures with
+   * exponential backoff and reporting the cause while it does. Returns `null`
+   * if the attempt was superseded (a newer session took over), if the failure
+   * can never succeed on a retry, or if the budget ran out - the latter two
+   * having entered TERMINAL on the way out.
+   */
+  private async _acquireSessionToken(session: Session): Promise<string | null> {
+    for (;;) {
+      const result = await this._fetchSessionToken(session.uid);
+      if (this._isSuperseded(session)) return null;
+
+      if (result.token !== null) {
+        this._tokenFetchFailures = 0;
+        this.emit('error', null);
+        return result.token;
+      }
+
+      if (result.permanent) {
+        this._enterTerminal({ severity: 'error', message: result.message });
+        return null;
+      }
+
+      this._tokenFetchFailures++;
+      if (this._tokenFetchFailures >= MAX_TOKEN_FETCH_FAILURES) {
+        this._enterTerminal({
+          severity: 'error',
+          message: `${result.message} This kiosk has stopped retrying; an administrator needs to check the ScribeAR services.`,
+        });
+        return null;
+      }
+
+      // Say which failure this is while it is still retrying. The banner's
+      // generic "Connection lost. Reconnecting…" cannot distinguish
+      // session-manager being down from a 429 from a revoked device cookie,
+      // and those want three different people to do three different things.
+      this.emit('error', { severity: 'warning', message: result.message });
+
+      const delayMs = Math.min(
+        TOKEN_FETCH_RETRY_BASE_MS * 2 ** (this._tokenFetchFailures - 1),
+        TOKEN_FETCH_RETRY_MAX_MS,
+      );
+      await sleep(delayMs + jitter(delayMs, TOKEN_REFRESH_JITTER));
+      if (this._isSuperseded(session)) return null;
+    }
+  }
+
+  /**
+   * Whether an in-flight retry for `session` should abandon: a newer
+   * `_enterActive`/`_enterIdle` took over, or the socket's close handler
+   * declared this session terminal while we were awaiting. Both leave the
+   * retry loop with nothing useful to do and no right to touch the state the
+   * newer flow now owns.
+   */
+  private _isSuperseded(session: Session): boolean {
+    return this._activeSession !== session || this._terminal;
+  }
+
+  private async _fetchSessionToken(
+    sessionUid: string,
+  ): Promise<TokenFetchResult> {
     const [response, error] =
       await this._sessionManagerClient.sessionAuth.exchangeDeviceToken({
         body: { sessionUid },
       });
 
-    if (error !== null) return null;
-    if (response.status !== 200) return null;
-    return response.data.sessionToken;
+    if (error !== null) {
+      if (error instanceof NetworkError) {
+        return {
+          token: null,
+          permanent: false,
+          message: 'Cannot reach the ScribeAR session service. Retrying…',
+        };
+      }
+      // The only other failure `createEndpointClient` reports is an
+      // undeclared status: a 429 from a room full of devices behind one NAT,
+      // or a 502/503/504 from the gateway. All transient by construction -
+      // everything permanent here is a declared status, handled below.
+      return {
+        token: null,
+        permanent: false,
+        message: `The session service could not issue credentials (HTTP ${error.status.toString()}). Retrying…`,
+      };
+    }
+
+    if (response.status !== 200) {
+      return { token: null, ...describeTokenFetchFailure(response.status) };
+    }
+    return { token: response.data.sessionToken };
   }
 
   private _connectSocket(session: Session, isSource: boolean): void {
@@ -755,7 +1075,14 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
         // on the `open` handler to remember to.
         onHandshake: async (sender, messages) => {
           const sessionToken = this._sessionToken;
-          if (sessionToken === null) return;
+          if (sessionToken === null) {
+            // Rejecting abandons this attempt and schedules a retry, which is
+            // the truth. Returning - as this used to - resolved the handshake
+            // without sending AUTH, so the client reported OPEN, the banner
+            // closed, and the room read "connected" with no captions until
+            // node-server's five-second auth watchdog closed the socket.
+            throw new Error('No session token available for AUTH.');
+          }
           sender.send({
             type: TranscriptionStreamClientMessageType.AUTH,
             sessionToken,
@@ -824,8 +1151,10 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
     socket.on('message', (msg) => {
       switch (msg.type) {
         case TranscriptionStreamServerMessageType.AUTH_OK:
-          // Auth acknowledged. No further action needed - audio/transcripts
-          // flow on the established channel.
+          // Auth acknowledged - audio/transcripts flow on the established
+          // channel. This is the only proof the credential was accepted, so
+          // it is what clears the consecutive-1008 budget.
+          this._authFailures = 0;
           break;
         case TranscriptionStreamServerMessageType.TRANSCRIPT:
           this.emit('transcript', {
@@ -863,13 +1192,35 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
       }
     });
 
-    socket.on('close', (code) => {
+    socket.on('close', (code, reason) => {
       // 1000 = normal close (sessionEnded), 1008 = auth failure.
       if (code === 1000) {
         void this._enterIdle();
       } else if (code === 1008) {
-        // Auth failed - session token may have been rejected. Drop to IDLE
-        // and let schedule sync rediscover the session if it's still active.
+        // Auth failed - the session token was rejected. Dropping to IDLE and
+        // letting schedule sync rediscover the session is the right move for
+        // a token that was merely stale, and the wrong move forever for one
+        // that was rejected for a reason a fresh token cannot change: the
+        // kiosk re-entered ACTIVE, was closed 1008 again, and looped with the
+        // panel reading "Inactive, waiting for a session to start." between
+        // cycles. So the reason is inspected, and the unrecognised case is
+        // bounded rather than trusted.
+        this._authFailures++;
+        if (PERMANENT_AUTH_CLOSE_REASONS.has(reason)) {
+          this._enterTerminal({
+            severity: 'error',
+            message:
+              'This kiosk is not permitted to join the session running in this room. An administrator needs to check its role and room assignment.',
+          });
+          return;
+        }
+        if (this._authFailures >= MAX_CONSECUTIVE_AUTH_FAILURES) {
+          this._enterTerminal({
+            severity: 'error',
+            message: `The session refused this kiosk's credentials ${this._authFailures.toString()} times in a row${reason === '' ? '' : ` (${reason})`}. An administrator needs to check this device and the ScribeAR services.`,
+          });
+          return;
+        }
         void this._enterIdle();
       }
       // Other codes trigger automatic reconnection inside WebSocketClient.
@@ -886,8 +1237,16 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
 
     socket.on('error', (err) => {
       if (err instanceof WsSchemaValidationError) {
-        this.emit('error', 'Session stream protocol mismatch.');
-        void this._enterIdle();
+        // Kiosk and node-server disagree about the wire format - schema drift
+        // after a partial deploy. Reconnecting cannot fix it, and dropping to
+        // IDLE (as this used to) threw the explanation away along with the
+        // session: the panel went back to "Inactive, waiting for a session to
+        // start." and the message reached nothing, because nothing read it.
+        this._enterTerminal({
+          severity: 'error',
+          message:
+            'Session stream protocol mismatch: this kiosk is running a different version from the server. Reload this page; if that does not help, it needs redeploying.',
+        });
       }
     });
 
@@ -988,18 +1347,19 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
   private async _refreshSessionToken(sessionUid: string): Promise<void> {
     const socket = this._socket;
     if (socket === null) return;
-    if (this._activeSession?.uid !== sessionUid) return;
+    const session = this._activeSession;
+    if (session?.uid !== sessionUid) return;
 
-    const token = await this._fetchSessionToken(sessionUid);
+    const token = await this._acquireSessionToken(session);
     // Re-check after the await: teardown or a session switch may have swapped
     // or dropped the socket while the token request was in flight. Comparing
     // against the captured handle catches both (null, or a different socket).
     if (this._socket !== socket) return;
-    if (token === null) {
-      // Refresh failed - drop the connection and let schedule sync recover.
-      void this._enterIdle();
-      return;
-    }
+    // Retrying and giving up are `_acquireSessionToken`'s job. The socket is
+    // still open and still authenticated on the *old* token, so there is
+    // nothing to tear down here - dropping to IDLE on the first transient
+    // failure, as this used to, threw away a working connection.
+    if (token === null) return;
     this._sessionToken = token;
     socket.send({
       type: TranscriptionStreamClientMessageType.AUTH,
@@ -1047,14 +1407,44 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
     }, delayMs);
   }
 
-  private _teardownActiveSession(): void {
+  /**
+   * Declare the current session unrecoverable: stop every retry loop, close
+   * the socket, and say - with the cause and the next action - that this
+   * kiosk has stopped trying.
+   *
+   * Deliberately keeps {@link KioskLifecycle.ACTIVE} and the active-session
+   * identity, unlike {@link _teardownActiveSession}: the captions already on
+   * the wall stay up, the panel keeps naming the session, and the banner has
+   * somewhere to render. Dropping to IDLE instead would replace the
+   * explanation with "Inactive, waiting for a session to start." - a
+   * reassuring sentence that would be false.
+   *
+   * The join-code refresh is left running on purpose. It is a separate REST
+   * loop against session-manager, and a room whose kiosk cannot join the
+   * session can still have an audience joining it on their own devices.
+   *
+   * One-way until the session is torn down; `_teardownActiveSession` clears
+   * it, so the next session (or this one ending) starts fresh.
+   */
+  private _enterTerminal(fault: KioskFault): void {
+    if (this._terminal) return;
+    this._terminal = true;
+    this._stopSessionTransport();
+    this.emit('error', fault);
+    this.emit('connectionStatus', SessionConnectionStatus.TERMINAL);
+  }
+
+  /**
+   * Stop everything carrying this session's audio and transcripts - socket,
+   * capture, clock sync, token refresh - while leaving the session's identity
+   * and join code alone. Split out of {@link _teardownActiveSession} so
+   * {@link _enterTerminal} can stop the transport without also erasing the
+   * session the user is being told about.
+   */
+  private _stopSessionTransport(): void {
     if (this._tokenRefreshTimer !== null) {
       clearTimeout(this._tokenRefreshTimer);
       this._tokenRefreshTimer = null;
-    }
-    if (this._joinCodeRefreshTimer !== null) {
-      clearTimeout(this._joinCodeRefreshTimer);
-      this._joinCodeRefreshTimer = null;
     }
     if (this._timeSyncTimer !== null) {
       clearInterval(this._timeSyncTimer);
@@ -1070,11 +1460,20 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
       this._socket.terminate(1000, 'session-end');
       this._socket = null;
     }
+    this._sessionToken = null;
+  }
+
+  private _teardownActiveSession(): void {
+    this._stopSessionTransport();
+    if (this._joinCodeRefreshTimer !== null) {
+      clearTimeout(this._joinCodeRefreshTimer);
+      this._joinCodeRefreshTimer = null;
+    }
+    this._terminal = false;
     if (this._activeSession !== null) {
       this._activeSession = null;
       this.emit('activeSession', null);
     }
-    this._sessionToken = null;
     this.emit('joinCode', null);
   }
 
@@ -1094,6 +1493,13 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
       this._schedulePoll.close();
       this._schedulePoll = null;
     }
+    // A full restart (start/stop, or a device change) is the one thing that
+    // legitimately refills every budget: nothing about the previous device,
+    // room, or session is still being retried.
+    this._failureBudgetSessionUid = null;
+    this._tokenFetchFailures = 0;
+    this._authFailures = 0;
+    this._schedulePollFailures = 0;
     this._teardownActiveSession();
   }
 

--- a/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
@@ -173,15 +173,37 @@ function base64UrlDecode(value: string): string {
   return atob(value.replaceAll('-', '+').replaceAll('_', '/'));
 }
 
+/** A ScribeAR session token has exactly two segments: payload, then HMAC. */
+const SESSION_TOKEN_SEGMENTS = 2;
+
 /**
- * Decode the `exp` claim of a JWT. Returns `null` if the token can't be
- * parsed (malformed or unsigned).
+ * Read the `exp` claim out of a session token. Returns `null` if the token
+ * can't be parsed.
+ *
+ * A ScribeAR session token is NOT a JWT, despite looking like one: it is
+ * `base64url(payloadJSON).base64url(HMAC-SHA256)` - **two** segments, payload
+ * first (see session-manager's `SessionTokenService.sign`). This previously
+ * read `parts[1]` as a JWT's payload would be, so it fed the raw HMAC
+ * signature to `JSON.parse` and returned `null` for every token ever issued.
+ * Nothing crashed, because both callers treat `null` as "unknown expiry" -
+ * which silently meant `_scheduleTokenRefresh` never armed a proactive
+ * refresh on any connection. A socket that stayed open never noticed (auth is
+ * only checked at AUTH time, not continuously), but any reconnect after the
+ * token's 5-minute lifetime - a tab reload, a network blip, a service
+ * restart - presented the same stale, never-refreshed token and was closed
+ * 1008 `token-expired`, dropping the source to IDLE with nothing surfaced.
+ * client-webapp had the identical bug, fixed in `8ff4582`.
+ *
+ * The signature is not checked here; only session-manager and node-server
+ * hold the signing key. This is a scheduling hint, not an authorization
+ * decision - a tampered `exp` can only make this kiosk refresh at the wrong
+ * time, never make a bad token acceptable.
  */
-function decodeJwtExpiryMs(token: string): number | null {
+function decodeSessionTokenExpiryMs(token: string): number | null {
   const parts = token.split('.');
-  if (parts.length < 2) return null;
+  if (parts.length !== SESSION_TOKEN_SEGMENTS) return null;
   try {
-    const payload = JSON.parse(base64UrlDecode(parts[1] ?? '')) as {
+    const payload = JSON.parse(base64UrlDecode(parts[0] ?? '')) as {
       exp?: number;
     };
     if (typeof payload.exp !== 'number') return null;
@@ -937,7 +959,7 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
       this._tokenRefreshTimer = null;
     }
 
-    const expiryMs = decodeJwtExpiryMs(token);
+    const expiryMs = decodeSessionTokenExpiryMs(token);
     if (expiryMs === null) return;
 
     const remainingMs = expiryMs - Date.now();

--- a/apps/kiosk-webapp/src/features/kiosk-provider/stores/kiosk-middleware.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/stores/kiosk-middleware.ts
@@ -21,6 +21,7 @@ import {
   setLifecycle,
   setRegistrationError,
   setRoom,
+  setScheduleSyncError,
   setSessionStatus,
   setSessions,
 } from './kiosk-slice';
@@ -95,8 +96,11 @@ export const createKioskMiddleware =
     kioskService.on('registrationError', (message) => {
       store.dispatch(setRegistrationError(message));
     });
-    kioskService.on('error', (message) => {
-      store.dispatch(setError(message));
+    kioskService.on('error', (fault) => {
+      store.dispatch(setError(fault));
+    });
+    kioskService.on('scheduleSyncError', (fault) => {
+      store.dispatch(setScheduleSyncError(fault));
     });
 
     return (next) => (action) => {

--- a/apps/kiosk-webapp/src/features/kiosk-provider/stores/kiosk-slice.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/stores/kiosk-slice.ts
@@ -13,6 +13,7 @@ import type { RootState } from '#src/store/store';
 import type {
   DeviceInfo,
   JoinCodeEntry,
+  KioskFault,
   RoomInfo,
   SessionStatusSnapshot,
 } from '../services/kiosk-service';
@@ -41,7 +42,14 @@ export interface KioskSliceState {
     nextJoinCode: JoinCodeEntry | null;
   } | null;
   registrationError: string | null;
-  error: string | null;
+  /** Why the kiosk is degraded or stuck. Rendered by the connection banner. */
+  error: KioskFault | null;
+  /**
+   * Health of the schedule long-poll. Separate from {@link error} because
+   * they are independent failure domains - the schedule can be dead while a
+   * session runs fine, and vice versa - and one must not overwrite the other.
+   */
+  scheduleSyncError: KioskFault | null;
 }
 
 const initialState: KioskSliceState = {
@@ -52,6 +60,7 @@ const initialState: KioskSliceState = {
   activeSession: null,
   registrationError: null,
   error: null,
+  scheduleSyncError: null,
 };
 
 export const selectLifecycle = (state: RootState) => state.kiosk.lifecycle;
@@ -63,6 +72,8 @@ export const selectActiveSession = (state: RootState) =>
 export const selectRegistrationError = (state: RootState) =>
   state.kiosk.registrationError;
 export const selectError = (state: RootState) => state.kiosk.error;
+export const selectScheduleSyncError = (state: RootState) =>
+  state.kiosk.scheduleSyncError;
 
 /**
  * Result of {@link deriveConnectionBanner}: either the banner should be
@@ -76,29 +87,64 @@ export type ConnectionBannerState =
 
 /**
  * Pure derivation of what the kiosk's `ConnectionStatusBanner` should show,
- * given the two independent signals the kiosk tracks while a session is
- * active: the kiosk's own socket to node-server (`connectionStatus`), and
- * node-server's upstream link to the transcription service
- * (`sessionStatus.transcriptionServiceConnected`).
+ * given the four independent signals the kiosk tracks: whatever the service
+ * has named as the current fault (`error`), the kiosk's own socket to
+ * node-server (`connectionStatus`), node-server's upstream link to the
+ * transcription service (`sessionStatus.transcriptionServiceConnected`), and
+ * the health of the schedule long-poll (`scheduleSyncError`).
  *
- * Priority: a broken `connectionStatus` explains everything else (no session
- * data is flowing at all, regardless of what the last-known `sessionStatus`
- * said), so it's checked first. Only once the kiosk's own socket is
- * confirmed `CONNECTED` does a stale-but-still-informative
- * `sessionStatus.transcriptionServiceConnected === false` matter.
+ * Priority, most explanatory first:
+ * 1. `TERMINAL` - the kiosk has stopped retrying. Always an `'error'`, and it
+ *    renders the service's own explanation rather than a generic string,
+ *    because the whole point of a terminal state is naming *which*
+ *    unrecoverable thing happened and who has to fix it.
+ * 2. Any other named fault (`error`), at the severity the service chose. This
+ *    is what makes `selectError` real: `'Failed to fetch device info…'` and
+ *    friends were dispatched into Redux on every failure and read by nothing,
+ *    so the code looked like it reported errors and the wall stayed silent.
+ *    A named cause outranks the generic "Connection lost" below because it
+ *    says the same thing with the reason attached.
+ * 3. A broken `connectionStatus`, which explains everything under it - no
+ *    session data is flowing at all, regardless of what the last-known
+ *    `sessionStatus` said.
+ * 4. node-server's upstream link, only once the kiosk's own socket is
+ *    confirmed `CONNECTED` and a stale-but-informative snapshot can be
+ *    trusted.
+ * 5. Degraded schedule sync. Last because it does not stop a running session
+ *    from working; it stops the *next* one from starting, which is invisible
+ *    behind an idle kiosk's perfectly calm status panel.
  *
  * No session (`connectionStatus === null`) means there is nothing to report
- * - the kiosk isn't participating in a session, so there's no connection to
- * be lost. Almost every case here is a retrying/transient state (matching
- * this feature's fail-open philosophy elsewhere) and so is a `'warning'`. The
- * one exception is `INVALID_REQUEST`: the transcription service rejected this
- * session's configuration and will reject the identical retry forever, so
- * there is nothing to wait for and it is reported as an `'error'`.
+ * about a session - but the kiosk can still be broken in the other three
+ * ways, all of which are reachable while `IDLE` or `INITIALIZING`.
+ *
+ * Almost every case here is a retrying/transient state (matching this
+ * feature's fail-open philosophy elsewhere) and so is a `'warning'`. The
+ * exceptions are `TERMINAL`, a fault the service itself marked `'error'`, and
+ * `INVALID_REQUEST`: the transcription service rejected this session's
+ * configuration and will reject the identical retry forever, so there is
+ * nothing to wait for.
  */
 export function deriveConnectionBanner(
   connectionStatus: SessionConnectionStatus | null,
   sessionStatus: SessionStatusSnapshot | null,
+  error: KioskFault | null = null,
+  scheduleSyncError: KioskFault | null = null,
 ): ConnectionBannerState {
+  if (connectionStatus === SessionConnectionStatus.TERMINAL) {
+    return {
+      open: true,
+      severity: 'error',
+      message:
+        error?.message ??
+        'This kiosk cannot connect to the session running in this room and has stopped trying. An administrator needs to check it.',
+    };
+  }
+
+  if (error !== null) {
+    return { open: true, severity: error.severity, message: error.message };
+  }
+
   if (
     connectionStatus !== null &&
     connectionStatus !== SessionConnectionStatus.CONNECTED
@@ -147,14 +193,26 @@ export function deriveConnectionBanner(
     };
   }
 
+  if (scheduleSyncError !== null) {
+    return {
+      open: true,
+      severity: scheduleSyncError.severity,
+      message: scheduleSyncError.message,
+    };
+  }
+
   return { open: false };
 }
 
 /**
  * Selector wrapping {@link deriveConnectionBanner} over the active session's
- * `connectionStatus`/`sessionStatus`. `null` for both when there is no
- * active session, which `deriveConnectionBanner` treats as "nothing to
- * report".
+ * `connectionStatus`/`sessionStatus` plus the two service-reported faults.
+ * The session pair is `null` when there is no active session, which
+ * `deriveConnectionBanner` treats as "nothing to report about a session" -
+ * the faults are still reported, since both can occur with no session at all.
+ *
+ * This is the sole consumer of `selectError`, and the reason that slice field
+ * exists.
  */
 export const selectConnectionBanner = (
   state: RootState,
@@ -162,6 +220,8 @@ export const selectConnectionBanner = (
   deriveConnectionBanner(
     state.kiosk.activeSession?.connectionStatus ?? null,
     state.kiosk.activeSession?.sessionStatus ?? null,
+    selectError(state),
+    selectScheduleSyncError(state),
   );
 
 export const kioskSlice = createSlice({
@@ -224,8 +284,11 @@ export const kioskSlice = createSlice({
     setRegistrationError: (state, action: PayloadAction<string | null>) => {
       state.registrationError = action.payload;
     },
-    setError: (state, action: PayloadAction<string | null>) => {
+    setError: (state, action: PayloadAction<KioskFault | null>) => {
       state.error = action.payload;
+    },
+    setScheduleSyncError: (state, action: PayloadAction<KioskFault | null>) => {
+      state.scheduleSyncError = action.payload;
     },
   },
 });
@@ -243,6 +306,7 @@ export const {
   setJoinCodes,
   setRegistrationError,
   setError,
+  setScheduleSyncError,
 } = kioskSlice.actions;
 
 /**

--- a/apps/kiosk-webapp/tests/features/kiosk-provider/services/kiosk-service.test.ts
+++ b/apps/kiosk-webapp/tests/features/kiosk-provider/services/kiosk-service.test.ts
@@ -1,0 +1,651 @@
+import { EventEmitter } from 'eventemitter3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NetworkError } from '@scribear/base-api-client';
+import type { MicrophoneService } from '@scribear/microphone-store';
+import type { NodeServerClient } from '@scribear/node-server-client';
+import { createNodeServerClient } from '@scribear/node-server-client';
+import {
+  TranscriptionStreamClientMessageType,
+  TranscriptionStreamServerMessageType,
+} from '@scribear/node-server-schema';
+import type { SessionManagerClient } from '@scribear/session-manager-client';
+import { createSessionManagerClient } from '@scribear/session-manager-client';
+import type { Session } from '@scribear/session-manager-schema';
+
+import { KioskService } from '#src/features/kiosk-provider/services/kiosk-service';
+import { KioskLifecycle } from '#src/features/kiosk-provider/services/kiosk-service-status';
+
+vi.mock('@scribear/node-server-client', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@scribear/node-server-client')>();
+  return {
+    ...actual,
+    createNodeServerClient: vi.fn(),
+  };
+});
+
+vi.mock('@scribear/session-manager-client', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@scribear/session-manager-client')>();
+  return {
+    ...actual,
+    createSessionManagerClient: vi.fn(),
+  };
+});
+
+/**
+ * Minimal stand-in for the transcription-stream `WebSocketClient` - an
+ * EventEmitter with the handful of methods `KioskService` calls on it. Real
+ * connect/handshake/reconnect behavior lives in `@scribear/base-websocket-client`
+ * and is out of scope here; these tests only exercise how `KioskService`
+ * reacts once the socket reaches `open`/`close`/`message`/`error`.
+ */
+function createFakeSocket() {
+  const socket = new EventEmitter();
+  return Object.assign(socket, {
+    start: vi.fn(),
+    send: vi.fn(),
+    sendBinary: vi.fn(),
+    terminate: vi.fn(),
+  });
+}
+
+/** Minimal stand-in for the `mySchedule` long-poll client. */
+function createFakePoll() {
+  const poll = new EventEmitter();
+  return Object.assign(poll, {
+    start: vi.fn(),
+    close: vi.fn(),
+  });
+}
+
+/** Minimal stand-in for `MicrophoneService` - only the two methods a source
+ * kiosk calls on it. */
+function createFakeMicrophoneService() {
+  return {
+    getAudioStream: vi.fn().mockResolvedValue({}),
+    closeAudioStream: vi.fn(),
+  } as unknown as MicrophoneService;
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+}
+
+/**
+ * Mint a session token exactly the way session-manager's
+ * `SessionTokenService.sign` does: `base64url(payloadJSON)` and a base64url
+ * HMAC-SHA256 over that, joined by a `.`. **Two** segments, payload first.
+ *
+ * Reproducing the real minting is the point: the bug this regression-tests
+ * (`decodeJwtExpiryMs`, now `decodeSessionTokenExpiryMs`) read `parts[1]` - a
+ * JWT's payload index - and so threw on the raw HMAC signature of every
+ * device-issued token this system has ever produced. A hand-written
+ * three-segment fixture is exactly what let the equivalent client-webapp bug
+ * pass its tests for as long as it did (see `8ff4582`).
+ */
+async function mintSessionToken(expSeconds: number): Promise<string> {
+  const encoder = new TextEncoder();
+  const encodedPayload = base64UrlEncode(
+    encoder.encode(
+      JSON.stringify({
+        sessionUid: SESSION_UID,
+        clientId: 'device-id',
+        scopes: ['SEND_AUDIO'],
+        exp: expSeconds,
+      }),
+    ),
+  );
+  const key = await globalThis.crypto.subtle.importKey(
+    'raw',
+    encoder.encode('test-signing-key'),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await globalThis.crypto.subtle.sign(
+    'HMAC',
+    key,
+    encoder.encode(encodedPayload),
+  );
+  return `${encodedPayload}.${base64UrlEncode(new Uint8Array(signature))}`;
+}
+
+/** The shape the decoder used to (wrongly) assume: a three-segment JWT. */
+function mintJwtShapedToken(expSeconds: number): string {
+  const encoder = new TextEncoder();
+  const seg = (value: object) =>
+    base64UrlEncode(encoder.encode(JSON.stringify(value)));
+  return `${seg({ alg: 'HS256' })}.${seg({ exp: expSeconds })}.signature`;
+}
+
+const DEVICE_UID = 'device-uid';
+const ROOM_UID = 'room-uid';
+const SESSION_UID = 'session-uid';
+const NOW_MS = 1_800_000_000_000;
+
+function deviceOk(
+  overrides: { isSource?: boolean; roomUid?: string | null } = {},
+) {
+  return [
+    {
+      status: 200,
+      data: {
+        uid: DEVICE_UID,
+        name: 'Kiosk',
+        roomUid: overrides.roomUid === undefined ? ROOM_UID : overrides.roomUid,
+        isSource: overrides.isSource ?? false,
+      },
+    },
+    null,
+  ];
+}
+
+function roomOk() {
+  return [
+    { status: 200, data: { uid: ROOM_UID, name: 'Room', timezone: 'UTC' } },
+    null,
+  ];
+}
+
+function exchangeOk(sessionToken: string) {
+  return [{ status: 200, data: { sessionToken } }, null];
+}
+
+/** An ACTIVE session (started in the past, no end) - the shape `_syncSchedule`
+ * needs to immediately call `_enterActive`. */
+function activeSession(
+  overrides: { joinCodeScopes?: string[]; effectiveEnd?: string | null } = {},
+): Session {
+  return {
+    uid: SESSION_UID,
+    name: 'Live session',
+    effectiveStart: new Date(NOW_MS - 60_000).toISOString(),
+    effectiveEnd: overrides.effectiveEnd ?? null,
+    joinCodeScopes: overrides.joinCodeScopes ?? [],
+  } as unknown as Session;
+}
+
+/** An UPCOMING session, `startInMs` from now. */
+function upcomingSession(startInMs: number): Session {
+  return {
+    uid: 'upcoming-session',
+    name: 'Upcoming session',
+    effectiveStart: new Date(NOW_MS + startInMs).toISOString(),
+    effectiveEnd: null,
+    joinCodeScopes: [],
+  } as unknown as Session;
+}
+
+let fakeSocket: ReturnType<typeof createFakeSocket>;
+let fakeSourceSocket: ReturnType<typeof createFakeSocket>;
+let fakePoll: ReturnType<typeof createFakePoll>;
+let getMyDevice: ReturnType<typeof vi.fn>;
+let getMyRoom: ReturnType<typeof vi.fn>;
+let mySchedule: ReturnType<typeof vi.fn>;
+let exchangeDeviceToken: ReturnType<typeof vi.fn>;
+let activateDevice: ReturnType<typeof vi.fn>;
+let fetchJoinCode: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW_MS);
+  // No jitter, so refresh/timer delays are exact fractions rather than +/-10%.
+  vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+  fakeSocket = createFakeSocket();
+  fakeSourceSocket = createFakeSocket();
+  fakePoll = createFakePoll();
+  getMyDevice = vi.fn().mockResolvedValue(deviceOk());
+  getMyRoom = vi.fn().mockResolvedValue(roomOk());
+  mySchedule = vi.fn(() => fakePoll);
+  exchangeDeviceToken = vi.fn();
+  activateDevice = vi.fn();
+  fetchJoinCode = vi.fn().mockResolvedValue([
+    {
+      status: 200,
+      data: {
+        current: { joinCode: 'ABC123', validStart: '', validEnd: '' },
+        next: null,
+      },
+    },
+    null,
+  ]);
+
+  vi.mocked(createNodeServerClient).mockReturnValue({
+    transcriptionStreamClient: vi.fn(() => fakeSocket),
+    transcriptionStreamSource: vi.fn(() => fakeSourceSocket),
+  } as unknown as NodeServerClient);
+
+  vi.mocked(createSessionManagerClient).mockReturnValue({
+    deviceManagement: { getMyDevice, activateDevice },
+    roomManagement: { getMyRoom },
+    scheduleManagement: { mySchedule },
+    sessionAuth: { exchangeDeviceToken, fetchJoinCode },
+  } as unknown as SessionManagerClient);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+/** Drive a fresh KioskService from `start()` through IDLE (schedule poll
+ * listening, no active session). */
+async function bringToIdle(
+  microphoneService = createFakeMicrophoneService(),
+): Promise<KioskService> {
+  const service = new KioskService(microphoneService);
+  service.start();
+  await vi.advanceTimersByTimeAsync(0);
+  return service;
+}
+
+/** Drive a fresh KioskService from `start()` through to a live, open socket
+ * for the given session (defaults to a non-source display kiosk). */
+async function bringSessionActive(
+  session: Session = activeSession(),
+  microphoneService = createFakeMicrophoneService(),
+): Promise<{ service: KioskService; socket: typeof fakeSocket }> {
+  const service = await bringToIdle(microphoneService);
+
+  fakePoll.emit('data', {
+    serverTime: new Date(NOW_MS).toISOString(),
+    sessions: [session],
+  });
+  await vi.advanceTimersByTimeAsync(0);
+
+  const socket = fakeSocket;
+  socket.emit('open');
+  await vi.advanceTimersByTimeAsync(0);
+  return { service, socket };
+}
+
+describe('KioskService session-token refresh (regression: decodeSessionTokenExpiryMs)', () => {
+  it('arms a proactive refresh at half the token lifetime and re-AUTHs on the open socket', async () => {
+    const first = await mintSessionToken(NOW_MS / 1000 + 600);
+    const second = await mintSessionToken(NOW_MS / 1000 + 1200);
+    const third = await mintSessionToken(NOW_MS / 1000 + 1800);
+    exchangeDeviceToken
+      .mockResolvedValueOnce(exchangeOk(first))
+      .mockResolvedValueOnce(exchangeOk(second))
+      .mockResolvedValueOnce(exchangeOk(third));
+
+    const { socket } = await bringSessionActive();
+
+    // Before the fix, decodeJwtExpiryMs(first) always returned null (it read
+    // the raw HMAC signature as parts[1]), so _scheduleTokenRefresh returned
+    // early and no refresh was ever armed - this would still be 1 forever.
+    expect(exchangeDeviceToken).toHaveBeenCalledTimes(1);
+
+    // Just short of the halfway point (300s): nothing should have fired yet.
+    await vi.advanceTimersByTimeAsync(299_000);
+    expect(exchangeDeviceToken).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(exchangeDeviceToken).toHaveBeenCalledTimes(2);
+    expect(socket.send).toHaveBeenCalledWith({
+      type: TranscriptionStreamClientMessageType.AUTH,
+      sessionToken: second,
+    });
+
+    // And the next refresh is armed off the new token's own lifetime.
+    await vi.advanceTimersByTimeAsync(601_000);
+    expect(exchangeDeviceToken).toHaveBeenCalledTimes(3);
+  });
+
+  it('never refreshes a token whose expiry it cannot read (JWT-shaped, three segments)', async () => {
+    const token = mintJwtShapedToken(NOW_MS / 1000 + 600);
+    exchangeDeviceToken.mockResolvedValue(exchangeOk(token));
+
+    await bringSessionActive();
+    expect(exchangeDeviceToken).toHaveBeenCalledTimes(1);
+
+    // A full 10 minutes with no proactive refresh firing - _scheduleTokenRefresh
+    // returns early on an unreadable expiry rather than guessing.
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+    expect(exchangeDeviceToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads the real session token's expiry from parts[0], not parts[1]", async () => {
+    // A regression-focused counterpart to the two tests above: a real,
+    // correctly-shaped token's signature segment (parts[1]) is deliberately
+    // NOT valid base64url-encoded JSON, so if the decoder ever regresses back
+    // to reading parts[1], this fails with an unreadable-expiry result
+    // (no refresh ever fires) instead of a thrown exception.
+    const token = await mintSessionToken(NOW_MS / 1000 + 600);
+    exchangeDeviceToken.mockResolvedValue(exchangeOk(token));
+
+    await bringSessionActive();
+    await vi.advanceTimersByTimeAsync(301_000);
+
+    expect(exchangeDeviceToken).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to IDLE when a refresh fails, instead of authing with a stale token', async () => {
+    const first = await mintSessionToken(NOW_MS / 1000 + 600);
+    exchangeDeviceToken
+      .mockResolvedValueOnce(exchangeOk(first))
+      .mockResolvedValueOnce([null, new NetworkError('offline')]);
+
+    const { service } = await bringSessionActive();
+    const lifecycles: KioskLifecycle[] = [];
+    service.on('lifecycleChange', (l) => lifecycles.push(l));
+
+    await vi.advanceTimersByTimeAsync(301_000);
+
+    expect(lifecycles).toContain(KioskLifecycle.IDLE);
+  });
+
+  it('falls back to IDLE, without opening a socket, when the initial token fetch fails', async () => {
+    exchangeDeviceToken.mockResolvedValue([null, new NetworkError('offline')]);
+    const service = await bringToIdle();
+    const lifecycles: KioskLifecycle[] = [];
+    service.on('lifecycleChange', (l) => lifecycles.push(l));
+
+    fakePoll.emit('data', {
+      serverTime: new Date(NOW_MS).toISOString(),
+      sessions: [activeSession()],
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fakeSocket.start).not.toHaveBeenCalled();
+    expect(lifecycles).toContain(KioskLifecycle.IDLE);
+  });
+});
+
+describe('KioskService registration / initialization', () => {
+  it('shows UNREGISTERED when getMyDevice answers 401', async () => {
+    getMyDevice.mockResolvedValue([{ status: 401, data: null }, null]);
+    const service = new KioskService(createFakeMicrophoneService());
+    const lifecycles: KioskLifecycle[] = [];
+    service.on('lifecycleChange', (l) => lifecycles.push(l));
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(lifecycles).toContain(KioskLifecycle.UNREGISTERED);
+    expect(getMyRoom).not.toHaveBeenCalled();
+  });
+
+  it('retries on a network error from getMyDevice', async () => {
+    getMyDevice
+      .mockResolvedValueOnce([null, new NetworkError('offline')])
+      .mockResolvedValueOnce(deviceOk());
+
+    const service = new KioskService(createFakeMicrophoneService());
+    service.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getMyDevice).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(getMyDevice).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats an unassigned device (no room) as IDLE with no schedule poll', async () => {
+    getMyDevice.mockResolvedValue(deviceOk({ roomUid: null }));
+    const service = new KioskService(createFakeMicrophoneService());
+    const lifecycles: KioskLifecycle[] = [];
+    service.on('lifecycleChange', (l) => lifecycles.push(l));
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(lifecycles).toContain(KioskLifecycle.IDLE);
+    expect(mySchedule).not.toHaveBeenCalled();
+  });
+});
+
+describe('KioskService activateDevice', () => {
+  it('reports a network error without restarting', async () => {
+    activateDevice.mockResolvedValue([null, new NetworkError('offline')]);
+    const service = new KioskService(createFakeMicrophoneService());
+    const errors: (string | null)[] = [];
+    service.on('registrationError', (m) => errors.push(m));
+
+    await service.activateDevice('CODE1');
+
+    expect(errors.at(-1)).toMatch(/network error/i);
+    expect(getMyDevice).not.toHaveBeenCalled();
+  });
+
+  it('restarts initialization on a successful activation', async () => {
+    activateDevice.mockResolvedValue([{ status: 200, data: null }, null]);
+    const service = new KioskService(createFakeMicrophoneService());
+
+    await service.activateDevice('CODE1');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(getMyDevice).toHaveBeenCalledTimes(1);
+  });
+
+  it('names an expired activation code (410) distinctly from not-found (404)', async () => {
+    const service = new KioskService(createFakeMicrophoneService());
+    const errors: (string | null)[] = [];
+    service.on('registrationError', (m) => errors.push(m));
+
+    activateDevice.mockResolvedValueOnce([{ status: 410, data: null }, null]);
+    await service.activateDevice('EXPIRED');
+    expect(errors.at(-1)).toMatch(/expired/i);
+
+    activateDevice.mockResolvedValueOnce([{ status: 404, data: null }, null]);
+    await service.activateDevice('UNKNOWN');
+    expect(errors.at(-1)).toMatch(/not found/i);
+  });
+});
+
+describe('KioskService mute/unmute', () => {
+  it('sends SOURCE_STATE on mute/unmute when a socket is connected', async () => {
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const { service, socket } = await bringSessionActive(
+      activeSession(),
+      createFakeMicrophoneService(),
+    );
+
+    service.unmute();
+    expect(socket.send).toHaveBeenCalledWith({
+      type: TranscriptionStreamClientMessageType.SOURCE_STATE,
+      microphoneActive: true,
+    });
+
+    service.mute();
+    expect(socket.send).toHaveBeenCalledWith({
+      type: TranscriptionStreamClientMessageType.SOURCE_STATE,
+      microphoneActive: false,
+    });
+  });
+
+  it('is a no-op when no socket is connected yet', async () => {
+    const service = await bringToIdle();
+    expect(() => {
+      service.mute();
+    }).not.toThrow();
+  });
+});
+
+describe('KioskService schedule sync', () => {
+  it('schedules a session-start timer for the soonest upcoming session and enters ACTIVE when it fires', async () => {
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const service = await bringToIdle();
+    const active: unknown[] = [];
+    service.on('activeSession', (a) => active.push(a));
+
+    fakePoll.emit('data', {
+      serverTime: new Date(NOW_MS).toISOString(),
+      sessions: [upcomingSession(30_000)],
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(active).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(30_001);
+    expect(active.filter(Boolean)).toHaveLength(1);
+  });
+
+  it('drops back to IDLE when the active session disappears from the schedule', async () => {
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const service = await bringToIdle();
+    const lifecycles: KioskLifecycle[] = [];
+
+    fakePoll.emit('data', {
+      serverTime: new Date(NOW_MS).toISOString(),
+      sessions: [activeSession()],
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    service.on('lifecycleChange', (l) => lifecycles.push(l));
+
+    fakePoll.emit('data', {
+      serverTime: new Date(NOW_MS).toISOString(),
+      sessions: [],
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(lifecycles).toContain(KioskLifecycle.IDLE);
+  });
+});
+
+describe('KioskService socket close / error handling', () => {
+  it('returns to IDLE on a normal 1000 close (session ended)', async () => {
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const { service, socket } = await bringSessionActive();
+    const lifecycles: KioskLifecycle[] = [];
+    service.on('lifecycleChange', (l) => lifecycles.push(l));
+
+    socket.emit('close', 1000, 'session-end', 1000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(lifecycles).toContain(KioskLifecycle.IDLE);
+  });
+
+  it('returns to IDLE on a 1008 auth failure and lets schedule sync rediscover the session', async () => {
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const { service, socket } = await bringSessionActive();
+    const lifecycles: KioskLifecycle[] = [];
+    service.on('lifecycleChange', (l) => lifecycles.push(l));
+
+    socket.emit('close', 1008, 'token-expired', 1000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(lifecycles).toContain(KioskLifecycle.IDLE);
+  });
+});
+
+describe('KioskService transcription-stream message handling', () => {
+  it('emits transcript and sessionStatus events from server messages', async () => {
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const { service, socket } = await bringSessionActive();
+    const transcripts: unknown[] = [];
+    const statuses: unknown[] = [];
+    service.on('transcript', (t) => transcripts.push(t));
+    service.on('sessionStatus', (s) => statuses.push(s));
+
+    socket.emit('message', {
+      type: TranscriptionStreamServerMessageType.TRANSCRIPT,
+      final: { text: 'hello', startMs: 0, endMs: 100 },
+      inProgress: null,
+    });
+    socket.emit('message', {
+      type: TranscriptionStreamServerMessageType.SESSION_STATUS,
+      transcriptionServiceConnected: true,
+      sourceDeviceConnected: true,
+    });
+
+    expect(transcripts).toEqual([
+      { final: { text: 'hello', startMs: 0, endMs: 100 }, inProgress: null },
+    ]);
+    expect(statuses).toEqual([
+      { transcriptionServiceConnected: true, sourceDeviceConnected: true },
+    ]);
+  });
+});
+
+describe('KioskService source role', () => {
+  it('begins audio capture, starts time-sync pings, and seeds mic state on open', async () => {
+    const mic = createFakeMicrophoneService();
+    getMyDevice.mockResolvedValue(deviceOk({ isSource: true }));
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+
+    const service = await bringToIdle(mic);
+    fakePoll.emit('data', {
+      serverTime: new Date(NOW_MS).toISOString(),
+      sessions: [activeSession()],
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    fakeSourceSocket.emit('open');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mic.getAudioStream).toHaveBeenCalledTimes(1);
+    expect(fakeSourceSocket.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: TranscriptionStreamClientMessageType.TIME_SYNC_PING,
+      }),
+    );
+    expect(fakeSourceSocket.send).toHaveBeenCalledWith({
+      type: TranscriptionStreamClientMessageType.SOURCE_STATE,
+      microphoneActive: false,
+    });
+    void service;
+  });
+
+  it('fetches a join code when the session has non-empty joinCodeScopes', async () => {
+    getMyDevice.mockResolvedValue(deviceOk({ isSource: false }));
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+
+    await bringSessionActive(
+      activeSession({ joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'] }),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fetchJoinCode).toHaveBeenCalledWith({
+      body: { sessionUid: SESSION_UID },
+    });
+  });
+
+  it('does not fetch a join code when joinCodeScopes is empty', async () => {
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+
+    await bringSessionActive(activeSession({ joinCodeScopes: [] }));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fetchJoinCode).not.toHaveBeenCalled();
+  });
+});
+
+describe('KioskService stop/teardown', () => {
+  it('closes the schedule poll and socket, and returns to INITIALIZING', async () => {
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const { service } = await bringSessionActive();
+
+    service.stop();
+
+    expect(fakePoll.close).toHaveBeenCalled();
+    expect(fakeSocket.terminate).toHaveBeenCalledWith(1000, 'session-end');
+    expect(service.lifecycle).toBe(KioskLifecycle.INITIALIZING);
+  });
+});

--- a/apps/kiosk-webapp/tests/features/kiosk-provider/services/kiosk-service.test.ts
+++ b/apps/kiosk-webapp/tests/features/kiosk-provider/services/kiosk-service.test.ts
@@ -1,7 +1,11 @@
 import { EventEmitter } from 'eventemitter3';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { NetworkError } from '@scribear/base-api-client';
+import {
+  NetworkError,
+  UnexpectedResponseError,
+} from '@scribear/base-api-client';
+import { SchemaValidationError as WsSchemaValidationError } from '@scribear/base-websocket-client';
 import type { MicrophoneService } from '@scribear/microphone-store';
 import type { NodeServerClient } from '@scribear/node-server-client';
 import { createNodeServerClient } from '@scribear/node-server-client';
@@ -13,8 +17,12 @@ import type { SessionManagerClient } from '@scribear/session-manager-client';
 import { createSessionManagerClient } from '@scribear/session-manager-client';
 import type { Session } from '@scribear/session-manager-schema';
 
+import type { KioskFault } from '#src/features/kiosk-provider/services/kiosk-service';
 import { KioskService } from '#src/features/kiosk-provider/services/kiosk-service';
-import { KioskLifecycle } from '#src/features/kiosk-provider/services/kiosk-service-status';
+import {
+  KioskLifecycle,
+  SessionConnectionStatus,
+} from '#src/features/kiosk-provider/services/kiosk-service-status';
 
 vi.mock('@scribear/node-server-client', async (importOriginal) => {
   const actual =
@@ -191,6 +199,7 @@ let getMyRoom: ReturnType<typeof vi.fn>;
 let mySchedule: ReturnType<typeof vi.fn>;
 let exchangeDeviceToken: ReturnType<typeof vi.fn>;
 let activateDevice: ReturnType<typeof vi.fn>;
+let transcriptionStreamClient: ReturnType<typeof vi.fn>;
 let fetchJoinCode: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
@@ -204,7 +213,14 @@ beforeEach(() => {
   fakePoll = createFakePoll();
   getMyDevice = vi.fn().mockResolvedValue(deviceOk());
   getMyRoom = vi.fn().mockResolvedValue(roomOk());
-  mySchedule = vi.fn(() => fakePoll);
+  // A fresh poll per call, as the real client does. `_enterIdle` starts a new
+  // one on every drop out of a session, and reusing one emitter across those
+  // cycles would stack listeners and make the reconnect-loop tests below
+  // count each failure several times over.
+  mySchedule = vi.fn(() => {
+    fakePoll = createFakePoll();
+    return fakePoll;
+  });
   exchangeDeviceToken = vi.fn();
   activateDevice = vi.fn();
   fetchJoinCode = vi.fn().mockResolvedValue([
@@ -218,8 +234,9 @@ beforeEach(() => {
     null,
   ]);
 
+  transcriptionStreamClient = vi.fn(() => fakeSocket);
   vi.mocked(createNodeServerClient).mockReturnValue({
-    transcriptionStreamClient: vi.fn(() => fakeSocket),
+    transcriptionStreamClient,
     transcriptionStreamSource: vi.fn(() => fakeSourceSocket),
   } as unknown as NodeServerClient);
 
@@ -247,6 +264,16 @@ async function bringToIdle(
   return service;
 }
 
+/** Deliver a schedule long-poll response on whichever poll is currently live
+ * (`_enterIdle` replaces it every time the kiosk drops out of a session). */
+async function deliverSchedule(sessions: Session[]): Promise<void> {
+  fakePoll.emit('data', {
+    serverTime: new Date(NOW_MS).toISOString(),
+    sessions,
+  });
+  await vi.advanceTimersByTimeAsync(0);
+}
+
 /** Drive a fresh KioskService from `start()` through to a live, open socket
  * for the given session (defaults to a non-source display kiosk). */
 async function bringSessionActive(
@@ -255,16 +282,29 @@ async function bringSessionActive(
 ): Promise<{ service: KioskService; socket: typeof fakeSocket }> {
   const service = await bringToIdle(microphoneService);
 
-  fakePoll.emit('data', {
-    serverTime: new Date(NOW_MS).toISOString(),
-    sessions: [session],
-  });
-  await vi.advanceTimersByTimeAsync(0);
+  await deliverSchedule([session]);
 
   const socket = fakeSocket;
   socket.emit('open');
   await vi.advanceTimersByTimeAsync(0);
   return { service, socket };
+}
+
+/**
+ * Record every fault, connection status and lifecycle change a service emits
+ * from this point on. Most assertions below are about what the room was
+ * *told*, which is precisely what these three streams carry.
+ */
+function observe(service: KioskService) {
+  const faults: (KioskFault | null)[] = [];
+  const scheduleFaults: (KioskFault | null)[] = [];
+  const statuses: SessionConnectionStatus[] = [];
+  const lifecycles: KioskLifecycle[] = [];
+  service.on('error', (f) => faults.push(f));
+  service.on('scheduleSyncError', (f) => scheduleFaults.push(f));
+  service.on('connectionStatus', (s) => statuses.push(s));
+  service.on('lifecycleChange', (l) => lifecycles.push(l));
+  return { faults, scheduleFaults, statuses, lifecycles };
 }
 
 describe('KioskService session-token refresh (regression: decodeSessionTokenExpiryMs)', () => {
@@ -328,35 +368,66 @@ describe('KioskService session-token refresh (regression: decodeSessionTokenExpi
     expect(exchangeDeviceToken).toHaveBeenCalledTimes(2);
   });
 
-  it('falls back to IDLE when a refresh fails, instead of authing with a stale token', async () => {
+  it('keeps the working socket when a proactive refresh fails, and retries instead of dropping the session', async () => {
     const first = await mintSessionToken(NOW_MS / 1000 + 600);
     exchangeDeviceToken
       .mockResolvedValueOnce(exchangeOk(first))
-      .mockResolvedValueOnce([null, new NetworkError('offline')]);
+      .mockResolvedValue([null, new NetworkError('offline')]);
 
-    const { service } = await bringSessionActive();
-    const lifecycles: KioskLifecycle[] = [];
-    service.on('lifecycleChange', (l) => lifecycles.push(l));
+    const { service, socket } = await bringSessionActive();
+    const { faults, lifecycles } = observe(service);
 
+    // Halfway through the token's lifetime the proactive refresh fires and
+    // fails. The socket is still open and still authenticated on the current
+    // token, so tearing the session down (as this used to) would throw away a
+    // working connection over a blip.
     await vi.advanceTimersByTimeAsync(301_000);
 
-    expect(lifecycles).toContain(KioskLifecycle.IDLE);
+    expect(lifecycles).not.toContain(KioskLifecycle.IDLE);
+    expect(socket.terminate).not.toHaveBeenCalled();
+    expect(faults.at(-1)).toEqual({
+      severity: 'warning',
+      message: expect.stringMatching(/cannot reach/i),
+    });
   });
 
-  it('falls back to IDLE, without opening a socket, when the initial token fetch fails', async () => {
+  it('goes TERMINAL when the refresh retry budget is exhausted', async () => {
+    const first = await mintSessionToken(NOW_MS / 1000 + 600);
+    exchangeDeviceToken
+      .mockResolvedValueOnce(exchangeOk(first))
+      .mockResolvedValue([null, new NetworkError('offline')]);
+
+    const { service } = await bringSessionActive();
+    const { faults, statuses } = observe(service);
+
+    // 300 s to the refresh, then 500 + 1000 + 2000 + 4000 ms of backoff
+    // across the five allowed attempts.
+    await vi.advanceTimersByTimeAsync(301_000 + 7_600);
+
+    expect(statuses.at(-1)).toBe(SessionConnectionStatus.TERMINAL);
+    expect(faults.at(-1)?.severity).toBe('error');
+    expect(faults.at(-1)?.message).toMatch(/stopped retrying/i);
+    // Still ACTIVE: the captions already on the wall stay up and the panel
+    // keeps naming the session, rather than claiming the room is idle.
+    expect(service.lifecycle).toBe(KioskLifecycle.ACTIVE);
+  });
+
+  it('never reports CONNECTED, or opens a socket at all, when the initial token fetch fails', async () => {
     exchangeDeviceToken.mockResolvedValue([null, new NetworkError('offline')]);
     const service = await bringToIdle();
-    const lifecycles: KioskLifecycle[] = [];
-    service.on('lifecycleChange', (l) => lifecycles.push(l));
+    const { faults, statuses } = observe(service);
 
-    fakePoll.emit('data', {
-      serverTime: new Date(NOW_MS).toISOString(),
-      sessions: [activeSession()],
-    });
-    await vi.advanceTimersByTimeAsync(0);
+    await deliverSchedule([activeSession()]);
 
+    // The handshake used to resolve with no AUTH sent, so the socket reached
+    // OPEN, the banner closed, and the room read "connected" with no captions
+    // until node-server's auth watchdog closed it five seconds later.
     expect(fakeSocket.start).not.toHaveBeenCalled();
-    expect(lifecycles).toContain(KioskLifecycle.IDLE);
+    expect(statuses).not.toContain(SessionConnectionStatus.CONNECTED);
+    expect(faults.at(-1)).toEqual({
+      severity: 'warning',
+      message: 'Cannot reach the ScribeAR session service. Retrying…',
+    });
   });
 });
 
@@ -530,18 +601,385 @@ describe('KioskService socket close / error handling', () => {
     expect(lifecycles).toContain(KioskLifecycle.IDLE);
   });
 
-  it('returns to IDLE on a 1008 auth failure and lets schedule sync rediscover the session', async () => {
+  it('returns to IDLE on a single 1008 auth failure and lets schedule sync rediscover the session', async () => {
     exchangeDeviceToken.mockResolvedValue(
       exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
     );
     const { service, socket } = await bringSessionActive();
-    const lifecycles: KioskLifecycle[] = [];
-    service.on('lifecycleChange', (l) => lifecycles.push(l));
+    const { lifecycles, statuses } = observe(service);
 
+    // A merely-stale token also closes 1008 and is genuinely fixed by the
+    // refetch on the next attempt, so the first one is not terminal.
     socket.emit('close', 1008, 'token-expired', 1000);
     await vi.advanceTimersByTimeAsync(0);
 
     expect(lifecycles).toContain(KioskLifecycle.IDLE);
+    expect(statuses).not.toContain(SessionConnectionStatus.TERMINAL);
+  });
+
+  it('goes TERMINAL immediately on a 1008 whose reason can never succeed on a retry', async () => {
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const { service, socket } = await bringSessionActive();
+    const { faults, statuses, lifecycles } = observe(service);
+    const tokenCallsBefore = exchangeDeviceToken.mock.calls.length;
+
+    socket.emit('close', 1008, 'missing-scope', 1000);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(statuses.at(-1)).toBe(SessionConnectionStatus.TERMINAL);
+    expect(faults.at(-1)?.severity).toBe('error');
+    expect(faults.at(-1)?.message).toMatch(/not permitted to join/i);
+    // Nothing keeps trying: no fresh token is fetched, and the kiosk does not
+    // bounce through IDLE claiming to be waiting for a session to start.
+    expect(exchangeDeviceToken.mock.calls.length).toBe(tokenCallsBefore);
+    expect(lifecycles).not.toContain(KioskLifecycle.IDLE);
+  });
+
+  it('goes TERMINAL after three 1008 closes whose reason is unfamiliar, counting across reconnects', async () => {
+    const session = activeSession();
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const { service, socket } = await bringSessionActive(session);
+    const { faults, statuses } = observe(service);
+
+    // Each close drops the kiosk to IDLE, where schedule sync immediately
+    // rediscovers the same still-active session and reconnects. A per-socket
+    // counter would be refilled by that very loop; this budget is not.
+    socket.emit('close', 1008, '', 1000);
+    await vi.advanceTimersByTimeAsync(0);
+    await deliverSchedule([session]);
+    expect(statuses).not.toContain(SessionConnectionStatus.TERMINAL);
+
+    socket.emit('close', 1008, '', 1000);
+    await vi.advanceTimersByTimeAsync(0);
+    await deliverSchedule([session]);
+    expect(statuses).not.toContain(SessionConnectionStatus.TERMINAL);
+
+    socket.emit('close', 1008, '', 1000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(statuses.at(-1)).toBe(SessionConnectionStatus.TERMINAL);
+    expect(faults.at(-1)?.message).toMatch(/3 times in a row/);
+    expect(service.lifecycle).toBe(KioskLifecycle.ACTIVE);
+  });
+
+  it('clears the 1008 budget on AUTH_OK, so an accepted credential resets the count', async () => {
+    const session = activeSession();
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const { service, socket } = await bringSessionActive(session);
+    const { statuses } = observe(service);
+
+    socket.emit('close', 1008, '', 1000);
+    await vi.advanceTimersByTimeAsync(0);
+    await deliverSchedule([session]);
+    socket.emit('close', 1008, '', 1000);
+    await vi.advanceTimersByTimeAsync(0);
+    await deliverSchedule([session]);
+
+    // The server accepts this one - the only proof the credential was good.
+    socket.emit('message', {
+      type: TranscriptionStreamServerMessageType.AUTH_OK,
+    });
+
+    socket.emit('close', 1008, '', 1000);
+    await vi.advanceTimersByTimeAsync(0);
+    await deliverSchedule([session]);
+    socket.emit('close', 1008, '', 1000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(statuses).not.toContain(SessionConnectionStatus.TERMINAL);
+  });
+
+  it('starts a genuinely different session with a full 1008 budget', async () => {
+    const first = activeSession();
+    const second: Session = { ...activeSession(), uid: 'other-session' };
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const { service, socket } = await bringSessionActive(first);
+    const { statuses } = observe(service);
+
+    socket.emit('close', 1008, '', 1000);
+    await vi.advanceTimersByTimeAsync(0);
+    await deliverSchedule([first]);
+    socket.emit('close', 1008, '', 1000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // A new session is a new credential and a new configuration; the previous
+    // session's failures say nothing about it.
+    await deliverSchedule([second]);
+    socket.emit('close', 1008, '', 1000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(statuses).not.toContain(SessionConnectionStatus.TERMINAL);
+  });
+
+  it('goes TERMINAL on a schema mismatch rather than silently dropping to IDLE', async () => {
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const { service, socket } = await bringSessionActive();
+    const { faults, statuses, lifecycles } = observe(service);
+
+    socket.emit('error', new WsSchemaValidationError('bad message'));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(statuses.at(-1)).toBe(SessionConnectionStatus.TERMINAL);
+    expect(faults.at(-1)?.message).toMatch(/protocol mismatch/i);
+    expect(lifecycles).not.toContain(KioskLifecycle.IDLE);
+  });
+
+  it('clears a terminal session once it disappears from the schedule', async () => {
+    const session = activeSession();
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const { service, socket } = await bringSessionActive(session);
+    const { faults, lifecycles } = observe(service);
+
+    socket.emit('close', 1008, 'session-mismatch', 1000);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(service.lifecycle).toBe(KioskLifecycle.ACTIVE);
+
+    // Terminal is scoped to one session: when that session ends, the kiosk
+    // goes back to a clean IDLE rather than staying stuck on a stale message.
+    await deliverSchedule([]);
+
+    expect(lifecycles).toContain(KioskLifecycle.IDLE);
+    expect(faults.at(-1)).toBeNull();
+  });
+});
+
+describe('KioskService session-token failures (2.4)', () => {
+  it('goes TERMINAL immediately, without retrying, when the device is not in the session room', async () => {
+    exchangeDeviceToken.mockResolvedValue([
+      { status: 403, data: { code: 'DEVICE_NOT_IN_SESSION_ROOM' } },
+      null,
+    ]);
+    const service = await bringToIdle();
+    const { faults, statuses } = observe(service);
+
+    await deliverSchedule([activeSession()]);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(exchangeDeviceToken).toHaveBeenCalledTimes(1);
+    expect(statuses.at(-1)).toBe(SessionConnectionStatus.TERMINAL);
+    expect(faults.at(-1)?.message).toMatch(/not assigned to the room/i);
+  });
+
+  it('names the HTTP status when the session service refuses with an undeclared one', async () => {
+    exchangeDeviceToken.mockResolvedValue([
+      null,
+      new UnexpectedResponseError(429),
+    ]);
+    const service = await bringToIdle();
+    const { faults } = observe(service);
+
+    await deliverSchedule([activeSession()]);
+
+    // 429, 500 and "session-manager is down" used to be one indistinguishable
+    // silence; a room full of devices behind one NAT is a real 429 source.
+    expect(faults.at(-1)?.message).toMatch(/HTTP 429/);
+    expect(faults.at(-1)?.severity).toBe('warning');
+  });
+
+  it('rejects the handshake, rather than reporting OPEN, when no token is available', async () => {
+    exchangeDeviceToken.mockResolvedValue(
+      exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+    );
+    const { service } = await bringSessionActive();
+    const options = transcriptionStreamClient.mock.calls[0]?.[1] as {
+      onHandshake: (sender: unknown, messages: unknown) => Promise<void>;
+    };
+
+    // Teardown drops the token. A reconnect that ran the handshake anyway
+    // used to *return*, resolving it without sending AUTH - so the client
+    // reported OPEN and the banner closed with nothing authenticated.
+    service.stop();
+    const sender = { send: vi.fn(), sendBinary: vi.fn() };
+
+    await expect(
+      options.onHandshake(sender, new EventEmitter()),
+    ).rejects.toThrow(/session token/i);
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+
+  it('abandons an in-flight token fetch when a newer session takes over', async () => {
+    const token = await mintSessionToken(NOW_MS / 1000 + 600);
+    // One slow, shared in-flight response, so both sessions' fetches are
+    // still pending when the second one takes over.
+    const pending = new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(exchangeOk(token));
+      }, 1_000);
+    });
+    exchangeDeviceToken.mockReturnValue(pending);
+    const service = await bringToIdle();
+    const other: Session = { ...activeSession(), uid: 'other-session' };
+
+    // Both fetches are in flight at once; only the newer session may act on
+    // its result, or the superseded one leaks a second socket over it.
+    fakePoll.emit('data', {
+      serverTime: new Date(NOW_MS).toISOString(),
+      sessions: [activeSession()],
+    });
+    fakePoll.emit('data', {
+      serverTime: new Date(NOW_MS).toISOString(),
+      sessions: [other],
+    });
+    await vi.advanceTimersByTimeAsync(1_100);
+
+    expect(fakeSocket.start).toHaveBeenCalledTimes(1);
+    expect(service.lifecycle).toBe(KioskLifecycle.ACTIVE);
+  });
+
+  it('abandons a backing-off retry when a newer session takes over', async () => {
+    exchangeDeviceToken.mockResolvedValue([null, new NetworkError('offline')]);
+    const service = await bringToIdle();
+    const { statuses } = observe(service);
+    const other: Session = { ...activeSession(), uid: 'other-session' };
+
+    await deliverSchedule([activeSession()]);
+    await deliverSchedule([other]);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // Exactly one terminal declaration: the abandoned loop woke from its
+    // backoff, saw it had been superseded, and stopped without spending the
+    // new session's budget or announcing a failure that no longer applies.
+    expect(
+      statuses.filter((s) => s === SessionConnectionStatus.TERMINAL),
+    ).toHaveLength(1);
+  });
+
+  it('recovers, connects and clears the fault when a transient failure stops', async () => {
+    exchangeDeviceToken
+      .mockResolvedValueOnce([null, new NetworkError('offline')])
+      .mockResolvedValue(
+        exchangeOk(await mintSessionToken(NOW_MS / 1000 + 600)),
+      );
+    const service = await bringToIdle();
+    const { faults, statuses } = observe(service);
+
+    await deliverSchedule([activeSession()]);
+    expect(faults.at(-1)?.severity).toBe('warning');
+
+    await vi.advanceTimersByTimeAsync(600);
+    fakeSocket.emit('open');
+    fakeSocket.emit('stateChange', 'OPEN');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fakeSocket.start).toHaveBeenCalled();
+    expect(faults.at(-1)).toBeNull();
+    expect(statuses.at(-1)).toBe(SessionConnectionStatus.CONNECTED);
+  });
+});
+
+describe('KioskService schedule long-poll health (2.5)', () => {
+  it('says nothing about a single transient poll failure', async () => {
+    const service = await bringToIdle();
+    const { scheduleFaults } = observe(service);
+
+    fakePoll.emit('error', new NetworkError('offline'));
+    fakePoll.emit('error', new NetworkError('offline'));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(scheduleFaults).toEqual([]);
+  });
+
+  it('reports a sustained schedule-sync outage, naming the cause and the consequence', async () => {
+    const service = await bringToIdle();
+    const { scheduleFaults } = observe(service);
+
+    for (let i = 0; i < 3; i++) {
+      fakePoll.emit('error', new NetworkError('offline'));
+    }
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The whole point: this used to be `poll.on('error', () => {})`, so
+    // schedule sync could be dead for hours behind "Inactive, waiting for a
+    // session to start." - the same sentence a healthy kiosk shows.
+    expect(scheduleFaults.at(-1)).toEqual({
+      severity: 'warning',
+      message:
+        'Cannot reach the ScribeAR schedule service. Scheduled sessions may not start or end on time on this kiosk.',
+    });
+  });
+
+  it('distinguishes a failing schedule service from an unreachable one', async () => {
+    const service = await bringToIdle();
+    const { scheduleFaults } = observe(service);
+
+    for (let i = 0; i < 3; i++) {
+      fakePoll.emit('error', new UnexpectedResponseError(500));
+    }
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(scheduleFaults.at(-1)?.message).toMatch(/HTTP 500/);
+  });
+
+  it('clears the schedule-sync fault as soon as a response arrives', async () => {
+    const service = await bringToIdle();
+    const { scheduleFaults } = observe(service);
+
+    for (let i = 0; i < 3; i++) {
+      fakePoll.emit('error', new NetworkError('offline'));
+    }
+    await vi.advanceTimersByTimeAsync(0);
+    expect(scheduleFaults.at(-1)).not.toBeNull();
+
+    await deliverSchedule([]);
+
+    expect(scheduleFaults.at(-1)).toBeNull();
+  });
+});
+
+describe('KioskService device-info failures (2.2)', () => {
+  it('reports an unreachable server while it retries initialization', async () => {
+    getMyDevice.mockResolvedValue([null, new NetworkError('offline')]);
+    const service = new KioskService(createFakeMicrophoneService());
+    const { faults } = observe(service);
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(faults.at(-1)).toEqual({
+      severity: 'warning',
+      message: 'Cannot reach the ScribeAR server. Retrying…',
+    });
+  });
+
+  it('names the HTTP status when device info is refused, and clears it on recovery', async () => {
+    getMyDevice
+      .mockResolvedValueOnce([null, new UnexpectedResponseError(500)])
+      .mockResolvedValue(deviceOk());
+    const service = new KioskService(createFakeMicrophoneService());
+    const { faults } = observe(service);
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(faults.at(-1)?.message).toMatch(/HTTP 500/);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(faults.at(-1)).toBeNull();
+  });
+
+  it('says nothing extra when the device is simply unregistered', async () => {
+    getMyDevice.mockResolvedValue([{ status: 401, data: null }, null]);
+    const service = new KioskService(createFakeMicrophoneService());
+    const { faults } = observe(service);
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The activation form this drops to is itself the explanation; a banner
+    // on top of it would be noise, not information.
+    expect(faults.filter(Boolean)).toEqual([]);
   });
 });
 

--- a/apps/kiosk-webapp/tests/features/kiosk-provider/stores/kiosk-slice.test.ts
+++ b/apps/kiosk-webapp/tests/features/kiosk-provider/stores/kiosk-slice.test.ts
@@ -2,14 +2,22 @@ import { describe, expect } from 'vitest';
 
 import { TranscriptionServiceDisconnectReason } from '@scribear/node-server-schema';
 
-import type { SessionStatusSnapshot } from '#src/features/kiosk-provider/services/kiosk-service';
+import type {
+  KioskFault,
+  SessionStatusSnapshot,
+} from '#src/features/kiosk-provider/services/kiosk-service';
 import { SessionConnectionStatus } from '#src/features/kiosk-provider/services/kiosk-service-status';
 import {
   deriveConnectionBanner,
   kioskReducer,
+  selectConnectionBanner,
   setActiveSession,
+  setConnectionStatus,
+  setError,
+  setScheduleSyncError,
   setSessionStatus,
 } from '#src/features/kiosk-provider/stores/kiosk-slice';
+import type { RootState } from '#src/store/store';
 
 function statusSnapshot(
   overrides: Partial<SessionStatusSnapshot> = {},
@@ -118,6 +126,187 @@ describe('deriveConnectionBanner', (it) => {
       severity: 'warning',
       message: 'Connection lost. Reconnecting…',
     });
+  });
+});
+
+describe('deriveConnectionBanner faults', (it) => {
+  const warning: KioskFault = {
+    severity: 'warning',
+    message: 'Cannot reach the ScribeAR session service. Retrying…',
+  };
+  const fatal: KioskFault = {
+    severity: 'error',
+    message: 'This kiosk is not assigned to the room running this session.',
+  };
+
+  it('renders the service’s own explanation in the TERMINAL branch', () => {
+    expect(
+      deriveConnectionBanner(SessionConnectionStatus.TERMINAL, null, fatal),
+    ).toEqual({ open: true, severity: 'error', message: fatal.message });
+  });
+
+  it('still says something useful in TERMINAL with no explanation attached', () => {
+    const banner = deriveConnectionBanner(
+      SessionConnectionStatus.TERMINAL,
+      null,
+      null,
+    );
+
+    expect(banner).toMatchObject({ open: true, severity: 'error' });
+    expect(banner.open && banner.message).toMatch(/stopped trying/i);
+  });
+
+  it('reports a fault with no session at all - initialization failures reach the wall too', () => {
+    // `'Failed to fetch device info.'` happens during INITIALIZING, before any
+    // session exists. Gating the banner on an active session is how that
+    // message was computed, dispatched, stored, and never seen.
+    expect(deriveConnectionBanner(null, null, warning)).toEqual({
+      open: true,
+      severity: 'warning',
+      message: warning.message,
+    });
+  });
+
+  it('prefers a named cause over the generic "Connection lost" wording', () => {
+    expect(
+      deriveConnectionBanner(SessionConnectionStatus.CONNECTING, null, warning),
+    ).toEqual({
+      open: true,
+      severity: 'warning',
+      message: warning.message,
+    });
+  });
+
+  it('reports degraded schedule sync when nothing more urgent is wrong', () => {
+    const scheduleFault: KioskFault = {
+      severity: 'warning',
+      message: 'Cannot reach the ScribeAR schedule service.',
+    };
+
+    expect(deriveConnectionBanner(null, null, null, scheduleFault)).toEqual({
+      open: true,
+      severity: 'warning',
+      message: scheduleFault.message,
+    });
+  });
+
+  it('lets a live-session fault outrank degraded schedule sync', () => {
+    const scheduleFault: KioskFault = {
+      severity: 'warning',
+      message: 'Cannot reach the ScribeAR schedule service.',
+    };
+
+    expect(
+      deriveConnectionBanner(
+        SessionConnectionStatus.TERMINAL,
+        null,
+        fatal,
+        scheduleFault,
+      ),
+    ).toEqual({ open: true, severity: 'error', message: fatal.message });
+  });
+
+  it('is closed when a healthy session has no faults of either kind', () => {
+    expect(
+      deriveConnectionBanner(
+        SessionConnectionStatus.CONNECTED,
+        statusSnapshot(),
+        null,
+        null,
+      ),
+    ).toEqual({ open: false });
+  });
+});
+
+describe('selectConnectionBanner', (it) => {
+  const asRootState = (kiosk: ReturnType<typeof kioskReducer>) =>
+    ({ kiosk }) as RootState;
+
+  it('feeds selectError into the banner - the wiring that did not exist', () => {
+    // The regression this pins: `selectError` was defined, dispatched to on
+    // every failure, and read by no component. The service can emit whatever
+    // it likes; if this selector drops it, the room learns nothing.
+    const fault: KioskFault = {
+      severity: 'error',
+      message: 'Session stream protocol mismatch.',
+    };
+    const state = kioskReducer(undefined, setError(fault));
+
+    expect(selectConnectionBanner(asRootState(state))).toEqual({
+      open: true,
+      severity: 'error',
+      message: fault.message,
+    });
+  });
+
+  it('feeds selectScheduleSyncError into the banner', () => {
+    const fault: KioskFault = {
+      severity: 'warning',
+      message: 'Schedule updates have stopped arriving.',
+    };
+    const state = kioskReducer(undefined, setScheduleSyncError(fault));
+
+    expect(selectConnectionBanner(asRootState(state))).toEqual({
+      open: true,
+      severity: 'warning',
+      message: fault.message,
+    });
+  });
+
+  it('renders the terminal branch from the active session’s connection status', () => {
+    const fault: KioskFault = {
+      severity: 'error',
+      message: 'This kiosk is not permitted to join this session.',
+    };
+    let state = kioskReducer(
+      undefined,
+      setActiveSession({ sessionUid: 'session-1', name: 'Session One' }),
+    );
+    state = kioskReducer(
+      state,
+      setConnectionStatus(SessionConnectionStatus.TERMINAL),
+    );
+    state = kioskReducer(state, setError(fault));
+
+    expect(selectConnectionBanner(asRootState(state))).toEqual({
+      open: true,
+      severity: 'error',
+      message: fault.message,
+    });
+  });
+
+  it('is closed on a clean initial state', () => {
+    const state = kioskReducer(undefined, { type: 'noop' });
+
+    expect(selectConnectionBanner(asRootState(state))).toEqual({ open: false });
+  });
+});
+
+describe('kioskReducer fault fields', (it) => {
+  it('stores and clears the session fault', () => {
+    const fault: KioskFault = { severity: 'warning', message: 'Retrying…' };
+    const set = kioskReducer(undefined, setError(fault));
+    expect(set.error).toEqual(fault);
+
+    expect(kioskReducer(set, setError(null)).error).toBeNull();
+  });
+
+  it('keeps the schedule fault independent of the session fault', () => {
+    const sessionFault: KioskFault = {
+      severity: 'error',
+      message: 'Protocol mismatch.',
+    };
+    const scheduleFault: KioskFault = {
+      severity: 'warning',
+      message: 'Schedule sync degraded.',
+    };
+    let state = kioskReducer(undefined, setError(sessionFault));
+    state = kioskReducer(state, setScheduleSyncError(scheduleFault));
+    state = kioskReducer(state, setError(null));
+
+    // Two failure domains: clearing one must not silence the other.
+    expect(state.error).toBeNull();
+    expect(state.scheduleSyncError).toEqual(scheduleFault);
   });
 });
 

--- a/apps/kiosk-webapp/vitest.config.ts
+++ b/apps/kiosk-webapp/vitest.config.ts
@@ -12,6 +12,7 @@ export default mergeConfig(
           extends: true,
           test: {
             name: 'unit',
+            environment: 'jsdom',
           },
         },
       ],

--- a/apps/session-manager/src/server/features/room-management/room-management.controller.ts
+++ b/apps/session-manager/src/server/features/room-management/room-management.controller.ts
@@ -314,6 +314,13 @@ export class RoomManagementController {
         'Device is already a member of a room.',
       );
     }
+    if (result === 'TOO_MANY_SOURCE_DEVICES') {
+      throw HttpError.conflict(
+        'TOO_MANY_SOURCE_DEVICES',
+        'Room already has a source device. Add the device without asSource ' +
+          'and use set-source-device to replace the current one.',
+      );
+    }
 
     res.code(204).send(null);
   }

--- a/apps/session-manager/src/server/features/room-management/room-management.repository.ts
+++ b/apps/session-manager/src/server/features/room-management/room-management.repository.ts
@@ -468,6 +468,27 @@ export class RoomManagementRepository {
   }
 
   /**
+   * Returns the UID of the room's current source device, if it has one.
+   *
+   * The partial index `idx_room_devices_source` covers exactly this predicate.
+   * At most one row can match: `room_devices_single_source` is a deferred
+   * constraint trigger, so a transaction can transiently hold two, but nothing
+   * outside a transaction ever observes that state.
+   *
+   * @param roomUid The room to look up.
+   * @returns The source device's UID, or `undefined` if the room has no source.
+   */
+  async findSourceDeviceUid(roomUid: string): Promise<string | undefined> {
+    const row = await this._dbClient.db
+      .selectFrom('room_devices')
+      .select('device_uid')
+      .where('room_uid', '=', roomUid)
+      .where('is_source', '=', true)
+      .executeTakeFirst();
+    return row?.device_uid;
+  }
+
+  /**
    * Checks whether a room with the given UID exists.
    * @param roomUid The room UID to check.
    * @returns `true` if the room exists, `false` otherwise.

--- a/apps/session-manager/src/server/features/room-management/room-management.service.ts
+++ b/apps/session-manager/src/server/features/room-management/room-management.service.ts
@@ -272,8 +272,8 @@ export class RoomManagementService {
    * Adds a device to a room as either a source or non-source member.
    * @param params.roomUid The room to add the device to.
    * @param params.deviceUid The device to add; must not already be in a room.
-   * @param params.asSource Whether to designate this device as the room's source.
-   * @returns `undefined` on success, or an error code: `'DEMO_ROOM_NOT_ASSIGNABLE'`, `'DEMO_SOURCE_DEVICE_NOT_ASSIGNABLE'`, `'TEST_AUDIO_ROOM_NOT_ASSIGNABLE'`, `'TEST_AUDIO_DEVICE_NOT_ASSIGNABLE'`, `'CANARY_ROOM_NOT_ASSIGNABLE'`, `'CANARY_DEVICE_NOT_ASSIGNABLE'`, `'ROOM_NOT_FOUND'`, `'DEVICE_NOT_FOUND'`, or `'DEVICE_ALREADY_IN_ROOM'`.
+   * @param params.asSource Whether to designate this device as the room's source. Refused with `'TOO_MANY_SOURCE_DEVICES'` when the room already has one; swapping the source is `setSourceDevice`'s job.
+   * @returns `undefined` on success, or an error code: `'DEMO_ROOM_NOT_ASSIGNABLE'`, `'DEMO_SOURCE_DEVICE_NOT_ASSIGNABLE'`, `'TEST_AUDIO_ROOM_NOT_ASSIGNABLE'`, `'TEST_AUDIO_DEVICE_NOT_ASSIGNABLE'`, `'CANARY_ROOM_NOT_ASSIGNABLE'`, `'CANARY_DEVICE_NOT_ASSIGNABLE'`, `'ROOM_NOT_FOUND'`, `'DEVICE_NOT_FOUND'`, `'DEVICE_ALREADY_IN_ROOM'`, or `'TOO_MANY_SOURCE_DEVICES'`.
    */
   async addDeviceToRoom(params: {
     roomUid: string;
@@ -302,6 +302,31 @@ export class RoomManagementService {
     if (!roomExists) return 'ROOM_NOT_FOUND';
     if (!device) return 'DEVICE_NOT_FOUND';
     if (device.roomUid !== null) return 'DEVICE_ALREADY_IN_ROOM';
+
+    // A room takes exactly one source device (`room_devices_single_source`),
+    // and the repository's `asSource` branch clears `is_source` across the
+    // room before inserting - so without this check the call silently demotes
+    // the incumbent and answers 204. The demoted device keeps its membership
+    // and its long-lived device token, still resolves the session, and is
+    // simply no longer granted SEND_AUDIO: a kiosk that starts, connects,
+    // displays a join code and sends no audio, with nothing anywhere
+    // reporting a fault. That is the exact harm the reserved test-audio and
+    // canary rooms are already guarded against; ordinary teaching rooms had
+    // no such guard.
+    //
+    // Refusing rather than swapping is deliberate. `set-source-device` is the
+    // deliberate replace-the-source flow and it already exists, so an
+    // operator who means to swap says so in one call (add the device as a
+    // plain member, then promote it) and one who does not is told why. This
+    // is also the 409 the route has always published and nothing could
+    // produce: only `createRoom` emitted `TOO_MANY_SOURCE_DEVICES`.
+    if (params.asSource) {
+      const existingSource =
+        await this._roomManagementRepository.findSourceDeviceUid(
+          params.roomUid,
+        );
+      if (existingSource !== undefined) return 'TOO_MANY_SOURCE_DEVICES';
+    }
 
     await this._roomManagementRepository.addDeviceToRoom(
       params.roomUid,

--- a/apps/session-manager/src/server/features/schedule-management/schedule-management.controller.ts
+++ b/apps/session-manager/src/server/features/schedule-management/schedule-management.controller.ts
@@ -271,6 +271,10 @@ export class ScheduleManagementController {
         'INVALID_ACTIVE_END',
         'activeEnd must be strictly after activeStart.',
       );
+    if (result === 'INVALID_LOCAL_TIMES')
+      throw HttpError.badRequest(
+        'localStartTime and localEndTime must not be equal.',
+      );
 
     res.code(201).send(this._mapWindow(result));
   }
@@ -336,6 +340,10 @@ export class ScheduleManagementController {
       throw HttpError.unprocessable(
         'INVALID_ACTIVE_END',
         'activeEnd must be strictly after activeStart.',
+      );
+    if (result === 'INVALID_LOCAL_TIMES')
+      throw HttpError.badRequest(
+        'localStartTime and localEndTime must not be equal.',
       );
 
     res.code(200).send(this._mapWindow(result));

--- a/apps/session-manager/src/server/features/schedule-management/schedule-management.service.ts
+++ b/apps/session-manager/src/server/features/schedule-management/schedule-management.service.ts
@@ -25,7 +25,10 @@ import { assertCancelable, assertUncancelable } from './utils/cancellation.js';
 import type { CancelEligibility } from './utils/cancellation.js';
 import { detectConflict } from './utils/conflict-detector.js';
 import { buildScheduledSessionRow } from './utils/occurrence-to-session.js';
-import { materializeSchedule } from './utils/schedule-materializer.js';
+import {
+  MIN_SESSION_DURATION_SECONDS,
+  materializeSchedule,
+} from './utils/schedule-materializer.js';
 import type { ScheduleForMaterialization } from './utils/schedule-materializer.js';
 import { materializeWindow } from './utils/window-materializer.js';
 
@@ -67,7 +70,6 @@ export class MaterializationFailedError extends Error {
 }
 
 const MATERIALIZATION_WINDOW_DAYS = 7;
-const MIN_AUTO_SESSION_DURATION_SECONDS = 60;
 const CONFLICT_CHECK_HORIZON_DAYS = 14;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -369,7 +371,7 @@ export class ScheduleManagementService {
         room.timezone,
         now,
         windowEnd,
-        MIN_AUTO_SESSION_DURATION_SECONDS,
+        MIN_SESSION_DURATION_SECONDS,
         newAutoEnabled,
         collector.sessionBumps,
       );
@@ -488,7 +490,7 @@ export class ScheduleManagementService {
       room.timezone,
       now,
       windowEnd,
-      MIN_AUTO_SESSION_DURATION_SECONDS,
+      MIN_SESSION_DURATION_SECONDS,
       room.autoSessionEnabled,
       collector.sessionBumps,
     );
@@ -835,7 +837,7 @@ export class ScheduleManagementService {
         room.timezone,
         now,
         windowEnd,
-        MIN_AUTO_SESSION_DURATION_SECONDS,
+        MIN_SESSION_DURATION_SECONDS,
         room.autoSessionEnabled,
         collector.sessionBumps,
       );
@@ -1025,7 +1027,7 @@ export class ScheduleManagementService {
         room.timezone,
         now,
         windowEnd,
-        MIN_AUTO_SESSION_DURATION_SECONDS,
+        MIN_SESSION_DURATION_SECONDS,
         room.autoSessionEnabled,
         collector.sessionBumps,
       );
@@ -1114,7 +1116,7 @@ export class ScheduleManagementService {
         room.timezone,
         now,
         windowEnd,
-        MIN_AUTO_SESSION_DURATION_SECONDS,
+        MIN_SESSION_DURATION_SECONDS,
         room.autoSessionEnabled,
         collector.sessionBumps,
       );
@@ -1172,7 +1174,7 @@ export class ScheduleManagementService {
         room.timezone,
         now,
         windowEnd,
-        MIN_AUTO_SESSION_DURATION_SECONDS,
+        MIN_SESSION_DURATION_SECONDS,
         room.autoSessionEnabled,
         collector.sessionBumps,
       );
@@ -1224,7 +1226,7 @@ export class ScheduleManagementService {
         room.timezone,
         now,
         windowEnd,
-        MIN_AUTO_SESSION_DURATION_SECONDS,
+        MIN_SESSION_DURATION_SECONDS,
         room.autoSessionEnabled,
         collector.sessionBumps,
       );
@@ -1410,7 +1412,7 @@ export class ScheduleManagementService {
       room.timezone,
       now,
       windowEnd,
-      MIN_AUTO_SESSION_DURATION_SECONDS,
+      MIN_SESSION_DURATION_SECONDS,
       room.autoSessionEnabled,
       collector.sessionBumps,
     );
@@ -1470,7 +1472,7 @@ export class ScheduleManagementService {
       room.timezone,
       now,
       windowEnd,
-      MIN_AUTO_SESSION_DURATION_SECONDS,
+      MIN_SESSION_DURATION_SECONDS,
       room.autoSessionEnabled,
       collector.sessionBumps,
     );
@@ -1583,7 +1585,7 @@ export class ScheduleManagementService {
         room.timezone,
         now,
         windowEnd,
-        MIN_AUTO_SESSION_DURATION_SECONDS,
+        MIN_SESSION_DURATION_SECONDS,
         room.autoSessionEnabled,
         collector.sessionBumps,
       );
@@ -1627,7 +1629,7 @@ export class ScheduleManagementService {
         room.timezone,
         now,
         windowEnd,
-        MIN_AUTO_SESSION_DURATION_SECONDS,
+        MIN_SESSION_DURATION_SECONDS,
         room.autoSessionEnabled,
         collector.sessionBumps,
       );

--- a/apps/session-manager/src/server/features/schedule-management/schedule-management.service.ts
+++ b/apps/session-manager/src/server/features/schedule-management/schedule-management.service.ts
@@ -190,6 +190,26 @@ function scheduleToMaterializationRecord(
 }
 
 /**
+ * Whether two local wall-clock times denote the same time of day.
+ *
+ * A string comparison is not enough. `HH:MM` and `HH:MM:SS` are both accepted
+ * on the wire and the database stores either as `TIME`, so a row written as
+ * `08:00` reads back as `08:00:00`. An update that merges a request's `08:00`
+ * against that stored value is exactly the collision the
+ * `*_local_times_distinct` CHECK constraints fire on, and `'08:00:00' ===
+ * '08:00'` is false - so a naive pre-check passes the request straight through
+ * to the constraint and the operator gets a 500 for a plain input error.
+ */
+function localTimesEqual(a: string, b: string): boolean {
+  return toSecondsOfDay(a) === toSecondsOfDay(b);
+}
+
+function toSecondsOfDay(time: string): number {
+  const [h = 0, m = 0, s = 0] = time.split(':').map(Number);
+  return h * 3600 + m * 60 + s;
+}
+
+/**
  * Thrown inside a `_runWithEvents` transaction callback to force a rollback
  * while still returning a typed result code to the caller. Kysely commits on
  * normal return and rolls back on throw; this sentinel bridges the gap for
@@ -665,6 +685,7 @@ export class ScheduleManagementService {
     | 'ROOM_NOT_FOUND'
     | 'CONFLICT'
     | 'INVALID_ACTIVE_END'
+    | 'INVALID_LOCAL_TIMES'
     | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
   > {
     if (!this._isKnownTranscriptionProvider(data.transcriptionProviderId)) {
@@ -754,6 +775,7 @@ export class ScheduleManagementService {
     | 'NOT_FOUND'
     | 'CONFLICT'
     | 'INVALID_ACTIVE_END'
+    | 'INVALID_LOCAL_TIMES'
     | 'UNKNOWN_TRANSCRIPTION_PROVIDER'
   > {
     if (!this._isKnownTranscriptionProvider(data.transcriptionProviderId)) {
@@ -1295,7 +1317,7 @@ export class ScheduleManagementService {
     }
 
     // Validate before the DB CHECK fires (local_times_distinct constraint).
-    if (data.localStartTime === data.localEndTime) {
+    if (localTimesEqual(data.localStartTime, data.localEndTime)) {
       return 'INVALID_LOCAL_TIMES';
     }
 
@@ -1476,10 +1498,24 @@ export class ScheduleManagementService {
     now: Date,
     collector: EventCollector,
     options: { skipReconcile?: boolean } = {},
-  ): Promise<AutoSessionWindow | 'CONFLICT' | 'INVALID_ACTIVE_END'> {
+  ): Promise<
+    | AutoSessionWindow
+    | 'CONFLICT'
+    | 'INVALID_ACTIVE_END'
+    | 'INVALID_LOCAL_TIMES'
+  > {
     const { activeStart, activeEnd } = data;
     if (activeEnd !== null && activeEnd.getTime() <= activeStart.getTime()) {
       return 'INVALID_ACTIVE_END';
+    }
+
+    // Validate before the DB CHECK fires
+    // (auto_session_windows_local_times_distinct constraint), exactly as
+    // `_doCreateSchedule` does. Without it the CHECK raises inside the
+    // transaction and the operator gets an opaque 500 for the same typo the
+    // schedule path answers with a sentence.
+    if (localTimesEqual(data.localStartTime, data.localEndTime)) {
+      return 'INVALID_LOCAL_TIMES';
     }
 
     const windowEnd = addDays(now, MATERIALIZATION_WINDOW_DAYS);

--- a/apps/session-manager/src/server/features/schedule-management/utils/schedule-materializer.ts
+++ b/apps/session-manager/src/server/features/schedule-management/utils/schedule-materializer.ts
@@ -38,7 +38,27 @@ const DOW_TO_LUXON: Record<string, number> = {
 const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 
 /**
+ * The shortest session worth creating, and therefore the floor below which a
+ * *clipped* occurrence is discarded rather than materialized.
+ *
+ * Exported because the AUTO slot materializer applies the same floor to the
+ * gaps it fills; one constant keeps a clipped occurrence and an AUTO slot
+ * agreeing on what "too short to be worth creating" means.
+ *
+ * Sixty seconds is not arbitrary: join codes are handed over in a 60 s window
+ * (`session-auth`), so a session shorter than this cannot reliably be joined
+ * even by a client that is already waiting for it.
+ */
+export const MIN_SESSION_DURATION_SECONDS = 60;
+
+const MIN_SESSION_DURATION_MS = MIN_SESSION_DURATION_SECONDS * 1000;
+
+/**
  * Expands a schedule's occurrences within [windowStart, windowEnd).
+ *
+ * Occurrences are *clipped* to the schedule's `[activeStart, activeEnd]`
+ * range rather than dropped when they straddle either end - see
+ * {@link clipToActiveRange}.
  *
  * Handles all DST edge cases:
  * - Spring-forward: times in the skipped interval snap to the first valid instant.
@@ -84,8 +104,8 @@ export function materializeSchedule(
       wraps,
       timezone,
     );
-    if (occ && inRange(occ, schedule, windowStart, windowEnd)) return [occ];
-    return [];
+    const admitted = occ ? admit(occ, schedule, windowStart, windowEnd) : null;
+    return admitted ? [admitted] : [];
   }
 
   const anchorWeekStart = DateTime.fromJSDate(schedule.anchorStart, {
@@ -127,8 +147,10 @@ export function materializeSchedule(
           wraps,
           timezone,
         );
-        if (occ && inRange(occ, schedule, windowStart, windowEnd))
-          occurrences.push(occ);
+        const admitted = occ
+          ? admit(occ, schedule, windowStart, windowEnd)
+          : null;
+        if (admitted) occurrences.push(admitted);
       }
     }
     cursor = cursor.plus({ days: 1 });
@@ -179,18 +201,86 @@ function buildOccurrence(
   };
 }
 
-function inRange(
+/**
+ * Clips an occurrence to the schedule's active range, then tests it against
+ * the caller's materialization window.
+ *
+ * @returns the occurrence to materialize (clipped if it straddled either end
+ * of the active range), or `null` if nothing usable remains.
+ */
+function admit(
   occ: Occurrence,
   schedule: ScheduleForMaterialization,
   windowStart: Date,
   windowEnd: Date,
-): boolean {
-  if (occ.startUtc < schedule.activeStart) return false;
-  if (schedule.activeEnd && occ.endUtc > schedule.activeEnd) return false;
+): Occurrence | null {
+  const clipped = clipToActiveRange(occ, schedule);
+  if (!clipped) return null;
   // Occurrence must overlap the window: end after windowStart AND start before windowEnd.
-  if (occ.endUtc <= windowStart) return false;
-  if (occ.startUtc >= windowEnd) return false;
-  return true;
+  if (clipped.endUtc <= windowStart) return null;
+  if (clipped.startUtc >= windowEnd) return null;
+  return clipped;
+}
+
+/**
+ * Trims an occurrence to `[activeStart, activeEnd]`.
+ *
+ * Both ends used to *drop* an occurrence that straddled them, which read as a
+ * safe conservative choice and is not: the shape the admin console creates is
+ * a daily `00:00-23:59` window, so every occurrence straddles both ends of any
+ * active range that does not begin at midnight and finish at 23:59. "Auto
+ * sessions every day, until 30 minutes from now" therefore materialized
+ * *nothing*, and narrowing a live window ended the running session
+ * immediately instead of at the requested instant. `activeStart` had the
+ * mirror-image failure: a window starting "now" produced its first session
+ * only on the next local day.
+ *
+ * Clipping is what the field names imply ("active *between* these instants")
+ * and what `materializeAutoSessions` already does when it fills a window
+ * around a blocking session. Clipping happens on absolute UTC instants, so a
+ * DST-adjusted occurrence keeps whichever instants `buildOccurrence` resolved.
+ *
+ * The floor applies only when the occurrence was actually clipped: a residue
+ * shorter than {@link MIN_SESSION_DURATION_SECONDS} is an artefact of the
+ * operator's boundary rather than something they asked for, and materializing
+ * it would insert a session nobody can join - or, at exactly zero length, one
+ * the `sessions_scheduled_end_after_start` CHECK rejects, turning the write
+ * into a 500. An *unclipped* occurrence is the operator's explicit request and
+ * keeps its existing treatment, so this cannot retroactively invalidate a
+ * short schedule that materializes today.
+ *
+ * The floor is enforced here rather than in the callers because SCHEDULED
+ * occurrences go straight to `insertSessions` with no other length check;
+ * AUTO window occurrences pass through `materializeAutoSessions`, which
+ * already applies the same floor to every slot it emits.
+ */
+function clipToActiveRange(
+  occ: Occurrence,
+  schedule: ScheduleForMaterialization,
+): Occurrence | null {
+  const startMs = Math.max(
+    occ.startUtc.getTime(),
+    schedule.activeStart.getTime(),
+  );
+  const endMs = schedule.activeEnd
+    ? Math.min(occ.endUtc.getTime(), schedule.activeEnd.getTime())
+    : occ.endUtc.getTime();
+
+  if (
+    startMs === occ.startUtc.getTime() &&
+    endMs === occ.endUtc.getTime() &&
+    startMs < endMs
+  ) {
+    return occ;
+  }
+
+  if (endMs - startMs < MIN_SESSION_DURATION_MS) return null;
+
+  return {
+    scheduleUid: occ.scheduleUid,
+    startUtc: new Date(startMs),
+    endUtc: new Date(endMs),
+  };
 }
 
 /**

--- a/apps/session-manager/tests/integration/features/room-management/room-management.repository.test.ts
+++ b/apps/session-manager/tests/integration/features/room-management/room-management.repository.test.ts
@@ -81,7 +81,10 @@ describe('RoomManagementRepository', () => {
       expect(result.uid).toBe(FIXED_UID);
       expect(result.name).toBe('Demo Room');
 
-      const all = await dbContext.db.selectFrom('rooms').select('uid').execute();
+      const all = await dbContext.db
+        .selectFrom('rooms')
+        .select('uid')
+        .execute();
       expect(all).toHaveLength(1);
     });
   });
@@ -357,6 +360,35 @@ describe('RoomManagementRepository', () => {
 
       // Act
       const result = await repository.findRoomMembership(deviceUid);
+
+      // Assert
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('findSourceDeviceUid', (it) => {
+    it("returns the source device's uid", async () => {
+      // Arrange - one source and one plain member, so the query has to
+      // discriminate rather than just return the first membership row.
+      const { uid: roomUid } = await insertRoom();
+      const { uid: sourceUid } = await insertDevice();
+      const { uid: memberUid } = await insertDevice();
+      await repository.addDeviceToRoom(roomUid, sourceUid, true);
+      await repository.addDeviceToRoom(roomUid, memberUid, false);
+
+      // Act
+      const result = await repository.findSourceDeviceUid(roomUid);
+
+      // Assert
+      expect(result).toBe(sourceUid);
+    });
+
+    it('returns undefined for a room with no source device', async () => {
+      // Arrange
+      const { uid: roomUid } = await insertRoom();
+
+      // Act
+      const result = await repository.findSourceDeviceUid(roomUid);
 
       // Assert
       expect(result).toBeUndefined();

--- a/apps/session-manager/tests/integration/features/room-management/room-management.routes.test.ts
+++ b/apps/session-manager/tests/integration/features/room-management/room-management.routes.test.ts
@@ -517,6 +517,71 @@ describe('Room Management Routes', () => {
       expect(res.statusCode).toBe(409);
       expect(res.json<{ code: string }>().code).toBe('DEVICE_ALREADY_IN_ROOM');
     });
+
+    // The repository's `asSource` branch clears `is_source` across the room
+    // before inserting, so this used to answer 204 and silently demote the
+    // incumbent kiosk - which kept its membership and its device token and
+    // just stopped being granted SEND_AUDIO. The 409 the route has always
+    // published for this had no producer.
+    it('returns 409 TOO_MANY_SOURCE_DEVICES when the room already has a source', async () => {
+      // Arrange
+      const { deviceUid: sourceUid } = await setupActivatedDevice('Source');
+      const { uid: roomUid } = await createRoom(sourceUid);
+      const { deviceUid: secondUid } = await setupActivatedDevice('Second');
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${ROOM_BASE}/add-device-to-room`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { roomUid, deviceUid: secondUid, asSource: true },
+      });
+
+      // Assert - refused, and the incumbent is untouched.
+      expect(res.statusCode).toBe(409);
+      expect(res.json<{ code: string }>().code).toBe('TOO_MANY_SOURCE_DEVICES');
+      const members = await dbContext.db
+        .selectFrom('room_devices')
+        .select(['device_uid', 'is_source'])
+        .where('room_uid', '=', roomUid)
+        .execute();
+      expect(members).toEqual([{ device_uid: sourceUid, is_source: true }]);
+    });
+
+    it('still supports a deliberate source swap via add-as-member then set-source-device', async () => {
+      // Arrange - the flow the refusal above points operators at.
+      const { deviceUid: sourceUid } = await setupActivatedDevice('Source');
+      const { uid: roomUid } = await createRoom(sourceUid);
+      const { deviceUid: secondUid } = await setupActivatedDevice('Second');
+
+      // Act
+      const attach = await server.fastify.inject({
+        method: 'POST',
+        url: `${ROOM_BASE}/add-device-to-room`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { roomUid, deviceUid: secondUid, asSource: false },
+      });
+      const promote = await server.fastify.inject({
+        method: 'POST',
+        url: `${ROOM_BASE}/set-source-device`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { roomUid, deviceUid: secondUid },
+      });
+
+      // Assert
+      expect(attach.statusCode).toBe(204);
+      expect(promote.statusCode).toBe(204);
+      const members = await dbContext.db
+        .selectFrom('room_devices')
+        .select(['device_uid', 'is_source'])
+        .where('room_uid', '=', roomUid)
+        .orderBy('is_source', 'desc')
+        .execute();
+      expect(members).toEqual([
+        { device_uid: secondUid, is_source: true },
+        { device_uid: sourceUid, is_source: false },
+      ]);
+    });
   });
 
   describe('POST /remove-device-from-room', (it) => {

--- a/apps/session-manager/tests/integration/features/schedule-management/schedule-management.routes.test.ts
+++ b/apps/session-manager/tests/integration/features/schedule-management/schedule-management.routes.test.ts
@@ -726,6 +726,40 @@ describe('Schedule Management Routes', () => {
       expect(windows).toHaveLength(0);
     });
 
+    it('returns 400 with a sentence when localStartTime equals localEndTime', async () => {
+      // Arrange - the same typo `create-schedule` answers with a sentence used
+      // to reach the `auto_session_windows_local_times_distinct` CHECK inside
+      // the transaction and come back as an opaque 500 INTERNAL_ERROR. 400
+      // VALIDATION_ERROR is already declared on this route via
+      // STANDARD_ERROR_REPLIES, exactly as on the schedule route, so nothing
+      // about the published contract changes.
+      const { roomUid } = await setupRoom();
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/create-auto-session-window`,
+        headers: { authorization: ADMIN_HEADER },
+        body: defaultWindowBody(roomUid, {
+          localStartTime: '10:00',
+          localEndTime: '10:00',
+        }),
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(400);
+      const body = res.json<{ code: string; message: string }>();
+      expect(body.code).toBe('VALIDATION_ERROR');
+      expect(body.message).toBe(
+        'localStartTime and localEndTime must not be equal.',
+      );
+      const created = await dbContext.db
+        .selectFrom('auto_session_windows')
+        .select('uid')
+        .execute();
+      expect(created).toHaveLength(0);
+    });
+
     it('returns 404 when the room does not exist', async () => {
       // Arrange / Act
       const res = await server.fastify.inject({
@@ -851,6 +885,44 @@ describe('Schedule Management Routes', () => {
       expect(res.json<{ localStartTime: string }>().localStartTime).toBe(
         '08:00:00',
       );
+    });
+
+    it('returns 400 when the merged local times are equal', async () => {
+      // Arrange - the stored row reads back as `09:00:00`, so this also
+      // exercises the HH:MM / HH:MM:SS comparison a string `===` would miss.
+      const { roomUid } = await setupRoom();
+      const create = await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/create-auto-session-window`,
+        headers: { authorization: ADMIN_HEADER },
+        body: defaultWindowBody(roomUid),
+      });
+      const { uid: windowUid } = create.json<{ uid: string }>();
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/update-auto-session-window`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { windowUid, localEndTime: '09:00' },
+      });
+
+      // Assert - refused, and the original window survives the rollback.
+      expect(res.statusCode).toBe(400);
+      const body = res.json<{ code: string; message: string }>();
+      expect(body.code).toBe('VALIDATION_ERROR');
+      expect(body.message).toBe(
+        'localStartTime and localEndTime must not be equal.',
+      );
+      const survived = await server.fastify.inject({
+        method: 'GET',
+        url: `${SCHEDULE_BASE}/get-auto-session-window/${windowUid}`,
+        headers: { authorization: ADMIN_HEADER },
+      });
+      expect(survived.statusCode).toBe(200);
+      expect(
+        survived.json<{ localEndTime: string; activeEnd: string | null }>(),
+      ).toMatchObject({ localEndTime: '17:00:00', activeEnd: null });
     });
 
     it('returns 404 when the window does not exist', async () => {

--- a/apps/session-manager/tests/integration/features/schedule-management/schedule-management.service.test.ts
+++ b/apps/session-manager/tests/integration/features/schedule-management/schedule-management.service.test.ts
@@ -4107,4 +4107,119 @@ describe('ScheduleManagementService', () => {
       );
     });
   });
+  // BUG-1: `_doCreateWindow` had no `localStartTime !== localEndTime`
+  // pre-check, so the `auto_session_windows_local_times_distinct` CHECK fired
+  // inside the transaction and the operator got a 500 for the same typo
+  // `_doCreateSchedule` answers with a sentence.
+  describe('auto-session windows - INVALID_LOCAL_TIMES', (it) => {
+    async function seedOpenWindow(roomUid: string, now: Date) {
+      const win = await service.createAutoSessionWindow(
+        {
+          roomUid,
+          activeStart: new Date(now.getTime() + 86_400_000),
+          activeEnd: null,
+          localStartTime: '08:00',
+          localEndTime: '09:00',
+          daysOfWeek: ['MON'],
+          joinCodeScopes: [],
+          transcriptionProviderId: 'whisper',
+          transcriptionStreamConfig: {},
+        },
+        now,
+      );
+      if (typeof win === 'string')
+        throw new Error('seed window failed: ' + win);
+      return win;
+    }
+
+    it('returns INVALID_LOCAL_TIMES from createAutoSessionWindow instead of tripping the DB CHECK', async () => {
+      // Arrange
+      const { uid: roomUid } = await insertRoom('UTC');
+      const now = new Date('2024-06-02T12:00:00Z');
+
+      // Act
+      const result = await service.createAutoSessionWindow(
+        {
+          roomUid,
+          activeStart: new Date(now.getTime() + 86_400_000),
+          activeEnd: null,
+          localStartTime: '10:00',
+          localEndTime: '10:00',
+          daysOfWeek: ['MON'],
+          joinCodeScopes: [],
+          transcriptionProviderId: 'whisper',
+          transcriptionStreamConfig: {},
+        },
+        now,
+      );
+
+      // Assert - a typed refusal, and no row written.
+      expect(result).toBe('INVALID_LOCAL_TIMES');
+      const windows = await service.listAutoSessionWindowsForRoom(roomUid, {});
+      expect(windows).toEqual([]);
+    });
+
+    it('catches HH:MM against a stored HH:MM:SS on update, which a string compare misses', async () => {
+      // Arrange - the stored row reads back as `08:00:00`; the request says
+      // `08:00`. Same time of day, different strings - so a naive `===`
+      // pre-check would pass this straight through to the CHECK constraint.
+      const { uid: roomUid } = await insertRoom('UTC');
+      const now = new Date('2024-06-02T12:00:00Z');
+      const win = await seedOpenWindow(roomUid, now);
+      expect(win.localStartTime).toBe('08:00:00');
+
+      // Act
+      const result = await service.updateAutoSessionWindow(
+        win.uid,
+        { localEndTime: '08:00' },
+        now,
+      );
+
+      // Assert - refused, and the close-and-reinsert rolled back so the
+      // original window is still open and unchanged.
+      expect(result).toBe('INVALID_LOCAL_TIMES');
+      const stillThere = await service.findAutoSessionWindowByUid(win.uid);
+      if (typeof stillThere === 'string')
+        throw new Error('window unexpectedly missing');
+      expect(stillThere.localEndTime).toBe('09:00:00');
+      expect(stillThere.activeEnd).toBeNull();
+    });
+
+    it('catches the same HH:MM / HH:MM:SS mismatch on a schedule update', async () => {
+      // Arrange - the schedule path had the identical hole; it was simply
+      // never reached because its `===` check caught the obvious typo first.
+      const { uid: roomUid } = await insertRoom('UTC');
+      const now = new Date('2024-06-02T12:00:00Z');
+      const created = await service.createSchedule(
+        {
+          roomUid,
+          name: 'S',
+          activeStart: new Date(now.getTime() + 86_400_000),
+          activeEnd: null,
+          localStartTime: '08:00',
+          localEndTime: '09:00',
+          frequency: 'WEEKLY',
+          daysOfWeek: ['MON'],
+          joinCodeScopes: [],
+          transcriptionProviderId: 'whisper',
+          transcriptionStreamConfig: {},
+        },
+        now,
+      );
+      if (typeof created === 'string')
+        throw new Error('seed schedule failed: ' + created);
+
+      // Act
+      const result = await service.updateSchedule(
+        created.uid,
+        { localEndTime: '08:00' },
+        now,
+      );
+
+      // Assert
+      expect(result).toBe('INVALID_LOCAL_TIMES');
+    });
+  });
+
+
 });

--- a/apps/session-manager/tests/integration/features/schedule-management/schedule-management.service.test.ts
+++ b/apps/session-manager/tests/integration/features/schedule-management/schedule-management.service.test.ts
@@ -4221,5 +4221,252 @@ describe('ScheduleManagementService', () => {
     });
   });
 
+  // BUG-2: `inRange` dropped an occurrence that straddled either end of the
+  // active range instead of clipping it. For the daily 00:00-23:59 window the
+  // admin console creates, every occurrence straddles both ends of any range
+  // that does not begin at midnight and finish at 23:59.
+  describe('active range clipping', (it) => {
+    const DAILY = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'] as const;
 
+    it('materializes an AUTO session ending at activeEnd rather than nothing at all', async () => {
+      // Arrange - "auto sessions every day, until 30 minutes from now".
+      const { uid: roomUid } = await insertRoom('UTC');
+      const now = new Date('2024-06-05T14:00:00Z');
+      const activeEnd = new Date('2024-06-05T14:30:00Z');
+
+      // Act
+      const win = await service.createAutoSessionWindow(
+        {
+          roomUid,
+          activeStart: new Date('2024-06-05T00:00:00Z'),
+          activeEnd,
+          localStartTime: '00:00',
+          localEndTime: '23:59',
+          daysOfWeek: [...DAILY],
+          joinCodeScopes: [],
+          transcriptionProviderId: 'whisper',
+          transcriptionStreamConfig: {},
+        },
+        now,
+      );
+
+      // Assert - exactly one AUTO covering now and ending at activeEnd.
+      if (typeof win === 'string') throw new Error('create failed: ' + win);
+      const autos = (await listSessionsForRoom(roomUid)).filter(
+        (s) => s.type === 'AUTO',
+      );
+      expect(autos).toHaveLength(1);
+      expect(autos[0]!.scheduled_start_time).toEqual(now);
+      expect(autos[0]!.scheduled_end_time).toEqual(activeEnd);
+      const active = await service.findActiveSession(roomUid, now);
+      expect(active).not.toBeNull();
+    });
+
+    it('narrowing a live window ends the running AUTO at the requested instant, not now', async () => {
+      // Arrange - an AUTO running since midnight, as a backdated daily window
+      // produces. This is the "stop after this afternoon" request that used to
+      // stop the room mid-lecture.
+      const { uid: roomUid } = await insertRoom('UTC');
+      const createNow = new Date('2024-06-05T09:00:00Z');
+      const win = await service.createAutoSessionWindow(
+        {
+          roomUid,
+          activeStart: new Date('2024-05-29T00:00:00Z'),
+          activeEnd: null,
+          localStartTime: '00:00',
+          localEndTime: '23:59',
+          daysOfWeek: [...DAILY],
+          joinCodeScopes: [],
+          transcriptionProviderId: 'whisper',
+          transcriptionStreamConfig: {},
+        },
+        createNow,
+      );
+      if (typeof win === 'string') throw new Error('seed failed: ' + win);
+      const activeAuto = (await listSessionsForRoom(roomUid)).find(
+        (s) => s.type === 'AUTO' && s.scheduled_start_time <= createNow,
+      );
+      if (!activeAuto) throw new Error('expected a live AUTO session');
+
+      // Act - narrow the window to end 30 minutes from now.
+      const updateNow = new Date('2024-06-05T14:00:00Z');
+      const stopAt = new Date('2024-06-05T14:30:00Z');
+      const result = await service.updateAutoSessionWindow(
+        win.uid,
+        { activeEnd: stopAt },
+        updateNow,
+      );
+
+      // Assert - the same row survives, still running, ending at stopAt.
+      if (typeof result === 'string')
+        throw new Error('update failed: ' + result);
+      const sameRow = (await listSessionsForRoom(roomUid)).find(
+        (s) => s.uid === activeAuto.uid,
+      );
+      if (!sameRow) throw new Error('the live AUTO row was deleted');
+      expect(sameRow.end_override).toBeNull();
+      expect(sameRow.scheduled_end_time).toEqual(stopAt);
+      const active = await service.findActiveSession(roomUid, updateNow);
+      if (active === 'ROOM_NOT_FOUND') throw new Error('room vanished');
+      expect(active?.uid).toBe(activeAuto.uid);
+    });
+
+    it('produces a session covering now for a window whose activeStart is now', async () => {
+      // Arrange - the mirror-image failure: today's occurrence started at
+      // 00:00, before activeStart, so the whole day used to disappear and the
+      // first session appeared only on the next local day.
+      const { uid: roomUid } = await insertRoom('UTC');
+      const now = new Date('2024-06-05T16:00:00Z');
+
+      // Act
+      const win = await service.createAutoSessionWindow(
+        {
+          roomUid,
+          activeStart: now,
+          activeEnd: null,
+          localStartTime: '00:00',
+          localEndTime: '23:59',
+          daysOfWeek: [...DAILY],
+          joinCodeScopes: [],
+          transcriptionProviderId: 'whisper',
+          transcriptionStreamConfig: {},
+        },
+        now,
+      );
+
+      // Assert
+      if (typeof win === 'string') throw new Error('create failed: ' + win);
+      const active = await service.findActiveSession(roomUid, now);
+      if (active === 'ROOM_NOT_FOUND') throw new Error('room vanished');
+      expect(active?.type).toBe('AUTO');
+      expect(active?.effectiveStart).toEqual(now);
+      expect(active?.effectiveEnd).toEqual(new Date('2024-06-05T23:59:00Z'));
+    });
+
+    it('clips a SCHEDULED occurrence to activeStart', async () => {
+      // Arrange - schedules go straight to `insertSessions` with no length
+      // check of their own, so this is the path the minimum-duration floor in
+      // the materializer exists for.
+      const { uid: roomUid } = await insertRoom('UTC', false);
+      const now = new Date('2024-06-04T12:00:00Z');
+      const activeStart = new Date('2024-06-05T10:00:00Z');
+
+      // Act
+      const created = await service.createSchedule(
+        {
+          roomUid,
+          name: 'All day',
+          activeStart,
+          activeEnd: new Date('2024-06-05T15:00:00Z'),
+          localStartTime: '00:00',
+          localEndTime: '23:59',
+          frequency: 'WEEKLY',
+          daysOfWeek: [...DAILY],
+          joinCodeScopes: [],
+          transcriptionProviderId: 'whisper',
+          transcriptionStreamConfig: {},
+        },
+        now,
+      );
+
+      // Assert - one SCHEDULED session, clipped at both ends.
+      if (typeof created === 'string')
+        throw new Error('create failed: ' + created);
+      const scheduled = (await listSessionsForRoom(roomUid)).filter(
+        (s) => s.type === 'SCHEDULED',
+      );
+      expect(scheduled).toHaveLength(1);
+      expect(scheduled[0]!.scheduled_start_time).toEqual(activeStart);
+      expect(scheduled[0]!.scheduled_end_time).toEqual(
+        new Date('2024-06-05T15:00:00Z'),
+      );
+    });
+
+    it('drops a residue shorter than the minimum instead of writing a degenerate session', async () => {
+      // Arrange - activeEnd 30 s after activeStart would leave a half-minute
+      // session; at exactly zero it would violate
+      // `sessions_scheduled_end_after_start` and surface as a 500.
+      const { uid: roomUid } = await insertRoom('UTC', false);
+      const now = new Date('2024-06-04T12:00:00Z');
+
+      // Act
+      const created = await service.createSchedule(
+        {
+          roomUid,
+          name: 'Sliver',
+          activeStart: new Date('2024-06-05T10:00:00Z'),
+          activeEnd: new Date('2024-06-05T10:00:30Z'),
+          localStartTime: '00:00',
+          localEndTime: '23:59',
+          frequency: 'WEEKLY',
+          daysOfWeek: [...DAILY],
+          joinCodeScopes: [],
+          transcriptionProviderId: 'whisper',
+          transcriptionStreamConfig: {},
+        },
+        now,
+      );
+
+      // Assert
+      if (typeof created === 'string')
+        throw new Error('create failed: ' + created);
+      const sessions = await listSessionsForRoom(roomUid);
+      expect(sessions).toEqual([]);
+    });
+
+    it('does not let a clipped occurrence overlap the session it abuts', async () => {
+      // Arrange - a clipped AUTO range must still respect the
+      // `sessions_no_overlap` exclusion constraint against a SCHEDULED
+      // session inside the same window.
+      const { uid: roomUid } = await insertRoom('UTC');
+      const now = new Date('2024-06-04T12:00:00Z');
+      const schedule = await service.createSchedule(
+        {
+          roomUid,
+          name: 'Lecture',
+          activeStart: new Date('2024-06-05T09:00:00Z'),
+          activeEnd: new Date('2024-06-05T11:00:00Z'),
+          localStartTime: '09:00',
+          localEndTime: '11:00',
+          frequency: 'WEEKLY',
+          daysOfWeek: [...DAILY],
+          joinCodeScopes: [],
+          transcriptionProviderId: 'whisper',
+          transcriptionStreamConfig: {},
+        },
+        now,
+      );
+      if (typeof schedule === 'string')
+        throw new Error('seed schedule failed: ' + schedule);
+
+      // Act - a daily window clipped to 08:00-15:00 on the same day.
+      const win = await service.createAutoSessionWindow(
+        {
+          roomUid,
+          activeStart: new Date('2024-06-05T08:00:00Z'),
+          activeEnd: new Date('2024-06-05T15:00:00Z'),
+          localStartTime: '00:00',
+          localEndTime: '23:59',
+          daysOfWeek: [...DAILY],
+          joinCodeScopes: [],
+          transcriptionProviderId: 'whisper',
+          transcriptionStreamConfig: {},
+        },
+        now,
+      );
+
+      // Assert - the transaction committed (the constraint is deferred to
+      // COMMIT, so a violation would surface as a throw here), and the AUTO
+      // sessions fill the window either side of the lecture.
+      if (typeof win === 'string') throw new Error('create failed: ' + win);
+      const sessions = await listSessionsForRoom(roomUid);
+      const autos = sessions.filter((s) => s.type === 'AUTO');
+      expect(
+        autos.map((a) => [a.scheduled_start_time, a.scheduled_end_time]),
+      ).toEqual([
+        [new Date('2024-06-05T08:00:00Z'), new Date('2024-06-05T09:00:00Z')],
+        [new Date('2024-06-05T11:00:00Z'), new Date('2024-06-05T15:00:00Z')],
+      ]);
+    });
+  });
 });

--- a/apps/session-manager/tests/unit/features/room-management/room-management.controller.test.ts
+++ b/apps/session-manager/tests/unit/features/room-management/room-management.controller.test.ts
@@ -446,6 +446,24 @@ describe('RoomManagementController', () => {
       });
     });
 
+    it("throws 409 naming set-source-device when service returns 'TOO_MANY_SOURCE_DEVICES'", async () => {
+      // Arrange - the operator has to be told which call does what they meant,
+      // or the refusal just looks like a bug in the console.
+      mockService.addDeviceToRoom.mockResolvedValue('TOO_MANY_SOURCE_DEVICES');
+      const mockReq = {
+        body: { roomUid: 'room-1', deviceUid: 'device-1', asSource: true },
+      };
+
+      // Act + Assert
+      await expect(
+        controller.addDeviceToRoom(mockReq as never, mockRes as never),
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        code: 'TOO_MANY_SOURCE_DEVICES',
+        message: expect.stringContaining('set-source-device') as string,
+      });
+    });
+
     it("throws 409 with a message naming the missing audio path when service returns 'DEMO_ROOM_NOT_ASSIGNABLE'", async () => {
       // Arrange - the refusal is only useful if the operator learns *why*, so
       // the message (not just the code) is asserted here.

--- a/apps/session-manager/tests/unit/features/room-management/room-management.service.test.ts
+++ b/apps/session-manager/tests/unit/features/room-management/room-management.service.test.ts
@@ -47,6 +47,7 @@ describe('RoomManagementService', () => {
     setSourceDevice: Mock;
     findRoomMembership: Mock;
     findRoomExists: Mock;
+    findSourceDeviceUid: Mock;
   };
   let mockDeviceRepo: { findById: Mock };
   let service: RoomManagementService;
@@ -63,6 +64,10 @@ describe('RoomManagementService', () => {
       setSourceDevice: vi.fn(),
       findRoomMembership: vi.fn(),
       findRoomExists: vi.fn(),
+      // Default: the room has no source device, so `asSource` attaches
+      // without tripping the one-source-per-room guard. Tests that exercise
+      // the guard override this.
+      findSourceDeviceUid: vi.fn().mockResolvedValue(undefined),
     };
     mockDeviceRepo = { findById: vi.fn() };
 
@@ -423,6 +428,94 @@ describe('RoomManagementService', () => {
 
       // Assert
       expect(result).toBeUndefined();
+    });
+
+    // The repository's `asSource` branch clears `is_source` across the whole
+    // room before inserting, so without this guard the call answers 204 and
+    // silently demotes the incumbent kiosk - which keeps its membership and
+    // its device token, still resolves the session, and is simply no longer
+    // granted SEND_AUDIO.
+    it("returns 'TOO_MANY_SOURCE_DEVICES' when the room already has a source and asSource is true", async () => {
+      // Arrange
+      mockRoomRepo.findRoomExists.mockResolvedValue(true);
+      mockDeviceRepo.findById.mockResolvedValue(mockDevice);
+      mockRoomRepo.findSourceDeviceUid.mockResolvedValue('incumbent-device');
+
+      // Act
+      const result = await service.addDeviceToRoom({
+        roomUid: 'room-1',
+        deviceUid: 'device-1',
+        asSource: true,
+      });
+
+      // Assert - and nothing was written, so the incumbent keeps SEND_AUDIO.
+      expect(result).toBe('TOO_MANY_SOURCE_DEVICES');
+      expect(mockRoomRepo.addDeviceToRoom).not.toHaveBeenCalled();
+    });
+
+    it('still attaches a non-source device to a room that already has a source', async () => {
+      // Arrange - the first half of the deliberate swap: attach as a plain
+      // member, then promote with `setSourceDevice`.
+      mockRoomRepo.findRoomExists.mockResolvedValue(true);
+      mockDeviceRepo.findById.mockResolvedValue(mockDevice);
+      mockRoomRepo.findSourceDeviceUid.mockResolvedValue('incumbent-device');
+      mockRoomRepo.addDeviceToRoom.mockResolvedValue(undefined);
+
+      // Act
+      const result = await service.addDeviceToRoom({
+        roomUid: 'room-1',
+        deviceUid: 'device-1',
+        asSource: false,
+      });
+
+      // Assert
+      expect(result).toBeUndefined();
+      expect(mockRoomRepo.addDeviceToRoom).toHaveBeenCalledWith(
+        'room-1',
+        'device-1',
+        false,
+      );
+    });
+
+    it('does not look up the room’s source when asSource is false', async () => {
+      // Arrange
+      mockRoomRepo.findRoomExists.mockResolvedValue(true);
+      mockDeviceRepo.findById.mockResolvedValue(mockDevice);
+      mockRoomRepo.addDeviceToRoom.mockResolvedValue(undefined);
+
+      // Act
+      await service.addDeviceToRoom({
+        roomUid: 'room-1',
+        deviceUid: 'device-1',
+        asSource: false,
+      });
+
+      // Assert
+      expect(mockRoomRepo.findSourceDeviceUid).not.toHaveBeenCalled();
+    });
+
+    it('accepts asSource on a room that has no source yet', async () => {
+      // Arrange - a room can transiently have no source (the trigger is
+      // row-level on `room_devices`, so an empty room fires nothing).
+      mockRoomRepo.findRoomExists.mockResolvedValue(true);
+      mockDeviceRepo.findById.mockResolvedValue(mockDevice);
+      mockRoomRepo.findSourceDeviceUid.mockResolvedValue(undefined);
+      mockRoomRepo.addDeviceToRoom.mockResolvedValue(undefined);
+
+      // Act
+      const result = await service.addDeviceToRoom({
+        roomUid: 'room-1',
+        deviceUid: 'device-1',
+        asSource: true,
+      });
+
+      // Assert
+      expect(result).toBeUndefined();
+      expect(mockRoomRepo.addDeviceToRoom).toHaveBeenCalledWith(
+        'room-1',
+        'device-1',
+        true,
+      );
     });
   });
 

--- a/apps/session-manager/tests/unit/features/schedule-management/schedule-management.controller.test.ts
+++ b/apps/session-manager/tests/unit/features/schedule-management/schedule-management.controller.test.ts
@@ -414,6 +414,27 @@ describe('ScheduleManagementController', () => {
         ),
       ).rejects.toMatchObject({ statusCode: 409, code: 'CONFLICT' });
     });
+
+    // Matches the schedule path exactly: 400 VALIDATION_ERROR with a sentence
+    // naming the problem, rather than the 500 the DB CHECK used to produce.
+    it("throws 400 when service returns 'INVALID_LOCAL_TIMES'", async () => {
+      // Arrange
+      mockScheduleService.createAutoSessionWindow.mockResolvedValue(
+        'INVALID_LOCAL_TIMES',
+      );
+
+      // Act + Assert
+      await expect(
+        controller.createAutoSessionWindow(
+          { body: makeBody() } as never,
+          mockRes as never,
+        ),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
+        message: 'localStartTime and localEndTime must not be equal.',
+      });
+    });
   });
 
   describe('getAutoSessionWindow', (it) => {
@@ -500,6 +521,25 @@ describe('ScheduleManagementController', () => {
           mockRes as never,
         ),
       ).rejects.toMatchObject({ statusCode: 409, code: 'CONFLICT' });
+    });
+
+    it("throws 400 when service returns 'INVALID_LOCAL_TIMES'", async () => {
+      // Arrange
+      mockScheduleService.updateAutoSessionWindow.mockResolvedValue(
+        'INVALID_LOCAL_TIMES',
+      );
+
+      // Act + Assert
+      await expect(
+        controller.updateAutoSessionWindow(
+          { body: { windowUid: 'win-1' } } as never,
+          mockRes as never,
+        ),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
+        message: 'localStartTime and localEndTime must not be equal.',
+      });
     });
   });
 

--- a/apps/session-manager/tests/unit/features/schedule-management/utils/schedule-materializer.test.ts
+++ b/apps/session-manager/tests/unit/features/schedule-management/utils/schedule-materializer.test.ts
@@ -76,9 +76,9 @@ describe('materializeSchedule', () => {
       expect(result).toHaveLength(0);
     });
 
-    it('drops the occurrence when occurrence start is before activeStart', () => {
-      // Arrange - activeStart is late in the day; localStartTime is earlier, so
-      // the computed UTC start would be before activeStart.
+    it('drops the occurrence when clipping to activeStart leaves nothing of it', () => {
+      // Arrange - activeStart is at the occurrence's own end, so clipping the
+      // start forward to activeStart leaves a zero-length residue.
       const schedule = makeSchedule({
         activeStart: new Date('2024-06-03T14:00:00Z'), // 14:00 UTC = 10:00 EDT
         frequency: 'ONCE',
@@ -125,7 +125,7 @@ describe('materializeSchedule', () => {
       expect(result[2]!.startUtc).toEqual(new Date('2024-06-07T14:00:00Z')); // Fri
     });
 
-    it('respects activeEnd and excludes occurrences whose end exceeds it', () => {
+    it('respects activeEnd and excludes occurrences that fall entirely beyond it', () => {
       // Arrange
       const schedule = makeSchedule({
         activeEnd: new Date('2024-06-05T14:30:00Z'), // Cuts off after Wed
@@ -143,12 +143,13 @@ describe('materializeSchedule', () => {
         new Date('2024-06-10T00:00:00Z'),
       );
 
-      // Assert - Mon and Wed qualify; Fri's end (14:30) > activeEnd (14:30 on Wed) - wait, activeEnd is Jun 5 14:30
-      // Fri Jun 7 14:30 > Jun 5 14:30 → excluded
-      // Wed Jun 5 14:30 <= Jun 5 14:30 → included
+      // Assert - Mon and Wed qualify. Wed ends exactly at activeEnd, so
+      // clipping is a no-op and it survives whole. Fri Jun 7 starts a full two
+      // days after activeEnd, so clipping leaves nothing at all and it goes.
       expect(result).toHaveLength(2);
       expect(result[0]!.startUtc).toEqual(new Date('2024-06-03T14:00:00Z'));
       expect(result[1]!.startUtc).toEqual(new Date('2024-06-05T14:00:00Z'));
+      expect(result[1]!.endUtc).toEqual(new Date('2024-06-05T14:30:00Z'));
     });
 
     it('includes an occurrence that started before windowStart but ends within it', () => {
@@ -425,6 +426,207 @@ describe('materializeSchedule', () => {
       expect(result).toHaveLength(1);
       expect(result[0]!.startUtc).toEqual(new Date('2024-06-03T13:00:00Z'));
       expect(result[0]!.endUtc).toEqual(new Date('2024-06-03T14:00:00Z'));
+    });
+  });
+
+  // Both ends of the active range used to *drop* an occurrence that straddled
+  // them. For the daily 00:00-23:59 window the admin console creates, every
+  // occurrence straddles both ends of any range that does not begin at
+  // midnight and finish at 23:59, so "auto sessions until 15:00" materialized
+  // nothing at all and "from now" materialized nothing until tomorrow.
+  describe('clipping to the active range', () => {
+    const DAILY = {
+      localStartTime: '00:00:00',
+      localEndTime: '23:59:00',
+      frequency: 'WEEKLY' as const,
+      daysOfWeek: ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'],
+    };
+
+    it('clips an occurrence to activeEnd instead of dropping it', () => {
+      // Arrange - a daily 00:00-23:59 window ending at 15:00 on Wednesday.
+      const schedule = makeSchedule({
+        ...DAILY,
+        activeStart: new Date('2024-06-05T00:00:00Z'),
+        activeEnd: new Date('2024-06-05T15:00:00Z'),
+      });
+
+      // Act
+      const result = materializeSchedule(
+        schedule,
+        TZ_UTC,
+        new Date('2024-06-05T00:00:00Z'),
+        new Date('2024-06-12T00:00:00Z'),
+      );
+
+      // Assert - one occurrence, running to activeEnd rather than to 23:59.
+      expect(result).toHaveLength(1);
+      expect(result[0]!.startUtc).toEqual(new Date('2024-06-05T00:00:00Z'));
+      expect(result[0]!.endUtc).toEqual(new Date('2024-06-05T15:00:00Z'));
+    });
+
+    it('clips an occurrence to activeStart instead of dropping it', () => {
+      // Arrange - the same daily window, starting at 16:00 on Wednesday.
+      const schedule = makeSchedule({
+        ...DAILY,
+        activeStart: new Date('2024-06-05T16:00:00Z'),
+        activeEnd: null,
+      });
+
+      // Act
+      const result = materializeSchedule(
+        schedule,
+        TZ_UTC,
+        new Date('2024-06-05T16:00:00Z'),
+        new Date('2024-06-07T00:00:00Z'),
+      );
+
+      // Assert - today's occurrence survives, starting at activeStart; the
+      // next day's is untouched.
+      expect(result).toHaveLength(2);
+      expect(result[0]!.startUtc).toEqual(new Date('2024-06-05T16:00:00Z'));
+      expect(result[0]!.endUtc).toEqual(new Date('2024-06-05T23:59:00Z'));
+      expect(result[1]!.startUtc).toEqual(new Date('2024-06-06T00:00:00Z'));
+    });
+
+    it('clips both ends of a single occurrence', () => {
+      // Arrange
+      const schedule = makeSchedule({
+        ...DAILY,
+        activeStart: new Date('2024-06-05T09:00:00Z'),
+        activeEnd: new Date('2024-06-05T15:00:00Z'),
+      });
+
+      // Act
+      const result = materializeSchedule(
+        schedule,
+        TZ_UTC,
+        new Date('2024-06-05T00:00:00Z'),
+        new Date('2024-06-12T00:00:00Z'),
+      );
+
+      // Assert
+      expect(result).toHaveLength(1);
+      expect(result[0]!.startUtc).toEqual(new Date('2024-06-05T09:00:00Z'));
+      expect(result[0]!.endUtc).toEqual(new Date('2024-06-05T15:00:00Z'));
+    });
+
+    it('drops a clipped residue shorter than the minimum session duration', () => {
+      // Arrange - activeEnd 30 s into the day leaves half a minute, which is
+      // shorter than a join-code handoff window and, at exactly zero, would
+      // violate `sessions_scheduled_end_after_start`.
+      const schedule = makeSchedule({
+        ...DAILY,
+        activeStart: new Date('2024-06-05T00:00:00Z'),
+        activeEnd: new Date('2024-06-05T00:00:30Z'),
+      });
+
+      // Act
+      const result = materializeSchedule(
+        schedule,
+        TZ_UTC,
+        new Date('2024-06-05T00:00:00Z'),
+        new Date('2024-06-12T00:00:00Z'),
+      );
+
+      // Assert
+      expect(result).toHaveLength(0);
+    });
+
+    it('keeps a clipped residue of exactly the minimum session duration', () => {
+      // Arrange - the boundary of the previous case.
+      const schedule = makeSchedule({
+        ...DAILY,
+        activeStart: new Date('2024-06-05T00:00:00Z'),
+        activeEnd: new Date('2024-06-05T00:01:00Z'),
+      });
+
+      // Act
+      const result = materializeSchedule(
+        schedule,
+        TZ_UTC,
+        new Date('2024-06-05T00:00:00Z'),
+        new Date('2024-06-12T00:00:00Z'),
+      );
+
+      // Assert
+      expect(result).toHaveLength(1);
+      expect(result[0]!.endUtc).toEqual(new Date('2024-06-05T00:01:00Z'));
+    });
+
+    it('leaves an unclipped occurrence shorter than the minimum alone', () => {
+      // Arrange - a 30-second occurrence the operator asked for explicitly.
+      // The floor applies to clipped residues, not to what was requested.
+      const schedule = makeSchedule({
+        activeStart: new Date('2024-06-03T00:00:00Z'),
+        activeEnd: null,
+        localStartTime: '09:00:00',
+        localEndTime: '09:00:30',
+        frequency: 'ONCE',
+        daysOfWeek: null,
+      });
+
+      // Act
+      const result = materializeSchedule(
+        schedule,
+        TZ_UTC,
+        new Date('2024-06-01T00:00:00Z'),
+        new Date('2024-06-30T00:00:00Z'),
+      );
+
+      // Assert
+      expect(result).toHaveLength(1);
+      expect(result[0]!.endUtc).toEqual(new Date('2024-06-03T09:00:30Z'));
+    });
+
+    it('clips on absolute instants, so a DST-shifted occurrence keeps the right ones', () => {
+      // Arrange - fall-back day. 01:30 local resolves to the standard-time
+      // instant 06:30 UTC, so the 00:30-01:30 occurrence really runs
+      // 04:30-06:30 UTC (two hours). An activeEnd of 06:00 UTC must clip it
+      // there - not to the daylight reading's 05:30, and not drop it.
+      const schedule = makeSchedule({
+        activeStart: new Date('2024-11-03T04:00:00Z'),
+        activeEnd: new Date('2024-11-03T06:00:00Z'),
+        localStartTime: '00:30:00',
+        localEndTime: '01:30:00',
+        frequency: 'ONCE',
+        daysOfWeek: null,
+      });
+
+      // Act
+      const result = materializeSchedule(
+        schedule,
+        TZ_NY,
+        new Date('2024-11-03T00:00:00Z'),
+        new Date('2024-11-04T00:00:00Z'),
+      );
+
+      // Assert
+      expect(result).toHaveLength(1);
+      expect(result[0]!.startUtc).toEqual(new Date('2024-11-03T04:30:00Z'));
+      expect(result[0]!.endUtc).toEqual(new Date('2024-11-03T06:00:00Z'));
+    });
+
+    it('still drops an occurrence that lies entirely outside the active range', () => {
+      // Arrange - Monday only, with an active range covering the Wednesday.
+      const schedule = makeSchedule({
+        activeStart: new Date('2024-06-05T00:00:00Z'),
+        activeEnd: new Date('2024-06-06T00:00:00Z'),
+        localStartTime: '09:00:00',
+        localEndTime: '10:00:00',
+        frequency: 'WEEKLY',
+        daysOfWeek: ['MON'],
+      });
+
+      // Act
+      const result = materializeSchedule(
+        schedule,
+        TZ_UTC,
+        new Date('2024-06-01T00:00:00Z'),
+        new Date('2024-06-30T00:00:00Z'),
+      );
+
+      // Assert
+      expect(result).toHaveLength(0);
     });
   });
 

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -80,7 +80,9 @@ DB_PASSWORD=CHANGEME
 # -- Database Backups -------
 # db-backup pg_dumps DB_NAME every BACKUP_INTERVAL_SECONDS and keeps
 # BACKUP_RETENTION_DAYS of it under BACKUP_OUTPUT_PATH. Runs by default -
-# these three are safe to leave as-is.
+# these three are safe to leave as-is. BACKUP_INTERVAL_SECONDS and
+# BACKUP_OFFSITE_METHOD below are also read by admin-server, which reports on
+# db-backup's health and configuration in Deployment Check.
 BACKUP_INTERVAL_SECONDS=14400
 BACKUP_RETENTION_DAYS=14
 BACKUP_OUTPUT_PATH=./db-backups

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -78,14 +78,37 @@ DB_USER=scribear
 DB_PASSWORD=CHANGEME
 
 # -- Database Backups -------
-# db-backup pg_dumps DB_NAME every BACKUP_INTERVAL_SECONDS and keeps
-# BACKUP_RETENTION_DAYS of it under BACKUP_OUTPUT_PATH. Runs by default -
-# these three are safe to leave as-is. BACKUP_INTERVAL_SECONDS and
-# BACKUP_OFFSITE_METHOD below are also read by admin-server, which reports on
-# db-backup's health and configuration in Deployment Check.
+# db-backup pg_dumps DB_NAME (plus a small pg_dumpall --globals-only for
+# roles) every BACKUP_INTERVAL_SECONDS and keeps BACKUP_RETENTION_DAYS of it
+# under BACKUP_OUTPUT_PATH. Runs by default - these three are safe to leave
+# as-is. BACKUP_INTERVAL_SECONDS, BACKUP_OFFSITE_METHOD and BACKUP_ENABLED
+# below are also read by admin-server, which reports on db-backup's health
+# and configuration in Deployment Check.
+#
+# This is a recovery POINT of up to BACKUP_INTERVAL_SECONDS, not a recovery
+# TIME: a failure 3h59m after the last good dump loses everything since, by
+# design - pg_dump is a periodic logical backup, not continuous WAL
+# archiving. If that RPO is too high for your data, look at a PITR tool
+# (pgBackRest, Barman) instead of shortening this interval indefinitely -
+# pg_dump's cost scales with database size, not with how often you run it.
 BACKUP_INTERVAL_SECONDS=14400
 BACKUP_RETENTION_DAYS=14
 BACKUP_OUTPUT_PATH=./db-backups
+
+# Set to false for a deployment on managed Postgres (RDS and similar) that
+# already has its own backups. db-backup idles rather than dumping, and
+# Deployment Check reports that as a deliberate choice instead of "no backup
+# found" forever.
+BACKUP_ENABLED=true
+
+# Optional at-rest encryption (GPG AES256, symmetric) for every dump this
+# writes or pushes offsite. Empty (the default) leaves dumps exactly as
+# pg_dump/pg_dumpall produce them: compressed, NOT encrypted - readable by
+# anyone with filesystem access to this host or the offsite one. Set this to
+# a high-entropy passphrase to encrypt every dump from then on; db-restore
+# needs the SAME value to read one back, and cannot decrypt one written under
+# a value that has since changed.
+BACKUP_ENCRYPTION_KEY=
 
 # Off-host copy of each dump, over scp or rsync-over-ssh. Local retention
 # above shares a disk with the database itself, so it does not survive losing
@@ -101,6 +124,12 @@ BACKUP_OFFSITE_PATH=
 # -f ./db-backup-ssh-key`, with its public half added to that account's
 # authorized_keys. Read whether or not BACKUP_OFFSITE_METHOD is set - unused
 # and safe to leave as the placeholder path below otherwise.
+#
+# The first connection to a new BACKUP_OFFSITE_HOST trusts whatever host key
+# it presents (`StrictHostKeyChecking=accept-new`) rather than refusing an
+# unknown one - simpler to set up, at the cost of trusting that first
+# connection. Pre-populate known_hosts yourself (mount it alongside the key
+# above) if that first-contact trust is not acceptable for your threat model.
 BACKUP_SSH_KEY_PATH=./db-backup-ssh-key
 
 # -- Telemetry Backplane ----

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -77,6 +77,30 @@ DB_NAME=scribear-db
 DB_USER=scribear
 DB_PASSWORD=CHANGEME
 
+# -- Database Backups -------
+# db-backup pg_dumps DB_NAME every BACKUP_INTERVAL_SECONDS and keeps
+# BACKUP_RETENTION_DAYS of it under BACKUP_OUTPUT_PATH. Runs by default -
+# these three are safe to leave as-is.
+BACKUP_INTERVAL_SECONDS=14400
+BACKUP_RETENTION_DAYS=14
+BACKUP_OUTPUT_PATH=./db-backups
+
+# Off-host copy of each dump, over scp or rsync-over-ssh. Local retention
+# above shares a disk with the database itself, so it does not survive losing
+# this host - set these to also get a copy somewhere else. Leave
+# BACKUP_OFFSITE_METHOD=none (the default) to skip this. rsync additionally
+# needs the `rsync` binary on the receiving host; scp does not.
+BACKUP_OFFSITE_METHOD=none
+BACKUP_OFFSITE_HOST=
+BACKUP_OFFSITE_PORT=22
+BACKUP_OFFSITE_USER=
+BACKUP_OFFSITE_PATH=
+# Private key for the account above, e.g. `ssh-keygen -t ed25519 -N ""
+# -f ./db-backup-ssh-key`, with its public half added to that account's
+# authorized_keys. Read whether or not BACKUP_OFFSITE_METHOD is set - unused
+# and safe to leave as the placeholder path below otherwise.
+BACKUP_SSH_KEY_PATH=./db-backup-ssh-key
+
 # -- Telemetry Backplane ----
 # Redis, used only by the monitoring/fleet view (B1.7). Nothing in the
 # transcription path reads or writes it. Consumers are gated on their own

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,59 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — db-backup hardening: retry, integrity check, opt-out, encryption (`compose.yml` v12)
+
+**Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. A
+stock deployment needs to do nothing new — every variable below defaults to
+today's behavior.
+
+A round of hardening on the backup service from v10/v11, from a code review
+after it shipped:
+
+- **Failed off-host pushes now retry.** Previously, a push that failed (the
+  offsite host down, say) was never retried — the next cycle pushed only its
+  own fresh dump, silently leaving the failed one un-pushed forever until
+  local retention pruned it. Each cycle now retries every not-yet-pushed dump
+  first, so a sustained outage closes the gap entirely once the offsite host
+  is reachable again, rather than leaving a permanent hole in the off-host
+  history.
+- **Every dump is integrity-checked before being kept.** `pg_dump` can exit 0
+  on an archive nothing can actually read back (catalog corruption, OOM
+  mid-dump). `pg_restore -l` now runs against every dump immediately, and a
+  dump that fails it is discarded rather than kept and pushed.
+- **`pg_dumpall --globals-only` runs alongside the main dump.** `pg_dump`
+  never covered roles; this closes that gap. Small and fast next to the main
+  dump, so it's not worth its own schedule.
+- **`BACKUP_ENABLED`** (default `true`) — set to `false` for a deployment on
+  managed Postgres (RDS and similar) that already has its own backups.
+  db-backup idles instead of dumping, and Deployment Check reports the choice
+  explicitly instead of "no backup found" forever.
+- **`BACKUP_ENCRYPTION_KEY`** (empty/off by default) — optional GPG AES256
+  encryption for every dump, at rest and in the offsite copy. Without it,
+  dumps are compressed but not encrypted — readable by anyone with
+  filesystem access to either host. db-restore needs the same value to read
+  an encrypted dump back.
+- **`start_period` on db-backup's healthcheck is now 30 minutes**, up from 2.
+  `pg_dump` is single-threaded, so a multi-GB database's first dump can
+  easily outrun a 2-minute grace period, which read an in-progress backup as
+  a failed container.
+- The `db-restore` comment claiming `--clean --if-exists` "overwrites" the
+  target database was wrong: it drops and recreates only what the dump
+  itself contains, not the whole database. Corrected; see the comment above
+  that service for what that means for a forward-migrated target.
+
+**Not changed, and worth knowing:** this remains a periodic logical backup
+(`pg_dump`), not continuous WAL archiving — the recovery point is up to
+`BACKUP_INTERVAL_SECONDS` old, by design, not an emergent property of a
+tuning knob. If that gap is too wide for your data, the alternative is a
+PITR tool (pgBackRest, Barman), not a shorter interval — `pg_dump`'s cost
+scales with database size. Also unchanged: the first connection to a new
+`BACKUP_OFFSITE_HOST` trusts its host key on faith
+(`StrictHostKeyChecking=accept-new`); pre-populate `known_hosts` yourself if
+that is not acceptable for your threat model.
+
+---
+
 ## Unreleased — Deployment Check reports on Postgres backups (`compose.yml` v11)
 
 **Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. A

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,32 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — Deployment Check reports on Postgres backups (`compose.yml` v11)
+
+**Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. A
+stock deployment needs to do nothing new — this only wires up reporting on
+the `db-backup` service from v10, above; no new required variable.
+
+`admin-server` gains a read-only bind mount of `db-backup`'s output directory
+and reads `BACKUP_OFFSITE_METHOD`/`BACKUP_INTERVAL_SECONDS` directly. `db-backup`
+has no HTTP surface for Config Check to probe the way every other dependency
+on that page is probed — it is a cron loop, not a service — so the shared
+bind mount is the only channel between the two containers. Deployment Check's
+**Config Check** now reports, under a new `backups` category:
+
+- **`backup-offsite-not-configured`** (advisory in development/staging,
+  warning in production) — `BACKUP_OFFSITE_METHOD` is still `none`, so
+  backups do not survive losing this host.
+- **`backup-none-found`** (advisory/warning/warning) — no `.dump` file has
+  landed yet. Expected for a short time after first bringing the stack up;
+  otherwise check `docker compose logs db-backup`.
+- **`backup-stale`** (warning in development, critical in staging/production)
+  — the newest backup is older than `BACKUP_INTERVAL_SECONDS` plus an hour of
+  grace, the same threshold `infra/scribear-db/backup-healthcheck.sh` uses, so
+  this finding and that container's `docker compose ps` health status agree.
+
+---
+
 ## Unreleased — periodic Postgres backups ship with the stack (`compose.yml` v10)
 
 **Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. Unlike

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,62 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — periodic Postgres backups ship with the stack (`compose.yml` v10)
+
+**Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. Unlike
+most entries below, a stock deployment is not a no-op here: a new `db-backup`
+service starts `pg_dump`ing `DB_NAME` every four hours and keeping 14 days of
+it under `./db-backups` (next to this file), from the moment you bring the new
+file up. Nothing else changes — no new required variable, no `:?`-guard.
+
+There is no external host script or crontab to set up. `db-backup` runs
+straight off the `scribear-db` image over the `backend` network with the same
+`DB_HOST`/`DB_USER`/`DB_PASSWORD` every other service already uses — no
+`docker exec`, no Docker socket. That was a deliberate choice over the more
+familiar shape (a cron entry on the host, `docker exec db pg_dumpall`): a host
+script has to be remembered and kept in sync on every box separately — the
+exact failure mode `run-migrator.sh` used to have, see `db-migrate` above —
+where anything in `compose.yml` reaches every environment the same way a
+`docker compose pull` already does.
+
+It reuses the `scribear-db` image rather than a generic Postgres client image
+so `pg_dump`'s version can never drift from the server it's backing up, and it
+does **not** use the `pg_cron` extension already loaded into that same image —
+`pg_cron` schedules SQL run *by* Postgres; it has no way to shell out to the
+external `pg_dump` client, which is what actually walks the catalogs to
+produce a dump.
+
+Six variables, all optional, tune it — see
+[`.env.example`](.env.example#L69) for the full set with defaults:
+
+| `.env` key | Default | What it does |
+| --- | --- | --- |
+| `BACKUP_INTERVAL_SECONDS` | `14400` (4h) | How often to dump |
+| `BACKUP_RETENTION_DAYS` | `14` | How long to keep local copies |
+| `BACKUP_OUTPUT_PATH` | `./db-backups` | Where dumps land on the host |
+| `BACKUP_OFFSITE_METHOD` | `none` | `none`, `scp`, or `rsync` — push each dump off this host too |
+| `BACKUP_OFFSITE_HOST` / `_PORT` / `_USER` / `_PATH` | *(empty)* | Where to push it, when the above is not `none` |
+| `BACKUP_SSH_KEY_PATH` | `./db-backup-ssh-key` | Private key for the offsite account |
+
+**Local retention alone does not survive losing this host** — it shares a disk
+with `postgres_data`. Set `BACKUP_OFFSITE_METHOD` to `scp` or `rsync` (the
+latter needs the `rsync` binary on the *receiving* host too) to also copy each
+dump somewhere else — another box you control, or anywhere else reachable over
+SSH. `db-backup`'s own healthcheck reports unhealthy in `docker compose ps` if
+no backup has landed in `BACKUP_OUTPUT_PATH` within one interval plus an hour
+of grace, so a stuck or misconfigured push shows up rather than failing
+silently.
+
+A profile-gated `db-restore` service ships alongside it —
+`RESTORE_FILE=<name>.dump docker compose --profile restore run --rm
+db-restore` — for restore drills and the real thing. It is not started by
+`up -d`; run it once against a scratch database (a separate `DB_NAME`, or a
+`compose.override.yml` pointed at a throwaway Postgres) to find out the
+restore path actually works before the day it has to. `pg_restore --clean
+--if-exists` **overwrites** whatever is already in the target database.
+
+---
+
 ## Unreleased — the capacity estimator's knobs are reachable from `.env` (`compose.yml` v9)
 
 **Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. **A

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -219,7 +219,7 @@ services:
       # Not `:?`-guarded, like DEPLOYMENT_ENV below and unlike the secrets: it
       # changes what is *reported*, never what runs, and must not be able to
       # stop a stack from starting.
-      COMPOSE_FILE_VERSION: "9"
+      COMPOSE_FILE_VERSION: "10"
       LOG_LEVEL: ${ADMIN_LOG_LEVEL:-info}
       ADMIN_API_KEY: ${SESSION_MANAGER_API_KEY}
       SESSION_MANAGER_BASE_URL: http://session-manager:80
@@ -356,6 +356,115 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+
+  # Periodic Postgres backups (compose.yml v10).
+  #
+  # Ships in the scribear-db image so `docker compose pull && up -d` alone
+  # keeps it current on every box, rather than a host crontab an operator has
+  # to remember to set up (and keep in sync) on every deployment separately -
+  # that was run-migrator.sh's failure mode, see the comment on db-migrate
+  # above. Runs by default: unlike most variables in this file, leaving
+  # everything below at its default does not make this a no-op - it starts
+  # writing dumps into BACKUP_OUTPUT_PATH on the first `up -d`.
+  #
+  # Reuses the scribear-db image, with a different entrypoint, rather than a
+  # stock postgres/alpine client image: pg_dump must track the server version
+  # it backs up, and a client pulled from a different tag or package repo
+  # could drift and fail a version check silently. Reaches Postgres over the
+  # `backend` network with the same DB_* variables every other service in
+  # this file already uses - no `docker exec`, no Docker socket.
+  #
+  # Not pg_cron, despite that extension already being loaded into this same
+  # image (see infra/scribear-db/entrypoint.sh): pg_cron schedules SQL
+  # statements executed BY Postgres. It has no way to shell out to the
+  # external pg_dump client, which is what actually walks the catalogs to
+  # produce a dump.
+  db-backup:
+    image: ${IMAGE_REGISTRY:-ghcr.io/scribear}/scribear-db:${IMAGE_TAG:-latest}
+    entrypoint: ["scribear-backup-entrypoint.sh"]
+    environment:
+      DB_HOST: ${DB_HOST:-scribear-db}
+      DB_PORT: ${DB_PORT:-5432}
+      DB_NAME: ${DB_NAME}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      # How often to dump, and how long to keep local copies. The 6x/day
+      # cadence (`10 */4 * * *`) this replaces is the default, so a deployment
+      # copying that schedule in sees no change.
+      BACKUP_INTERVAL_SECONDS: ${BACKUP_INTERVAL_SECONDS:-14400}
+      BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-14}
+      # Local retention shares a disk with postgres_data: it protects against
+      # a bad migration or an operator mistake, not against losing this host.
+      # Set BACKUP_OFFSITE_METHOD to also push each dump somewhere else -
+      # see deployment/UPGRADING.md and .env.example.
+      BACKUP_OFFSITE_METHOD: ${BACKUP_OFFSITE_METHOD:-none} # none | scp | rsync
+      BACKUP_OFFSITE_HOST: ${BACKUP_OFFSITE_HOST:-}
+      BACKUP_OFFSITE_PORT: ${BACKUP_OFFSITE_PORT:-22}
+      BACKUP_OFFSITE_USER: ${BACKUP_OFFSITE_USER:-}
+      BACKUP_OFFSITE_PATH: ${BACKUP_OFFSITE_PATH:-}
+    volumes:
+      - ${BACKUP_OUTPUT_PATH:-./db-backups}:/backups
+      # Harmless empty directory when BACKUP_OFFSITE_METHOD is "none" (the
+      # default) - the entrypoint only reads this path when it is scp or
+      # rsync. Point BACKUP_SSH_KEY_PATH at a real private key to use either.
+      - ${BACKUP_SSH_KEY_PATH:-./db-backup-ssh-key}:/keys/backup_key:ro
+    depends_on:
+      scribear-db:
+        condition: service_healthy
+    networks:
+      - backend
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "scribear-backup-healthcheck.sh"]
+      interval: 5m
+      timeout: 10s
+      retries: 1
+      start_period: 2m
+
+  # Manual, one-shot restore from a dump db-backup produced. Never started by
+  # `up -d` - profile-gated so an untested restore path does not sit there
+  # looking like coverage it has not earned. Run it once after setting this
+  # up, against a scratch database, to find out whether it actually works
+  # before the day it has to.
+  #
+  # `pg_restore --clean --if-exists` DROPS existing objects before recreating
+  # them - this overwrites whatever is currently in DB_NAME. Point DB_NAME (or
+  # a compose.override.yml) at a scratch database for a restore drill.
+  #
+  # `--no-owner` because the dump's ALTER OWNER commands name whatever DB_USER
+  # produced it - restoring under a differently-named role (a scratch DB on
+  # another box, say) fails every one of them otherwise. DB_USER is this
+  # stack's only role, so tables ending up owned by whichever role runs this
+  # restore is already correct here, not merely tolerated. Verified against a
+  # scratch database as part of building this: `--clean --if-exists` alone
+  # exits 1 on 20 ALTER OWNER errors even though every table and row restores
+  # correctly; adding `--no-owner` exits 0.
+  #
+  # Usage:
+  #   RESTORE_FILE=scribear-db-20260802T040000Z.dump \
+  #     docker compose --profile restore run --rm db-restore
+  db-restore:
+    profiles: ["restore"]
+    image: ${IMAGE_REGISTRY:-ghcr.io/scribear}/scribear-db:${IMAGE_TAG:-latest}
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        set -eu
+        : "$${RESTORE_FILE:?Set RESTORE_FILE to a filename under /backups, e.g. RESTORE_FILE=scribear-db-20260802T040000Z.dump}"
+        echo "Restoring /backups/$$RESTORE_FILE into $$DB_NAME @ $$DB_HOST - this OVERWRITES existing data there."
+        PGPASSWORD="$$DB_PASSWORD" pg_restore -h "$$DB_HOST" -p "$$DB_PORT" -U "$$DB_USER" -d "$$DB_NAME" --clean --if-exists --no-owner "/backups/$$RESTORE_FILE"
+    environment:
+      DB_HOST: ${DB_HOST:-scribear-db}
+      DB_PORT: ${DB_PORT:-5432}
+      DB_NAME: ${DB_NAME}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      RESTORE_FILE: ${RESTORE_FILE:-}
+    volumes:
+      - ${BACKUP_OUTPUT_PATH:-./db-backups}:/backups:ro
+    networks:
+      - backend
+    restart: "no"
 
   # Telemetry backplane for the fleet dashboard (B1.7).
   #

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -219,7 +219,7 @@ services:
       # Not `:?`-guarded, like DEPLOYMENT_ENV below and unlike the secrets: it
       # changes what is *reported*, never what runs, and must not be able to
       # stop a stack from starting.
-      COMPOSE_FILE_VERSION: "10"
+      COMPOSE_FILE_VERSION: "11"
       LOG_LEVEL: ${ADMIN_LOG_LEVEL:-info}
       ADMIN_API_KEY: ${SESSION_MANAGER_API_KEY}
       SESSION_MANAGER_BASE_URL: http://session-manager:80
@@ -273,6 +273,20 @@ services:
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
+      # db-backup's own settings (compose.yml v10), read directly rather than
+      # inferred: neither is a secret, and Config Check can state db-backup's
+      # actual configuration instead of guessing at it the way it has to for
+      # values that live only in another container's environment.
+      BACKUP_OFFSITE_METHOD: ${BACKUP_OFFSITE_METHOD:-none}
+      BACKUP_INTERVAL_SECONDS: ${BACKUP_INTERVAL_SECONDS:-14400}
+    volumes:
+      # Read-only: the only channel Config Check has into db-backup's health,
+      # since that container has no HTTP surface of its own to probe the way
+      # every other dependency on this page is probed. Same host path as
+      # db-backup/db-restore's own mount below, deliberately - three services
+      # agreeing on one bind mount rather than a fourth variable to keep in
+      # sync with it.
+      - ${BACKUP_OUTPUT_PATH:-./db-backups}:/backups:ro
     depends_on:
       session-manager:
         condition: service_healthy

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -219,7 +219,7 @@ services:
       # Not `:?`-guarded, like DEPLOYMENT_ENV below and unlike the secrets: it
       # changes what is *reported*, never what runs, and must not be able to
       # stop a stack from starting.
-      COMPOSE_FILE_VERSION: "11"
+      COMPOSE_FILE_VERSION: "12"
       LOG_LEVEL: ${ADMIN_LOG_LEVEL:-info}
       ADMIN_API_KEY: ${SESSION_MANAGER_API_KEY}
       SESSION_MANAGER_BASE_URL: http://session-manager:80
@@ -279,6 +279,7 @@ services:
       # values that live only in another container's environment.
       BACKUP_OFFSITE_METHOD: ${BACKUP_OFFSITE_METHOD:-none}
       BACKUP_INTERVAL_SECONDS: ${BACKUP_INTERVAL_SECONDS:-14400}
+      BACKUP_ENABLED: ${BACKUP_ENABLED:-true}
     volumes:
       # Read-only: the only channel Config Check has into db-backup's health,
       # since that container has no HTTP surface of its own to probe the way
@@ -402,11 +403,24 @@ services:
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
+      # Set to false for a deployment on managed Postgres (RDS and similar)
+      # that already has its own backups - db-backup idles rather than
+      # dumping, and admin-server's Deployment Check reports that as a
+      # deliberate choice instead of "no backup found" forever.
+      BACKUP_ENABLED: ${BACKUP_ENABLED:-true}
       # How often to dump, and how long to keep local copies. The 6x/day
       # cadence (`10 */4 * * *`) this replaces is the default, so a deployment
-      # copying that schedule in sees no change.
+      # copying that schedule in sees no change. This is a logical-backup
+      # interval, not a recovery point: a failure 3h59m after the last good
+      # dump loses everything since - see deployment/UPGRADING.md.
       BACKUP_INTERVAL_SECONDS: ${BACKUP_INTERVAL_SECONDS:-14400}
       BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-14}
+      # Optional at-rest encryption (GPG AES256, symmetric) for every dump
+      # this writes or pushes offsite - local retention and the offsite copy
+      # are both plaintext-readable without it. Empty leaves dumps as
+      # pg_dump/pg_dumpall already produce them: compressed, not encrypted.
+      # db-restore needs the same value to read an encrypted dump back.
+      BACKUP_ENCRYPTION_KEY: ${BACKUP_ENCRYPTION_KEY:-}
       # Local retention shares a disk with postgres_data: it protects against
       # a bad migration or an operator mistake, not against losing this host.
       # Set BACKUP_OFFSITE_METHOD to also push each dump somewhere else -
@@ -433,7 +447,11 @@ services:
       interval: 5m
       timeout: 10s
       retries: 1
-      start_period: 2m
+      # Generous on purpose: `pg_dump` is single-threaded, so a multi-GB
+      # database can take well past a couple of minutes for its first dump,
+      # and a `start_period` shorter than that reads a backup in progress as
+      # a failed container.
+      start_period: 30m
 
   # Manual, one-shot restore from a dump db-backup produced. Never started by
   # `up -d` - profile-gated so an untested restore path does not sit there
@@ -441,9 +459,15 @@ services:
   # up, against a scratch database, to find out whether it actually works
   # before the day it has to.
   #
-  # `pg_restore --clean --if-exists` DROPS existing objects before recreating
-  # them - this overwrites whatever is currently in DB_NAME. Point DB_NAME (or
-  # a compose.override.yml) at a scratch database for a restore drill.
+  # `pg_restore --clean --if-exists` drops and recreates every object PRESENT
+  # IN THE DUMP before restoring it - not a true overwrite. An object created
+  # in DB_NAME after the dump was taken (a table added by a later migration,
+  # say) is untouched and stays exactly as it was; only what the dump itself
+  # names gets dropped and rebuilt. For the documented restore-drill use case
+  # (a fresh scratch database) that distinction is moot - there is nothing
+  # else there. For a real disaster-recovery restore into a database that has
+  # migrated forward since the dump, `DROP DATABASE` first (or `pg_restore
+  # --create` against an empty cluster) for a true overwrite.
   #
   # `--no-owner` because the dump's ALTER OWNER commands name whatever DB_USER
   # produced it - restoring under a differently-named role (a scratch DB on
@@ -457,6 +481,12 @@ services:
   # Usage:
   #   RESTORE_FILE=scribear-db-20260802T040000Z.dump \
   #     docker compose --profile restore run --rm db-restore
+  #
+  # A `-globals-*.sql[.gpg]` file next to the dump (roles - see db-backup's
+  # pg_dumpall --globals-only) is not applied here. It matters only for a
+  # restore onto a cluster that never had DB_USER provisioned at all, which
+  # this stack's own scribear-db always does on first boot - apply it by hand
+  # with psql first if you are restoring onto a bare cluster that does not.
   db-restore:
     profiles: ["restore"]
     image: ${IMAGE_REGISTRY:-ghcr.io/scribear}/scribear-db:${IMAGE_TAG:-latest}
@@ -465,14 +495,24 @@ services:
       - |
         set -eu
         : "$${RESTORE_FILE:?Set RESTORE_FILE to a filename under /backups, e.g. RESTORE_FILE=scribear-db-20260802T040000Z.dump}"
-        echo "Restoring /backups/$$RESTORE_FILE into $$DB_NAME @ $$DB_HOST - this OVERWRITES existing data there."
-        PGPASSWORD="$$DB_PASSWORD" pg_restore -h "$$DB_HOST" -p "$$DB_PORT" -U "$$DB_USER" -d "$$DB_NAME" --clean --if-exists --no-owner "/backups/$$RESTORE_FILE"
+        SRC="/backups/$$RESTORE_FILE"
+        case "$$RESTORE_FILE" in
+          *.gpg)
+            : "$${BACKUP_ENCRYPTION_KEY:?$$RESTORE_FILE is encrypted - set BACKUP_ENCRYPTION_KEY to the value db-backup used to write it}"
+            DECRYPTED="/tmp/$$(basename "$$RESTORE_FILE" .gpg)"
+            printf '%s' "$$BACKUP_ENCRYPTION_KEY" | gpg --batch --yes --pinentry-mode loopback --decrypt --passphrase-fd 0 -o "$$DECRYPTED" "$$SRC"
+            SRC="$$DECRYPTED"
+            ;;
+        esac
+        echo "Restoring $$SRC into $$DB_NAME @ $$DB_HOST - drops and recreates every object present in that dump (see the comment above this service)."
+        PGPASSWORD="$$DB_PASSWORD" pg_restore -h "$$DB_HOST" -p "$$DB_PORT" -U "$$DB_USER" -d "$$DB_NAME" --clean --if-exists --no-owner "$$SRC"
     environment:
       DB_HOST: ${DB_HOST:-scribear-db}
       DB_PORT: ${DB_PORT:-5432}
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
+      BACKUP_ENCRYPTION_KEY: ${BACKUP_ENCRYPTION_KEY:-}
       RESTORE_FILE: ${RESTORE_FILE:-}
     volumes:
       - ${BACKUP_OUTPUT_PATH:-./db-backups}:/backups:ro

--- a/infra/scribear-db/Dockerfile
+++ b/infra/scribear-db/Dockerfile
@@ -19,9 +19,10 @@ RUN apk add --no-cache \
     && apk del build-base clang19 llvm19-dev curl
 
 # openssh-client + rsync for db-backup's optional off-host push (scp or
-# rsync-over-ssh, see deployment/compose.yml). Kept in the final image, unlike
-# the build-only deps above - this same image also runs as db-backup.
-RUN apk add --no-cache openssh-client rsync
+# rsync-over-ssh), gnupg for its optional at-rest encryption (BACKUP_ENCRYPTION_KEY)
+# - see deployment/compose.yml. Kept in the final image, unlike the build-only
+# deps above - this same image also runs as db-backup/db-restore.
+RUN apk add --no-cache openssh-client rsync gnupg
 
 COPY entrypoint.sh /usr/local/bin/scribear-entrypoint.sh
 COPY backup-entrypoint.sh /usr/local/bin/scribear-backup-entrypoint.sh

--- a/infra/scribear-db/Dockerfile
+++ b/infra/scribear-db/Dockerfile
@@ -18,8 +18,17 @@ RUN apk add --no-cache \
     && rm -rf /tmp/pg_cron.tar.gz "/tmp/pg_cron-${PG_CRON_VERSION}" \
     && apk del build-base clang19 llvm19-dev curl
 
+# openssh-client + rsync for db-backup's optional off-host push (scp or
+# rsync-over-ssh, see deployment/compose.yml). Kept in the final image, unlike
+# the build-only deps above - this same image also runs as db-backup.
+RUN apk add --no-cache openssh-client rsync
+
 COPY entrypoint.sh /usr/local/bin/scribear-entrypoint.sh
-RUN chmod +x /usr/local/bin/scribear-entrypoint.sh
+COPY backup-entrypoint.sh /usr/local/bin/scribear-backup-entrypoint.sh
+COPY backup-healthcheck.sh /usr/local/bin/scribear-backup-healthcheck.sh
+RUN chmod +x /usr/local/bin/scribear-entrypoint.sh \
+             /usr/local/bin/scribear-backup-entrypoint.sh \
+             /usr/local/bin/scribear-backup-healthcheck.sh
 ENTRYPOINT ["scribear-entrypoint.sh"]
 CMD []
 

--- a/infra/scribear-db/backup-entrypoint.sh
+++ b/infra/scribear-db/backup-entrypoint.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# db-backup's entire job: on a schedule, pg_dump $DB_NAME, keep
+# BACKUP_RETENTION_DAYS days of it under $BACKUP_DIR, and - if configured -
+# push each dump off this host over scp or rsync-over-ssh. See
+# deployment/UPGRADING.md.
+set -eu
+
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
+INTERVAL="${BACKUP_INTERVAL_SECONDS:-14400}"
+RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-14}"
+OFFSITE_METHOD="${BACKUP_OFFSITE_METHOD:-none}"
+SSH_KEY_MOUNT="/keys/backup_key"
+SSH_KEY_RUNTIME="/tmp/backup_ssh_key"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%FT%TZ)" "$*"
+}
+
+case "$OFFSITE_METHOD" in
+  none)
+    ;;
+  scp | rsync)
+    : "${BACKUP_OFFSITE_HOST:?BACKUP_OFFSITE_METHOD=$OFFSITE_METHOD needs BACKUP_OFFSITE_HOST}"
+    : "${BACKUP_OFFSITE_USER:?BACKUP_OFFSITE_METHOD=$OFFSITE_METHOD needs BACKUP_OFFSITE_USER}"
+    : "${BACKUP_OFFSITE_PATH:?BACKUP_OFFSITE_METHOD=$OFFSITE_METHOD needs BACKUP_OFFSITE_PATH}"
+    if [ ! -s "$SSH_KEY_MOUNT" ]; then
+      log "BACKUP_SSH_KEY_PATH does not point at a readable private key - refusing to start."
+      exit 1
+    fi
+    # Copied out of the read-only bind mount because ssh/scp/rsync refuse a
+    # key with group/other permission bits set, and a `:ro` mount cannot be
+    # chmod'd in place.
+    cp "$SSH_KEY_MOUNT" "$SSH_KEY_RUNTIME"
+    chmod 600 "$SSH_KEY_RUNTIME"
+    ;;
+  *)
+    log "Unknown BACKUP_OFFSITE_METHOD '$OFFSITE_METHOD' (expected none, scp or rsync) - refusing to start."
+    exit 1
+    ;;
+esac
+
+mkdir -p "$BACKUP_DIR"
+
+push_offsite() {
+  file="$1"
+  dest="${BACKUP_OFFSITE_USER}@${BACKUP_OFFSITE_HOST}:${BACKUP_OFFSITE_PATH%/}/"
+  case "$OFFSITE_METHOD" in
+    scp)
+      scp -i "$SSH_KEY_RUNTIME" -P "${BACKUP_OFFSITE_PORT:-22}" \
+        -o StrictHostKeyChecking=accept-new \
+        "$file" "$dest"
+      ;;
+    rsync)
+      rsync -az -e "ssh -i $SSH_KEY_RUNTIME -p ${BACKUP_OFFSITE_PORT:-22} -o StrictHostKeyChecking=accept-new" \
+        "$file" "$dest"
+      ;;
+  esac
+}
+
+run_backup() {
+  ts="$(date -u +%Y%m%dT%H%M%SZ)"
+  file="$BACKUP_DIR/${DB_NAME}-${ts}.dump"
+  tmp="${file}.tmp"
+
+  log "Starting pg_dump of ${DB_NAME}@${DB_HOST} -> ${file}"
+  # --lock-wait-timeout, not because the dump would otherwise deadlock, but so
+  # an ACCESS SHARE lock queued behind a db-migrate DDL run during a deploy
+  # fails fast and retries next cycle instead of stalling that migration.
+  if PGPASSWORD="$DB_PASSWORD" pg_dump \
+       -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+       --lock-wait-timeout=5000 -Fc -f "$tmp"
+  then
+    mv "$tmp" "$file"
+    log "Backup complete: ${file} ($(du -h "$file" | cut -f1))"
+    if [ "$OFFSITE_METHOD" != "none" ]; then
+      if push_offsite "$file"; then
+        log "Pushed ${file} to ${BACKUP_OFFSITE_HOST} via ${OFFSITE_METHOD}"
+      else
+        log "WARNING: offsite push of ${file} failed - local copy retained, will retry next cycle with a fresh dump"
+      fi
+    fi
+  else
+    log "WARNING: pg_dump failed - no backup written this cycle"
+    rm -f "$tmp"
+  fi
+
+  find "$BACKUP_DIR" -name "${DB_NAME}-*.dump" -mtime "+${RETENTION_DAYS}" -delete
+}
+
+log "db-backup starting: interval=${INTERVAL}s retention=${RETENTION_DAYS}d offsite=${OFFSITE_METHOD}"
+while true; do
+  run_backup
+  sleep "$INTERVAL"
+done

--- a/infra/scribear-db/backup-entrypoint.sh
+++ b/infra/scribear-db/backup-entrypoint.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
-# db-backup's entire job: on a schedule, pg_dump $DB_NAME, keep
-# BACKUP_RETENTION_DAYS days of it under $BACKUP_DIR, and - if configured -
-# push each dump off this host over scp or rsync-over-ssh. See
-# deployment/UPGRADING.md.
+# db-backup's entire job: on a schedule, pg_dump $DB_NAME (plus a small
+# pg_dumpall --globals-only alongside it, for the roles pg_dump does not
+# cover), keep BACKUP_RETENTION_DAYS days of both under $BACKUP_DIR, and - if
+# configured - push each one off this host over scp or rsync-over-ssh,
+# retrying any that failed to push on a prior cycle before creating a new
+# one. See deployment/UPGRADING.md.
 set -eu
 
 BACKUP_DIR="${BACKUP_DIR:-/backups}"
 INTERVAL="${BACKUP_INTERVAL_SECONDS:-14400}"
 RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-14}"
 OFFSITE_METHOD="${BACKUP_OFFSITE_METHOD:-none}"
+ENABLED="${BACKUP_ENABLED:-true}"
+ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY:-}"
 SSH_KEY_MOUNT="/keys/backup_key"
 SSH_KEY_RUNTIME="/tmp/backup_ssh_key"
 
@@ -16,9 +20,41 @@ log() {
   printf '[%s] %s\n' "$(date -u +%FT%TZ)" "$*"
 }
 
-case "$OFFSITE_METHOD" in
-  none)
+is_positive_int() {
+  case "$1" in
+    '' | *[!0-9]*) return 1 ;;
+    0) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+is_positive_int "$INTERVAL" || {
+  log "BACKUP_INTERVAL_SECONDS must be a positive integer, got '${INTERVAL}' - refusing to start."
+  exit 1
+}
+is_positive_int "$RETENTION_DAYS" || {
+  log "BACKUP_RETENTION_DAYS must be a positive integer, got '${RETENTION_DAYS}' - refusing to start."
+  exit 1
+}
+
+case "$ENABLED" in
+  true) ;;
+  false)
+    log "BACKUP_ENABLED=false - idling. No backups will be taken until this is unset or set to true."
+    # A long sleep loop rather than exiting: an exited container reads as
+    # crashed in `docker compose ps`, and `restart: unless-stopped` would just
+    # start it again anyway. `scribear-backup-healthcheck.sh` reads this same
+    # variable and reports healthy while idling, for the same reason.
+    while true; do sleep 3600; done
     ;;
+  *)
+    log "BACKUP_ENABLED must be true or false, got '${ENABLED}' - refusing to start."
+    exit 1
+    ;;
+esac
+
+case "$OFFSITE_METHOD" in
+  none) ;;
   scp | rsync)
     : "${BACKUP_OFFSITE_HOST:?BACKUP_OFFSITE_METHOD=$OFFSITE_METHOD needs BACKUP_OFFSITE_HOST}"
     : "${BACKUP_OFFSITE_USER:?BACKUP_OFFSITE_METHOD=$OFFSITE_METHOD needs BACKUP_OFFSITE_USER}"
@@ -34,12 +70,21 @@ case "$OFFSITE_METHOD" in
     chmod 600 "$SSH_KEY_RUNTIME"
     ;;
   *)
-    log "Unknown BACKUP_OFFSITE_METHOD '$OFFSITE_METHOD' (expected none, scp or rsync) - refusing to start."
+    log "Unknown BACKUP_OFFSITE_METHOD '${OFFSITE_METHOD}' (expected none, scp or rsync) - refusing to start."
     exit 1
     ;;
 esac
 
 mkdir -p "$BACKUP_DIR"
+
+# Cleared once each scratch file has been dealt with, so a SIGTERM or crash
+# mid-dump/mid-encrypt never leaves an unencrypted or partial file sitting in
+# $BACKUP_DIR - only ever whatever `CURRENT_TMP` names at the moment of exit.
+CURRENT_TMP=""
+cleanup_tmp() {
+  [ -n "$CURRENT_TMP" ] && rm -f "$CURRENT_TMP"
+}
+trap cleanup_tmp EXIT INT TERM
 
 push_offsite() {
   file="$1"
@@ -57,37 +102,136 @@ push_offsite() {
   esac
 }
 
-run_backup() {
+# Pushes $1 unless a `.pushed` marker next to it says a prior cycle already
+# did, and marks it on success. The marker - not the offsite host - is the
+# source of truth for "was this pushed", so retrying costs one stat per file
+# per cycle rather than a directory listing on the remote end.
+push_if_unpushed() {
+  file="$1"
+  [ -f "${file}.pushed" ] && return 0
+  if push_offsite "$file"; then
+    touch "${file}.pushed"
+    log "Pushed ${file} to ${BACKUP_OFFSITE_HOST} via ${OFFSITE_METHOD}"
+  else
+    log "WARNING: offsite push of ${file} failed - local copy retained, will retry next cycle"
+    return 1
+  fi
+}
+
+# Retries every unpushed dump/globals file before this cycle creates a new
+# one. Without this, a sustained offsite outage created a permanent gap: the
+# original version of this script only ever pushed the file it had just
+# created, so anything produced while the offsite host was unreachable was
+# never pushed once it recovered - it just aged out of local retention
+# unpushed. This closes that: every cycle sweeps for leftovers first.
+retry_unpushed() {
+  [ "$OFFSITE_METHOD" = "none" ] && return 0
+  for f in "$BACKUP_DIR/${DB_NAME}"-*.dump "$BACKUP_DIR/${DB_NAME}"-*.dump.gpg \
+    "$BACKUP_DIR/${DB_NAME}"-globals-*.sql "$BACKUP_DIR/${DB_NAME}"-globals-*.sql.gpg; do
+    [ -e "$f" ] || continue
+    push_if_unpushed "$f" || true
+  done
+}
+
+# Encrypts $1 (a scratch file holding plaintext) to $2 when
+# BACKUP_ENCRYPTION_KEY is set, appending `.gpg`; otherwise just moves it to
+# $2 unchanged. Callers always produce plaintext first and let this decide
+# what actually lands in $BACKUP_DIR, so the integrity check in run_dump
+# below runs on plaintext regardless of whether encryption is on.
+finalize() {
+  src="$1"
+  dest="$2"
+  if [ -n "$ENCRYPTION_KEY" ]; then
+    printf '%s' "$ENCRYPTION_KEY" |
+      gpg --batch --yes --pinentry-mode loopback --symmetric --cipher-algo AES256 \
+        --passphrase-fd 0 -o "${dest}.gpg" "$src"
+    rm -f "$src"
+  else
+    mv "$src" "$dest"
+  fi
+}
+
+run_dump() {
   ts="$(date -u +%Y%m%dT%H%M%SZ)"
   file="$BACKUP_DIR/${DB_NAME}-${ts}.dump"
-  tmp="${file}.tmp"
+  CURRENT_TMP="${file}.tmp"
 
   log "Starting pg_dump of ${DB_NAME}@${DB_HOST} -> ${file}"
   # --lock-wait-timeout, not because the dump would otherwise deadlock, but so
   # an ACCESS SHARE lock queued behind a db-migrate DDL run during a deploy
   # fails fast and retries next cycle instead of stalling that migration.
-  if PGPASSWORD="$DB_PASSWORD" pg_dump \
-       -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
-       --lock-wait-timeout=5000 -Fc -f "$tmp"
-  then
-    mv "$tmp" "$file"
-    log "Backup complete: ${file} ($(du -h "$file" | cut -f1))"
-    if [ "$OFFSITE_METHOD" != "none" ]; then
-      if push_offsite "$file"; then
-        log "Pushed ${file} to ${BACKUP_OFFSITE_HOST} via ${OFFSITE_METHOD}"
-      else
-        log "WARNING: offsite push of ${file} failed - local copy retained, will retry next cycle with a fresh dump"
-      fi
-    fi
-  else
+  if ! PGPASSWORD="$DB_PASSWORD" pg_dump \
+    -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+    --lock-wait-timeout=5000 -Fc -f "$CURRENT_TMP"; then
     log "WARNING: pg_dump failed - no backup written this cycle"
-    rm -f "$tmp"
+    rm -f "$CURRENT_TMP"
+    CURRENT_TMP=""
+    return
   fi
 
-  find "$BACKUP_DIR" -name "${DB_NAME}-*.dump" -mtime "+${RETENTION_DAYS}" -delete
+  # A dump pg_dump exits 0 on can still be an archive nothing can read back -
+  # catalog corruption or OOM mid-dump both complete with exit 0. Listing it
+  # is the cheapest check that catches that here rather than on restore day.
+  if ! pg_restore -l "$CURRENT_TMP" >/dev/null 2>&1; then
+    log "WARNING: pg_dump exited 0 but the archive failed pg_restore -l - discarding"
+    rm -f "$CURRENT_TMP"
+    CURRENT_TMP=""
+    return
+  fi
+
+  finalize "$CURRENT_TMP" "$file"
+  CURRENT_TMP=""
+  [ -n "$ENCRYPTION_KEY" ] && file="${file}.gpg"
+  log "Backup complete: ${file} ($(du -h "$file" | cut -f1))"
+
+  if [ "$OFFSITE_METHOD" != "none" ]; then
+    push_if_unpushed "$file" || true
+  fi
 }
 
-log "db-backup starting: interval=${INTERVAL}s retention=${RETENTION_DAYS}d offsite=${OFFSITE_METHOD}"
+# Cluster-level objects pg_dump does not cover - roles, in this stack's case,
+# since DB_USER is the only one it needs to restore. Small and fast next to
+# the main dump, so it runs every cycle rather than on a schedule of its own.
+run_globals() {
+  ts="$(date -u +%Y%m%dT%H%M%SZ)"
+  file="$BACKUP_DIR/${DB_NAME}-globals-${ts}.sql"
+  CURRENT_TMP="${file}.tmp"
+
+  if ! PGPASSWORD="$DB_PASSWORD" pg_dumpall \
+    -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" \
+    --globals-only -f "$CURRENT_TMP"; then
+    log "WARNING: pg_dumpall --globals-only failed - no globals backup written this cycle"
+    rm -f "$CURRENT_TMP"
+    CURRENT_TMP=""
+    return
+  fi
+
+  finalize "$CURRENT_TMP" "$file"
+  CURRENT_TMP=""
+  [ -n "$ENCRYPTION_KEY" ] && file="${file}.gpg"
+
+  if [ "$OFFSITE_METHOD" != "none" ]; then
+    push_if_unpushed "$file" || true
+  fi
+}
+
+prune_retention() {
+  find "$BACKUP_DIR" \
+    \( -name "${DB_NAME}-*.dump" -o -name "${DB_NAME}-*.dump.gpg" \
+    -o -name "${DB_NAME}-*.dump.pushed" -o -name "${DB_NAME}-*.dump.gpg.pushed" \
+    -o -name "${DB_NAME}-globals-*.sql" -o -name "${DB_NAME}-globals-*.sql.gpg" \
+    -o -name "${DB_NAME}-globals-*.sql.pushed" -o -name "${DB_NAME}-globals-*.sql.gpg.pushed" \) \
+    -mtime "+${RETENTION_DAYS}" -delete
+}
+
+run_backup() {
+  retry_unpushed
+  run_dump
+  run_globals
+  prune_retention
+}
+
+log "db-backup starting: interval=${INTERVAL}s retention=${RETENTION_DAYS}d offsite=${OFFSITE_METHOD} encryption=$([ -n "$ENCRYPTION_KEY" ] && echo on || echo off)"
 while true; do
   run_backup
   sleep "$INTERVAL"

--- a/infra/scribear-db/backup-healthcheck.sh
+++ b/infra/scribear-db/backup-healthcheck.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Fails if no backup has landed in $BACKUP_DIR within the current interval
+# plus an hour of grace, so a stuck or crash-looping db-backup shows as
+# unhealthy in `docker compose ps` instead of silently stopping protecting
+# anything.
+set -eu
+
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
+INTERVAL="${BACKUP_INTERVAL_SECONDS:-14400}"
+MAX_AGE_MIN=$(( (INTERVAL + 3600) / 60 ))
+
+find "$BACKUP_DIR" -name '*.dump' -mmin "-${MAX_AGE_MIN}" 2>/dev/null | grep -q .

--- a/infra/scribear-db/backup-healthcheck.sh
+++ b/infra/scribear-db/backup-healthcheck.sh
@@ -5,8 +5,12 @@
 # anything.
 set -eu
 
+# Always healthy while idling: BACKUP_ENABLED=false means db-backup is
+# deliberately not dumping, so there is nothing here to be stuck on.
+[ "${BACKUP_ENABLED:-true}" = "false" ] && exit 0
+
 BACKUP_DIR="${BACKUP_DIR:-/backups}"
 INTERVAL="${BACKUP_INTERVAL_SECONDS:-14400}"
 MAX_AGE_MIN=$(( (INTERVAL + 3600) / 60 ))
 
-find "$BACKUP_DIR" -name '*.dump' -mmin "-${MAX_AGE_MIN}" 2>/dev/null | grep -q .
+find "$BACKUP_DIR" \( -name '*.dump' -o -name '*.dump.gpg' \) -mmin "-${MAX_AGE_MIN}" 2>/dev/null | grep -q .

--- a/libs/schemas/session-manager-schema/src/room-management/routes/add-device-to-room.schema.ts
+++ b/libs/schemas/session-manager-schema/src/room-management/routes/add-device-to-room.schema.ts
@@ -16,7 +16,7 @@ import { ROOM_MANAGEMENT_TAG } from '#src/tags.js';
 
 const ADD_DEVICE_TO_ROOM_SCHEMA = {
   description:
-    'Attach a device to a room. If the device already belongs to another room it is first detached from that room in the same transaction. Setting a device as source replaces existing source device in room. Refused with 409 when either side is part of the synthetic demo caption room, which has no audio path.',
+    'Attach a device to a room. If the device already belongs to another room it is first detached from that room in the same transaction. `asSource` is refused with 409 TOO_MANY_SOURCE_DEVICES when the room already has a source device - replacing a source is set-source-device’s job, so that a swap is always deliberate rather than a side effect of attaching a device. Refused with 409 when either side is part of the synthetic demo caption room, which has no audio path.',
   tags: [ROOM_MANAGEMENT_TAG],
   security: ADMIN_API_KEY_SECURITY,
   headers: Type.Object({

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,8 @@
       "devDependencies": {
         "@eslint-react/eslint-plugin": "5.18.0",
         "eslint-plugin-react-hooks": "7.1.1",
-        "eslint-plugin-react-refresh": "0.5.3"
+        "eslint-plugin-react-refresh": "0.5.3",
+        "jsdom": "29.1.1"
       }
     },
     "apps/monitoring-sidecar": {

--- a/tools/session-corner-cases/README.md
+++ b/tools/session-corner-cases/README.md
@@ -75,6 +75,17 @@ has sat at 5/6 ever since.
 
 ## Bugs this suite found
 
+All three were fixed in `2026-08-01-SessionBugFixes`; the assertions that used
+to pin the broken behaviour now assert the correct behaviour, which is what
+turned them red and forced this section to be rewritten. They are kept here
+because the defect explains why the check is shaped the way it is.
+
+### Numbering
+
+`BUG-n` / `QUIRK-n` are stable identifiers, not a sequence: they are not
+renumbered when one is fixed, so a label in an old run log or commit message
+still resolves. `QUIRK-4` being the only surviving pin is expected.
+
 ### BUG-1 — an auto-session window with equal local times answered 500
 
 `create-auto-session-window` and `update-auto-session-window` had **no
@@ -155,17 +166,17 @@ half.
 the old drop behaviour as its discriminator and had to be rebuilt around
 clipping — see "What is checked" below.
 
-### BUG-3 — `add-device-to-room` silently demotes a room's source device
+### BUG-3 — `add-device-to-room` silently demoted a room's source device
 
-`add-device-to-room` **publishes a `409 TOO_MANY_SOURCE_DEVICES` reply that
-nothing can produce**: that code is only ever returned by `createRoom`.
-`RoomManagementService.addDeviceToRoom` runs no "this room already has a source"
+`add-device-to-room` **published a `409 TOO_MANY_SOURCE_DEVICES` reply that
+nothing could produce**: that code was only ever returned by `createRoom`.
+`RoomManagementService.addDeviceToRoom` ran no "this room already has a source"
 check, and `RoomManagementRepository.addDeviceToRoom` clears `is_source` across
-the entire room before inserting when `asSource` is true. So the call succeeds
-with `204` and swaps the room's source out from under the operator.
+the entire room before inserting when `asSource` is true. So the call succeeded
+with `204` and swapped the room's source out from under the operator.
 
-The victim keeps its room membership and its long-lived `DEVICE_TOKEN`, still
-sees the session through `my-schedule`, and still gets a session token — with
+The victim kept its room membership and its long-lived `DEVICE_TOKEN`, still
+saw the session through `my-schedule`, and still got a session token — with
 `["RECEIVE_TRANSCRIPTIONS"]` instead of `["SEND_AUDIO","RECEIVE_TRANSCRIPTIONS"]`.
 That is a kiosk that starts, connects, shows a join code, and sends no audio,
 with nothing anywhere reporting a fault.
@@ -175,25 +186,19 @@ the reserved rooms — "Promoting some other device to source silently demotes t
 synthetic source, which then still authenticates and still finds the session but
 is no longer granted SEND_AUDIO, so the operator sees a device that starts and
 sends nothing" — and guards `TEST_AUDIO_ROOM_NOT_ASSIGNABLE` /
-`CANARY_ROOM_NOT_ASSIGNABLE` against. Ordinary teaching rooms have no such
-guard.
+`CANARY_ROOM_NOT_ASSIGNABLE` against. Ordinary teaching rooms had no such guard.
 
-Minimal reproduction:
+`asSource` on a room that already has a source is now refused with the 409 the
+route always published. Replacing a source is a real operator need — kiosk
+hardware breaks — so it keeps working, as the two deliberate calls it always
+should have been: attach with `asSource: false`, then `set-source-device`. Both
+admin-console callers (the kiosk wizard's "add to an existing room" and the room
+detail page's "add as source device") now do exactly that, because every room
+has a source and so both of those were _always_ swaps.
 
-```bash
-# room R with source device D1, live session S; D2 registered and activated, in no room
-curl -sk -X POST .../room-management/add-device-to-room -H "authorization: Bearer $KEY" \
-  -H 'content-type: application/json' \
-  -d '{"roomUid":"R","deviceUid":"D2","asSource":true}'          # 204
-
-curl -sk -X POST .../session-auth/exchange-device-token -H "cookie: DEVICE_TOKEN=<D1>" \
-  -H 'content-type: application/json' -d '{"sessionUid":"S"}'
-# 200 {"scopes":["RECEIVE_TRANSCRIPTIONS"]}      <- was ["SEND_AUDIO", ...]
-```
-
-Suggested fix: return the already-published `TOO_MANY_SOURCE_DEVICES` when
-`asSource` is true and the room has a source, and leave deliberate swaps to
-`set-source-device`. Pinned by `a-room-takes-exactly-one-source-device`.
+Asserted by `a-room-takes-exactly-one-source-device`, which checks the 409, that
+the incumbent keeps `SEND_AUDIO` afterwards, and that the attach-then-promote
+path completes the swap (new device gains `SEND_AUDIO`, old one loses it).
 
 ## Questionable-but-current behaviour also pinned
 
@@ -304,7 +309,9 @@ behaviour (BUG-1 ×2, BUG-2 ×2, BUG-3 ×3, QUIRK-3 ×2, QUIRK-4 ×1).
 
 ### Rooms / devices
 
-- exactly one source device per room (BUG-3).
+- exactly one source device per room: `add-device-to-room` with `asSource`
+  is `409 TOO_MANY_SOURCE_DEVICES` when the room has one, and the deliberate
+  swap through `set-source-device` still works (BUG-3).
 - a device cannot belong to two rooms.
 - a room's source device cannot be deleted or detached.
 - deleting a room with a live session cascades the session and kills its join

--- a/tools/session-corner-cases/README.md
+++ b/tools/session-corner-cases/README.md
@@ -100,44 +100,60 @@ deeper; both are fixed.
 Asserted by `equal-local-start-and-end-times-are-refused-on-schedules-and-windows`,
 whose update leg deliberately sends `08:00` against a stored `08:00:00`.
 
-### BUG-2 — `activeEnd` inside an occurrence deletes the occurrence instead of clipping it
+### BUG-2 — an occurrence straddling either end of the active range was dropped, not clipped
 
-`inRange` (`schedule-materializer.ts`) rejects an occurrence outright when
-`occ.endUtc > schedule.activeEnd`:
+`inRange` (`schedule-materializer.ts`) rejected an occurrence outright at both
+ends of the schedule's active range:
 
 ```ts
+if (occ.startUtc < schedule.activeStart) return false;
 if (schedule.activeEnd && occ.endUtc > schedule.activeEnd) return false;
 ```
 
-For the shape the admin console actually creates — a daily `00:00–23:59` window
-— that means **any** `activeEnd` before `23:59` removes the whole day, not the
-tail of it. Two operator-visible consequences, both reproduced by the suite:
+For the shape the admin console actually creates — a daily `00:00-23:59` window
+— _every_ occurrence straddles both ends of any active range that does not
+begin at midnight and finish at 23:59. Three operator-visible consequences, all
+reproduced by the suite before the fix:
 
-1. Creating "auto sessions every day, until 30 minutes from now" produces **no
+1. Creating "auto sessions every day, until 30 minutes from now" produced **no
    auto session at all**, not a 30-minute one.
 2. Narrowing a **live** window (`update-auto-session-window` with an `activeEnd`
-   later today) **ends the AUTO session that is running right now**. The
-   reconciler finds no window occurrence covering the active session's start, so
-   it takes the `end_override = now` branch. An operator asking for "stop after
-   this afternoon" stops the room mid-lecture.
+   later today) **ended the AUTO session that was running right then**. The
+   reconciler found no window occurrence covering the active session's start, so
+   it took the `end_override = now` branch. An operator asking for "stop after
+   this afternoon" stopped the room mid-lecture.
+3. The mirror image at the other end: a window with `activeStart = now` lost
+   today's occurrence (it started at 00:00) and first materialized at tomorrow's
+   midnight. This was tracked separately as QUIRK-3, and is the reason
+   `tools/demo-e2e` backdates `activeStart` a week and the admin dialog forces
+   `activeStart` into the future.
 
-Minimal reproduction: create an auto-enabled room, a `00:00–23:59` window
-backdated a week (so it covers now), confirm `get-active-session` returns an
-AUTO session, then
+Occurrences are now **clipped** to `[activeStart, activeEnd]` —
+`startUtc = max(startUtc, activeStart)`, `endUtc = min(endUtc, activeEnd)` —
+which is what the field names imply and what `materializeAutoSessions` already
+did when filling a window around a blocking session. Clipping is arithmetic on
+absolute UTC instants, so a DST-adjusted occurrence keeps whichever instants
+`buildOccurrence` resolved.
 
-```bash
-curl -sk -X POST .../schedule-management/update-auto-session-window \
-  -H "authorization: Bearer $KEY" -H 'content-type: application/json' \
-  -d '{"windowUid":"<w>","activeEnd":"<now+30min>"}'      # 200 OK
-curl -sk .../schedule-management/get-active-session/<room> -H "authorization: Bearer $KEY"
-# null
-```
+A clipped residue shorter than `MIN_SESSION_DURATION_SECONDS` (60 s, the
+existing AUTO-slot floor) is dropped instead of materialized. The floor applies
+to clipped residues only, not to a short occurrence the operator asked for
+explicitly, and it applies to SCHEDULED occurrences as well as AUTO ones:
+SCHEDULED occurrences go straight to `insertSessions` with no other length
+check, so a zero-length residue would violate
+`sessions_scheduled_end_after_start` and come back as a 500 — the very failure
+mode BUG-1 is about. AUTO occurrences pass through `materializeAutoSessions`,
+which already applies the same floor to every slot.
 
-Whether clipping or dropping is _correct_ is a product decision — clipping is
-what the wording of the field implies and what the reconciler's own
-`materializeAutoSessions` does for blocker sessions — but silently ending a live
-session is not defensible either way. Pinned by
-`an-activeEnd-inside-an-occurrence-drops-the-occurrence-instead-of-clipping-it`.
+Asserted by `an-activeEnd-inside-an-occurrence-clips-it-instead-of-dropping-it`
+(both the fresh-window and narrow-a-live-window cases, including that the live
+session keeps its uid and ends at the requested instant) and by
+`an-auto-window-starting-now-covers-the-rest-of-today` for the `activeStart`
+half.
+
+`a-fall-back-ambiguous-local-time-resolves-to-the-standard-time-instant` used
+the old drop behaviour as its discriminator and had to be rebuilt around
+clipping — see "What is checked" below.
 
 ### BUG-3 — `add-device-to-room` silently demotes a room's source device
 
@@ -184,19 +200,6 @@ Suggested fix: return the already-published `TOO_MANY_SOURCE_DEVICES` when
 These are not bugs so much as sharp edges. They are pinned so that changing them
 is a deliberate act.
 
-### QUIRK-3 — a window starting "now" produces nothing until tomorrow
-
-`inRange` also drops an occurrence whose **start** precedes `activeStart`. A
-daily `00:00–23:59` window created at 16:00 with `activeStart = now` loses
-today's occurrence (it started at 00:00) and first materializes at tomorrow's
-midnight. The admin dialog forces `activeStart` into the future, so an operator
-creating "auto sessions, every day, from now" gets nothing for the rest of the
-day and no explanation. `tools/demo-e2e` backdates `activeStart` a week for
-exactly this reason, with an hour of debugging recorded in its comments.
-
-Pinned by `an-auto-window-must-start-before-the-occurrence-to-cover-today`,
-which also asserts the backdated control case does work.
-
 ### QUIRK-4 — a schedule beyond a ranged listing is invisible to that range
 
 A schedule starting 120 days out does not appear in a 90-day
@@ -204,6 +207,11 @@ A schedule starting 120 days out does not appear in a 90-day
 is the session-manager half of `SCHEDULE_BEYOND_90_DAY_WINDOW_INVISIBLE`, which
 `tools/admin-scheduling-e2e` documents as an accepted limitation of the admin
 console.
+
+### QUIRK-3 — retired
+
+"A window starting _now_ produces nothing until tomorrow" was the `activeStart`
+half of BUG-2 and was fixed with it. See BUG-2.
 
 ## What is checked
 
@@ -268,9 +276,13 @@ behaviour (BUG-1 ×2, BUG-2 ×2, BUG-3 ×3, QUIRK-3 ×2, QUIRK-4 ×1).
 - **fall-back**: ambiguous local times resolve to the **later, standard-time**
   instant. Conflict detection alone cannot see this (local→UTC is strictly
   increasing under either reading, so overlap decisions are identical) — the
-  check uses `inRange`'s `activeEnd` test as the discriminator instead: with
-  `activeEnd` placed _between_ the two candidate ends both occurrences are
-  dropped, and with it past the standard-time end they survive and conflict.
+  check uses where `activeEnd` cuts as the discriminator instead. Both
+  schedules sit wholly inside the ambiguous hour (`01:15–01:45` and
+  `01:20–01:40`) and `activeEnd` is the transition instant itself: under the
+  daylight reading they precede it, survive, and conflict; under the standard
+  reading they begin after it, clip to nothing, and vanish. A control with
+  `activeEnd` an hour later proves the pair really does conflict once inside
+  the range, so "no conflict" is a positive statement rather than an artefact.
 - DST transition instants are **computed from the host ICU database**, not
   hardcoded, so the checks keep working after the dates they were written
   against have passed — a hardcoded `2027-03-14` becomes an
@@ -282,7 +294,9 @@ behaviour (BUG-1 ×2, BUG-2 ×2, BUG-3 ×3, QUIRK-3 ×2, QUIRK-4 ×1).
   occurrence by a week).
 - the horizons: 90-day ranged listing (QUIRK-4), 7-day materialization, and
   `list-sessions` refusing a range over 31 days.
-- `activeEnd` mid-occurrence (BUG-2).
+- `activeEnd` and `activeStart` mid-occurrence **clip** rather than drop
+  (BUG-2), including that narrowing a live window keeps the running AUTO
+  session and moves its end.
 - toggling `autoSessionEnabled` off ends the live AUTO session and back on
   resumes from the untouched window.
 - deleting a window with a live AUTO session ends it (and is `404` the second
@@ -319,9 +333,10 @@ behaviour (BUG-1 ×2, BUG-2 ×2, BUG-3 ×3, QUIRK-3 ×2, QUIRK-4 ×1).
 
 - **Activation-code expiry** is asserted from the advertised `expiry` timestamp,
   not by waiting five minutes for a code to lapse.
-- **Fall-back occurrence duration** is pinned indirectly, through `inRange`.
-  Observing the two-hour `00:30–01:30` occurrence directly would need the
-  transition inside the 7-day materialization horizon, which is true for a few
-  days a year.
+- **Fall-back occurrence duration** is not asserted. The check proves the
+  ambiguous local time resolves to the instant _after_ the transition;
+  observing the resulting two-hour `00:30–01:30` occurrence directly would need
+  the transition inside the 7-day materialization horizon, which is true for a
+  few days a year.
 - The suite asserts **session-manager and node-server** behaviour. The admin
   console's rendering of any of it is `tools/admin-scheduling-e2e`'s job.

--- a/tools/session-corner-cases/README.md
+++ b/tools/session-corner-cases/README.md
@@ -75,42 +75,30 @@ has sat at 5/6 ever since.
 
 ## Bugs this suite found
 
-### BUG-1 — an auto-session window with equal local times answers 500
+### BUG-1 — an auto-session window with equal local times answered 500
 
-`create-auto-session-window` and `update-auto-session-window` have **no
-`localStartTime !== localEndTime` pre-check**. `_doCreateSchedule` has one
+`create-auto-session-window` and `update-auto-session-window` had **no
+`localStartTime !== localEndTime` pre-check**. `_doCreateSchedule` had one
 (`INVALID_LOCAL_TIMES` → `400`, with a sentence naming the problem); the window
-path (`_doCreateWindow`) validates only `activeEnd`, so the
-`auto_session_windows_local_times_distinct` CHECK fires inside the transaction
-and the operator gets an opaque `500 INTERNAL_ERROR` for the same typo.
+path (`_doCreateWindow`) validated only `activeEnd`, so the
+`auto_session_windows_local_times_distinct` CHECK fired inside the transaction
+and the operator got an opaque `500 INTERNAL_ERROR` for the same typo.
 
-Minimal reproduction:
+Both window paths now mirror the schedule path exactly:
+`400 VALIDATION_ERROR` with `"localStartTime and localEndTime must not be
+equal."`. No schema change was needed — `400 VALIDATION_ERROR` is already
+declared on every route through `STANDARD_ERROR_REPLIES`, which is also all the
+schedule route ever declared for it.
 
-```bash
-curl -sk -X POST https://localhost:8443/api/session-manager/v1/schedule-management/create-auto-session-window \
-  -H "authorization: Bearer $SESSION_MANAGER_API_KEY" -H 'content-type: application/json' \
-  -d '{"roomUid":"<room>","localStartTime":"10:00","localEndTime":"10:00",
-       "daysOfWeek":["MON"],"activeStart":"2026-08-02T00:00:00Z","activeEnd":null,
-       "joinCodeScopes":["RECEIVE_TRANSCRIPTIONS"],"transcriptionProviderId":"whisper",
-       "transcriptionStreamConfig":{}}'
-# {"code":"INTERNAL_ERROR","message":"Server encountered an unexpected error..."}
-```
+The comparison is on time-of-day, not on the string: `HH:MM` and `HH:MM:SS` are
+both accepted on the wire and the database stores either as `TIME`, so a row
+written as `08:00` reads back as `08:00:00` and an update merging a request's
+`08:00` against it is exactly the collision the CHECK fires on. A string
+`===` misses that, which is why the schedule path had the same hole one level
+deeper; both are fixed.
 
-session-manager logs the cause:
-
-```
-error: new row for relation "auto_session_windows" violates check constraint
-       "auto_session_windows_local_times_distinct"
-```
-
-The same request against `create-schedule` returns
-`400 "localStartTime and localEndTime must not be equal."`.
-
-Suggested fix: mirror the schedule path's check at the top of `_doCreateWindow`
-and add an `INVALID_LOCAL_TIMES` reply to the two window schemas. Pinned by
-`equal-local-start-and-end-times-are-refused-on-schedules-and-windows`.
-
-Not fixed here — the brief was to find and report, not to change behaviour.
+Asserted by `equal-local-start-and-end-times-are-refused-on-schedules-and-windows`,
+whose update leg deliberately sends `08:00` against a stored `08:00:00`.
 
 ### BUG-2 — `activeEnd` inside an occurrence deletes the occurrence instead of clipping it
 
@@ -320,7 +308,8 @@ behaviour (BUG-1 ×2, BUG-2 ×2, BUG-3 ×3, QUIRK-3 ×2, QUIRK-4 ×1).
   including that the message names the deployment's configured providers.
 - an invalid timezone (`422`), an empty one, and that the `Etc/UTC` alias
   `Intl.supportedValuesOf` omits is still accepted.
-- equal local start/end times (BUG-1).
+- equal local start/end times on schedules **and** windows, including the
+  `HH:MM` vs stored `HH:MM:SS` form a string compare misses (BUG-1).
 - malformed vs unknown UUIDs, distinguished per resource.
 - `frequency`/`daysOfWeek` disagreement — including `daysOfWeek: []`, which the
   DB CHECK cannot catch (`array_length()` is `NULL` for an empty array, so the

--- a/tools/session-corner-cases/session-corner-cases.mjs
+++ b/tools/session-corner-cases/session-corner-cases.mjs
@@ -2075,12 +2075,13 @@ const CHECKS = [
         `${none.status} ${none.body?.code}`,
       );
 
-      // BUG-3. `add-device-to-room` publishes a 409 TOO_MANY_SOURCE_DEVICES
-      // reply that nothing can ever produce: only `createRoom` emits that code.
-      // The service runs no "this room already has a source" check, and the
+      // `add-device-to-room` used to publish a 409 TOO_MANY_SOURCE_DEVICES
+      // reply that nothing could produce: only `createRoom` emitted that code.
+      // The service ran no "this room already has a source" check, and the
       // repository's `asSource` branch clears `is_source` across the whole room
-      // before inserting - so the call silently demotes the room's kiosk and
-      // answers 204.
+      // before inserting - so the call silently demoted the room's kiosk and
+      // answered 204. It now refuses, and a deliberate swap goes through
+      // `set-source-device`, which is asserted below.
       const room = await fx.room('one-src');
       const session = await fx.onDemand(room.roomUid, 'one-src');
       const beforeScopes = await api.device(
@@ -2099,12 +2100,11 @@ const CHECKS = [
         deviceUid: b.deviceUid,
         asSource: true,
       });
-      t.pin(
-        'adding a second device asSource is accepted (204) rather than refused',
-        second.status === 204,
-        `got ${second.status} ${second.body?.code ?? ''}; the route publishes a ` +
-          '409 TOO_MANY_SOURCE_DEVICES reply that only create-room can produce',
-        'BUG-3',
+      t.status(
+        'adding a second device asSource is refused 409 TOO_MANY_SOURCE_DEVICES',
+        second,
+        409,
+        'TOO_MANY_SOURCE_DEVICES',
       );
 
       const afterScopes = await api.device(
@@ -2112,24 +2112,51 @@ const CHECKS = [
         'session-auth/exchange-device-token',
         { sessionUid: session.body.uid },
       );
-      t.pin(
-        'and it silently demotes the original source, which keeps its token but loses SEND_AUDIO',
+      t.ok(
+        'and the original source keeps SEND_AUDIO',
         afterScopes.status === 200 &&
-          !afterScopes.body?.scopes?.includes('SEND_AUDIO'),
-        `original source scopes are now ${JSON.stringify(afterScopes.body?.scopes)} - ` +
-          'a kiosk that still authenticates, still finds the session, and sends nothing',
-        'BUG-3',
+          afterScopes.body?.scopes?.includes('SEND_AUDIO'),
+        `original source scopes are ${JSON.stringify(afterScopes.body?.scopes)}`,
       );
+
+      // The deliberate replace-the-source flow the refusal points at. A kiosk
+      // really does get swapped sometimes (broken hardware), so this has to
+      // keep working - it is now two calls instead of one silent side effect.
+      const asMember = await api.post('room-management/add-device-to-room', {
+        roomUid: room.roomUid,
+        deviceUid: b.deviceUid,
+        asSource: false,
+      });
+      t.status(
+        'the same device can be attached as a plain member',
+        asMember,
+        204,
+      );
+      const promote = await api.post('room-management/set-source-device', {
+        roomUid: room.roomUid,
+        deviceUid: b.deviceUid,
+      });
+      t.status('and set-source-device then promotes it', promote, 204);
+
       const promoted = await api.device(
         b.deviceToken,
         'session-auth/exchange-device-token',
         { sessionUid: session.body.uid },
       );
-      t.pin(
-        'while the newly added device now holds SEND_AUDIO',
+      t.ok(
+        'after which the promoted device holds SEND_AUDIO',
         promoted.body?.scopes?.includes('SEND_AUDIO'),
         JSON.stringify(promoted.body?.scopes),
-        'BUG-3',
+      );
+      const demoted = await api.device(
+        room.device.deviceToken,
+        'session-auth/exchange-device-token',
+        { sessionUid: session.body.uid },
+      );
+      t.ok(
+        'and the device it replaced no longer does',
+        demoted.status === 200 && !demoted.body?.scopes?.includes('SEND_AUDIO'),
+        `replaced source scopes are ${JSON.stringify(demoted.body?.scopes)}`,
       );
     },
   },

--- a/tools/session-corner-cases/session-corner-cases.mjs
+++ b/tools/session-corner-cases/session-corner-cases.mjs
@@ -2475,35 +2475,37 @@ const CHECKS = [
         400,
       );
 
-      // BUG-1: the window path has no equivalent pre-check, so the
-      // `auto_session_windows_local_times_distinct` CHECK fires and the
-      // operator gets a 500 for the same typo the schedule path answers with a
-      // sentence.
+      // The window path used to have no equivalent pre-check, so the
+      // `auto_session_windows_local_times_distinct` CHECK fired inside the
+      // transaction and the operator got a 500 for the same typo the schedule
+      // path answers with a sentence.
       const window = await fx.window(room.roomUid, {
         localStartTime: '10:00',
         localEndTime: '10:00',
       });
-      t.pin(
-        'an auto-session window with equal local times answers 500, not 400',
-        window.status === 500 && window.body?.code === 'INTERNAL_ERROR',
-        `got ${window.status} ${window.body?.code ?? ''} - the schedule path ` +
-          'validates this and returns 400; the window path lets the DB CHECK fire',
-        'BUG-1',
+      t.ok(
+        'an auto-session window with equal local times is refused 400, like a schedule',
+        window.status === 400 &&
+          window.body?.code === 'VALIDATION_ERROR' &&
+          /must not be equal/.test(window.body?.message ?? ''),
+        `got ${window.status} ${window.body?.code ?? ''} ${window.body?.message ?? ''}`,
       );
 
       const good = await fx.window(room.roomUid, {
         localStartTime: '08:00',
         localEndTime: '09:00',
       });
+      // `08:00` against a row that reads back as `08:00:00`: the same time of
+      // day, different strings, so a string-equality pre-check would miss it
+      // and let the CHECK constraint answer instead.
       const narrowed = await api.post(
         'schedule-management/update-auto-session-window',
         { windowUid: good.body.uid, localEndTime: '08:00' },
       );
-      t.pin(
-        'and so does updating an existing window to equal local times',
-        narrowed.status === 500 && narrowed.body?.code === 'INTERNAL_ERROR',
-        `got ${narrowed.status} ${narrowed.body?.code ?? ''}`,
-        'BUG-1',
+      t.ok(
+        'and so is updating an existing window to the same local time in a different format',
+        narrowed.status === 400 && narrowed.body?.code === 'VALIDATION_ERROR',
+        `got ${narrowed.status} ${narrowed.body?.code ?? ''} ${narrowed.body?.message ?? ''}`,
       );
       const survived = await api.get(
         `schedule-management/get-auto-session-window/${good.body.uid}`,

--- a/tools/session-corner-cases/session-corner-cases.mjs
+++ b/tools/session-corner-cases/session-corner-cases.mjs
@@ -92,14 +92,16 @@ const ALL_DAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
- * How far back an auto-session window's `activeStart` is placed when the check
- * wants a session covering *now*.
+ * How far back an auto-session window's `activeStart` is placed by default.
  *
- * `inRange` in `schedule-materializer.ts` drops any occurrence whose *start*
- * precedes `activeStart`, so a daily 00:00-23:59 window created at 16:00 with
- * `activeStart = now` loses today's occurrence entirely and first materializes
- * tomorrow. A week back clears the day boundary in any timezone. This is the
- * behaviour `auto-window-activeStart-must-precede-...` pins on purpose.
+ * No longer required to get a session covering *now* - `inRange` clips an
+ * occurrence to `activeStart` rather than dropping it, so a window created at
+ * 16:00 with `activeStart = now` covers the rest of today (asserted by
+ * `an-auto-window-starting-now-covers-the-rest-of-today`). It is kept because
+ * several checks want a window that has been active for a while, so the AUTO
+ * session's `effectiveStart` is in the past: that is what exercises the
+ * reconciler's preserve-the-running-AUTO branch rather than its
+ * create-a-fresh-slot one.
  */
 const BACKDATE_MS = 7 * DAY_MS;
 
@@ -1517,49 +1519,45 @@ const CHECKS = [
 
   {
     group: 'calendar / scheduling',
-    name: 'an-auto-window-must-start-before-the-occurrence-to-cover-today',
+    name: 'an-auto-window-starting-now-covers-the-rest-of-today',
     async run(t, { fx }) {
-      // `inRange` drops any occurrence whose *start* precedes `activeStart`,
-      // so a daily 00:00-23:59 window created at 16:00 with `activeStart = now`
-      // loses today's occurrence entirely and first materializes tomorrow. The
-      // admin dialog forces `activeStart` into the future, so an operator who
-      // creates "auto sessions, every day, from now" gets nothing until
-      // midnight. demo-e2e backdates a week for exactly this reason.
+      // `inRange` clips an occurrence to `activeStart` rather than dropping
+      // it. The daily 00:00-23:59 window the admin console creates started at
+      // midnight, before any `activeStart` an operator can type, so dropping
+      // meant "auto sessions, every day, from now" produced nothing until the
+      // next local midnight - with no explanation, and with the admin dialog
+      // forcing `activeStart` into the future to hide it.
       const today = await fx.room('as-today', { auto: true });
+      const startedNow = new Date();
       await fx.window(today.roomUid, {
-        activeStart: new Date().toISOString(),
+        activeStart: startedNow.toISOString(),
       });
-      const noneNow = await fx.activeSession(today.roomUid, 3_000);
-      t.pin(
-        'a window whose activeStart is "now" produces NO session covering now',
-        noneNow === null,
-        noneNow === null
-          ? 'no active session, as inRange drops the occurrence that started at 00:00'
-          : `unexpectedly active: ${noneNow.effectiveStart}`,
-        'QUIRK-3',
+      const live = await fx.activeSession(today.roomUid);
+      t.ok(
+        'a window whose activeStart is "now" produces a session covering now',
+        live?.type === 'AUTO',
+        `active ${live?.type ?? 'none'}`,
       );
-      const upcoming = await fx.listSessions(
-        today.roomUid,
-        -60_000,
-        2 * DAY_MS,
+      t.ok(
+        'and that session starts at activeStart, not at the occurrence’s midnight',
+        live !== null &&
+          Math.abs(Date.parse(live.effectiveStart) - startedNow.getTime()) <
+            5 * 60_000,
+        `effectiveStart ${live?.effectiveStart} vs activeStart ${startedNow.toISOString()}`,
       );
-      t.pin(
-        'and the first AUTO session appears only on the next local day',
-        upcoming.length > 0 &&
-          Date.parse(upcoming[0].effectiveStart) > Date.now(),
-        upcoming.length
-          ? `first at ${upcoming[0].effectiveStart}`
-          : 'no sessions in the next two days',
-        'QUIRK-3',
+      t.ok(
+        'and it still runs to the end of the local day',
+        live !== null && Date.parse(live.effectiveEnd) > Date.now(),
+        `effectiveEnd ${live?.effectiveEnd}`,
       );
 
       const backdated = await fx.room('as-backdated', { auto: true });
       await fx.window(backdated.roomUid);
-      const live = await fx.activeSession(backdated.roomUid);
+      const older = await fx.activeSession(backdated.roomUid);
       t.ok(
-        'the same window backdated a week does cover now',
-        live?.type === 'AUTO',
-        `active ${live?.type ?? 'none'}`,
+        'the same window backdated a week also covers now',
+        older?.type === 'AUTO',
+        `active ${older?.type ?? 'none'}`,
       );
     },
   },
@@ -1678,16 +1676,18 @@ const CHECKS = [
     name: 'a-fall-back-ambiguous-local-time-resolves-to-the-standard-time-instant',
     async run(t, { fx }) {
       // At fall-back, local 01:00-01:59 happens twice. `localToUtc` picks the
-      // LATER (standard-time) instant, so an occurrence 00:30-01:30 runs two
-      // hours, not one.
+      // LATER (standard-time) instant, so an occurrence at 01:15-01:45 local
+      // lands *after* the transition, not before it.
       //
       // Conflict detection alone cannot see this: local -> UTC is strictly
       // increasing under either reading, so overlap decisions are identical.
-      // What does distinguish them is `inRange`'s activeEnd test, which drops
-      // an occurrence whose end exceeds activeEnd. Put activeEnd *between* the
-      // two candidate ends and the occurrences survive only under the earlier
-      // (daylight) reading - so "no conflict" here is a positive statement
-      // that the later instant was chosen.
+      // What does distinguish them is where `activeEnd` cuts. Both occurrences
+      // sit wholly inside the ambiguous hour, and `activeEnd` is placed at the
+      // transition instant itself: under the daylight reading they precede it
+      // and survive (and conflict); under the standard reading they begin
+      // after it, clip to nothing, and vanish. So "no conflict" here is a
+      // positive statement that the later instant was chosen, and the control
+      // below proves the pair does conflict once it is inside the range.
       const zone = 'America/Chicago';
       const fall = nextTransitions(zone, new Date(), 4).find(
         (x) => x.toOffset < x.fromOffset,
@@ -1697,11 +1697,11 @@ const CHECKS = [
       }
       const dow = localDayOfWeek(zone, new Date(fall.at.getTime() + 60_000));
       const activeStart = new Date(fall.at.getTime() - 8 * 60 * 60 * 1000);
-      // 00:30 local is unambiguous (daylight); 01:30 local is ambiguous.
-      // daylight reading ends 30 min BEFORE the transition instant, standard
-      // reading 30 min after.
-      const between = new Date(fall.at.getTime());
-      const afterBoth = new Date(fall.at.getTime() + 90 * 60_000);
+      // Under the daylight reading 01:15-01:45 runs from 45 to 15 minutes
+      // BEFORE the transition instant; under the standard reading, from 15 to
+      // 45 minutes after it.
+      const atTransition = new Date(fall.at.getTime());
+      const afterBoth = new Date(fall.at.getTime() + 60 * 60_000);
       const pair = (roomUid, ls, le, activeEnd) => ({
         roomUid,
         frequency: 'WEEKLY',
@@ -1715,14 +1715,14 @@ const CHECKS = [
       const decisive = await fx.room('dst-fall', { timezone: zone });
       const d1 = await fx.schedule(
         decisive.roomUid,
-        pair(decisive.roomUid, '00:30', '01:30', between),
+        pair(decisive.roomUid, '01:15', '01:45', atTransition),
       );
       const d2 = await fx.schedule(
         decisive.roomUid,
-        pair(decisive.roomUid, '00:45', '01:15', between),
+        pair(decisive.roomUid, '01:20', '01:40', atTransition),
       );
       t.ok(
-        'with activeEnd between the daylight and standard readings both occurrences vanish',
+        'with activeEnd at the transition instant both occurrences fall outside it and vanish',
         d1.status === 201 && d2.status === 201,
         `${d1.status}/${d2.status} ${d2.body?.code ?? ''} ` +
           `(transition at ${fall.at.toISOString()})`,
@@ -1731,11 +1731,11 @@ const CHECKS = [
       const control = await fx.room('dst-fall-ctl', { timezone: zone });
       const c1 = await fx.schedule(
         control.roomUid,
-        pair(control.roomUid, '00:30', '01:30', afterBoth),
+        pair(control.roomUid, '01:15', '01:45', afterBoth),
       );
       const c2 = await fx.schedule(
         control.roomUid,
-        pair(control.roomUid, '00:45', '01:15', afterBoth),
+        pair(control.roomUid, '01:20', '01:40', afterBoth),
       );
       t.ok(
         'with activeEnd past the standard reading they survive and conflict',
@@ -1884,25 +1884,30 @@ const CHECKS = [
 
   {
     group: 'calendar / scheduling',
-    name: 'an-activeEnd-inside-an-occurrence-drops-the-occurrence-instead-of-clipping-it',
+    name: 'an-activeEnd-inside-an-occurrence-clips-it-instead-of-dropping-it',
     async run(t, { fx, api }) {
-      // `inRange` rejects an occurrence whose end exceeds `activeEnd` rather
-      // than clipping it. For a daily 00:00-23:59 window that means setting
-      // activeEnd to any instant before 23:59 removes the whole day. An
-      // operator reading "auto sessions until 15:00" gets none at all - and,
-      // worse, narrowing a *live* window ends the session that is running now.
+      // `inRange` clips an occurrence to `activeEnd` rather than rejecting it.
+      // For the daily 00:00-23:59 window the admin console creates, dropping
+      // meant *any* activeEnd before 23:59 removed the whole day: "auto
+      // sessions until 15:00" produced none at all, and narrowing a *live*
+      // window ended the session that was running right then.
+      const stopFresh = new Date(Date.now() + 30 * 60_000);
       const fresh = await fx.room('clip-fresh', { auto: true });
       await fx.window(fresh.roomUid, {
-        activeEnd: new Date(Date.now() + 30 * 60_000).toISOString(),
+        activeEnd: stopFresh.toISOString(),
       });
-      const none = await fx.activeSession(fresh.roomUid, 3_000);
-      t.pin(
-        'a window whose activeEnd lands mid-occurrence produces no session at all',
-        none === null,
-        none === null
-          ? 'no active session (the whole occurrence was dropped, not clipped to activeEnd)'
-          : `unexpectedly active until ${none.effectiveEnd}`,
-        'BUG-2',
+      const clipped = await fx.activeSession(fresh.roomUid);
+      t.ok(
+        'a window whose activeEnd lands mid-occurrence still produces a session covering now',
+        clipped?.type === 'AUTO',
+        `active ${clipped?.type ?? 'none'}`,
+      );
+      t.ok(
+        'and that session ends at activeEnd, not at the occurrence’s own end',
+        clipped !== null &&
+          Math.abs(Date.parse(clipped.effectiveEnd) - stopFresh.getTime()) <
+            60_000,
+        `effectiveEnd ${clipped?.effectiveEnd} vs activeEnd ${stopFresh.toISOString()}`,
       );
 
       const live = await fx.room('clip-live', { auto: true });
@@ -1922,13 +1927,15 @@ const CHECKS = [
       const after = await api.get(
         `schedule-management/get-active-session/${live.roomUid}`,
       );
-      t.pin(
-        'and it ends the running AUTO session NOW rather than at the new activeEnd',
-        after.body === null,
+      t.ok(
+        'and the running AUTO session survives, now ending at the new activeEnd',
+        after.body !== null &&
+          after.body.uid === before?.uid &&
+          Math.abs(Date.parse(after.body.effectiveEnd) - stopAt.getTime()) <
+            60_000,
         after.body === null
           ? `no active session, though the operator asked for one until ${stopAt.toISOString()}`
-          : `still active until ${after.body.effectiveEnd}`,
-        'BUG-2',
+          : `session ${after.body.uid} (was ${before?.uid}) active until ${after.body.effectiveEnd}`,
       );
     },
   },


### PR DESCRIPTION
## Summary
- Refuse `add-device-to-room` with `asSource: true` when the room already has a source device (409), instead of silently swapping the kiosk out from under the operator; both admin-console callers now do an explicit attach-then-promote swap.
- Clip auto/scheduled occurrences to the active window's start/end instead of dropping any occurrence that straddles the boundary — fixes windows materializing nothing and live sessions being cut off mid-lecture.
- Return 400 (not 500) from `create/update-auto-session-window` when `localStartTime === localEndTime`, matching the existing schedule-route validation.

## Test plan
- [x] `tools/session-corner-cases` suite updated and passing (BUG-1, BUG-2, BUG-3, QUIRK-3 pins flipped to assert correct behavior)
- [x] Unit/integration tests added for repository, service, controller, and materializer changes