### PR TITLE
Restrict every route to campus/VPN; rename PR preview image tags

### DIFF
--- a/.changeset/deployment-build-versions.md
+++ b/.changeset/deployment-build-versions.md
@@ -47,13 +47,16 @@ can confirm what is actually deployed and running.
 - **`scribear-db` and `redis`** appear in the table as `n/a` with the reason:
   neither has an HTTP surface to report a build on.
 
-- **PR images are published again.** A pull request into `main` or `staging`
-  pushes `ghcr.io/scribear/<image>:PR-<n>`, so a reviewer can pull the exact
-  build under review rather than rebuilding it — and the image says which
-  commit it is. The tag moves with the PR head. Set the repository variable
+- **PR images are published again, named for their target environment.** A
+  pull request into `staging` pushes
+  `ghcr.io/scribear/<image>:staging-pr<n>`; into `main`,
+  `ghcr.io/scribear/<image>:production-pr<n>` — so a reviewer can pull the
+  exact build under review rather than rebuilding it, and tell at a glance
+  which environment it's a candidate for, without cross-referencing the PR
+  on GitHub. The tag moves with the PR head. Set the repository variable
   `PUBLISH_PR_IMAGES` to `false` to switch it off, or `true` to publish for
-  every base branch. Fork PRs still build without publishing, since their
-  `GITHUB_TOKEN` cannot push.
+  every base branch (tagged `<base-branch>-pr<n>`). Fork PRs still build
+  without publishing, since their `GITHUB_TOKEN` cannot push.
 
 Nothing new is required in `deployment/.env`. The six new admin-server base-URL
 variables all default to their compose service names.

--- a/.github/actions/resolve-container-tags/action.yml
+++ b/.github/actions/resolve-container-tags/action.yml
@@ -6,10 +6,11 @@ inputs:
     required: true
   publish_pr_images:
     description: >
-      Override for whether a pull_request build publishes a PR-<n> image.
-      Leave empty (the default) to use the base-branch rule: PRs into main or
-      staging publish, anything else does not. "false" switches PR images off
-      entirely; "true" publishes them whatever the base branch is. Wired to the
+      Override for whether a pull_request build publishes a staging-pr<n>/
+      production-pr<n> preview image. Leave empty (the default) to use the
+      base-branch rule: PRs into main or staging publish, anything else does
+      not. "false" switches PR images off entirely; "true" publishes them
+      whatever the base branch is (tagged <base-branch>-pr<n>). Wired to the
       repository variable PUBLISH_PR_IMAGES (Settings > Secrets and variables >
       Actions > Variables), so either override is a one-field change with no
       code edit - which is what you want when the registry needs draining in a
@@ -86,18 +87,31 @@ runs:
         PR_IMAGE_BASE_BRANCHES = {"main", "staging"}
 
         def publishes_pr_image() -> bool:
-            """Whether this PR build should push a PR-<n> image."""
+            """Whether this PR build should push a preview image."""
             override = os.environ.get("PUBLISH_PR_IMAGES", "").strip().lower()
             if override in ("true", "false"):
                 return override == "true"
             return os.environ.get("PR_BASE_REF", "") in PR_IMAGE_BASE_BRANCHES
+
+        # Named for the environment a merge would land in, not just the PR
+        # number: `docker pull ...:PR-157` alone doesn't say whether that's
+        # a staging or a production candidate, and telling them apart
+        # otherwise means cross-referencing the PR on GitHub. `staging`/`main`
+        # map to the two real environments; anything else only reaches here
+        # at all when PUBLISH_PR_IMAGES=true overrides the base-branch rule
+        # above, so it falls back to the branch's own name rather than
+        # inventing an environment label for it.
+        def pr_image_tag(pr_number: str) -> str:
+            base = os.environ.get("PR_BASE_REF", "")
+            environment = {"staging": "staging", "main": "production"}.get(base, base)
+            return f"{environment}-pr{pr_number}" if environment else f"PR-{pr_number}"
 
         if event_name == "pull_request":
             # No tags means "build but do not publish" - see build-container.
             # A fork PR resolves a tag here and still does not push: its
             # GITHUB_TOKEN is read-only, which build-container detects.
             if pr_number and publishes_pr_image():
-                tags.append(f"PR-{pr_number}")
+                tags.append(pr_image_tag(pr_number))
         elif event_name == "push" and github_ref == "refs/heads/staging":
             tags.extend(["staging", f"staging-{short_sha}"])
         elif event_name == "push" and github_ref == "refs/heads/main":

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -191,10 +191,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # PRs into main or staging publish a PR-<n> image, so a reviewer can pull
-      # the exact build under review instead of rebuilding it. The tag moves
-      # with the PR head - `PR-157` is always that PR's latest push, and the
-      # image says which commit it is via GET /build-info.
+      # PRs into main or staging publish a staging-pr<n>/production-pr<n>
+      # image (named for which environment a merge would land in, not just
+      # the PR number), so a reviewer can pull the exact build under review
+      # instead of rebuilding it. The tag moves with the PR head -
+      # `production-pr157` is always PR #157's latest push targeting main,
+      # and the image says which commit it is via GET /build-info.
       #
       # Set the repository variable PUBLISH_PR_IMAGES to "false" to switch this
       # off (or "true" to publish for every base branch); either is a one-field

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -104,10 +104,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # PRs into main or staging publish a PR-<n> image, so a reviewer can pull
-      # the exact build under review instead of rebuilding it. The tag moves
-      # with the PR head - `PR-157` is always that PR's latest push, and the
-      # image says which commit it is via GET /build-info.
+      # PRs into main or staging publish a staging-pr<n>/production-pr<n>
+      # image (named for which environment a merge would land in, not just
+      # the PR number), so a reviewer can pull the exact build under review
+      # instead of rebuilding it. The tag moves with the PR head -
+      # `production-pr157` is always PR #157's latest push targeting main,
+      # and the image says which commit it is via GET /build-info.
       #
       # Set the repository variable PUBLISH_PR_IMAGES to "false" to switch this
       # off (or "true" to publish for every base branch); either is a one-field

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
@@ -50,7 +50,7 @@ export interface ContainerVersion {
  * version.test.ts` fails if the two ever disagree, or if that file changes
  * without someone having made that call.
  */
-export const EXPECTED_COMPOSE_FILE_VERSION = 12;
+export const EXPECTED_COMPOSE_FILE_VERSION = 13;
 
 /**
  * How the running `compose.yml` compares to the one this image was built for.

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  '3f17fa29b049183cdb4cf17e331fb1af0b382952228504228eeff8781be7f541';
+  '07a6ea57690229b170c6cf94d0c427222a73104e54f1a02aab17b4627f55d7fe';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -63,6 +63,18 @@ NGINX_HTTPS_PORT=443
 SSL_CERT_PATH=/etc/ssl/certs/your-cert.cer
 SSL_KEY_PATH=/etc/ssl/private/your-key.key
 
+# Onsite-only access gate. Empty/unset uses onsite/allowlist.default.conf and
+# onsite/content-default/ - permissive, so a stock deployment is never gated
+# by accident. To actually restrict access (every API 403s, every frontend
+# redirects to a landing page, for anyone outside these ranges), copy
+# onsite-allowlist.example.conf, edit it for your own network, and point
+# ONSITE_ALLOWLIST_PATH at your copy. ONSITE_CONTENT_PATH is the directory
+# serving the landing page itself (and the ungated /extlanding devops preview
+# route - see nginx.conf) - point it at your own directory to customize the
+# wording/branding.
+ONSITE_ALLOWLIST_PATH=
+ONSITE_CONTENT_PATH=
+
 # -- Scripts -----------------
 ORIGIN=https://localhost:443
 

--- a/deployment/.gitignore
+++ b/deployment/.gitignore
@@ -1,1 +1,7 @@
 provider_config.json
+
+# A real deployment's own onsite allowlist/landing content, copied from
+# onsite-allowlist.example.conf / onsite/content-default and customized -
+# same reasoning as provider_config.json above.
+onsite-allowlist.conf
+onsite-content/

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -42,8 +42,21 @@ IP ranges, instead of being reachable from anywhere on the internet:
   `ONSITE_CONTENT_PATH` can preview what an off-campus visitor sees without
   spoofing their own IP address. Every gated frontend route redirects here.
 
+**Prerequisite if you set `ONSITE_ALLOWLIST_PATH` to a real allowlist: nginx
+must be the actual internet-facing edge.** The gate trusts `$remote_addr`
+directly. If a load balancer, CDN, or any other proxy sits in front of this
+nginx, every request arrives looking like it came from that proxy, not the
+real client — and if the proxy's own address happens to fall inside your
+allowlist (plausible if it runs on-campus), **every off-campus request
+passes the gate**, silently. This is a fail-*open* failure, the opposite of
+the gate's purpose, and it produces no error to notice. If that's your
+topology, configure `set_real_ip_from`/`real_ip_header` in `nginx.conf`
+first (commented-out guidance is right next to the `$onsite` allowlist
+include) — don't turn on a real allowlist without doing this first.
+
 Design and the full campus-network research behind the default allowlist:
-`2026-08-02-01-PLAN-OnsiteAccess.md` (not tracked in this repo).
+`2026-08-02-PLAN-AccessRulesLandingPage.md` (not tracked in this repo). Code
+review: `2026-08-02-REVIEW-AccessRulesLandingPage.md` (same location).
 
 ## Unreleased — db-backup hardening: retry, integrity check, opt-out, encryption (`compose.yml` v12)
 

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,39 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — onsite-only access gate (`compose.yml` v13)
+
+**Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. A
+stock deployment needs to do nothing new — the two variables below default to
+"nobody is restricted," identical to today's behavior.
+
+`nginx.conf` can now restrict every route — every API (403) and every
+frontend (redirected to a landing page) — to an explicit allowlist of source
+IP ranges, instead of being reachable from anywhere on the internet:
+
+- **`ONSITE_ALLOWLIST_PATH`** (default `./onsite/allowlist.default.conf`, a
+  permissive "everyone is onsite" file checked into this directory) — point
+  this at a real allowlist (see
+  [`onsite-allowlist.example.conf`](onsite-allowlist.example.conf), built for
+  University of Illinois Urbana-Champaign's own published ranges, as a
+  starting point for another campus/network) to actually restrict access.
+  Unlike `PROVIDER_CONFIG_PATH`, this default is a real, live file, not a
+  `.template` to copy first — "nobody is restricted" is a sane universal
+  default here, so a deployment that never touches this variable is simply
+  never gated.
+- **`ONSITE_CONTENT_PATH`** (default `./onsite/content-default`) — the static
+  landing page shown to a gated frontend request, explaining that live
+  captions require an on-campus or VPN connection. Point this at your own
+  directory to customize the wording or add branding.
+- **`/extlanding`** is a new route, deliberately **never** gated. It serves
+  the exact same landing page a gated visitor would see, reachable from
+  anywhere — including from on campus — so whoever maintains
+  `ONSITE_CONTENT_PATH` can preview what an off-campus visitor sees without
+  spoofing their own IP address. Every gated frontend route redirects here.
+
+Design and the full campus-network research behind the default allowlist:
+`2026-08-02-01-PLAN-OnsiteAccess.md` (not tracked in this repo).
+
 ## Unreleased — db-backup hardening: retry, integrity check, opt-out, encryption (`compose.yml` v12)
 
 **Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. A

--- a/deployment/check-webapp-routing.sh
+++ b/deployment/check-webapp-routing.sh
@@ -216,9 +216,15 @@ declare -A EXPECT_TITLE_BY_PATH=(
   [/client/]="ScribeAR Client"
   [/kiosk/]="ScribeAR Kiosk"
   [/standalone/]="ScribeAR - Live Captions"
+  [/admin/]="ScribeAR Admin"
 )
 
-for path in /client/ /kiosk/ /standalone/; do
+# /admin/ isn't part of the client/kiosk/standalone "swap" scenario sections
+# 1-3 diagnose (those three are interchangeable single-page apps that could
+# plausibly get mistagged with each other; admin-webapp never was), so it's
+# only checked here - this section's job is "what did nginx actually serve,"
+# and the onsite gate now covers /admin/ too.
+for path in /client/ /kiosk/ /standalone/ /admin/; do
   result=$(fetch_via_nginx "$path")
   status=$(printf '%s\n' "$result" | sed -n '1p')
   location=$(printf '%s\n' "$result" | sed -n '2p')

--- a/deployment/check-webapp-routing.sh
+++ b/deployment/check-webapp-routing.sh
@@ -17,6 +17,18 @@
 # project's containers). Read-only: only runs `docker inspect`, `docker exec`
 # of read-only commands (wget/cat), and `docker images`.
 #
+# If ONSITE_ALLOWLIST_PATH (see UPGRADING.md) is set to a real allowlist,
+# section 4's "curl https://localhost/..." may get redirected to /extlanding
+# instead of the app's real content - handled below, not a routing bug, and
+# expected. Whether it actually happens depends on Docker's own compose
+# network bridge gateway address (what nginx sees curl-from-the-host as),
+# which is assigned per-project and outside your control - it may coincide
+# with a private range your allowlist admits, in which case this section
+# passes/fails exactly as it did before this feature existed. Neither outcome
+# says anything about whether the onsite gate itself is working; that's
+# infra/scribear-nginx/tests/unit/onsite-gate.test.ts's job, not this
+# script's.
+#
 # Usage:
 #   ./check-webapp-routing.sh [compose-project-name-or-container-prefix]
 #
@@ -184,15 +196,20 @@ fi
 # ---------------------------------------------------------------------------
 section "4. Content served through nginx end-to-end (what IT actually saw)"
 # ---------------------------------------------------------------------------
-fetch_title_via_nginx() {
-  # $1 = path, e.g. /client/
+fetch_via_nginx() {
+  # $1 = path, e.g. /client/. Prints "STATUS\nLOCATION\nBODY" (LOCATION empty
+  # if the response wasn't a redirect) - not following redirects, since a
+  # redirect to /extlanding is itself a meaningful, distinguishable result
+  # (see the onsite-gate check below), not something to chase through.
   local path="$1"
-  local body
-  body=$(curl -sk "https://localhost${path}" 2>/dev/null) || true
-  if [ -z "$body" ]; then
-    body=$(curl -s "http://localhost${path}" 2>/dev/null) || true
-  fi
-  printf '%s' "$body" | grep -o '<title>[^<]*</title>' | head -1 | sed -e 's/<title>//' -e 's/<\/title>//'
+  local out
+  out=$(curl -sk -D - -o - "https://localhost${path}" 2>/dev/null) || \
+  out=$(curl -s -D - -o - "http://localhost${path}" 2>/dev/null) || true
+  local status location body
+  status=$(printf '%s' "$out" | head -1 | tr -d '\r')
+  location=$(printf '%s' "$out" | grep -i '^location:' | head -1 | sed -e 's/^[Ll]ocation: *//' -e 's/\r$//')
+  body=$(printf '%s' "$out" | awk 'f; /^\r?$/{f=1}')
+  printf '%s\n%s\n%s' "$status" "$location" "$body"
 }
 
 declare -A EXPECT_TITLE_BY_PATH=(
@@ -202,8 +219,26 @@ declare -A EXPECT_TITLE_BY_PATH=(
 )
 
 for path in /client/ /kiosk/ /standalone/; do
-  title=$(fetch_title_via_nginx "$path")
+  result=$(fetch_via_nginx "$path")
+  status=$(printf '%s\n' "$result" | sed -n '1p')
+  location=$(printf '%s\n' "$result" | sed -n '2p')
+  body=$(printf '%s\n' "$result" | sed -n '3,$p')
   expected="${EXPECT_TITLE_BY_PATH[$path]}"
+
+  if [ -n "$location" ] && printf '%s' "$location" | grep -q '/extlanding'; then
+    # The onsite-only access gate (nginx.conf's $onsite check) redirected
+    # this request - expected and CORRECT if the deployment has a real
+    # allowlist configured (ONSITE_ALLOWLIST_PATH), since this script runs
+    # on the docker host itself and curl's "https://localhost" is loopback,
+    # which is never on-campus/VPN under any real allowlist. Not a routing
+    # bug, and not something this check can see past from localhost - if you
+    # need to verify the actual app content, curl the same path from a
+    # machine your allowlist actually admits.
+    warn "https://localhost$path : redirected to /extlanding (onsite gate active). Inconclusive from localhost - this is expected if ONSITE_ALLOWLIST_PATH is set to a real allowlist; re-run this check from an allowlisted network to verify $path's actual content."
+    continue
+  fi
+
+  title=$(printf '%s' "$body" | grep -o '<title>[^<]*</title>' | head -1 | sed -e 's/<title>//' -e 's/<\/title>//')
   if [ -z "$title" ]; then
     warn "https://localhost$path : no response / could not parse title (is nginx reachable on localhost from this host?)."
   elif [ "$title" = "$expected" ]; then

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -226,7 +226,7 @@ services:
       # Not `:?`-guarded, like DEPLOYMENT_ENV below and unlike the secrets: it
       # changes what is *reported*, never what runs, and must not be able to
       # stop a stack from starting.
-      COMPOSE_FILE_VERSION: "12"
+      COMPOSE_FILE_VERSION: "13"
       LOG_LEVEL: ${ADMIN_LOG_LEVEL:-info}
       ADMIN_API_KEY: ${SESSION_MANAGER_API_KEY}
       SESSION_MANAGER_BASE_URL: http://session-manager:80

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -8,6 +8,13 @@ services:
     volumes:
       - ${SSL_CERT_PATH}:/etc/nginx/ssl/pub.cert:ro
       - ${SSL_KEY_PATH}:/etc/nginx/ssl/priv.key:ro
+      # Onsite-only access gate (nginx.conf's `$onsite`). Defaults are real,
+      # live files checked into this directory - not `.template`s to copy
+      # first, unlike PROVIDER_CONFIG_PATH - because "nobody is restricted"
+      # is a sane universal default here. Point both at real files (see
+      # onsite-allowlist.example.conf) to actually restrict access.
+      - ${ONSITE_ALLOWLIST_PATH:-./onsite/allowlist.default.conf}:/etc/nginx/onsite/config/allowlist.conf:ro
+      - ${ONSITE_CONTENT_PATH:-./onsite/content-default}:/usr/share/nginx/onsite/content:ro
     depends_on:
       client-webapp:
         condition: service_healthy

--- a/deployment/onsite-allowlist.example.conf
+++ b/deployment/onsite-allowlist.example.conf
@@ -1,0 +1,91 @@
+# Example onsite-access allowlist for a University of Illinois Urbana-Champaign
+# deployment of ScribeAR.
+#
+# To use: copy this file (e.g. to onsite-allowlist.conf, ignored by git the
+# same way provider_config.json is), then point ONSITE_ALLOWLIST_PATH at it
+# in your .env. Until you do, nginx uses onsite/allowlist.default.conf - a
+# permissive "everyone is onsite" default - so a stock `docker compose up` is
+# never gated by accident.
+#
+# Source of truth: https://answers.uillinois.edu/illinois/page.php?id=47572
+# ("Guide to University of Illinois IP Spaces"), fetched 2026-08-02. Re-check
+# this page before reusing the file for a new academic year or a different
+# Illinois-system campus - these ranges are administered centrally (by
+# University Technology Services / AITS) and can change without this repo
+# being notified.
+#
+# Policy this file encodes: "onsite" means either physically on the
+# Urbana-Champaign campus network (wired, wireless, or NCSA, which is
+# co-located on that campus), OR connected through Illinois's own VPN
+# (either the MFA or the password-only pool) - VPN access is intentionally
+# treated as equivalent to physical presence, so a user working from off
+# campus does not need to be on-site as long as they've tunneled in.
+#
+# Deliberately EXCLUDED, even though the source page lists them:
+#   - UIC, UIS, COM Peoria, COM Rockford, CoP Rockford, JM Law School - each
+#     is a distinct Illinois-system campus with its own netblocks. A device
+#     physically at UIC is not "onsite" for a captioning deployment that
+#     serves Urbana-Champaign classrooms, and nothing here should be widened
+#     to include them without a deliberate, separate decision.
+#   - "System-wide Shared Services" (64.22.176.0/20, 204.93.0.0/19,
+#     2620:79:8000::/48) - this is AITS (Administrative Information
+#     Technology Services), which runs enterprise systems (Banner, HR/payroll,
+#     financial aid, finance) for the entire University of Illinois System -
+#     UIC, UIUC, and UIS together - out of shared System Office
+#     infrastructure. It is not physically scoped to Urbana-Champaign the way
+#     NCSA is, so including it would reopen the same "a machine at another
+#     campus can get in" gap this file exists to close.
+#
+# geo's source variable is explicit ($remote_addr) rather than left to the
+# implicit default, so this is unambiguous if this block is ever copied
+# somewhere that also sets a different geo source. IMPORTANT CAVEAT: this is
+# only correct if nginx sees the real client IP as $remote_addr - i.e. nothing
+# sits in front of this proxy silently substituting its own address (a load
+# balancer, CDN, or additional reverse proxy would break this unless paired
+# with ngx_http_realip_module and a trusted-proxy list). Confirm the actual
+# network path before relying on this in production.
+geo $remote_addr $onsite {
+    default 0;
+
+    # -- Urbana-Champaign campus: public --
+    72.36.64.0/18           1;
+    128.174.0.0/16          1;
+    130.126.0.0/16          1;
+    192.17.0.0/16           1;
+    2600:3900::/28          1;
+    2620:0:e00::/44         1;
+
+    # -- Urbana-Champaign campus: private (designated for campus-internal use) --
+    10.192.0.0/10           1;
+    172.16.0.0/13           1;
+
+    # -- NCSA: public (physically co-located on the Urbana-Champaign campus) --
+    141.142.0.0/16          1;
+    198.17.196.0/24         1;
+    2620:0:0c80::/48        1;
+
+    # -- NCSA: private --
+    172.24.0.0/13           1;
+
+    # -- Illinois VPN: MFA-authenticated pool --
+    # Client-tunnel-assigned addresses and the separate NAT/egress pool are
+    # both allowlisted, since it isn't confirmed which one this proxy will
+    # actually see as $remote_addr for real VPN traffic until it's tested
+    # against a live deployment. Harmless to allowlist both.
+    10.250.128.0/17               1;
+    128.174.180.128/25            1;
+    130.126.101.0/25              1;
+    130.126.101.128/25            1;  # NAT/egress pool
+    2600:3900:1010:1000::/52      1;
+    2620:0:e00:4400::/56          1;
+
+    # -- Illinois VPN: password-only pool --
+    10.250.0.0/17                 1;
+    130.126.144.0/22              1;
+    192.17.148.0/22               1;
+    130.126.143.0/25              1;  # NAT/egress pool
+    2620:0:e00:4024::/64          1;
+    2620:0:e00:4034::/64          1;
+    2620:0:e00:400f::/64          1;
+    2620:0:e00:403b::/64          1;
+}

--- a/deployment/onsite/allowlist.default.conf
+++ b/deployment/onsite/allowlist.default.conf
@@ -1,0 +1,15 @@
+# Permissive default for the onsite-only access gate (nginx.conf's
+# `include /etc/nginx/onsite/config/allowlist.conf;`). Bind-mounted here by
+# ONSITE_ALLOWLIST_PATH's default in compose.yml, so a stock
+# `docker compose up` - dev, deployment-iso, anyone who hasn't configured
+# this feature - is ungated out of the box.
+#
+# $onsite = 1 unconditionally: every request is treated as onsite, so every
+# `if ($onsite = 0) { ... }` gate in nginx.conf never fires. This is a
+# deliberate default, not a placeholder to fill in - see
+# ../onsite-allowlist.example.conf for a real, restrictive allowlist (built
+# for University of Illinois Urbana-Champaign) to copy and point
+# ONSITE_ALLOWLIST_PATH at for a real deployment.
+geo $remote_addr $onsite {
+    default 1;
+}

--- a/deployment/onsite/content-default/index.html
+++ b/deployment/onsite/content-default/index.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ScribeAR — onsite access required</title>
+    <style>
+      /* Same palette roles as libs/audio-meter-page/audio-meter.html, for a
+         consistent look across every static page this deployment serves. */
+      :root {
+        color-scheme: light;
+        --surface: #fcfcfb;
+        --plane: #f9f9f7;
+        --ink: #0b0b0b;
+        --ink-2: #52514e;
+        --ink-muted: #898781;
+        --border: rgba(11, 11, 11, 0.1);
+        --focus: #2a78d6;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root:where(:not([data-theme='light'])) {
+          color-scheme: dark;
+          --surface: #1a1a19;
+          --plane: #0d0d0d;
+          --ink: #ffffff;
+          --ink-2: #c3c2b7;
+          --ink-muted: #898781;
+          --border: rgba(255, 255, 255, 0.1);
+          --focus: #3987e5;
+        }
+      }
+      :root[data-theme='dark'] {
+        color-scheme: dark;
+        --surface: #1a1a19;
+        --plane: #0d0d0d;
+        --ink: #ffffff;
+        --ink-2: #c3c2b7;
+        --ink-muted: #898781;
+        --border: rgba(255, 255, 255, 0.1);
+        --focus: #3987e5;
+      }
+
+      body {
+        margin: 0;
+        background: var(--plane);
+        color: var(--ink);
+        font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+        font-size: 16px;
+        line-height: 1.6;
+      }
+      main {
+        max-width: 34rem;
+        margin: 3.5rem auto;
+        padding: 2rem;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 0.75rem;
+      }
+      h1 {
+        font-size: 1.25rem;
+        margin: 0 0 1rem;
+      }
+      p {
+        color: var(--ink-2);
+        margin: 0 0 1.5rem;
+      }
+      button {
+        font: inherit;
+        font-weight: 600;
+        color: var(--surface);
+        background: var(--ink);
+        border: none;
+        border-radius: 0.4rem;
+        padding: 0.6rem 1.2rem;
+        cursor: pointer;
+      }
+      button:focus-visible {
+        outline: 2px solid var(--focus);
+        outline-offset: 2px;
+      }
+      button:hover {
+        opacity: 0.85;
+      }
+      .muted {
+        color: var(--ink-muted);
+        font-size: 0.85rem;
+        margin-top: 1.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Onsite access required</h1>
+      <p>
+        Live Captions require an on-campus network connection; they are not
+        accessible from the internet. Connect your phone or laptop to the
+        VPN, campus WiFi (or ethernet), then reload.
+      </p>
+      <button type="button" id="reload">Reload</button>
+      <p class="muted">
+        If you're on campus or VPN and still see this page, the connection
+        may not have applied yet — wait a moment and reload again.
+      </p>
+    </main>
+    <script>
+      // Returns to wherever the visitor was trying to go (client/kiosk/admin/
+      // standalone), not just this landing page, once the network connects -
+      // otherwise "Reload" would just show this same page again forever,
+      // since this route is intentionally never gated (see /extlanding in
+      // nginx.conf). document.referrer, not a server-reflected query
+      // parameter: it's the browser's own navigation history, so there is
+      // nothing here for a crafted URL to inject.
+      (function () {
+        var button = document.getElementById('reload');
+        var target = null;
+        try {
+          if (document.referrer) {
+            var referrer = new URL(document.referrer);
+            if (referrer.origin === window.location.origin) {
+              target = referrer.href;
+            }
+          }
+        } catch (e) {
+          target = null;
+        }
+        button.addEventListener('click', function () {
+          window.location.href = target || window.location.href;
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/deployment/onsite/content-default/index.html
+++ b/deployment/onsite/content-default/index.html
@@ -110,6 +110,16 @@
       // nginx.conf). document.referrer, not a server-reflected query
       // parameter: it's the browser's own navigation history, so there is
       // nothing here for a crafted URL to inject.
+      //
+      // Known edge cases where `target` stays null and Reload just reloads
+      // THIS page instead of returning anywhere - accepted tradeoffs, not
+      // bugs, for the same reason: a strict Referrer-Policy or private
+      // browsing can empty document.referrer entirely; navigating here
+      // directly (the devops preview use case) has no referrer by
+      // definition; and a referrer from a different origin fails the check
+      // above on purpose. All three degrade to "Reload does nothing useful
+      // yet" rather than anything unsafe - the muted text below already
+      // covers the visible symptom ("wait a moment and reload again").
       (function () {
         var button = document.getElementById('reload');
         var target = null;

--- a/infra/scribear-nginx/Dockerfile
+++ b/infra/scribear-nginx/Dockerfile
@@ -9,6 +9,20 @@ FROM nginx:1.29.7-alpine3.23
 
 COPY infra/scribear-nginx/nginx.conf /etc/nginx/nginx.conf
 
+# Permissive defaults for the onsite-only access gate, baked in so the image
+# is self-sufficient - nginx.conf's `include` and `location = /extlanding`
+# reference these exact paths unconditionally, with no fallback if they're
+# absent. Without this, any compose file that doesn't yet know about
+# ONSITE_ALLOWLIST_PATH/ONSITE_CONTENT_PATH (found via code review: at least
+# five outside this repo don't) gets a nginx that refuses to start at all -
+# `nginx -t` fails on a missing include, which is a silent, total breaking
+# change to this image's runtime interface, not a gated-access nuance.
+# deployment/compose.yml's bind mounts still override these paths for a real
+# deployment; this is only the floor under compose files that haven't been
+# updated yet.
+COPY deployment/onsite/allowlist.default.conf /etc/nginx/onsite/config/allowlist.conf
+COPY deployment/onsite/content-default/index.html /usr/share/nginx/onsite/content/index.html
+
 # 127.0.0.1, not localhost: on alpine/busybox "localhost" resolves to ::1 first
 # and nginx listens only on IPv4, so localhost gives "connection refused". Hit
 # the dedicated /healthz (root "/" returns 404, which wget reads as failure).

--- a/infra/scribear-nginx/eslint.config.js
+++ b/infra/scribear-nginx/eslint.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'eslint/config';
+
+import baseConfig from '../../eslint.config.js';
+
+export default defineConfig([...baseConfig]);

--- a/infra/scribear-nginx/nginx.conf
+++ b/infra/scribear-nginx/nginx.conf
@@ -95,21 +95,69 @@ http {
     # $remote_addr against a `geo` block that lives outside this file - see
     # deployment/onsite-allowlist.example.conf for a real campus's ranges,
     # citations, and the reasoning behind what's included/excluded, and
-    # 2026-08-02-01-PLAN-OnsiteAccess.md (scribear2, not this repo) for the
+    # 2026-08-02-PLAN-AccessRulesLandingPage.md (scribear2, not this repo) for the
     # full design.
     #
-    # This include's target is deliberately NOT this file, and not baked into
-    # the image either: it is a bind mount (deployment/compose.yml,
-    # ONSITE_ALLOWLIST_PATH), defaulting to a permissive `default 1;` file
-    # checked into deployment/ so a stock `docker compose up` - dev,
-    # deployment-iso, anyone who's never heard of this feature - is
-    # ungated out of the box. Staging/production point ONSITE_ALLOWLIST_PATH
-    # at a real allowlist instead. Deliberately unlike
-    # PROVIDER_CONFIG_PATH's default (which requires copying a `.template`
-    # first, because there is no sane universal provider set): "nobody is
-    # restricted" is a sane universal default here, so the default file is
-    # real and live, not a template to copy.
+    # This include's target is deliberately NOT this file. A permissive
+    # `default 1;` version is baked into the image at this exact path
+    # (Dockerfile) so the image is self-sufficient and starts ungated even
+    # under a compose file that has never heard of this feature; a real
+    # deployment overrides it with a bind mount (deployment/compose.yml,
+    # ONSITE_ALLOWLIST_PATH) pointed at a real allowlist. The bind mount always
+    # wins when present - this include has no idea, and needs no idea, which
+    # one is actually live. Deliberately unlike PROVIDER_CONFIG_PATH's default
+    # (which requires copying a `.template` first, because there is no sane
+    # universal provider set): "nobody is restricted" is a sane universal
+    # default here, so the baked-in file is real and live, not a placeholder.
     include /etc/nginx/onsite/config/allowlist.conf;
+
+    # $onsite is only as trustworthy as $remote_addr. If a load balancer, CDN,
+    # or any other proxy sits in front of THIS nginx, $remote_addr becomes
+    # that proxy's address, not the real client's - every request looks like
+    # it came from the same place. The dangerous direction is silent
+    # fail-open: if the front proxy's own address happens to fall inside the
+    # allowlist (plausible if it runs on-campus), every off-campus request
+    # would pass the gate regardless of where it actually originated.
+    #
+    # Leave this disabled (the default - nginx is the actual internet-facing
+    # edge) unless there really is a trusted proxy in front of THIS
+    # container specifically. Enabling it with no such proxy present would let
+    # any client forge its own X-Forwarded-For and bypass the gate entirely -
+    # the opposite failure, self-inflicted. `http_realip_module` is already
+    # compiled into this image (`nginx -V` lists `--with-http_realip_module`),
+    # so turning this on is uncommenting and filling in real values, not a
+    # rebuild:
+    #
+    #   set_real_ip_from  <the front proxy's own IP or CIDR>;
+    #   real_ip_header    X-Forwarded-For;  # or `proxy_protocol;` if it speaks that instead
+    #   real_ip_recursive on;
+
+    # Marks a response the onsite gate denied, for log/header visibility only
+    # - $onsite itself (from the include above) is what actually drives the
+    # allow/deny decision in each location below; this only makes a gate-403
+    # distinguishable from an ordinary upstream 403 without inspecting
+    # response bodies. Deliberately NOT set inside any `if ($onsite = 0)`
+    # block - see the safe-`if` note further down - and deliberately empty
+    # (not e.g. "allowed") on the passthrough case: nginx omits an
+    # `add_header` entirely when its value is empty, so an allowed/proxied
+    # response is untouched rather than gaining a header nobody asked for.
+    map $onsite $onsite_gate_status {
+        0       "denied";
+        default "";
+    }
+
+    # Stops a stale 302 from being replayed by a caching intermediary after
+    # the client actually connects to campus/VPN - a redirect has no
+    # explicit cache directive otherwise, and some intermediary proxies
+    # cache one heuristically. Same empty-value-omits-the-header technique
+    # as $onsite_gate_status above, and for the same reason: several of the
+    # locations this applies to also proxy long-cached, hash-versioned
+    # static assets whose own upstream-set Cache-Control must not be touched
+    # on the allowed path.
+    map $onsite $onsite_no_cache {
+        0       "no-store";
+        default "";
+    }
 
     # Balancing key for the node-server upstream: the session uid out of the
     # URL path. Both transcription-stream routes carry it in the same position -
@@ -264,7 +312,7 @@ http {
         # off-campus visitor sees, without spoofing their source IP. Every
         # gated frontend route below redirects here; this is also directly
         # reachable on its own, from anywhere, on purpose. See
-        # 2026-08-02-01-PLAN-OnsiteAccess.md §3 (scribear2, not this repo).
+        # 2026-08-02-PLAN-AccessRulesLandingPage.md §3 (scribear2, not this repo).
         location = /extlanding {
             root /usr/share/nginx/onsite/content;
             try_files /index.html =404;
@@ -279,12 +327,23 @@ http {
         # `403`, not `404`: unlike the internal-only routes above, an
         # off-campus caller SHOULD be told the route exists and exactly why
         # it's withheld - that's the whole point of this gate, not something
-        # to obscure from a prober the way those routes are.
+        # to obscure from a prober the way those routes are. Every location
+        # also carries `add_header X-Onsite-Gate $onsite_gate_status
+        # always;`, outside the `if` for the reason given where that map is
+        # defined above - and, because THAT is this location's first
+        # add_header, also re-declares Strict-Transport-Security: nginx only
+        # inherits the server block's add_header directives when a location
+        # defines none of its own, so adding any add_header here silently
+        # drops HSTS otherwise (verified live - it disappeared from a real
+        # response the first time this was written without the re-declare).
+        # Same reasoning /admin/'s own re-declaration comment already gives.
 
         location /api/session-manager/ {
             if ($onsite = 0) {
                 return 403 "Onsite only; captions are not served to the internet.\n";
             }
+            add_header X-Onsite-Gate $onsite_gate_status always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             proxy_pass http://session-manager;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";
@@ -298,6 +357,8 @@ http {
             if ($onsite = 0) {
                 return 403 "Onsite only; captions are not served to the internet.\n";
             }
+            add_header X-Onsite-Gate $onsite_gate_status always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             proxy_pass http://admin-server;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";
@@ -317,6 +378,8 @@ http {
             if ($onsite = 0) {
                 return 403 "Onsite only; captions are not served to the internet.\n";
             }
+            add_header X-Onsite-Gate $onsite_gate_status always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             proxy_pass http://admin-server;
             proxy_set_header Host              $host;
             proxy_set_header X-Real-IP         $remote_addr;
@@ -336,6 +399,8 @@ http {
             if ($onsite = 0) {
                 return 403 "Onsite only; captions are not served to the internet.\n";
             }
+            add_header X-Onsite-Gate $onsite_gate_status always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             proxy_pass http://node-server;
             proxy_set_header Host              $host;
             proxy_set_header X-Real-IP         $remote_addr;
@@ -363,12 +428,21 @@ http {
         # Frontend surfaces below redirect to /extlanding rather than
         # returning a bare 403 - a person, not an API client, is on the other
         # end, and the landing page explains why and how to get in (VPN /
-        # campus network) rather than leaving a blank error.
+        # campus network) rather than leaving a blank error. Each also sets
+        # `Cache-Control: no-store` (via $onsite_no_cache, only on the
+        # gate's own 302 - see where that map is defined) so a caching
+        # intermediary can't replay a stale redirect after the client
+        # actually connects. And, since these are each location's first
+        # add_header, each also re-declares Strict-Transport-Security - see
+        # the API section's comment above for why that's necessary here.
 
         location /client/ {
             if ($onsite = 0) {
                 return 302 /extlanding;
             }
+            add_header X-Onsite-Gate $onsite_gate_status always;
+            add_header Cache-Control $onsite_no_cache always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             proxy_pass http://client-webapp/;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";
@@ -382,6 +456,9 @@ http {
             if ($onsite = 0) {
                 return 302 /extlanding;
             }
+            add_header X-Onsite-Gate $onsite_gate_status always;
+            add_header Cache-Control $onsite_no_cache always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             proxy_pass http://kiosk-webapp/;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";
@@ -395,6 +472,9 @@ http {
             if ($onsite = 0) {
                 return 302 /extlanding;
             }
+            add_header X-Onsite-Gate $onsite_gate_status always;
+            add_header Cache-Control $onsite_no_cache always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             proxy_pass http://standalone-webapp/;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";
@@ -433,6 +513,8 @@ http {
             if ($onsite = 0) {
                 return 302 /extlanding;
             }
+            add_header X-Onsite-Gate $onsite_gate_status always;
+            add_header Cache-Control $onsite_no_cache always;
             proxy_pass http://admin-webapp/audio-meter.html;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";
@@ -450,6 +532,8 @@ http {
             if ($onsite = 0) {
                 return 302 /extlanding;
             }
+            add_header X-Onsite-Gate $onsite_gate_status always;
+            add_header Cache-Control $onsite_no_cache always;
             proxy_pass http://admin-webapp/;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";

--- a/infra/scribear-nginx/nginx.conf
+++ b/infra/scribear-nginx/nginx.conf
@@ -91,6 +91,26 @@ http {
         ''      close;
     }
 
+    # Onsite-only access gate. Defines $onsite (1 = allowed, 0 = gated) from
+    # $remote_addr against a `geo` block that lives outside this file - see
+    # deployment/onsite-allowlist.example.conf for a real campus's ranges,
+    # citations, and the reasoning behind what's included/excluded, and
+    # 2026-08-02-01-PLAN-OnsiteAccess.md (scribear2, not this repo) for the
+    # full design.
+    #
+    # This include's target is deliberately NOT this file, and not baked into
+    # the image either: it is a bind mount (deployment/compose.yml,
+    # ONSITE_ALLOWLIST_PATH), defaulting to a permissive `default 1;` file
+    # checked into deployment/ so a stock `docker compose up` - dev,
+    # deployment-iso, anyone who's never heard of this feature - is
+    # ungated out of the box. Staging/production point ONSITE_ALLOWLIST_PATH
+    # at a real allowlist instead. Deliberately unlike
+    # PROVIDER_CONFIG_PATH's default (which requires copying a `.template`
+    # first, because there is no sane universal provider set): "nobody is
+    # restricted" is a sane universal default here, so the default file is
+    # real and live, not a template to copy.
+    include /etc/nginx/onsite/config/allowlist.conf;
+
     # Balancing key for the node-server upstream: the session uid out of the
     # URL path. Both transcription-stream routes carry it in the same position -
     # /api/node-server/v1/transcription-stream/<sessionUid>/source and
@@ -237,9 +257,34 @@ http {
             return 404;
         }
 
+        # -- Onsite gate: devops preview -------
+        #
+        # Deliberately NOT behind the $onsite check below - its entire
+        # purpose is letting someone on campus see exactly what an
+        # off-campus visitor sees, without spoofing their source IP. Every
+        # gated frontend route below redirects here; this is also directly
+        # reachable on its own, from anywhere, on purpose. See
+        # 2026-08-02-01-PLAN-OnsiteAccess.md §3 (scribear2, not this repo).
+        location = /extlanding {
+            root /usr/share/nginx/onsite/content;
+            try_files /index.html =404;
+        }
+
         # -- Backend APIs -------
+        #
+        # Each `if ($onsite = 0) { return 403 ...; }` below is the one form
+        # nginx's own docs call safe inside a location block - a bare
+        # `return`, nothing else - see
+        # https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/.
+        # `403`, not `404`: unlike the internal-only routes above, an
+        # off-campus caller SHOULD be told the route exists and exactly why
+        # it's withheld - that's the whole point of this gate, not something
+        # to obscure from a prober the way those routes are.
 
         location /api/session-manager/ {
+            if ($onsite = 0) {
+                return 403 "Onsite only; captions are not served to the internet.\n";
+            }
             proxy_pass http://session-manager;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";
@@ -250,6 +295,9 @@ http {
         }
 
         location /api/admin/ {
+            if ($onsite = 0) {
+                return 403 "Onsite only; captions are not served to the internet.\n";
+            }
             proxy_pass http://admin-server;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";
@@ -266,6 +314,9 @@ http {
         # it is not a keepalive-pooling candidate the way the block above is,
         # so it keeps managing its own Connection header instead of clearing it.
         location = /api/admin/v1/fleet/stream {
+            if ($onsite = 0) {
+                return 403 "Onsite only; captions are not served to the internet.\n";
+            }
             proxy_pass http://admin-server;
             proxy_set_header Host              $host;
             proxy_set_header X-Real-IP         $remote_addr;
@@ -280,6 +331,11 @@ http {
         }
 
         location /api/node-server/ {
+            # The transcription-stream WebSocket - the literal captions
+            # payload "captions are not served to the internet" refers to.
+            if ($onsite = 0) {
+                return 403 "Onsite only; captions are not served to the internet.\n";
+            }
             proxy_pass http://node-server;
             proxy_set_header Host              $host;
             proxy_set_header X-Real-IP         $remote_addr;
@@ -304,7 +360,15 @@ http {
             return 308 /client/;
         }
 
+        # Frontend surfaces below redirect to /extlanding rather than
+        # returning a bare 403 - a person, not an API client, is on the other
+        # end, and the landing page explains why and how to get in (VPN /
+        # campus network) rather than leaving a blank error.
+
         location /client/ {
+            if ($onsite = 0) {
+                return 302 /extlanding;
+            }
             proxy_pass http://client-webapp/;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";
@@ -315,6 +379,9 @@ http {
         }
 
         location /kiosk/ {
+            if ($onsite = 0) {
+                return 302 /extlanding;
+            }
             proxy_pass http://kiosk-webapp/;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";
@@ -325,6 +392,9 @@ http {
         }
 
         location /standalone/ {
+            if ($onsite = 0) {
+                return 302 /extlanding;
+            }
             proxy_pass http://standalone-webapp/;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";
@@ -360,6 +430,9 @@ http {
         # order; proxy_pass therefore has to name the upstream path in full,
         # since nginx replaces the whole matched URI with the one given here.
         location = /admin/audio-meter.html {
+            if ($onsite = 0) {
+                return 302 /extlanding;
+            }
             proxy_pass http://admin-webapp/audio-meter.html;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";
@@ -374,6 +447,9 @@ http {
         }
 
         location /admin/ {
+            if ($onsite = 0) {
+                return 302 /extlanding;
+            }
             proxy_pass http://admin-webapp/;
             proxy_http_version 1.1;
             proxy_set_header Connection        "";

--- a/infra/scribear-nginx/package.json
+++ b/infra/scribear-nginx/package.json
@@ -3,8 +3,13 @@
   "version": "0.2.0",
   "description": "",
   "author": "scribear",
+  "type": "module",
   "scripts": {
-    "lint": "echo 'No lintable source'",
-    "format": "echo 'No formattable source'"
+    "lint": "eslint ./tests",
+    "lint:fix": "eslint ./tests --fix",
+    "format": "prettier --check ./tests",
+    "format:fix": "prettier --write ./tests",
+    "test:dev": "vitest --ui --coverage",
+    "test:unit": "vitest run --project unit"
   }
 }

--- a/infra/scribear-nginx/tests/unit/onsite-gate.test.ts
+++ b/infra/scribear-nginx/tests/unit/onsite-gate.test.ts
@@ -8,7 +8,7 @@ import { describe, expect } from 'vitest';
  * nginx-session-config-stream-not-public.test.ts (session-manager) guard
  * their own routes: nginx.conf is the only place this policy is enforced,
  * and a comment asking not to delete a location block is weaker than a
- * failing test. See 2026-08-02-01-PLAN-OnsiteAccess.md (scribear2, not this
+ * failing test. See 2026-08-02-PLAN-AccessRulesLandingPage.md (scribear2, not this
  * repo) for the full design.
  *
  * This lives here, not in one of the app workspaces the way the two
@@ -70,13 +70,29 @@ describe('nginx onsite-only access gate', (it) => {
     expect(conf).toContain('include /etc/nginx/onsite/config/allowlist.conf;');
   });
 
+  it('defines the log/header-visibility maps every gated location depends on', () => {
+    // $onsite_gate_status backs X-Onsite-Gate (distinguishes a gate-403 from
+    // an upstream 403 in logs); $onsite_no_cache backs the frontend
+    // locations' Cache-Control (stops a stale 302 being replayed by a
+    // caching intermediary). Both must resolve to an EMPTY string on the
+    // allowed path (`default ""`), not e.g. "allowed" - nginx omits an
+    // add_header whose value is empty, which is what keeps these headers
+    // off an allowed/proxied response entirely.
+    expect(conf).toMatch(
+      /map \$onsite \$onsite_gate_status \{\s*0\s+"denied";\s*default\s+"";\s*\}/,
+    );
+    expect(conf).toMatch(
+      /map \$onsite \$onsite_no_cache \{\s*0\s+"no-store";\s*default\s+"";\s*\}/,
+    );
+  });
+
   it('serves /extlanding without an $onsite check - it must stay reachable from anywhere', () => {
     // Arrange
     const start = conf.indexOf('location = /extlanding {');
     expect(
       start,
       'nginx.conf has no /extlanding location. This route is the devops ' +
-        'preview page (see 2026-08-02-01-PLAN-OnsiteAccess.md §3) and every ' +
+        'preview page (see 2026-08-02-PLAN-AccessRulesLandingPage.md §3) and every ' +
         'gated frontend route redirects to it - it must exist and must never ' +
         'itself be gated.',
     ).toBeGreaterThanOrEqual(0);
@@ -116,7 +132,28 @@ describe('nginx onsite-only access gate', (it) => {
         expect(block).toContain(`return 403 "${ONSITE_DENIED_MESSAGE}`);
       } else {
         expect(block).toContain('return 302 /extlanding;');
+        // Stops a stale redirect from being replayed by a caching
+        // intermediary after the client actually connects - API 403s don't
+        // need this (they aren't redirects a client would "come back to").
+        expect(block).toContain(
+          'add_header Cache-Control $onsite_no_cache always;',
+        );
       }
+
+      // Every gated location tags a denied response for log visibility...
+      expect(block).toContain(
+        'add_header X-Onsite-Gate $onsite_gate_status always;',
+      );
+      // ...and, because that's this location's own add_header (the first
+      // one, for the API/client/kiosk/standalone locations; already present
+      // for a different reason on the two /admin* locations), it must
+      // re-declare HSTS or lose it silently: nginx only inherits the server
+      // block's add_header directives when a location defines none of its
+      // own. Verified live once already - the header actually disappeared
+      // from a real response the first time this gate shipped without it.
+      expect(block).toContain(
+        'add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;',
+      );
     });
   }
 

--- a/infra/scribear-nginx/tests/unit/onsite-gate.test.ts
+++ b/infra/scribear-nginx/tests/unit/onsite-gate.test.ts
@@ -1,0 +1,139 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect } from 'vitest';
+
+/**
+ * Guards the onsite-only access gate the same way
+ * nginx-status-not-public.test.ts (node-server) and
+ * nginx-session-config-stream-not-public.test.ts (session-manager) guard
+ * their own routes: nginx.conf is the only place this policy is enforced,
+ * and a comment asking not to delete a location block is weaker than a
+ * failing test. See 2026-08-02-01-PLAN-OnsiteAccess.md (scribear2, not this
+ * repo) for the full design.
+ *
+ * This lives here, not in one of the app workspaces the way the two
+ * precedents above do, because the gate spans every app's routes at once -
+ * there is no single owning service the way STATUS_ROUTE belongs to
+ * node-server.
+ */
+const NGINX_CONF_PATH = fileURLToPath(
+  new URL('../../nginx.conf', import.meta.url),
+);
+
+const ONSITE_DENIED_MESSAGE =
+  'Onsite only; captions are not served to the internet.';
+
+// Every location this gate must guard, and the exact denial each one must
+// perform when $onsite = 0. Frontend surfaces redirect to /extlanding so a
+// person sees an explanation; APIs 403 with a message, since the caller is
+// assumed to be a program, not a person reading a landing page.
+const GATED_LOCATIONS: {
+  name: string;
+  header: string;
+  denial: 'api' | 'frontend';
+}[] = [
+  {
+    name: 'session-manager API',
+    header: 'location /api/session-manager/ {',
+    denial: 'api',
+  },
+  { name: 'admin API', header: 'location /api/admin/ {', denial: 'api' },
+  {
+    name: 'admin fleet SSE stream',
+    header: 'location = /api/admin/v1/fleet/stream {',
+    denial: 'api',
+  },
+  {
+    name: 'node-server API (transcription-stream WebSocket)',
+    header: 'location /api/node-server/ {',
+    denial: 'api',
+  },
+  { name: 'client-webapp', header: 'location /client/ {', denial: 'frontend' },
+  { name: 'kiosk-webapp', header: 'location /kiosk/ {', denial: 'frontend' },
+  {
+    name: 'standalone-webapp',
+    header: 'location /standalone/ {',
+    denial: 'frontend',
+  },
+  {
+    name: 'admin-webapp audio meter',
+    header: 'location = /admin/audio-meter.html {',
+    denial: 'frontend',
+  },
+  { name: 'admin-webapp', header: 'location /admin/ {', denial: 'frontend' },
+];
+
+describe('nginx onsite-only access gate', (it) => {
+  const conf = readFileSync(NGINX_CONF_PATH, 'utf8');
+
+  it('includes the mounted/defaulted allowlist that defines $onsite', () => {
+    expect(conf).toContain('include /etc/nginx/onsite/config/allowlist.conf;');
+  });
+
+  it('serves /extlanding without an $onsite check - it must stay reachable from anywhere', () => {
+    // Arrange
+    const start = conf.indexOf('location = /extlanding {');
+    expect(
+      start,
+      'nginx.conf has no /extlanding location. This route is the devops ' +
+        'preview page (see 2026-08-02-01-PLAN-OnsiteAccess.md §3) and every ' +
+        'gated frontend route redirects to it - it must exist and must never ' +
+        'itself be gated.',
+    ).toBeGreaterThanOrEqual(0);
+    const block = conf.slice(start, conf.indexOf('\n        }', start));
+
+    // Assert
+    expect(block).not.toContain('$onsite');
+  });
+
+  for (const { name, header, denial } of GATED_LOCATIONS) {
+    it(`gates ${name} behind $onsite`, () => {
+      // Arrange
+      const start = conf.indexOf(header);
+      expect(
+        start,
+        `nginx.conf has no location block starting with "${header}". If ` +
+          'this route was renamed or restructured, this test needs updating ' +
+          'alongside it - do not just delete the assertion.',
+      ).toBeGreaterThanOrEqual(0);
+      const block = conf.slice(start, conf.indexOf('\n        }', start));
+
+      // Assert - the gate is the first thing in the block, before proxy_pass
+      // ever runs, and denies in the shape this route's audience expects.
+      const ifIndex = block.indexOf('if ($onsite = 0)');
+      const proxyIndex = block.indexOf('proxy_pass');
+      expect(
+        ifIndex,
+        `${name}'s location block is missing the "if ($onsite = 0) { ... }" gate.`,
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        ifIndex,
+        `${name}'s $onsite gate must run before proxy_pass, not after - ` +
+          'otherwise the request already reached the upstream before being denied.',
+      ).toBeLessThan(proxyIndex);
+
+      if (denial === 'api') {
+        expect(block).toContain(`return 403 "${ONSITE_DENIED_MESSAGE}`);
+      } else {
+        expect(block).toContain('return 302 /extlanding;');
+      }
+    });
+  }
+
+  it('gates every $onsite `if` the one way nginx documents as safe inside a location', () => {
+    // Every real gate in this file must be exactly `if ($onsite = 0) {
+    // return ...; }` - a single `return`, nothing else - per
+    // https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/. A
+    // future edit that adds a second directive inside one of these `if`
+    // blocks would reintroduce exactly the class of bug that page warns
+    // about, so this checks the *shape* of every gate, not just that the
+    // string "$onsite" appears somewhere (which a comment - like the one
+    // explaining this exact rule, a few lines above the first gate - would
+    // also satisfy).
+    const gatePattern =
+      /if \(\$onsite = 0\) \{\n\s+return (403 "[^"]*"|302 \/extlanding);\n\s+\}/g;
+    const matches = [...conf.matchAll(gatePattern)];
+
+    expect(matches).toHaveLength(GATED_LOCATIONS.length);
+  });
+});

--- a/infra/scribear-nginx/tsconfig.json
+++ b/infra/scribear-nginx/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "tests"
+  ],
+  "references": []
+}

--- a/infra/scribear-nginx/vitest.config.ts
+++ b/infra/scribear-nginx/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import sharedConfig from '../../vitest.shared.js';
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'unit',
+            environment: 'node',
+          },
+        },
+      ],
+    },
+  }),
+);


### PR DESCRIPTION
## Summary

**Onsite access gate** (`infra/scribear-nginx`, `deployment/`)
- Every nginx route — 3 APIs and 4 frontends — is now gated behind an explicit `$onsite` allowlist. Off-campus API requests get a `403`; off-campus frontend requests redirect to a landing page explaining how to connect (VPN/campus network).
- The allowlist is Illinois Urbana-Champaign + NCSA + both VPN pools, sourced from UIUC's own IP-space documentation — deliberately not a private-vs-public heuristic, since campus devices get public IPs directly (see `2026-08-02-LESSONSLEARNED-AccessRulesLandingPage.md`, not tracked in this repo).
- `/extlanding` is a new, deliberately ungated route serving the same landing page, so on-campus devops can preview it without spoofing their IP.
- Config/content are bind-mounted with permissive, checked-in defaults (`ONSITE_ALLOWLIST_PATH`/`ONSITE_CONTENT_PATH`), so a stock `docker compose up` stays fully open until an operator opts in.
- Second commit fixes a critical issue found in code review: the image had a hard runtime dependency on the bind-mounted allowlist with no fallback, so any compose file that doesn't know about the new mounts would get an nginx that refuses to start at all. The permissive defaults are now baked into the image itself; bind mounts still override them. Also adds `real_ip` guidance, `Cache-Control: no-store` on the gate's redirect, an `X-Onsite-Gate` response header, and extends `check-webapp-routing.sh` to cover `/admin/`.

**PR preview image tag naming** (`.github/actions/resolve-container-tags`)
- PR-preview images were tagged just `PR-<n>` regardless of which environment the PR targets. Now `staging-pr<n>` / `production-pr<n>` based on the PR's base branch, so the tag alone says which environment it's a candidate for.
- Independent of the onsite-gate work above — riding the same branch/PR since both were ready at the same time.

## Test plan
- [x] `infra/scribear-nginx`'s new unit test suite (13 assertions pinning the gate's shape) — `npm run test:unit --workspace=@scribear/scribear-nginx`
- [x] Live-verified against a real `nginx:1.29.7-alpine3.23` build: `nginx -t` with zero bind mounts (confirms the Dockerfile fix); custom Docker networks inside/outside the allowlist confirm 403/302/pass-through behavior and every response header (`X-Onsite-Gate`, `Cache-Control`, `Strict-Transport-Security`)
- [x] Tag-resolution logic exercised standalone across all 6 event/branch combinations (PR→staging, PR→main, override cases, both push paths)
- [ ] Live deployment verification (real campus/VPN traffic, real front-proxy topology if any) — not available this session