### PR TITLE
Implement Azure Entra ID SSO for the admin console

### DIFF
--- a/apps/admin-server/.env.example
+++ b/apps/admin-server/.env.example
@@ -57,8 +57,11 @@ DB_NAME=scribear-db-dev
 DB_USER=scribear
 DB_PASSWORD=CHANGEME
 
-#### (Future) Azure Entra ID SSO. Presence of these enables the SSO provider;
-#### leave unset for now. Documented for forward compatibility only.
+#### Azure Entra ID SSO. All five must be set to enable SSO; leaving any
+#### unset keeps SSO off (the login page shows local login only). See
+#### scribear.wiki/Developing Admin.md "Adding the Azure Entra ID provider"
+#### for the one-time Azure app-registration setup (emit the groups claim,
+#### assign the admin group, note the tenant/client/secret/redirect).
 # AZURE_TENANT_ID=
 # AZURE_CLIENT_ID=
 # AZURE_CLIENT_SECRET=

--- a/apps/admin-server/package.json
+++ b/apps/admin-server/package.json
@@ -51,6 +51,7 @@
     "env-schema": "7.0.0",
     "fastify": "5.10.0",
     "fastify-plugin": "5.1.0",
+    "jose": "6.2.7",
     "kysely": "0.28.17",
     "pg": "8.19.0",
     "typebox": "1.1.5"

--- a/apps/admin-server/src/app-config/app-config.ts
+++ b/apps/admin-server/src/app-config/app-config.ts
@@ -163,7 +163,8 @@ const CONFIG_SCHEMA = Type.Object({
   DB_USER: Type.String(),
   DB_PASSWORD: Type.String(),
 
-  // Future Azure Entra ID SSO. Presence enables the provider; empty = disabled.
+  // Azure Entra ID SSO. All five must be set (AzureOidcAuthService.isEnabled())
+  // for the provider to turn on; any left empty keeps it disabled.
   AZURE_TENANT_ID: Type.String({ default: '' }),
   AZURE_CLIENT_ID: Type.String({ default: '' }),
   AZURE_CLIENT_SECRET: Type.String({ default: '' }),
@@ -357,6 +358,7 @@ export class AppConfig {
       azureTenantId: this._env.AZURE_TENANT_ID,
       azureClientId: this._env.AZURE_CLIENT_ID,
       azureClientSecret: this._env.AZURE_CLIENT_SECRET,
+      azureRedirectUri: this._env.AZURE_REDIRECT_URI,
       allowedGroup: this._env.ADMIN_ALLOWED_GROUP,
       // Shared with the health rollup deliberately: both ask a sibling service a
       // question an operator is waiting on, so one knob should bound both.

--- a/apps/admin-server/src/server/features/auth/auth.controller.ts
+++ b/apps/admin-server/src/server/features/auth/auth.controller.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto';
 import { setTimeout as sleep } from 'node:timers/promises';
 
 import type {
@@ -12,14 +13,55 @@ import {
 } from '#src/server/shared/envelope/envelope.js';
 import {
   SESSION_COOKIE_NAME,
+  SSO_STATE_COOKIE_NAME,
   clearSessionCookieOptions,
+  clearSsoStateCookieOptions,
   sessionCookieOptions,
+  ssoStateCookieOptions,
 } from '#src/server/shared/http/cookie-options.js';
+import { SsoError } from '#src/server/shared/services/azure-oidc-auth.service.js';
 
 import type { LOGIN_SCHEMA } from './auth.schema.js';
 
 // Fixed delay applied to failed logins to blunt online password guessing.
 const FAILED_LOGIN_DELAY_MS = 400;
+
+/**
+ * Validates a `return_to` path so it can be safely used as a redirect target
+ * after SSO. Must be a relative path within the admin SPA (`/admin...`) and
+ * must not contain `//` (which could be a protocol-relative URL). Returns
+ * `/admin/` (the dashboard) if the input is missing or invalid — never an
+ * absolute URL, so there is no open-redirect surface.
+ */
+function sanitizeReturnTo(value: string | undefined): string {
+  if (!value) return '/admin/';
+  // Must be exactly '/admin' or start with '/admin/' — not '/adminXYZ',
+  // which isn't a route under the admin SPA. And no '//' anywhere, which
+  // could be a protocol-relative URL (open-redirect surface).
+  if (value !== '/admin' && !value.startsWith('/admin/')) return '/admin/';
+  if (value.includes('//')) return '/admin/';
+  return value;
+}
+
+/**
+ * Maps `SsoError` codes to the user-facing query parameter sent to the SPA
+ * login page. The detailed code is logged/audited but never sent to the
+ * browser — a generic param prevents information leakage about internal state.
+ */
+function ssoErrorToParam(code: SsoError['code']): string {
+  switch (code) {
+    case 'GROUP_REJECTED':
+      return 'group_rejected';
+    case 'GROUP_CLAIM_MISSING':
+    case 'GROUP_OVERAGE':
+      return 'config_error';
+    case 'TOKEN_EXCHANGE_FAILED':
+    case 'TOKEN_VALIDATION_FAILED':
+      return 'auth_failed';
+    default:
+      return 'auth_failed';
+  }
+}
 
 export class AuthController {
   private _localAuthService: AppDependencies['localAuthService'];
@@ -158,24 +200,211 @@ export class AuthController {
     );
   }
 
-  /** SSO stub: 404 until the Azure provider is configured + implemented. */
+  /**
+   * SSO login entry point: generate a PKCE pair + CSRF state, store them in a
+   * short-lived signed cookie, and redirect the browser to Azure's
+   * authorization endpoint. The SPA triggers this with a full-page navigation
+   * (not a fetch) — the redirect must be top-level so Azure's callback can
+   * redirect back to the BFF.
+   */
   ssoLogin(req: BaseFastifyRequest, res: BaseFastifyReply) {
-    this._ssoNotAvailable(req, res);
+    if (!this._azureOidcAuthService.isEnabled()) {
+      res
+        .code(404)
+        .send(
+          errorEnvelope(
+            'SSO_NOT_AVAILABLE',
+            'SSO is not configured on this deployment.',
+            req.id,
+          ),
+        );
+      return;
+    }
+
+    const { url, state, codeVerifier, nonce } =
+      this._azureOidcAuthService.buildAuthorizationUrl();
+
+    // Capture the SPA deep link the user was on, so the callback can return
+    // them there instead of always landing on the dashboard.
+    const query = req.query as { return_to?: string };
+    const returnTo = sanitizeReturnTo(query.return_to);
+
+    res.setCookie(
+      SSO_STATE_COOKIE_NAME,
+      JSON.stringify({ state, codeVerifier, nonce, returnTo }),
+      ssoStateCookieOptions(this._sessionService.config.secure),
+    );
+
+    res.redirect(url.toString());
   }
 
-  ssoCallback(req: BaseFastifyRequest, res: BaseFastifyReply) {
-    this._ssoNotAvailable(req, res);
-  }
+  /**
+   * SSO callback: Azure redirects here with `?code=...&state=...`. Verify the
+   * state against the cookie (CSRF), exchange the code for tokens, validate
+   * the id_token, enforce the group allowlist, and issue a session. On any
+   * failure, redirect to the login page with an error indicator — the SPA
+   * renders the message.
+   */
+  async ssoCallback(req: BaseFastifyRequest, res: BaseFastifyReply) {
+    if (!this._azureOidcAuthService.isEnabled()) {
+      res
+        .code(404)
+        .send(
+          errorEnvelope(
+            'SSO_NOT_AVAILABLE',
+            'SSO is not configured on this deployment.',
+            req.id,
+          ),
+        );
+      return;
+    }
 
-  private _ssoNotAvailable(req: BaseFastifyRequest, res: BaseFastifyReply) {
-    res
-      .code(404)
-      .send(
-        errorEnvelope(
-          'SSO_NOT_AVAILABLE',
-          'SSO is not configured on this deployment.',
-          req.id,
-        ),
+    const secure = this._sessionService.config.secure;
+
+    // Always clear the state cookie — it is one-time use.
+    res.clearCookie(SSO_STATE_COOKIE_NAME, clearSsoStateCookieOptions(secure));
+
+    const query = req.query as {
+      code?: string;
+      state?: string;
+      error?: string;
+    };
+
+    // Azure may redirect back with an error instead of a code.
+    if (query.error) {
+      await this._auditSsoFailure(
+        req,
+        'auth_failed',
+        `Azure error: ${query.error}`,
       );
+      res.redirect('/admin/login?sso_error=auth_failed');
+      return;
+    }
+
+    // Read and verify the state cookie (CSRF defense for the OIDC flow).
+    const rawCookie = req.unsignCookie(
+      req.cookies[SSO_STATE_COOKIE_NAME] ?? '',
+    );
+    if (!rawCookie.valid || !rawCookie.value) {
+      await this._auditSsoFailure(
+        req,
+        'state_error',
+        'SSO state cookie missing or invalid',
+      );
+      res.redirect('/admin/login?sso_error=state_error');
+      return;
+    }
+
+    let cookieState: string;
+    let codeVerifier: string;
+    let nonce: string;
+    let returnTo: string;
+    try {
+      const parsed = JSON.parse(rawCookie.value) as {
+        state: string;
+        codeVerifier: string;
+        nonce?: string;
+        returnTo?: string;
+      };
+      cookieState = parsed.state;
+      codeVerifier = parsed.codeVerifier;
+      nonce = parsed.nonce ?? '';
+      returnTo = sanitizeReturnTo(parsed.returnTo);
+    } catch {
+      await this._auditSsoFailure(
+        req,
+        'state_error',
+        'SSO state cookie unparseable',
+      );
+      res.redirect('/admin/login?sso_error=state_error');
+      return;
+    }
+
+    // Constant-time state comparison (defense-in-depth: the state is a
+    // 256-bit random value in a signed cookie, so timing attacks are
+    // impractical, but the cost is negligible).
+    const queryState = query.state ?? '';
+    if (
+      queryState.length !== cookieState.length ||
+      !timingSafeEqual(Buffer.from(queryState), Buffer.from(cookieState))
+    ) {
+      await this._auditSsoFailure(req, 'state_error', 'SSO state mismatch');
+      res.redirect('/admin/login?sso_error=state_error');
+      return;
+    }
+
+    if (!query.code) {
+      await this._auditSsoFailure(
+        req,
+        'state_error',
+        'SSO callback missing authorization code',
+      );
+      res.redirect('/admin/login?sso_error=state_error');
+      return;
+    }
+
+    let identity;
+    try {
+      identity = await this._azureOidcAuthService.handleCallback(
+        query.code,
+        codeVerifier,
+        nonce,
+      );
+    } catch (err) {
+      if (err instanceof SsoError) {
+        await this._auditSsoFailure(
+          req,
+          ssoErrorToParam(err.code),
+          err.message,
+        );
+        res.redirect(`/admin/login?sso_error=${ssoErrorToParam(err.code)}`);
+        return;
+      }
+      throw err;
+    }
+
+    const { sessionId } = this._sessionService.create(identity);
+    res.setCookie(
+      SESSION_COOKIE_NAME,
+      sessionId,
+      sessionCookieOptions(
+        secure,
+        this._sessionService.config.absoluteTimeoutMs,
+      ),
+    );
+
+    await this._auditService.record({
+      actorSubject: identity.subject,
+      actorProvider: 'sso',
+      action: 'login',
+      target: null,
+      paramsSummary: { outcome: 'success' },
+      result: 'success',
+      statusCode: 302,
+      requestId: req.id,
+    });
+
+    res.redirect(returnTo);
+  }
+
+  private async _auditSsoFailure(
+    req: BaseFastifyRequest,
+    param: string,
+    detail: string,
+  ): Promise<void> {
+    req.log.warn(
+      { ssoError: param, detail, requestId: req.id },
+      'SSO login failed',
+    );
+    await this._auditService.record({
+      actorSubject: 'unknown',
+      actorProvider: 'sso',
+      action: 'login',
+      target: null,
+      paramsSummary: { outcome: param },
+      result: 'failure',
+      statusCode: 302,
+      requestId: req.id,
+    });
   }
 }

--- a/apps/admin-server/src/server/features/auth/auth.router.ts
+++ b/apps/admin-server/src/server/features/auth/auth.router.ts
@@ -53,7 +53,10 @@ export function authRouter(
     handler: resolveHandler('authController', 'logout'),
   });
 
-  // SSO stubs (return 404 until Azure is configured).
+  // SSO routes: run the full OIDC flow when AZURE_* config is present, 404
+  // SSO_NOT_AVAILABLE when it isn't. No rate limit (the redirect to Azure is
+  // not a guessing surface), no session/CSRF preHandler (these are the
+  // endpoints that *establish* a session).
   fastify.route({
     ...SSO_LOGIN_ROUTE,
     handler: resolveHandler('authController', 'ssoLogin'),

--- a/apps/admin-server/src/server/features/config-check/config-check.service.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.service.ts
@@ -190,6 +190,8 @@ export interface ConfigCheckConfig {
   azureTenantId: string;
   azureClientId: string;
   azureClientSecret: string;
+  /** Never previously read here — see `sso-incomplete-config`'s history. */
+  azureRedirectUri: string;
   allowedGroup: string;
   /**
    * Bound on asking session-manager what schema version it expects. Shared with
@@ -433,10 +435,65 @@ export function evaluateStaticChecks(
 
   // ---- access ----
   const localLoginEnabled = config.adminLocalCredentials.trim() !== '';
+  // Loose "has an operator started down the SSO path" signal (3 of 5 vars) —
+  // deliberately looser than `isEnabled()`, since `local-login-only`'s job is
+  // "nudge someone who hasn't started" rather than "is SSO actually live."
   const ssoConfigured =
     config.azureTenantId !== '' &&
     config.azureClientId !== '' &&
     config.azureClientSecret !== '';
+
+  // Mirrors AzureOidcAuthService.isEnabled() exactly (all five vars) — this
+  // is the one that must answer "can someone actually complete SSO login,"
+  // not just "has an operator started configuring it." `no-login-method`
+  // below used to check the looser `ssoConfigured` and could report a
+  // deployment as having a working login method while local login was off
+  // and SSO was three-of-five-vars configured — i.e. actually unusable,
+  // silently. Fixed here rather than left as a footnote: this is exactly the
+  // "guard inherits the defect it's guarding" shape this deployment's own
+  // conventions call out elsewhere.
+  const azureVars = {
+    AZURE_TENANT_ID: config.azureTenantId,
+    AZURE_CLIENT_ID: config.azureClientId,
+    AZURE_CLIENT_SECRET: config.azureClientSecret,
+    AZURE_REDIRECT_URI: config.azureRedirectUri,
+    ADMIN_ALLOWED_GROUP: config.allowedGroup,
+  };
+  const azureVarsSet = Object.values(azureVars).filter((v) => v !== '').length;
+  const ssoFullyConfigured = azureVarsSet === 5;
+
+  const missingAzureVars = Object.entries(azureVars)
+    .filter(([, value]) => value === '')
+    .map(([key]) => key);
+  // Excludes the case where ADMIN_ALLOWED_GROUP is the ONLY thing missing:
+  // `sso-no-group-restriction` below already reports that specific,
+  // actionable case (and at a higher severity) — firing both here would be
+  // two findings naming the same root cause.
+  const missingBeyondGroup = missingAzureVars.filter(
+    (key) => key !== 'ADMIN_ALLOWED_GROUP',
+  );
+
+  if (azureVarsSet > 0 && azureVarsSet < 5 && missingBeyondGroup.length > 0) {
+    const missing = missingAzureVars;
+    findings.push(
+      finding(
+        {
+          id: 'sso-incomplete-config',
+          category: 'access',
+          title: 'Azure SSO configuration is incomplete',
+          detail:
+            `${missing.join(', ')} ${missing.length === 1 ? 'is' : 'are'} ` +
+            'empty while other AZURE_*/ADMIN_ALLOWED_GROUP variables are ' +
+            'set. AzureOidcAuthService.isEnabled() requires all five, so SSO ' +
+            'stays disabled — the only visible symptom is the "Sign in with ' +
+            'Illinois" button not appearing, with nothing pointing at why.',
+          remediation: `Set ${missing.join(', ')}, or clear the other Azure variables if SSO isn't intended yet.`,
+        },
+        { development: 'advisory', staging: 'warning', production: 'warning' },
+        env,
+      ),
+    );
+  }
 
   if (localLoginEnabled && isPlaceholder(config.adminLocalCredentials)) {
     findings.push(
@@ -460,8 +517,12 @@ export function evaluateStaticChecks(
     );
   }
 
-  if (!localLoginEnabled && !ssoConfigured) {
-    // Not a hardening nit: nobody can sign in at all.
+  if (!localLoginEnabled && !ssoFullyConfigured) {
+    // Not a hardening nit: nobody can sign in at all. Checks the same
+    // 5-var completeness as `isEnabled()`, not the looser `ssoConfigured` —
+    // a deployment with 3-of-5 Azure vars set does NOT have a working SSO
+    // login, so it must not read as "fine" here just because it looks
+    // SSO-configured to the looser check above.
     findings.push(
       finding(
         {
@@ -469,9 +530,9 @@ export function evaluateStaticChecks(
           category: 'access',
           title: 'No admin login method is configured',
           detail:
-            'ADMIN_LOCAL_CREDENTIALS is empty and Azure SSO is not configured, so no one can sign in to this console.',
+            'ADMIN_LOCAL_CREDENTIALS is empty and Azure SSO is not fully configured (or not configured at all), so no one can sign in to this console.',
           remediation:
-            'Set ADMIN_LOCAL_CREDENTIALS, or configure AZURE_TENANT_ID, AZURE_CLIENT_ID and AZURE_CLIENT_SECRET.',
+            'Set ADMIN_LOCAL_CREDENTIALS, or configure all five: AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_REDIRECT_URI and ADMIN_ALLOWED_GROUP.',
         },
         {
           development: 'critical',

--- a/apps/admin-server/src/server/shared/http/cookie-options.ts
+++ b/apps/admin-server/src/server/shared/http/cookie-options.ts
@@ -39,4 +39,47 @@ export function clearSessionCookieOptions(
   };
 }
 
+/**
+ * Name of the short-lived cookie that carries the PKCE code verifier and CSRF
+ * state between /auth/sso/login and /auth/sso/callback. See
+ * `2026-08-02-02-PLAN-AzureSso.md` §2.
+ */
+export const SSO_STATE_COOKIE_NAME = 'sso_state';
+
+/** Path the SSO state cookie is scoped to (covers both SSO routes only). */
+export const SSO_STATE_COOKIE_PATH = '/api/admin/v1/auth/sso';
+
+/** TTL for the SSO state cookie — enough for the OIDC redirect dance. */
+export const SSO_STATE_COOKIE_MAX_AGE_SEC = 300;
+
+/**
+ * Options for the SSO state cookie. `SameSite=Lax` (not `Strict`) is required:
+ * the OIDC callback is a cross-site redirect from Azure, and `Strict` would
+ * suppress the cookie on that redirect, breaking the flow. `Lax` sends
+ * cookies on top-level GET navigations — exactly what the callback is — while
+ * still providing CSRF protection for non-GET requests.
+ */
+export function ssoStateCookieOptions(secure: boolean): CookieSerializeOptions {
+  return {
+    httpOnly: true,
+    secure,
+    sameSite: 'lax',
+    signed: true,
+    path: SSO_STATE_COOKIE_PATH,
+    maxAge: SSO_STATE_COOKIE_MAX_AGE_SEC,
+  };
+}
+
+/** Options used when clearing the SSO state cookie (must match path/attributes). */
+export function clearSsoStateCookieOptions(
+  secure: boolean,
+): CookieSerializeOptions {
+  return {
+    httpOnly: true,
+    secure,
+    sameSite: 'lax',
+    path: SSO_STATE_COOKIE_PATH,
+  };
+}
+
 export { SESSION_COOKIE_NAME };

--- a/apps/admin-server/src/server/shared/services/azure-oidc-auth.service.ts
+++ b/apps/admin-server/src/server/shared/services/azure-oidc-auth.service.ts
@@ -1,4 +1,10 @@
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+
 import type { AppDependencies } from '#src/server/dependency-injection/app-dependencies.js';
+
+import type { Identity } from '../types/identity.js';
+import { ROLE_READ_WRITE } from '../types/identity.js';
 
 export interface AzureAuthConfig {
   tenantId: string;
@@ -9,32 +15,360 @@ export interface AzureAuthConfig {
 }
 
 /**
- * Stub for the future Azure Entra ID (OIDC, Auth Code + PKCE) provider. The
- * seams are in place so it drops in later without reworking session/CSRF/audit:
- * everything downstream sees only an `Identity`.
+ * Error thrown by `handleCallback` on any failure. The `code` is a stable
+ * machine-readable string the controller maps to a user-facing redirect
+ * parameter; `message` is for logs/audit and is never sent to the browser.
+ */
+export class SsoError extends Error {
+  readonly code: SsoErrorCode;
+  constructor(code: SsoErrorCode, message: string) {
+    super(message);
+    this.name = 'SsoError';
+    this.code = code;
+  }
+}
+
+export type SsoErrorCode =
+  | 'TOKEN_EXCHANGE_FAILED'
+  | 'TOKEN_VALIDATION_FAILED'
+  | 'GROUP_CLAIM_MISSING'
+  | 'GROUP_OVERAGE'
+  | 'GROUP_REJECTED';
+
+/**
+ * Azure Entra ID (OIDC) auth provider — Authorization Code + PKCE.
  *
- * Enabled only when all required `AZURE_*` config is present. Until then
- * `isEnabled()` is false and `/auth/config` reports `sso: false`.
+ * Enabled only when ALL five `AZURE_*` config vars are present (including
+ * `allowedGroup`). Until then `isEnabled()` is false, `/auth/config` reports
+ * `sso: false`, and the SSO routes return 404. An empty `allowedGroup` would
+ * let any tenant user administer the deployment, so fail-closed is the only
+ * safe default — the Config Check's `sso-no-group-restriction` critical
+ * finding enforces the same thing at the reporting layer.
+ *
+ * Everything downstream of authentication (session, CSRF, audit) sees only an
+ * `Identity`, never an Azure-specific credential — the pluggable-provider
+ * design from `archived-plans/2026-07-15-01-PLAN-ADMIN.md` §4.4.
  */
 export class AzureOidcAuthService {
   readonly id = 'sso' as const;
 
   private _enabled: boolean;
+  private _tenantId: string;
+  private _clientId: string;
+  private _clientSecret: string;
+  private _redirectUri: string;
+  private _allowedGroup: string;
+  private _issuer: string;
+  private _jwks: ReturnType<typeof createRemoteJWKSet>;
+  private _logger: AppDependencies['logger'];
 
-  constructor(azureAuthConfig: AppDependencies['azureAuthConfig']) {
+  constructor(
+    logger: AppDependencies['logger'],
+    azureAuthConfig: AppDependencies['azureAuthConfig'],
+  ) {
+    this._logger = logger;
     const cfg = azureAuthConfig;
-    this._enabled =
-      cfg.tenantId.trim() !== '' &&
-      cfg.clientId.trim() !== '' &&
-      cfg.clientSecret.trim() !== '' &&
-      cfg.redirectUri.trim() !== '';
+    this._tenantId = cfg.tenantId.trim();
+    this._clientId = cfg.clientId.trim();
+    this._clientSecret = cfg.clientSecret.trim();
+    this._redirectUri = cfg.redirectUri.trim();
+    this._allowedGroup = cfg.allowedGroup.trim();
+
+    const configured =
+      this._tenantId !== '' &&
+      this._clientId !== '' &&
+      this._clientSecret !== '' &&
+      this._redirectUri !== '' &&
+      this._allowedGroup !== '';
+
+    this._enabled = configured;
+    this._issuer = `https://login.microsoftonline.com/${this._tenantId}/v2.0`;
+    this._jwks = createRemoteJWKSet(
+      new URL(
+        `https://login.microsoftonline.com/${this._tenantId}/discovery/v2.0/keys`,
+      ),
+    );
   }
 
   isEnabled(): boolean {
     return this._enabled;
   }
 
-  // Intentionally not implemented yet. The route handlers guard on
-  // `isEnabled()` and return 404 while disabled; wiring the real OIDC flow
-  // (buildAuthorizationUrl / handleCallback -> Identity) happens here.
+  /**
+   * Build the Azure authorization URL and generate the PKCE pair + CSRF state
+   * + OIDC nonce. The controller stores `{ state, codeVerifier, nonce }` in a
+   * signed short-lived cookie and redirects the browser to `url`.
+   *
+   * The scope includes `https://graph.microsoft.com/.default` so the
+   * `access_token` carries whatever Graph API delegated permissions have been
+   * admin-consented on the app registration — needed by the group-overage
+   * fallback (`_checkGroupViaGraph`). Without it, Azure AD v2.0's per-request
+   * consent model would issue a token with only `openid profile email` and no
+   * Graph permission, making every overage-fallback call 403.
+   */
+  buildAuthorizationUrl(): {
+    url: URL;
+    state: string;
+    codeVerifier: string;
+    nonce: string;
+  } {
+    const codeVerifier = randomBytes(32).toString('base64url');
+    const codeChallenge = createHash('sha256')
+      .update(codeVerifier, 'ascii')
+      .digest('base64url');
+    const state = randomBytes(32).toString('base64url');
+    const nonce = randomBytes(32).toString('base64url');
+
+    const url = new URL(
+      `https://login.microsoftonline.com/${this._tenantId}/oauth2/v2.0/authorize`,
+    );
+    url.searchParams.set('client_id', this._clientId);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('redirect_uri', this._redirectUri);
+    url.searchParams.set(
+      'scope',
+      'openid profile email https://graph.microsoft.com/.default',
+    );
+    url.searchParams.set('state', state);
+    url.searchParams.set('nonce', nonce);
+    url.searchParams.set('code_challenge', codeChallenge);
+    url.searchParams.set('code_challenge_method', 'S256');
+
+    return { url, state, codeVerifier, nonce };
+  }
+
+  /**
+   * Exchange the authorization code for tokens, validate the `id_token`,
+   * enforce the group allowlist, and return an `Identity`. Throws `SsoError`
+   * on any failure — the controller catches it and maps `code` to a redirect.
+   *
+   * Group authorization checks the `groups` claim in the `id_token` first.
+   * When Azure emits an overage indicator (user has >200 groups, so the
+   * `groups` claim is replaced by `_claim_names`/`_claim_sources`), this falls
+   * back to the Microsoft Graph API `checkMemberGroups` endpoint using the
+   * `access_token` from the token response — so the operator does not have to
+   * configure "groups assigned to the application" in Azure as long as the
+   * app registration has delegated `Directory.Read.All` or
+   * `GroupMember.Read.All` permission with admin consent.
+   */
+  async handleCallback(
+    code: string,
+    codeVerifier: string,
+    expectedNonce: string,
+  ): Promise<Identity> {
+    const tokenResponse = await this._exchangeCode(code, codeVerifier);
+    const idToken = tokenResponse.id_token;
+    if (!idToken) {
+      throw new SsoError(
+        'TOKEN_VALIDATION_FAILED',
+        'Token endpoint did not return an id_token.',
+      );
+    }
+
+    const claims = await this._validateIdToken(idToken, expectedNonce);
+    await this._authorizeGroup(claims, tokenResponse.access_token);
+
+    const subject = typeof claims['sub'] === 'string' ? claims['sub'] : '';
+    const displayName =
+      typeof claims['name'] === 'string'
+        ? claims['name']
+        : typeof claims['preferred_username'] === 'string'
+          ? claims['preferred_username']
+          : subject;
+
+    return {
+      subject,
+      displayName,
+      provider: 'sso',
+      roles: [ROLE_READ_WRITE],
+    };
+  }
+
+  private async _exchangeCode(
+    code: string,
+    codeVerifier: string,
+  ): Promise<TokenEndpointResponse> {
+    const body = new URLSearchParams({
+      client_id: this._clientId,
+      client_secret: this._clientSecret,
+      code,
+      redirect_uri: this._redirectUri,
+      code_verifier: codeVerifier,
+      grant_type: 'authorization_code',
+    });
+
+    let res: Response;
+    try {
+      res = await fetch(
+        `https://login.microsoftonline.com/${this._tenantId}/oauth2/v2.0/token`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
+          body: body.toString(),
+        },
+      );
+    } catch (err) {
+      throw new SsoError(
+        'TOKEN_EXCHANGE_FAILED',
+        `Network error during token exchange: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new SsoError(
+        'TOKEN_EXCHANGE_FAILED',
+        `Token endpoint returned ${String(res.status)}: ${text.slice(0, 500)}`,
+      );
+    }
+
+    try {
+      return (await res.json()) as TokenEndpointResponse;
+    } catch (err) {
+      throw new SsoError(
+        'TOKEN_EXCHANGE_FAILED',
+        `Failed to parse token endpoint response: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private async _validateIdToken(
+    idToken: string,
+    expectedNonce: string,
+  ): Promise<Record<string, unknown>> {
+    try {
+      const { payload } = await jwtVerify(idToken, this._jwks, {
+        issuer: this._issuer,
+        audience: this._clientId,
+      });
+
+      // OIDC nonce check: binds this id_token to the specific authorization
+      // request that initiated the flow, preventing ID-token replay. The
+      // nonce was generated in buildAuthorizationUrl, stored in the signed
+      // sso_state cookie, and sent to Azure as the `nonce` param — Azure
+      // echoes it back unmodified in the id_token's `nonce` claim.
+      const tokenNonce = payload['nonce'];
+      if (
+        typeof tokenNonce !== 'string' ||
+        tokenNonce.length !== expectedNonce.length ||
+        !timingSafeEqual(Buffer.from(tokenNonce), Buffer.from(expectedNonce))
+      ) {
+        throw new SsoError(
+          'TOKEN_VALIDATION_FAILED',
+          'id_token nonce mismatch — possible replay attack.',
+        );
+      }
+
+      return payload;
+    } catch (err) {
+      if (err instanceof SsoError) throw err;
+      throw new SsoError(
+        'TOKEN_VALIDATION_FAILED',
+        `id_token validation failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private async _authorizeGroup(
+    claims: Record<string, unknown>,
+    accessToken: string | undefined,
+  ): Promise<void> {
+    // Azure emits an overage indicator when the user has >200 groups, instead
+    // of the groups array. Fall back to the Graph API's checkMemberGroups
+    // endpoint using the access_token — this requires the app registration to
+    // have delegated Directory.Read.All or GroupMember.Read.All permission
+    // with admin consent. If the app is configured with "groups assigned to
+    // the application" in Azure, the overage indicator never appears and this
+    // path is not reached.
+    if ('_claim_names' in claims || '_claim_sources' in claims) {
+      await this._checkGroupViaGraph(accessToken);
+      return;
+    }
+
+    const groups = claims['groups'];
+    if (!Array.isArray(groups)) {
+      throw new SsoError(
+        'GROUP_CLAIM_MISSING',
+        'id_token has no groups claim. Configure the app registration to emit the groups claim.',
+      );
+    }
+
+    if (!groups.includes(this._allowedGroup)) {
+      throw new SsoError(
+        'GROUP_REJECTED',
+        `User is not a member of the allowed group (${this._allowedGroup}).`,
+      );
+    }
+  }
+
+  /**
+   * Graph API fallback for the group overage case. Calls
+   * `checkMemberGroups` with the `access_token` to test membership in
+   * `allowedGroup` without relying on the `groups` claim.
+   */
+  private async _checkGroupViaGraph(
+    accessToken: string | undefined,
+  ): Promise<void> {
+    if (!accessToken) {
+      throw new SsoError(
+        'GROUP_OVERAGE',
+        'Group overage detected but no access_token was returned by the token endpoint ' +
+          'to call the Graph API fallback. Configure "groups assigned to the application" in Azure.',
+      );
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(
+        'https://graph.microsoft.com/v1.0/me/checkMemberGroups',
+        {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ groupIds: [this._allowedGroup] }),
+        },
+      );
+    } catch (err) {
+      throw new SsoError(
+        'GROUP_OVERAGE',
+        `Graph API call failed during group overage fallback: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new SsoError(
+        'GROUP_OVERAGE',
+        `Graph API returned ${String(res.status)}: ${text.slice(0, 500)}. ` +
+          'The app registration may need delegated Directory.Read.All or GroupMember.Read.All permission with admin consent, ' +
+          'or configure "groups assigned to the application" in Azure to avoid overage.',
+      );
+    }
+
+    try {
+      const body = (await res.json()) as { value?: string[] };
+      if (!body.value?.includes(this._allowedGroup)) {
+        throw new SsoError(
+          'GROUP_REJECTED',
+          `User is not a member of the allowed group (${this._allowedGroup}).`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof SsoError) throw err;
+      throw new SsoError(
+        'GROUP_OVERAGE',
+        `Failed to parse Graph API response: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+interface TokenEndpointResponse {
+  access_token?: string;
+  id_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  refresh_token?: string;
 }

--- a/apps/admin-server/tests/integration/auth-sso.routes.test.ts
+++ b/apps/admin-server/tests/integration/auth-sso.routes.test.ts
@@ -1,0 +1,388 @@
+import { SignJWT, exportJWK, generateKeyPair } from 'jose';
+import {
+  type MockInstance,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  vi,
+} from 'vitest';
+
+import { useServer } from '#tests/utils/use-server.js';
+
+const BASE = '/api/admin/v1';
+
+const SSO_CONFIG = {
+  tenantId: 'test-tenant',
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  redirectUri: 'https://example.edu/api/admin/v1/auth/sso/callback',
+  allowedGroup: 'admin-group-aaa',
+};
+
+const ISSUER = `https://login.microsoftonline.com/${SSO_CONFIG.tenantId}/v2.0`;
+const TOKEN_ENDPOINT = `https://login.microsoftonline.com/${SSO_CONFIG.tenantId}/oauth2/v2.0/token`;
+const JWKS_ENDPOINT = `https://login.microsoftonline.com/${SSO_CONFIG.tenantId}/discovery/v2.0/keys`;
+
+function requestUrl(input: string | URL | Request): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+describe('Auth SSO routes — disabled (default config)', () => {
+  const server = useServer();
+
+  describe('GET /auth/sso/login', (it) => {
+    it('returns 404 SSO_NOT_AVAILABLE when SSO is not configured', async () => {
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/sso/login`,
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(404);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'SSO_NOT_AVAILABLE',
+      );
+    });
+  });
+
+  describe('GET /auth/sso/callback', (it) => {
+    it('returns 404 SSO_NOT_AVAILABLE when SSO is not configured', async () => {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/sso/callback?code=x&state=y`,
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'SSO_NOT_AVAILABLE',
+      );
+    });
+  });
+});
+
+describe('Auth SSO routes — enabled', () => {
+  const server = useServer({ azureAuthConfig: SSO_CONFIG });
+
+  let testPrivateKey: CryptoKey;
+  let testPublicJwk: Record<string, unknown>;
+  let fetchSpy: MockInstance;
+
+  beforeAll(async () => {
+    const pair = await generateKeyPair('RS256');
+    testPrivateKey = pair.privateKey;
+    const jwk = await exportJWK(pair.publicKey);
+    testPublicJwk = { ...jwk, kid: 'test-kid' };
+  });
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function mockTokenEndpoint(idToken: string): void {
+    fetchSpy.mockImplementation((input: string | URL | Request) => {
+      const url = requestUrl(input);
+      if (url === JWKS_ENDPOINT) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ keys: [testPublicJwk] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url === TOKEN_ENDPOINT) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              id_token: idToken,
+              access_token: 'test-access',
+              token_type: 'Bearer',
+              expires_in: 3600,
+            }),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            },
+          ),
+        );
+      }
+      return Promise.resolve(new Response('not found', { status: 404 }));
+    });
+  }
+
+  async function signTestToken(
+    claims: Record<string, unknown>,
+    nonce?: string,
+  ): Promise<string> {
+    const payload = nonce ? { ...claims, nonce } : claims;
+    return new SignJWT(payload)
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-kid', typ: 'JWT' })
+      .setIssuer(ISSUER)
+      .setAudience(SSO_CONFIG.clientId)
+      .setIssuedAt()
+      .setExpirationTime('2h')
+      .sign(testPrivateKey);
+  }
+
+  /**
+   * Drives the login redirect to extract the sso_state cookie and the state
+   * and nonce params, so the callback test can present them as a browser
+   * would. The nonce is visible in the redirect URL (not in the signed
+   * cookie), so it can be extracted and baked into the test id_token.
+   */
+  async function startSsoLogin(returnTo?: string): Promise<{
+    cookie: string;
+    state: string;
+    nonce: string;
+  }> {
+    const url = returnTo
+      ? `${BASE}/auth/sso/login?return_to=${encodeURIComponent(returnTo)}`
+      : `${BASE}/auth/sso/login`;
+    const res = await server.fastify.inject({
+      method: 'GET',
+      url,
+    });
+
+    expect(res.statusCode).toBe(302);
+    const location = String(res.headers.location);
+    expect(location).toContain('login.microsoftonline.com');
+
+    // Extract the state and nonce from the redirect URL's query params.
+    const redirectUrl = new URL(location);
+    const state = redirectUrl.searchParams.get('state');
+    const nonce = redirectUrl.searchParams.get('nonce');
+    expect(state).toBeTruthy();
+    expect(nonce).toBeTruthy();
+
+    // Extract the sso_state cookie pair (name=value only).
+    const setCookie = res.headers['set-cookie'];
+    const raw = Array.isArray(setCookie)
+      ? (setCookie[0] ?? '')
+      : (setCookie ?? '');
+    const cookiePair = raw.split(';')[0] ?? '';
+
+    return { cookie: cookiePair, state: state!, nonce: nonce! };
+  }
+
+  describe('GET /auth/config', (it) => {
+    it('reports sso enabled alongside local', async () => {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/config`,
+      });
+      expect(res.json()).toEqual({
+        ok: true,
+        data: { local: true, sso: true },
+      });
+    });
+  });
+
+  describe('GET /auth/sso/login', (it) => {
+    it('redirects to Azure with PKCE challenge and sets a signed sso_state cookie', async () => {
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/sso/login`,
+      });
+
+      // Assert
+      expect(res.statusCode).toBe(302);
+      const location = new URL(String(res.headers.location));
+      expect(location.origin).toBe('https://login.microsoftonline.com');
+      expect(location.pathname).toBe(
+        `/${SSO_CONFIG.tenantId}/oauth2/v2.0/authorize`,
+      );
+      expect(location.searchParams.get('client_id')).toBe(SSO_CONFIG.clientId);
+      expect(location.searchParams.get('response_type')).toBe('code');
+      expect(location.searchParams.get('redirect_uri')).toBe(
+        SSO_CONFIG.redirectUri,
+      );
+      expect(location.searchParams.get('scope')).toBe(
+        'openid profile email https://graph.microsoft.com/.default',
+      );
+      expect(location.searchParams.get('code_challenge_method')).toBe('S256');
+      expect(location.searchParams.get('code_challenge')).toBeTruthy();
+      expect(location.searchParams.get('state')).toBeTruthy();
+      expect(location.searchParams.get('nonce')).toBeTruthy();
+
+      // A signed sso_state cookie is set.
+      const setCookie = String(res.headers['set-cookie']);
+      expect(setCookie).toContain('sso_state=');
+      expect(setCookie.toLowerCase()).toContain('httponly');
+      expect(setCookie.toLowerCase()).toContain('samesite=lax');
+    });
+  });
+
+  describe('GET /auth/sso/callback', (it) => {
+    it('creates a session and redirects to /admin/ on a valid callback', async () => {
+      // Arrange — start the SSO login to get the state cookie
+      const { cookie, state, nonce } = await startSsoLogin();
+
+      const idToken = await signTestToken(
+        {
+          sub: 'azure-user-001',
+          name: 'Test Admin',
+          groups: [SSO_CONFIG.allowedGroup],
+        },
+        nonce,
+      );
+      mockTokenEndpoint(idToken);
+
+      // Act — simulate Azure redirecting back with code + state
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/sso/callback?code=test-code&state=${state}`,
+        headers: { cookie },
+      });
+
+      // Assert — redirected to the SPA root with a session cookie
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe('/admin/');
+
+      const setCookie = String(res.headers['set-cookie']);
+      expect(setCookie).toContain('admin_session=');
+      // The sso_state cookie is cleared (one-time use).
+      expect(setCookie.toLowerCase()).toContain('sso_state=');
+      expect(setCookie.toLowerCase()).toContain('expires=thu, 01 jan 1970');
+
+      // The session is usable: /auth/me returns the SSO identity.
+      const sessionCookie = setCookie
+        .split(',')
+        .find((c) => c.trim().startsWith('admin_session='));
+      const cookiePair = (sessionCookie ?? '').split(';')[0] ?? '';
+      const meRes = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/me`,
+        headers: { cookie: cookiePair },
+      });
+      expect(meRes.statusCode).toBe(200);
+      const me = meRes.json<{
+        data: { identity: { subject: string; provider: string } };
+      }>();
+      expect(me.data.identity.subject).toBe('azure-user-001');
+      expect(me.data.identity.provider).toBe('sso');
+    });
+
+    it('redirects with sso_error=group_rejected when the user is not in the allowed group', async () => {
+      const { cookie, state, nonce } = await startSsoLogin();
+
+      const idToken = await signTestToken(
+        {
+          sub: 'azure-user-no-group',
+          name: 'Unauthorized',
+          groups: ['some-other-group'],
+        },
+        nonce,
+      );
+      mockTokenEndpoint(idToken);
+
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/sso/callback?code=test-code&state=${state}`,
+        headers: { cookie },
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe(
+        '/admin/login?sso_error=group_rejected',
+      );
+      // No session cookie issued.
+      const setCookie = String(res.headers['set-cookie'] ?? '');
+      expect(setCookie).not.toContain('admin_session=');
+    });
+
+    it('redirects with sso_error=state_error when the state cookie is missing', async () => {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/sso/callback?code=test-code&state=anything`,
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe('/admin/login?sso_error=state_error');
+    });
+
+    it('redirects with sso_error=state_error when the state does not match', async () => {
+      const { cookie } = await startSsoLogin();
+
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/sso/callback?code=test-code&state=wrong-state`,
+        headers: { cookie },
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe('/admin/login?sso_error=state_error');
+    });
+
+    it('redirects with sso_error=auth_failed when Azure sends an error param', async () => {
+      const { cookie, state } = await startSsoLogin();
+
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/sso/callback?error=access_denied&state=${state}`,
+        headers: { cookie },
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe('/admin/login?sso_error=auth_failed');
+    });
+
+    it('preserves a deep link through the SSO flow via return_to', async () => {
+      // Arrange — start SSO login with a return_to deep link
+      const { cookie, state, nonce } = await startSsoLogin('/admin/rooms/123');
+
+      const idToken = await signTestToken(
+        {
+          sub: 'azure-deep-link',
+          name: 'Deep Link User',
+          groups: [SSO_CONFIG.allowedGroup],
+        },
+        nonce,
+      );
+      mockTokenEndpoint(idToken);
+
+      // Act — callback with the state cookie
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/sso/callback?code=test-code&state=${state}`,
+        headers: { cookie },
+      });
+
+      // Assert — redirected to the deep link, not the dashboard
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe('/admin/rooms/123');
+    });
+
+    it('sanitizes a malicious return_to (absolute URL) to /admin/', async () => {
+      const { cookie, state, nonce } = await startSsoLogin(
+        'https://evil.com/admin/',
+      );
+
+      const idToken = await signTestToken(
+        {
+          sub: 'azure-sanitize',
+          name: 'Sanitize User',
+          groups: [SSO_CONFIG.allowedGroup],
+        },
+        nonce,
+      );
+      mockTokenEndpoint(idToken);
+
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/sso/callback?code=test-code&state=${state}`,
+        headers: { cookie },
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe('/admin/');
+    });
+  });
+});

--- a/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
+++ b/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
@@ -50,6 +50,7 @@ const CLEAN: ConfigCheckConfig = {
   azureTenantId: 'tenant-1',
   azureClientId: 'client-1',
   azureClientSecret: '0b4e8d2a7f16c395',
+  azureRedirectUri: 'https://example.edu/api/admin/v1/auth/sso/callback',
   allowedGroup: 'scribear-admins',
   upstreamTimeoutMs: 3_000,
 };
@@ -514,6 +515,66 @@ describe('evaluateStaticChecks', () => {
 
     it('flags SSO left open to the whole tenant', () => {
       expect(ids({ allowedGroup: '' })).toContain('sso-no-group-restriction');
+    });
+
+    // Regression test: `no-login-method` used to check the loose 3-of-5-var
+    // `ssoConfigured` instead of mirroring `isEnabled()`'s 5-var requirement,
+    // so a deployment with local login off and SSO merely "started" (not
+    // actually functional) read as having a working login method. It did not.
+    it('flags a deployment nobody can sign in to when SSO is only partially configured', () => {
+      expect(
+        ids({
+          adminLocalCredentials: '',
+          azureRedirectUri: '',
+          allowedGroup: '',
+        }),
+      ).toContain('no-login-method');
+    });
+
+    it('does not flag no-login-method when SSO is fully configured', () => {
+      expect(
+        ids({ adminLocalCredentials: '' }), // CLEAN's Azure vars are all set
+      ).not.toContain('no-login-method');
+    });
+
+    it('flags an incomplete SSO configuration missing more than just the group', () => {
+      const found = ids({ azureRedirectUri: '' });
+      expect(found).toContain('sso-incomplete-config');
+      expect(found).not.toContain('no-login-method'); // local login still covers access
+    });
+
+    it('names every missing variable in the incomplete-config finding', () => {
+      const [finding] = check({
+        azureRedirectUri: '',
+        allowedGroup: '',
+      }).filter((f) => f.id === 'sso-incomplete-config');
+      expect(finding?.detail).toContain('AZURE_REDIRECT_URI');
+      expect(finding?.detail).toContain('ADMIN_ALLOWED_GROUP');
+    });
+
+    it('does not flag sso-incomplete-config when ADMIN_ALLOWED_GROUP is the only thing missing', () => {
+      // sso-no-group-restriction already reports this specific, more
+      // actionable case - firing both would name the same root cause twice.
+      const found = ids({ allowedGroup: '' });
+      expect(found).toContain('sso-no-group-restriction');
+      expect(found).not.toContain('sso-incomplete-config');
+    });
+
+    it('does not flag sso-incomplete-config when no Azure vars are set at all', () => {
+      // Not "started and broken" - just "not configured yet", already
+      // covered by no-login-method/local-login-only as appropriate.
+      const found = ids({
+        azureTenantId: '',
+        azureClientId: '',
+        azureClientSecret: '',
+        azureRedirectUri: '',
+        allowedGroup: '',
+      });
+      expect(found).not.toContain('sso-incomplete-config');
+    });
+
+    it('does not flag sso-incomplete-config when all five vars are set', () => {
+      expect(ids({})).not.toContain('sso-incomplete-config');
     });
 
     it('treats a shared local account as a production concern only', () => {

--- a/apps/admin-server/tests/unit/shared/services/azure-oidc-auth.service.test.ts
+++ b/apps/admin-server/tests/unit/shared/services/azure-oidc-auth.service.test.ts
@@ -1,0 +1,638 @@
+import { SignJWT, exportJWK, generateKeyPair } from 'jose';
+import { createHash } from 'node:crypto';
+import {
+  type MockInstance,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  vi,
+} from 'vitest';
+
+import { AzureOidcAuthService } from '#src/server/shared/services/azure-oidc-auth.service.js';
+import { createMockLogger } from '#tests/utils/mock-logger.js';
+
+const TEST_CONFIG = {
+  tenantId: 'test-tenant-id',
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  redirectUri: 'https://example.edu/api/admin/v1/auth/sso/callback',
+  allowedGroup: 'group-aaa-111',
+};
+
+const TOKEN_ENDPOINT = `https://login.microsoftonline.com/${TEST_CONFIG.tenantId}/oauth2/v2.0/token`;
+const JWKS_ENDPOINT = `https://login.microsoftonline.com/${TEST_CONFIG.tenantId}/discovery/v2.0/keys`;
+const ISSUER = `https://login.microsoftonline.com/${TEST_CONFIG.tenantId}/v2.0`;
+
+const TEST_NONCE = 'test-nonce-12345';
+
+/**
+ * Builds a signed test id_token (and its matching JWKS) so `jose`'s
+ * `jwtVerify` + `createRemoteJWKSet` can validate it without a real Azure
+ * endpoint. `fetch` is mocked to serve the JWKS at the discovery URL and the
+ * token response at the token URL.
+ */
+async function buildTestToken(
+  privateKey: CryptoKey,
+  publicJwk: Record<string, unknown>,
+  claims: Record<string, unknown>,
+  nonce?: string,
+): Promise<string> {
+  const payload = nonce ? { ...claims, nonce } : claims;
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'RS256', kid: 'test-kid', typ: 'JWT' })
+    .setIssuer(ISSUER)
+    .setAudience(TEST_CONFIG.clientId)
+    .setSubject(claims['sub'] as string)
+    .setIssuedAt()
+    .setExpirationTime('2h')
+    .sign(privateKey);
+}
+
+function requestUrl(input: string | URL | Request): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+describe('AzureOidcAuthService', () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  describe('isEnabled', (it) => {
+    it('is enabled when all five config vars are set', () => {
+      // Arrange
+      const logger = createMockLogger();
+
+      // Act
+      const service = new AzureOidcAuthService(logger as never, TEST_CONFIG);
+
+      // Assert
+      expect(service.isEnabled()).toBe(true);
+    });
+
+    it('is disabled when tenantId is empty', () => {
+      const service = new AzureOidcAuthService(createMockLogger() as never, {
+        ...TEST_CONFIG,
+        tenantId: '',
+      });
+      expect(service.isEnabled()).toBe(false);
+    });
+
+    it('is disabled when allowedGroup is empty', () => {
+      const service = new AzureOidcAuthService(createMockLogger() as never, {
+        ...TEST_CONFIG,
+        allowedGroup: '',
+      });
+      expect(service.isEnabled()).toBe(false);
+    });
+
+    it('is disabled when redirectUri is empty', () => {
+      const service = new AzureOidcAuthService(createMockLogger() as never, {
+        ...TEST_CONFIG,
+        redirectUri: '',
+      });
+      expect(service.isEnabled()).toBe(false);
+    });
+
+    it('is disabled when all vars are empty', () => {
+      const service = new AzureOidcAuthService(createMockLogger() as never, {
+        tenantId: '',
+        clientId: '',
+        clientSecret: '',
+        redirectUri: '',
+        allowedGroup: '',
+      });
+      expect(service.isEnabled()).toBe(false);
+    });
+
+    it('trims whitespace before checking', () => {
+      const service = new AzureOidcAuthService(createMockLogger() as never, {
+        ...TEST_CONFIG,
+        allowedGroup: '  ',
+      });
+      expect(service.isEnabled()).toBe(false);
+    });
+  });
+
+  describe('buildAuthorizationUrl', (it) => {
+    it('builds a URL with all required OIDC params, PKCE, nonce, and Graph scope', () => {
+      // Arrange
+      const logger = createMockLogger();
+      const service = new AzureOidcAuthService(logger as never, TEST_CONFIG);
+
+      // Act
+      const { url, state, codeVerifier, nonce } =
+        service.buildAuthorizationUrl();
+
+      // Assert — URL points to Azure's authorize endpoint
+      expect(url.origin).toBe('https://login.microsoftonline.com');
+      expect(url.pathname).toBe(
+        `/${TEST_CONFIG.tenantId}/oauth2/v2.0/authorize`,
+      );
+      expect(url.searchParams.get('client_id')).toBe(TEST_CONFIG.clientId);
+      expect(url.searchParams.get('response_type')).toBe('code');
+      expect(url.searchParams.get('redirect_uri')).toBe(
+        TEST_CONFIG.redirectUri,
+      );
+      expect(url.searchParams.get('scope')).toBe(
+        'openid profile email https://graph.microsoft.com/.default',
+      );
+      expect(url.searchParams.get('state')).toBe(state);
+      expect(url.searchParams.get('nonce')).toBe(nonce);
+      expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+
+      // PKCE: the challenge is the SHA-256 hash of the verifier (base64url)
+      const expectedChallenge = createHash('sha256')
+        .update(codeVerifier, 'ascii')
+        .digest('base64url');
+      expect(url.searchParams.get('code_challenge')).toBe(expectedChallenge);
+
+      // State, verifier, and nonce are non-empty random strings, all distinct
+      expect(state.length).toBeGreaterThan(0);
+      expect(codeVerifier.length).toBeGreaterThan(0);
+      expect(nonce.length).toBeGreaterThan(0);
+      expect(state).not.toBe(codeVerifier);
+      expect(state).not.toBe(nonce);
+      expect(codeVerifier).not.toBe(nonce);
+    });
+
+    it('generates a different state, verifier, and nonce on each call', () => {
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+      const a = service.buildAuthorizationUrl();
+      const b = service.buildAuthorizationUrl();
+      expect(a.state).not.toBe(b.state);
+      expect(a.codeVerifier).not.toBe(b.codeVerifier);
+      expect(a.nonce).not.toBe(b.nonce);
+    });
+  });
+
+  describe('handleCallback', (it) => {
+    let testPrivateKey: CryptoKey;
+    let testPublicJwk: Record<string, unknown>;
+
+    beforeEach(async () => {
+      const pair = await generateKeyPair('RS256');
+      testPrivateKey = pair.privateKey;
+      const jwk = await exportJWK(pair.publicKey);
+      testPublicJwk = { ...jwk, kid: 'test-kid' };
+    });
+
+    const GRAPH_ENDPOINT =
+      'https://graph.microsoft.com/v1.0/me/checkMemberGroups';
+
+    /**
+     * Wires `fetch` to return a token response (with the given id_token) at
+     * the token endpoint and the test JWKS at the discovery/keys endpoint.
+     * Optionally also mocks the Graph API checkMemberGroups endpoint for the
+     * overage fallback path.
+     */
+    function mockFetchForToken(
+      idToken: string,
+      graphResult?: { member: boolean } | { errorStatus: number },
+    ): void {
+      fetchSpy.mockImplementation((input: string | URL | Request) => {
+        const url = requestUrl(input);
+        if (url === JWKS_ENDPOINT) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ keys: [testPublicJwk] }), {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }),
+          );
+        }
+        if (url === TOKEN_ENDPOINT) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                id_token: idToken,
+                access_token: 'test-access-token',
+                token_type: 'Bearer',
+                expires_in: 3600,
+              }),
+              {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+              },
+            ),
+          );
+        }
+        if (url === GRAPH_ENDPOINT) {
+          if (graphResult && 'errorStatus' in graphResult) {
+            return Promise.resolve(
+              new Response('{"error":{"code":"Authorization_RequestDenied"}}', {
+                status: graphResult.errorStatus,
+                headers: { 'content-type': 'application/json' },
+              }),
+            );
+          }
+          const member =
+            graphResult && 'member' in graphResult ? graphResult.member : false;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                value: member ? [TEST_CONFIG.allowedGroup] : [],
+              }),
+              {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+              },
+            ),
+          );
+        }
+        return Promise.resolve(new Response('not found', { status: 404 }));
+      });
+    }
+
+    it('returns an Identity with provider=sso when the code, token, and group are valid', async () => {
+      // Arrange
+      const idToken = await buildTestToken(
+        testPrivateKey,
+        testPublicJwk,
+        {
+          sub: 'azure-oid-123',
+          name: 'Jane Engineer',
+          preferred_username: 'jane@illinois.edu',
+          groups: [TEST_CONFIG.allowedGroup],
+        },
+        TEST_NONCE,
+      );
+      mockFetchForToken(idToken);
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      // Act
+      const identity = await service.handleCallback(
+        'test-code',
+        'test-verifier',
+        TEST_NONCE,
+      );
+
+      // Assert
+      expect(identity).toStrictEqual({
+        subject: 'azure-oid-123',
+        displayName: 'Jane Engineer',
+        provider: 'sso',
+        roles: ['read-write'],
+      });
+
+      // The token endpoint was called with the code and verifier
+      const tokenCall = fetchSpy.mock.calls.find(
+        (c) => (c[0] as string) === TOKEN_ENDPOINT,
+      );
+      expect(tokenCall).toBeDefined();
+      const body = (tokenCall![1]?.body as string) || '';
+      expect(body).toContain('code=test-code');
+      expect(body).toContain('code_verifier=test-verifier');
+    });
+
+    it('falls back to preferred_username when name claim is absent', async () => {
+      const idToken = await buildTestToken(
+        testPrivateKey,
+        testPublicJwk,
+        {
+          sub: 'azure-oid-456',
+          preferred_username: 'jane@illinois.edu',
+          groups: [TEST_CONFIG.allowedGroup],
+        },
+        TEST_NONCE,
+      );
+      mockFetchForToken(idToken);
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      const identity = await service.handleCallback(
+        'code',
+        'verifier',
+        TEST_NONCE,
+      );
+
+      expect(identity.displayName).toBe('jane@illinois.edu');
+    });
+
+    it('falls back to sub when both name and preferred_username are absent', async () => {
+      const idToken = await buildTestToken(
+        testPrivateKey,
+        testPublicJwk,
+        {
+          sub: 'azure-oid-789',
+          groups: [TEST_CONFIG.allowedGroup],
+        },
+        TEST_NONCE,
+      );
+      mockFetchForToken(idToken);
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      const identity = await service.handleCallback(
+        'code',
+        'verifier',
+        TEST_NONCE,
+      );
+
+      expect(identity.displayName).toBe('azure-oid-789');
+    });
+
+    it('throws GROUP_REJECTED when the user is not in the allowed group', async () => {
+      const idToken = await buildTestToken(
+        testPrivateKey,
+        testPublicJwk,
+        {
+          sub: 'azure-oid-no',
+          name: 'Unauthorized User',
+          groups: ['some-other-group'],
+        },
+        TEST_NONCE,
+      );
+      mockFetchForToken(idToken);
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      await expect(
+        service.handleCallback('code', 'verifier', TEST_NONCE),
+      ).rejects.toMatchObject({
+        code: 'GROUP_REJECTED',
+        name: 'SsoError',
+      });
+    });
+
+    it('throws GROUP_CLAIM_MISSING when the groups claim is absent', async () => {
+      const idToken = await buildTestToken(
+        testPrivateKey,
+        testPublicJwk,
+        {
+          sub: 'azure-oid-nogroup',
+          name: 'No Groups',
+        },
+        TEST_NONCE,
+      );
+      mockFetchForToken(idToken);
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      await expect(
+        service.handleCallback('code', 'verifier', TEST_NONCE),
+      ).rejects.toMatchObject({
+        code: 'GROUP_CLAIM_MISSING',
+      });
+    });
+
+    it('falls back to Graph API on overage and succeeds when the user is a member', async () => {
+      const overageClaims: Record<string, unknown> = {
+        sub: 'azure-oid-overage',
+        name: 'Overage User',
+      };
+      overageClaims['_claim_names'] = { groups: 'src1' };
+      overageClaims['_claim_sources'] = {
+        src1: { endpoint: 'https://graph.microsoft.com/...' },
+      };
+      const idToken = await buildTestToken(
+        testPrivateKey,
+        testPublicJwk,
+        overageClaims,
+        TEST_NONCE,
+      );
+      mockFetchForToken(idToken, { member: true });
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      const identity = await service.handleCallback(
+        'code',
+        'verifier',
+        TEST_NONCE,
+      );
+
+      expect(identity.subject).toBe('azure-oid-overage');
+      expect(identity.provider).toBe('sso');
+    });
+
+    it('falls back to Graph API on overage and rejects when the user is not a member', async () => {
+      const overageClaims: Record<string, unknown> = {
+        sub: 'azure-oid-overage-no',
+        name: 'Overage Non-Member',
+      };
+      overageClaims['_claim_names'] = { groups: 'src1' };
+      overageClaims['_claim_sources'] = {
+        src1: { endpoint: 'https://graph.microsoft.com/...' },
+      };
+      const idToken = await buildTestToken(
+        testPrivateKey,
+        testPublicJwk,
+        overageClaims,
+        TEST_NONCE,
+      );
+      mockFetchForToken(idToken, { member: false });
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      await expect(
+        service.handleCallback('code', 'verifier', TEST_NONCE),
+      ).rejects.toMatchObject({
+        code: 'GROUP_REJECTED',
+      });
+    });
+
+    it('throws GROUP_OVERAGE when the Graph API returns an error (insufficient permissions)', async () => {
+      const overageClaims: Record<string, unknown> = {
+        sub: 'azure-oid-overage-403',
+        name: 'Overage No Perm',
+      };
+      overageClaims['_claim_names'] = { groups: 'src1' };
+      overageClaims['_claim_sources'] = {
+        src1: { endpoint: 'https://graph.microsoft.com/...' },
+      };
+      const idToken = await buildTestToken(
+        testPrivateKey,
+        testPublicJwk,
+        overageClaims,
+        TEST_NONCE,
+      );
+      mockFetchForToken(idToken, { errorStatus: 403 });
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      await expect(
+        service.handleCallback('code', 'verifier', TEST_NONCE),
+      ).rejects.toMatchObject({
+        code: 'GROUP_OVERAGE',
+      });
+    });
+
+    it('throws TOKEN_EXCHANGE_FAILED when the token endpoint returns an error', async () => {
+      fetchSpy.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ error: 'invalid_grant' }), {
+            status: 400,
+            headers: { 'content-type': 'application/json' },
+          }),
+        ),
+      );
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      await expect(
+        service.handleCallback('bad-code', 'verifier', TEST_NONCE),
+      ).rejects.toMatchObject({
+        code: 'TOKEN_EXCHANGE_FAILED',
+      });
+    });
+
+    it('throws TOKEN_EXCHANGE_FAILED when fetch throws a network error', async () => {
+      fetchSpy.mockImplementation(() => {
+        throw new Error('ECONNREFUSED');
+      });
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      await expect(
+        service.handleCallback('code', 'verifier', TEST_NONCE),
+      ).rejects.toMatchObject({
+        code: 'TOKEN_EXCHANGE_FAILED',
+      });
+    });
+
+    it('throws TOKEN_VALIDATION_FAILED when the id_token signature is invalid', async () => {
+      // Sign with a different key pair than the JWKS advertises
+      const otherPair = await generateKeyPair('RS256');
+      const idToken = await buildTestToken(
+        otherPair.privateKey,
+        testPublicJwk,
+        {
+          sub: 'azure-oid-fake',
+          name: 'Fake Signature',
+          groups: [TEST_CONFIG.allowedGroup],
+        },
+      );
+      mockFetchForToken(idToken);
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      await expect(
+        service.handleCallback('code', 'verifier', TEST_NONCE),
+      ).rejects.toMatchObject({
+        code: 'TOKEN_VALIDATION_FAILED',
+      });
+    });
+
+    it('throws TOKEN_VALIDATION_FAILED when the id_token is missing from the response', async () => {
+      fetchSpy.mockImplementation((input: string | URL | Request) => {
+        const url = requestUrl(input);
+        if (url === TOKEN_ENDPOINT) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ access_token: 'only-access' }), {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }),
+          );
+        }
+        return Promise.resolve(new Response('not found', { status: 404 }));
+      });
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      await expect(
+        service.handleCallback('code', 'verifier', TEST_NONCE),
+      ).rejects.toMatchObject({
+        code: 'TOKEN_VALIDATION_FAILED',
+      });
+    });
+
+    it('throws TOKEN_VALIDATION_FAILED when the issuer is wrong', async () => {
+      const idToken = await new SignJWT({
+        sub: 'azure-oid-wrong-iss',
+        name: 'Wrong Issuer',
+        groups: [TEST_CONFIG.allowedGroup],
+      })
+        .setProtectedHeader({ alg: 'RS256', kid: 'test-kid' })
+        .setIssuer('https://login.microsoftonline.com/wrong-tenant/v2.0')
+        .setAudience(TEST_CONFIG.clientId)
+        .setIssuedAt()
+        .setExpirationTime('2h')
+        .sign(testPrivateKey);
+      mockFetchForToken(idToken);
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      await expect(
+        service.handleCallback('code', 'verifier', TEST_NONCE),
+      ).rejects.toMatchObject({
+        code: 'TOKEN_VALIDATION_FAILED',
+      });
+    });
+
+    it('throws TOKEN_VALIDATION_FAILED when the nonce does not match', async () => {
+      // Token signed with a different nonce than the one expected
+      const idToken = await buildTestToken(
+        testPrivateKey,
+        testPublicJwk,
+        {
+          sub: 'azure-oid-nonce-mismatch',
+          name: 'Nonce Mismatch',
+          groups: [TEST_CONFIG.allowedGroup],
+        },
+        'wrong-nonce',
+      );
+      mockFetchForToken(idToken);
+
+      const service = new AzureOidcAuthService(
+        createMockLogger() as never,
+        TEST_CONFIG,
+      );
+
+      await expect(
+        service.handleCallback('code', 'verifier', TEST_NONCE),
+      ).rejects.toMatchObject({
+        code: 'TOKEN_VALIDATION_FAILED',
+      });
+    });
+  });
+});

--- a/apps/admin-server/tests/utils/use-server.ts
+++ b/apps/admin-server/tests/utils/use-server.ts
@@ -179,6 +179,7 @@ export function buildTestAppConfig(
       azureTenantId: 'test-tenant',
       azureClientId: 'test-client',
       azureClientSecret: 'test-client-secret',
+      azureRedirectUri: 'https://example.edu/api/admin/v1/auth/sso/callback',
       allowedGroup: 'test-admins',
       // Was missing entirely until Phase 2: every prior caller of `_probe`
       // (`_checkMonitoring`) was gated behind `grafanaBaseUrl`/

--- a/apps/admin-webapp/src/features/auth/login-page.tsx
+++ b/apps/admin-webapp/src/features/auth/login-page.tsx
@@ -9,6 +9,7 @@ import Divider from '@mui/material/Divider';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
+import { useSearchParams } from 'react-router-dom';
 import { Navigate, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '#src/features/auth/auth-context';
@@ -17,14 +18,28 @@ import { ApiError } from '#src/lib/api-error';
 export const LoginPage = () => {
   const { status, config, configError, login } = useAuth();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
+  const ssoError = searchParams.get('sso_error');
+
   if (status === 'authed') {
     return <Navigate to="/" replace />;
   }
+
+  const ssoErrorMessage: Record<string, string> = {
+    state_error:
+      'Sign-in session expired or was tampered with. Please try again.',
+    auth_failed:
+      'Authentication failed. Please try again, or contact an operator if this continues.',
+    group_rejected:
+      'You are not authorized to administer this deployment. Contact an operator if you believe this is an error.',
+    config_error:
+      'SSO is misconfigured on the server (missing group claim). Contact an operator.',
+  };
 
   const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault();
@@ -77,6 +92,12 @@ export const LoginPage = () => {
             </Alert>
           )}
 
+          {ssoError && ssoErrorMessage[ssoError] && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {ssoErrorMessage[ssoError]}
+            </Alert>
+          )}
+
           {configError && (
             <Alert severity="error" sx={{ mb: 2 }}>
               Couldn&apos;t reach the admin server ({configError}). Try
@@ -124,7 +145,21 @@ export const LoginPage = () => {
           {config?.local && config.sso && <Divider sx={{ my: 2 }}>or</Divider>}
 
           {config?.sso && (
-            <Button variant="outlined" fullWidth size="large" disabled>
+            <Button
+              variant="outlined"
+              fullWidth
+              size="large"
+              onClick={() => {
+                const currentPath =
+                  window.location.pathname + window.location.search;
+                const loginUrl =
+                  '/api/admin/v1/auth/sso/login' +
+                  (currentPath && currentPath !== '/admin/login'
+                    ? `?return_to=${encodeURIComponent(currentPath)}`
+                    : '');
+                window.location.href = loginUrl;
+              }}
+            >
               Sign in with Illinois (Azure AD)
             </Button>
           )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "env-schema": "7.0.0",
         "fastify": "5.10.0",
         "fastify-plugin": "5.1.0",
+        "jose": "6.2.7",
         "kysely": "0.28.17",
         "pg": "8.19.0",
         "typebox": "1.1.5"
@@ -8588,6 +8589,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.7.tgz",
+      "integrity": "sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {


### PR DESCRIPTION
## Summary

Fills in the `AzureOidcAuthService` stub with the real OIDC Authorization Code + PKCE flow against Azure Entra ID — the admin BFF shipped every seam for this in place (`archived-plans/2026-07-15-01-PLAN-ADMIN.md` §4.4), this is that seam filled in.

- **PKCE + CSRF state + OIDC nonce**: `buildAuthorizationUrl()` generates all three; the callback validates the id_token's signature (`jose`'s `jwtVerify` + `createRemoteJWKSet`, issuer/audience/nonce checks) and enforces the group allowlist (`ADMIN_ALLOWED_GROUP`).
- **Scope includes `https://graph.microsoft.com/.default`**, so the `access_token` carries whatever Graph delegated permissions are admin-consented — needed by the group-overage fallback (Azure truncates the `groups` claim at 200 entries; the fallback calls Graph's `checkMemberGroups` directly).
- **`isEnabled()` requires all five `AZURE_*`/`ADMIN_ALLOWED_GROUP` vars** — fail-closed, since an empty group would let any tenant user administer the deployment.
- **State cookie**: signed, `HttpOnly`, `SameSite=Lax` (required — the callback is a cross-site redirect from Azure; `Strict` would suppress the cookie and break every login), 5-minute TTL, scoped to the two SSO routes. State/nonce comparisons are constant-time.
- **Deep-link preservation**: the SPA passes its current path as `return_to`; the BFF validates it (`sanitizeReturnTo`: must be `/admin` or start with `/admin/`, no `//`) before using it as the post-login redirect target — no open-redirect surface.
- **Config Check fix**: `AZURE_REDIRECT_URI` was never referenced in Config Check, which hid a real bug — `no-login-method` (critical severity) checked a loose 3-of-5-var proxy instead of mirroring `isEnabled()`'s actual 5-var requirement, so a partially-configured SSO (local login off, SSO "started" but not functional) reported no problem while nobody could actually sign in. Fixed, plus a new `sso-incomplete-config` finding naming exactly which vars are missing.
- Everything downstream of authentication (session, CSRF, audit) sees only an `Identity` — no session/CSRF/audit changes.

This branch went through an internal code review pass (critical finding: the Graph fallback originally requested the wrong OAuth scope, so it could never succeed regardless of Azure-side admin consent — fixed) before this PR was opened.

Design: `2026-08-02-02-PLAN-AzureSso.md` (not tracked in this repo).

## Test plan
- [x] Unit tests: 235/235 passing (`admin-server`), including 22 new SSO-specific tests (enabled/disabled, PKCE + nonce + Graph-scope URL construction, nonce mismatch, group rejection/overage/Graph-fallback success+rejection+API-error, token exchange failure, invalid signature, wrong issuer) and 7 new Config Check tests for the partial-SSO-config fix
- [x] Integration tests: 120/120 passing, including 11 SSO route tests (disabled 404, login redirect with PKCE/state/nonce/Graph scope, successful callback + session + deep-link redirect, group rejection, state mismatch, missing state cookie, Azure error param, deep-link preservation, malicious `return_to` sanitization)
- [x] `format`/`lint`/`tsc --build` clean on `admin-server` and `admin-webapp`
- [ ] Live verification against a real Azure app registration (tenant ID, group object ID, actual `groups`-claim behavior) — needs a real UIUC Entra ID tenant, out of reach for this review; the flow implements the standard OIDC spec Azure documents