### PR TITLE
feat(ci): transcription-service-cpu multi-arch + CPU default model base

### DIFF
--- a/.github/actions/transcription-image-matrix/action.yml
+++ b/.github/actions/transcription-image-matrix/action.yml
@@ -1,10 +1,26 @@
 name: "Transcription Image Matrix"
 description: "Builds the docker-build job matrix for transcription-service: the CPU image plus one entry per CUDA variant declared in transcription_service/cuda-variants.json."
+inputs:
+  workspaces:
+    description: "JSON array of affected workspace paths, from the detect-changes action. Currently unused — kept for interface symmetry with node-image-matrix so both matrix actions can be called the same way."
+    required: false
+    default: ""
 outputs:
   matrix:
     # No ${{ }} in this text: GitHub evaluates descriptions as expressions.
-    description: "JSON object with an `include` array, for use as a strategy.matrix via fromJSON."
+    description: "JSON object with an `include` array, for use as a strategy.matrix via fromJSON. One entry per image; `image_slug` is the image_name with '/' replaced by '-', for use in artifact names."
     value: ${{ steps.build.outputs.matrix }}
+  build_matrix:
+    description: >
+      JSON object with an `include` array, the cross product of the images
+      and the native runner for each published architecture. The CPU image
+      publishes both linux/amd64 and linux/arm64 (native runners, not QEMU
+      — see APPLE-SILICON-FINDINGS.md); the CUDA variants publish amd64
+      only, since no Mac can run them and no arm64 GPU deployment exists.
+      `platform_tag` is the platform with '/' replaced by '-' (the
+      buildcache tag suffix convention); `image_slug` is `image_name` with
+      '/' replaced by '-', for use in artifact names.
+    value: ${{ steps.build.outputs.build_matrix }}
 runs:
   using: "composite"
   steps:
@@ -35,6 +51,16 @@ runs:
                 "Each entry becomes an image name, so they must be unique."
             )
 
+        # Native arm64 runners, not QEMU (measured 9.9x slower on the CPU
+        # transcription image in APPLE-SILICON-FINDINGS.md). The CUDA variants
+        # stay amd64-only: no Mac can run them, and no arm64 GPU deployment
+        # (Grace/Jetson) exists for this project. Mirrors the PLATFORMS list
+        # in node-image-matrix for the images that do get both arches.
+        AMD64 = {"platform": "linux/amd64", "runs_on": "ubuntu-24.04"}
+        ARM64 = {"platform": "linux/arm64", "runs_on": "ubuntu-24.04-arm"}
+        CPU_PLATFORMS = [AMD64, ARM64]
+        CUDA_PLATFORMS = [AMD64]
+
         def entry(image_suffix: str, dockerfile: str, build_args: str) -> dict[str, str]:
             return {
                 "image_name": f"scribear/transcription-service-{image_suffix}",
@@ -44,8 +70,8 @@ runs:
                 "build_args": build_args,
             }
 
-        include = [entry("cpu", "Dockerfile_CPU", "")]
-        include += [
+        cpu_entry = entry("cpu", "Dockerfile_CPU", "")
+        cuda_entries = [
             entry(
                 variant["device"],
                 "Dockerfile_CUDA",
@@ -53,9 +79,35 @@ runs:
             )
             for variant in variants
         ]
+        include = [cpu_entry] + cuda_entries
+
+        # Per-image matrix (for docker-merge): one entry per image with
+        # image_slug for artifact naming.
+        for item in include:
+            item["image_slug"] = item["image_name"].replace("/", "-")
+
+        # Per-(image, arch) matrix (for docker-build): CPU gets both arches,
+        # CUDA variants get amd64 only. platform_tag follows the buildcache
+        # tag convention.
+        build_include = []
+        for item in include:
+            platforms = CPU_PLATFORMS if item is cpu_entry else CUDA_PLATFORMS
+            for plat in platforms:
+                build_include.append({
+                    **item,
+                    "platform": plat["platform"],
+                    "runs_on": plat["runs_on"],
+                    "platform_tag": plat["platform"].replace("/", "-"),
+                })
 
         with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_file:
             output_file.write("matrix=" + json.dumps({"include": include}) + "\n")
+            output_file.write("build_matrix=" + json.dumps({"include": build_include}) + "\n")
 
         print(f"{len(include)} images: {', '.join(item['image_name'] for item in include)}")
+        arches = {item["image_name"]: [] for item in build_include}
+        for item in build_include:
+            arches[item["image_name"]].append(item["platform"])
+        for name, plats in arches.items():
+            print(f"  {name}: {', '.join(plats)}")
         PY

--- a/.github/workflows/python-cd.yml
+++ b/.github/workflows/python-cd.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       transcription_service: ${{ steps.filter.outputs.transcription_service }}
       image_matrix: ${{ steps.image_matrix.outputs.matrix }}
+      build_matrix: ${{ steps.image_matrix.outputs.build_matrix }}
     steps:
       - uses: actions/checkout@v5
       - name: Detect changed paths
@@ -37,17 +38,21 @@ jobs:
         id: image_matrix
         uses: ./.github/actions/transcription-image-matrix
 
+  # One job per (image, native runner arch) pair. The CPU image builds on
+  # both linux/amd64 and linux/arm64 (native ubuntu-24.04-arm, not QEMU —
+  # measured 9.9x slower in APPLE-SILICON-FINDINGS.md); the CUDA variants
+  # build on amd64 only, since no Mac can run them and no arm64 GPU
+  # deployment exists. Each leg pushes its half of the image by digest;
+  # docker-merge below combines the digests into one multi-arch manifest.
+  # Mirrors the shape in node-cd.yml.
   docker-build:
     needs: [changes]
     if: needs.changes.outputs.transcription_service == 'true'
-    # One parallel job per image: the CPU build plus every CUDA variant in
-    # transcription_service/cuda-variants.json. fail-fast stays off so a broken
-    # new CUDA base image does not cancel the builds of the working ones.
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.changes.outputs.image_matrix) }}
-    name: docker-build (${{ matrix.image_name }})
-    runs-on: ubuntu-latest
+      matrix: ${{ fromJSON(needs.changes.outputs.build_matrix) }}
+    name: docker-build (${{ matrix.image_name }}, ${{ matrix.platform }})
+    runs-on: ${{ matrix.runs_on }}
     steps:
       - uses: actions/checkout@v5
 
@@ -69,3 +74,79 @@ jobs:
           cache_variant: ${{ github.ref_name }}
           custom_tags: ${{ steps.tags.outputs.tags }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          platforms: ${{ matrix.platform }}
+          push_by_digest: "true"
+
+  # Combines each image's per-arch digests (uploaded as artifacts by
+  # build-container above, one matrix job per image so a slow image's merge
+  # cannot block a fast one's) into a single manifest under the real tags,
+  # via `docker buildx imagetools create`. For CUDA variants this produces a
+  # single-arch manifest (one digest); for the CPU image it produces a real
+  # multi-arch index. Mirrors docker-merge in node-cd.yml.
+  docker-merge:
+    needs: [changes, docker-build]
+    if: needs.changes.outputs.transcription_service == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.changes.outputs.image_matrix) }}
+    name: docker-merge (${{ matrix.image_name }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Resolve image tags
+        id: tags
+        uses: ./.github/actions/resolve-container-tags
+        with:
+          version_file: ${{ matrix.version_file }}
+
+      # Matches nothing (and the download step below finds no files) on a build
+      # that resolved no tags - identical to the old "build without publishing"
+      # case, just discovered here instead of inside build-container.
+      - name: Download digests
+        if: steps.tags.outputs.tags != ''
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.image_slug }}-*
+          merge-multiple: true
+
+      - name: Login to GHCR
+        if: steps.tags.outputs.tags != ''
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.tags.outputs.tags != ''
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create and push the multi-arch manifest
+        if: steps.tags.outputs.tags != ''
+        working-directory: /tmp/digests
+        env:
+          IMAGE_NAME: ${{ matrix.image_name }}
+          TAGS: ${{ steps.tags.outputs.tags }}
+        run: |
+          tag_args=()
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && tag_args+=(-t "ghcr.io/${IMAGE_NAME}:${tag}")
+          done <<< "$TAGS"
+
+          digest_refs=()
+          for digest in *; do
+            digest_refs+=("ghcr.io/${IMAGE_NAME}@sha256:${digest}")
+          done
+
+          docker buildx imagetools create "${tag_args[@]}" "${digest_refs[@]}"
+
+      - name: Inspect the published manifest
+        if: steps.tags.outputs.tags != ''
+        env:
+          IMAGE_NAME: ${{ matrix.image_name }}
+          TAGS: ${{ steps.tags.outputs.tags }}
+        run: |
+          first_tag=$(echo "$TAGS" | head -n1)
+          docker buildx imagetools inspect "ghcr.io/${IMAGE_NAME}:${first_tag}"

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  '07a6ea57690229b170c6cf94d0c427222a73104e54f1a02aab17b4627f55d7fe';
+  'ddfe25a0eab605a44bb9972efb95bef96b903589337c09d8e9723407d7f329db';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,27 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — CPU default model is now `base`; `transcription-service-cpu` publishes multi-arch
+
+The shipped CPU provider template now defaults to whisper **`base`** instead
+of `small`. `base` has comfortable headroom on CPU (mean RTF 0.17 vs 0.47 for
+`small` at the same `cpu_threads`), making the out-of-box CPU experience
+reliable on a wider range of hardware. `small` remains a one-line config edit
+for hosts that can afford it — see
+[Transcription on CPU-Only Hardware](https://github.com/scribear/scribear/wiki/Transcription-on-CPU-Only-Hardware)
+for the measured tradeoffs.
+
+This affects `provider_config.template.json` only. An existing deployment's
+`provider_config.json` is a copy and is not overwritten; edit it by hand to
+change the model. Models download automatically on first use via the `/models`
+bind mount (`HF_HOME=/models/hf`), so switching is a config edit and a restart,
+not a manual download.
+
+`transcription-service-cpu` is now published as a multi-arch manifest
+(`linux/amd64` + `linux/arm64`) alongside the Node and infra images. A Mac
+pulling `transcription-service-cpu:staging` gets a native arm64 image with no
+emulation. The two CUDA variants remain amd64-only — they cannot run on a Mac.
+
 ## Unreleased — onsite-only access gate (`compose.yml` v13)
 
 **Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. A
@@ -780,12 +801,14 @@ counts when the sidecar starts; those events happened before it was watching.
 ### CPU deployments
 
 A full stack was run on `TRANSCRIPTION_DEVICE=cpu` for the first time. On an
-RTX-class host's CPU (`small`, `cpu_threads` 4, 5000 ms period) a healthy single
-session measured **mean RTF 0.45–0.479 and a 2.9% drop share**, and at 3 sessions
-**56.3%** — so the drop-share thresholds need no CPU override, but
-`MONITORING_ASR_DUTY_RATIO` does: the GPU-calibrated 0.45 sits exactly on the
-healthy CPU value. Set it to **0.7** on CPU. With that one line a healthy CPU
-stack reports `{"alerts":[]}`.
+RTX-class host's CPU (`small`, `cpu_threads` 4, 5000 ms period — the default at
+the time; the shipped default is now `base`, which measures lower) a healthy
+single session measured **mean RTF 0.45–0.479 and a 2.9% drop share**, and at 3
+sessions **56.3%** — so the drop-share thresholds need no CPU override, but
+`MONITORING_ASR_DUTY_RATIO` can still need one: the GPU-calibrated 0.45 sits
+exactly on the healthy `small` value. Set it to **0.7** on CPU if running
+`small`; with `base` (0.17) the default 0.45 has room. With that one line a
+healthy CPU stack reports `{"alerts":[]}`.
 
 Above ~3 concurrent sessions this CPU configuration stops working altogether: at
 6 sessions every one was closed `1007 Client sent audio too quickly` and no

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -718,10 +718,12 @@ services:
       # The transcription T1 thresholds. Plumbed because their right values are
       # hardware-dependent in a way the others are not, and the sidecar's own
       # defaults are calibrated on a GPU: healthy CUDA operation measured mean RTF
-      # 0.28-0.33, while the shipped CPU template (small, cpu_threads 4) measured
-      # 0.471 keeping up perfectly. So a CPU deployment left on the defaults gets
-      # a permanent T1 warning, and without these variables the only remedy was to
-      # edit this file. Empty means "use the sidecar default".
+      # 0.28-0.33, while a CPU stack can land near or past that line depending on
+      # model and load — the shipped `base` template measured 0.17 at one session
+      # but `small` measured 0.471, and either can climb under concurrency. So a
+      # CPU deployment left on the defaults may get a permanent T1 warning, and
+      # without these variables the only remedy was to edit this file. Empty
+      # means "use the sidecar default".
       #
       # The wiki's "Transcription on CPU-Only Hardware" page carries measured
       # values per model and thread count.

--- a/deployment/provider_config.template.json
+++ b/deployment/provider_config.template.json
@@ -6,7 +6,7 @@
       "worker_ids": [0],
       "tags": ["whisper_context"],
       "context_config": {
-        "model": "small",
+        "model": "base",
         "device": "cpu"
       }
     },

--- a/transcription_service/provider_config.template.json
+++ b/transcription_service/provider_config.template.json
@@ -6,7 +6,7 @@
             "worker_ids": [0],
             "tags": ["whisper_context"],
             "context_config": {
-                "model": "small",
+                "model": "base",
                 "device": "cpu"
             }
         },


### PR DESCRIPTION
## Summary

Completes the Apple Silicon work from `explore/apple-silicon` (APPLE-SILICON-FINDINGS.md §5). The cheap fixes (NVIDIA reservation guard, `runner.arch` cache key, macOS Chrome paths, puppeteer skip, wiki page) already landed on staging; this PR is the two remaining items:

### 1. `transcription-service-cpu` publishes multi-arch (`linux/amd64` + `linux/arm64`)

`python-cd.yml` now mirrors `node-cd.yml`'s per-arch build + digest-merge shape:
- `transcription-image-matrix` emits a `build_matrix` (per image × arch pair). CPU gets both arches; CUDA variants stay amd64-only (no Mac can run them, no arm64 GPU deployment exists).
- `docker-build` builds each arch natively (`ubuntu-24.04` / `ubuntu-24.04-arm`), pushes by digest.
- `docker-merge` combines digests into one multi-arch manifest via `docker buildx imagetools create`.

Native arm64 runners, not QEMU — measured 9.9× slower on the CPU transcription image under emulation.

PR CI (`python-ci.yml`) is unchanged: it builds on `ubuntu-latest` only, since its job is to prove the image compiles, not to publish.

### 2. CPU default model: `small` → `base`

`base` has comfortable headroom on CPU (mean RTF 0.17 vs 0.47 for `small` at `cpu_threads: 4`), making the out-of-box CPU experience reliable on wider hardware. `small` remains a one-line config edit for hosts that can afford it.

Models auto-download on first use via the `/models` bind mount (`HF_HOME=/models/hf`), so switching is a config edit + restart, not a manual download. An existing deployment's `provider_config.json` is a copy and is not overwritten.

### Files

- `.github/actions/transcription-image-matrix/action.yml` — emits `build_matrix` with per-arch entries
- `.github/workflows/python-cd.yml` — per-arch `docker-build` + `docker-merge` job
- `transcription_service/provider_config.template.json` — `small` → `base`
- `deployment/provider_config.template.json` — same
- `deployment/compose.yml`, `deployment/UPGRADING.md` — comments/notes updated for the new default

Wiki updated in the same direction ( Developing on Apple Silicon, Transcription on CPU-Only Hardware, Deployment, Building and Deploying Locally).

## Test plan

- [x] 536 Python unit tests pass
- [x] Workflow YAML validates
- [x] Matrix script tested locally — CPU gets `[linux/amd64, linux/arm64]`, CUDA variants get `[linux/amd64]`
- [ ] Live CI: multi-arch build + merge produces a real multi-arch manifest for `transcription-service-cpu` (will verify on the first push to `staging`)