### PR TITLE
Wire the Azure SSO env vars into compose.yml (follow-up to #190)

### DIFF
--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
@@ -50,7 +50,7 @@ export interface ContainerVersion {
  * version.test.ts` fails if the two ever disagree, or if that file changes
  * without someone having made that call.
  */
-export const EXPECTED_COMPOSE_FILE_VERSION = 13;
+export const EXPECTED_COMPOSE_FILE_VERSION = 14;
 
 /**
  * How the running `compose.yml` compares to the one this image was built for.

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  'ddfe25a0eab605a44bb9972efb95bef96b903589337c09d8e9723407d7f329db';
+  'af46c60f3084b1ec7610d13ceb6b9fb72de75bd89dc024454e914c20831d24ec';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -186,8 +186,21 @@ NODE_SERVER_REDIS_URL=
 # ADMIN_API_KEY reuses SESSION_MANAGER_API_KEY (see Session Manager section above).
 ADMIN_LOG_LEVEL=info
 ADMIN_SESSION_SECRET=CHANGEME-admin-session-secret-at-least-32-characters
-# "<username> <password>"; empty/unset disables local login. Azure SSO (AZURE_*) is future.
+# "<username> <password>"; empty/unset disables local login.
 ADMIN_LOCAL_CREDENTIALS=engrit CHANGEME
+
+# Azure Entra ID SSO. All five must be non-empty for the "Sign in with
+# Illinois" button to appear (AzureOidcAuthService.isEnabled() requires
+# every one) - leaving any unset keeps SSO off and local login (above) is
+# the only way in. See scribear.wiki/Developing Admin.md "Azure Entra ID SSO
+# provider" for the one-time Azure app-registration walkthrough and exactly
+# where each value below comes from in the Azure portal.
+# AZURE_TENANT_ID=
+# AZURE_CLIENT_ID=
+# AZURE_CLIENT_SECRET=
+# AZURE_REDIRECT_URI=
+# ADMIN_ALLOWED_GROUP=
+
 # Fleet telemetry read (B1.7). Unset means GET /api/admin/v1/fleet answers 503
 # TELEMETRY_UNAVAILABLE; the top-bar /health rollup is unaffected either way.
 # Uses REDIS_PASSWORD above:

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,25 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — Azure Entra ID SSO reaches admin-server (`compose.yml` v14)
+
+**Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. A
+stock deployment needs to do nothing new — all five variables below default
+to empty, identical to today's behavior (SSO off, local login only).
+
+`admin-server`'s `AzureOidcAuthService` was implemented, but the five
+`AZURE_*`/`ADMIN_ALLOWED_GROUP` variables it needs were never actually wired
+into `compose.yml` — setting them in `.env` had no effect at all, since the
+container never received them. Fixed:
+
+- **`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`,
+  `AZURE_REDIRECT_URI`, `ADMIN_ALLOWED_GROUP`** now pass through to
+  `admin-server`, matching `.env.example`. All five must be non-empty for
+  the "Sign in with Illinois" button to appear — see
+  [`.env.example`](.env.example) and `scribear.wiki/Developing Admin.md`
+  "Azure Entra ID SSO provider" for the one-time Azure app-registration
+  walkthrough and where each value comes from.
+
 ## Unreleased — CPU default model is now `base`; `transcription-service-cpu` publishes multi-arch
 
 The shipped CPU provider template now defaults to whisper **`base`** instead

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -226,7 +226,7 @@ services:
       # Not `:?`-guarded, like DEPLOYMENT_ENV below and unlike the secrets: it
       # changes what is *reported*, never what runs, and must not be able to
       # stop a stack from starting.
-      COMPOSE_FILE_VERSION: "13"
+      COMPOSE_FILE_VERSION: "14"
       LOG_LEVEL: ${ADMIN_LOG_LEVEL:-info}
       ADMIN_API_KEY: ${SESSION_MANAGER_API_KEY}
       SESSION_MANAGER_BASE_URL: http://session-manager:80
@@ -272,6 +272,16 @@ services:
       ADMIN_PROMETHEUS_BASE_URL: ${ADMIN_PROMETHEUS_BASE_URL:-}
       ADMIN_SESSION_SECRET: ${ADMIN_SESSION_SECRET}
       ADMIN_LOCAL_CREDENTIALS: ${ADMIN_LOCAL_CREDENTIALS}
+      # Azure Entra ID SSO (compose.yml v14). All five empty (the default)
+      # keeps SSO off - AzureOidcAuthService.isEnabled() requires every one -
+      # so a stock deployment is unaffected. See scribear.wiki/Developing
+      # Admin.md "Azure Entra ID SSO provider" for the one-time Azure
+      # app-registration walkthrough and where each value comes from.
+      AZURE_TENANT_ID: ${AZURE_TENANT_ID:-}
+      AZURE_CLIENT_ID: ${AZURE_CLIENT_ID:-}
+      AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET:-}
+      AZURE_REDIRECT_URI: ${AZURE_REDIRECT_URI:-}
+      ADMIN_ALLOWED_GROUP: ${ADMIN_ALLOWED_GROUP:-}
       # Defaulted to the bundled container. Point them at a managed Postgres
       # to run the database outside this stack - see deployment/UPGRADING.md,
       # which also covers removing the bundled service and its depends_on.


### PR DESCRIPTION
## Summary

Follow-up to #190 (Azure Entra ID SSO), found while writing the wiki setup docs and checking where each env var actually comes from in a real deployment.

`AzureOidcAuthService.isEnabled()` requires five variables (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_REDIRECT_URI`, `ADMIN_ALLOWED_GROUP`), but **none of them were ever passed from `deployment/.env` into the `admin-server` container** — `compose.yml` never referenced them, and `deployment/.env.example` didn't list them either (just a stale "is future" comment predating the SSO implementation). An operator following #190's own instructions to set these in `.env` would see zero effect: SSO would stay unreachable no matter how correctly Azure was configured on the other end.

- Added all five to `admin-server`'s `environment:` block in `compose.yml` (bumped `COMPOSE_FILE_VERSION` 13 → 14 and `EXPECTED_COMPOSE_FILE_VERSION` to match, re-pinned the hash test — this is a "operator must redeploy for it" change, new required wiring).
- Replaced the stale "(AZURE_* is future)" comment in `deployment/.env.example` with the real five-variable block.
- New `UPGRADING.md` entry.
- `apps/admin-server/.env.example` (used for running `admin-server` standalone, outside the compose stack) already documented these correctly — this gap was specific to the compose-orchestrated deployment path.

Also updates the wiki (`Developing Admin.md`, separate repo, pushed alongside this) with a full step-by-step Entra ID app-registration walkthrough — exact portal paths, which value maps to which env var, and the platform-type/permission-consent details the previous summary-level doc omitted.

## Test plan
- [x] `compose.yml` is valid YAML; the two vars/hash changes verified against the actual file content (`sha256sum`)
- [x] `admin-server` unit tests: 235/235 passing, including the updated `compose-file-version.test.ts` hash pin
- [x] `format`/`lint` clean
- [ ] Live deployment verification (confirm `docker compose up -d` with real `AZURE_*` values in `.env` actually reaches the container) — not available this session, same caveat as #190