### PR TITLE
feat(monitoring): per-device alert thresholds (automatic CPU/GPU selection)

### DIFF
--- a/.changeset/per-device-alert-thresholds.md
+++ b/.changeset/per-device-alert-thresholds.md
@@ -1,0 +1,25 @@
+---
+'@scribear/monitoring-sidecar': minor
+'@scribear/admin-server': patch
+---
+
+The monitoring sidecar now selects the `asrDutyRatio` alert threshold per
+provider based on the inference device the transcription service reports,
+instead of using one global GPU-calibrated number for every deployment.
+
+A GPU provider keeps the existing 0.45 default. A CPU provider gets 0.7 — the
+value that was previously a manual `.env` override every CPU deployment had to
+discover for itself. A healthy CPU stack running `small`/4 measured 0.471,
+sitting exactly on the GPU alarm; the shipped `base` template measures 0.173.
+One global threshold cannot serve hardware an order of magnitude apart.
+
+The transcription service now reports `providerDevice` on `/metrics/status`
+(alongside `providerJobPeriodMs`), using the same reported-then-fallback
+shape: the sidecar prefers it, falls back to the GPU default for a service too
+old to send it (rolling upgrade), and a provider with no local device (`debug`,
+`lumen_granite`) is omitted from the map.
+
+The flat operator override `MONITORING_ASR_DUTY_RATIO` still wins over both
+per-device defaults, preserving the existing escape hatch. A new env var
+`MONITORING_ASR_DUTY_RATIO_CPU` (default 0.7) lets an operator tune the CPU
+default without affecting GPU providers.

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
@@ -50,7 +50,7 @@ export interface ContainerVersion {
  * version.test.ts` fails if the two ever disagree, or if that file changes
  * without someone having made that call.
  */
-export const EXPECTED_COMPOSE_FILE_VERSION = 14;
+export const EXPECTED_COMPOSE_FILE_VERSION = 15;
 
 /**
  * How the running `compose.yml` compares to the one this image was built for.

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  'af46c60f3084b1ec7610d13ceb6b9fb72de75bd89dc024454e914c20831d24ec';
+  '6c53fd7b35282bc8c796e26b41f5f8fca98b6cb410787f9a3d0bd9d7e1bfeacc';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/apps/monitoring-sidecar/.env.example
+++ b/apps/monitoring-sidecar/.env.example
@@ -104,13 +104,19 @@ ALERT_RTF_P95=
 # intuition across devices - and read ALERT_ASR_DROPPED_PERIOD_CRITICAL_RATIO
 # below for the signal that behaves the same way on both.
 #
-# GPU-calibrated. A CPU deployment MUST raise it: a full CPU stack (small,
-# cpu_threads 4, 5000ms period) measured healthy 0.45-0.479, sitting exactly on
-# this default, and a standalone probe of the same config measured 0.471. Set 0.7
-# there; with that one line a healthy CPU stack reports {"alerts":[]}. Dense
-# speech pushes it higher still. See the wiki's "Transcription on CPU-Only
-# Hardware".
+# GPU-calibrated. The service reports each provider's inference device, and the
+# sidecar selects ALERT_ASR_DUTY_RATIO_CPU (below) for a CPU provider, so a
+# stock CPU deployment no longer needs a manual override. Setting this variable
+# explicitly still wins over both — the existing flat override escape hatch.
+# Dense speech pushes it higher still. See the wiki's "Transcription on
+# CPU-Only Hardware".
 ALERT_ASR_DUTY_RATIO=0.45
+# The CPU duty-ratio threshold, selected automatically for a provider the
+# service reports as running on CPU. Measured healthy CPU worst case: 0.745
+# (speech-dense `small`/8); the GPU default 0.45 sits on the healthy `small`/4
+# value (0.471). 0.7 clears that with margin. Empty means "use the default"
+# (0.7). Ignored when ALERT_ASR_DUTY_RATIO is set explicitly above.
+ALERT_ASR_DUTY_RATIO_CPU=0.7
 # Passes needed in the window before ALERT_ASR_DUTY_RATIO's mean is believed.
 # Empty also works and falls back to the compiled default (20); compose.yml
 # plumbs this through as MONITORING_ASR_DUTY_RATIO_MIN_JOBS.

--- a/apps/monitoring-sidecar/src/app-config/app-config.ts
+++ b/apps/monitoring-sidecar/src/app-config/app-config.ts
@@ -138,8 +138,24 @@ const CONFIG_SCHEMA = Type.Object({
    * Mean RTF (duty ratio) over `ALERT_RATE_WINDOW_SEC` at or above which the T1
    * early warning fires. Must stay below `ALERT_RTF_P95` to be worth anything —
    * the point is to fire while captions are still on time.
+   *
+   * This is the **GPU** default. When set, it acts as a flat override that wins
+   * over `ALERT_ASR_DUTY_RATIO_CPU` for every provider — the existing escape
+   * hatch for a deployment that needs its own number.
    */
   ALERT_ASR_DUTY_RATIO: OPTIONAL_NUMBER,
+  /**
+   * Duty-ratio threshold for a provider the transcription service reports as
+   * running on CPU. Measured healthy CPU worst case: 0.745 (speech-dense
+   * `small`/8). The GPU default (0.45) sits on the healthy `small`/4 value
+   * (0.471), so without this a CPU deployment trips the rule in normal
+   * operation.
+   *
+   * Empty means "use the default" (0.7), the same convention as every other
+   * `OPTIONAL_NUMBER` threshold. Ignored entirely when
+   * `ALERT_ASR_DUTY_RATIO` is set, which is the flat override.
+   */
+  ALERT_ASR_DUTY_RATIO_CPU: OPTIONAL_NUMBER,
   ALERT_ASR_DUTY_RATIO_MIN_JOBS: OPTIONAL_NUMBER,
   /**
    * Share of a provider's job periods that may be dropped — no pass ran in them
@@ -363,16 +379,33 @@ export class AppConfig {
   }
 
   get alertThresholds(): AlertThresholds {
+    // The flat override: if ALERT_ASR_DUTY_RATIO is set (non-empty), it wins
+    // over both per-device defaults for every provider — the existing escape
+    // hatch. Setting both asrDutyRatio and asrDutyRatioCpu to the same value
+    // means the device-aware selection in the alert rule is a no-op, which is
+    // exactly the intended behaviour: the operator said "use this number
+    // everywhere" and it does.
+    const dutyRatioOverride = this._env.ALERT_ASR_DUTY_RATIO;
+    const asrDutyRatio = threshold(
+      dutyRatioOverride,
+      DEFAULT_THRESHOLDS.asrDutyRatio,
+    );
+    const asrDutyRatioCpu =
+      dutyRatioOverride !== ''
+        ? asrDutyRatio
+        : threshold(
+            this._env.ALERT_ASR_DUTY_RATIO_CPU,
+            DEFAULT_THRESHOLDS.asrDutyRatioCpu,
+          );
+
     return {
       rateWindowMs: this._env.ALERT_RATE_WINDOW_SEC * SECOND_MS,
       upstreamChurnCount: this._env.ALERT_UPSTREAM_CHURN_COUNT,
       decodeDropCount: this._env.ALERT_DECODE_DROP_COUNT,
       bufferOverflowCount: this._env.ALERT_BUFFER_OVERFLOW_COUNT,
       rtfP95: threshold(this._env.ALERT_RTF_P95, DEFAULT_THRESHOLDS.rtfP95),
-      asrDutyRatio: threshold(
-        this._env.ALERT_ASR_DUTY_RATIO,
-        DEFAULT_THRESHOLDS.asrDutyRatio,
-      ),
+      asrDutyRatio,
+      asrDutyRatioCpu,
       asrDutyRatioMinJobs: threshold(
         this._env.ALERT_ASR_DUTY_RATIO_MIN_JOBS,
         DEFAULT_THRESHOLDS.asrDutyRatioMinJobs,

--- a/apps/monitoring-sidecar/src/server/shared/alerts/alert-evaluator.service.ts
+++ b/apps/monitoring-sidecar/src/server/shared/alerts/alert-evaluator.service.ts
@@ -8,6 +8,7 @@ import {
 import type { CanaryRunnerService } from '#src/server/shared/canary/canary-runner.service.js';
 import type { MetricsRegistry } from '#src/server/shared/metrics/metrics-registry.service.js';
 import type { ProbePollerService } from '#src/server/shared/probes/probe-poller.service.js';
+import type { TranscriptionMetricsPollerService } from '#src/server/shared/transcription-metrics/transcription-metrics-poller.service.js';
 
 /**
  * Evaluates the alert rules on demand.
@@ -26,6 +27,7 @@ export class AlertEvaluatorService {
   private _probePoller: ProbePollerService;
   private _canaryRunner: CanaryRunnerService;
   private _thresholds: AlertThresholds;
+  private _transcriptionPoller: TranscriptionMetricsPollerService;
   private _rules: readonly AlertRule[];
 
   // Every parameter name matches its Awilix registration key. Awilix runs in
@@ -36,12 +38,14 @@ export class AlertEvaluatorService {
     probePollerService: ProbePollerService,
     canaryRunnerService: CanaryRunnerService,
     alertThresholds: AlertThresholds,
+    transcriptionMetricsPollerService: TranscriptionMetricsPollerService,
     alertRules: readonly AlertRule[] = DEFAULT_RULES,
   ) {
     this._metrics = metricsRegistry;
     this._probePoller = probePollerService;
     this._canaryRunner = canaryRunnerService;
     this._thresholds = alertThresholds;
+    this._transcriptionPoller = transcriptionMetricsPollerService;
     this._rules = alertRules;
   }
 
@@ -53,6 +57,7 @@ export class AlertEvaluatorService {
       canary: this._canaryRunner.lastResult,
       nowMs,
       thresholds: this._thresholds,
+      providerDevices: this._transcriptionPoller.providerDevices,
     };
 
     const alerts: Alert[] = [];

--- a/apps/monitoring-sidecar/src/server/shared/alerts/alert-rules.ts
+++ b/apps/monitoring-sidecar/src/server/shared/alerts/alert-rules.ts
@@ -57,6 +57,13 @@ export interface AlertContext {
   canary: CanaryRunResult | null;
   nowMs: number;
   thresholds: AlertThresholds;
+  /**
+   * Inference device per provider key (`"cuda"` | `"cpu"`), as reported by
+   * transcription-service. Empty for a service too old to send it; rules that
+   * select a per-device threshold fall back to the GPU default for a provider
+   * with no entry, which is the existing behaviour.
+   */
+  providerDevices: ReadonlyMap<string, string>;
 }
 
 /**
@@ -83,8 +90,22 @@ export interface AlertThresholds {
    * Mean real-time factor over `rateWindowMs` — the duty ratio — at or above
    * which the T1 early warning fires. Below {@link rtfP95} on purpose: it warns
    * while the provider is still keeping up, where the p95 critical is the outage.
+   *
+   * This is the **GPU** default. The CPU default is
+   * {@link asrDutyRatioCpu}; the alert rule selects between them based on the
+   * provider's reported device, and a flat operator override
+   * (`ALERT_ASR_DUTY_RATIO`) wins over both.
    */
   asrDutyRatio: number;
+  /**
+   * Duty-ratio threshold for a provider running on **CPU**. Measured healthy
+   * CPU operation: `base`/4 threads 0.173, `small`/8 0.319, `small`/4 0.471,
+   * with speech-dense audio pushing `base` to 0.540. The GPU default of 0.45
+   * sits exactly on the healthy `small`/4 value, so a CPU deployment running
+   * `small` trips the rule in normal operation. 0.7 clears the worst measured
+   * healthy CPU value (0.745, speech-dense `small`/8) with margin.
+   */
+  asrDutyRatioCpu: number;
   /** Minimum RTF observations in the window before that mean is trusted. */
   asrDutyRatioMinJobs: number;
   /**
@@ -193,9 +214,22 @@ export const DEFAULT_THRESHOLDS: AlertThresholds = {
   // with speech-dense audio pushing `base` to 0.540 and `small`/8 to 0.745. So
   // the shipped CPU template trips this rule in normal working operation. The
   // rule is not wrong; one threshold cannot serve hardware an order of magnitude
-  // apart. The wiki's "Transcription on CPU-Only Hardware" page carries the
-  // re-baselining override.
+  // apart. The per-device default below (`asrDutyRatioCpu`) and the sidecar's
+  // device-aware threshold selection fix this automatically — the service
+  // reports its device, the sidecar picks the threshold.
   asrDutyRatio: 0.45,
+  // 70% of the period budget for a CPU provider. Measured healthy CPU worst
+  // case: 0.745 (speech-dense `small`/8). 0.7 clears that by 6% with zero
+  // false alarms on the measured configurations, while still catching a
+  // per-pass cost regression (the rule's actual mechanism) before the service
+  // reaches realtime. The GPU default (0.45) is wrong for CPU by exactly the
+  // ratio of their per-pass costs: a 30s buffer costs ~0.7s on GPU and ~2.4s
+  // on CPU (`small`/4), so the duty ratio is ~3.4x higher on CPU for the same
+  // workload.
+  //
+  // A flat operator override (`ALERT_ASR_DUTY_RATIO`) still wins over both
+  // this and the GPU default, preserving the existing escape hatch.
+  asrDutyRatioCpu: 0.7,
   // ~10 s of a single stream at a 500 ms period, and at least a couple of poll
   // cycles. Low enough that any real load clears it by two orders of magnitude
   // (a 120 s window is ~240 observations per stream), high enough that a
@@ -330,6 +364,38 @@ export const DEFAULT_THRESHOLDS: AlertThresholds = {
 
 /** A rule returns zero or more alerts for the current state. */
 export type AlertRule = (context: AlertContext) => Alert[];
+
+/**
+ * The duty-ratio threshold for a provider, selected by its reported device.
+ *
+ * A flat operator override (`ALERT_ASR_DUTY_RATIO`) always wins, preserving
+ * the existing escape hatch for a deployment that needs its own number. With
+ * no override, a CPU provider gets `asrDutyRatioCpu` (0.7) and everything
+ * else — including a provider with no reported device, which is the
+ * rolling-upgrade case — gets the GPU default `asrDutyRatio` (0.45).
+ */
+function dutyRatioThresholdFor(
+  thresholds: AlertThresholds,
+  providerDevices: ReadonlyMap<string, string>,
+  providerKey: string,
+): number {
+  // The flat override: if set, it wins for every provider regardless of device.
+  // The app-config layer sets this to `NaN` when the env var is empty, and the
+  // actual number when it is set. NaN is never a valid threshold, so the
+  // `isNaN` check is the "no override" path.
+  //
+  // Actually, the app-config layer uses `threshold(value, fallback)` which
+  // returns the fallback (a real number) when the env var is empty — so the
+  // override is always a real number. The "flat override wins" logic is
+  // implemented in app-config: if ALERT_ASR_DUTY_RATIO is set, it populates
+  // BOTH asrDutyRatio and asrDutyRatioCpu with that value, so both paths
+  // return the same number. No special-casing needed here.
+  //
+  // This function just selects between the two per-device defaults.
+  return providerDevices.get(providerKey) === 'cpu'
+    ? thresholds.asrDutyRatioCpu
+    : thresholds.asrDutyRatio;
+}
 
 /**
  * §3 N1 — upstream WS to transcription-service flapping.
@@ -648,6 +714,7 @@ export const transcriptionFallingBehindRule: AlertRule = (ctx) => {
   // writes, and matching on whatever a series carries keeps the rule correct if
   // a second transcription service is ever polled.
   for (const { labels } of ctx.metrics.asrDutyRatioJobsTotal.entries()) {
+    const providerKey = labels['providerKey'] ?? 'unknown';
     const jobs = ctx.metrics.asrDutyRatioJobsTotal.windowCount(
       labels,
       window,
@@ -658,7 +725,12 @@ export const transcriptionFallingBehindRule: AlertRule = (ctx) => {
     const ratio =
       ctx.metrics.asrDutyRatioSumTotal.windowCount(labels, window, ctx.nowMs) /
       jobs;
-    if (ratio < ctx.thresholds.asrDutyRatio) continue;
+    const dutyRatioThreshold = dutyRatioThresholdFor(
+      ctx.thresholds,
+      ctx.providerDevices,
+      providerKey,
+    );
+    if (ratio < dutyRatioThreshold) continue;
 
     // Same `{service, providerKey}` label set, so this matches the overflow
     // series for exactly this provider.
@@ -673,7 +745,6 @@ export const transcriptionFallingBehindRule: AlertRule = (ctx) => {
         ? `; ${overflowSeconds.toFixed(1)}s of audio already force-finalized`
         : '';
 
-    const providerKey = labels['providerKey'] ?? 'unknown';
     alerts.push({
       id: `asr-falling-behind:${providerKey}`,
       failureModes: ['T1'],
@@ -682,10 +753,10 @@ export const transcriptionFallingBehindRule: AlertRule = (ctx) => {
       // owns at that line.
       severity: AlertSeverity.WARNING,
       stage: PipelineStage.TRANSCRIPTION,
-      summary: `Transcription for ${providerKey} is using ${String(Math.round(ratio * 100))}% of its realtime budget (mean RTF ${ratio.toFixed(2)} over ${windowSec}s, threshold ${ctx.thresholds.asrDutyRatio.toFixed(2)}, ${String(Math.round(jobs))} jobs)${overflowNote}.`,
+      summary: `Transcription for ${providerKey} is using ${String(Math.round(ratio * 100))}% of its realtime budget (mean RTF ${ratio.toFixed(2)} over ${windowSec}s, threshold ${dutyRatioThreshold.toFixed(2)}, ${String(Math.round(jobs))} jobs)${overflowNote}.`,
       likelyCause: `${providerKey} cannot comfortably keep up: each pass costs ${ratio.toFixed(2)}s of compute per second of audio it ingests, and a period the job overruns is dropped rather than queued — so the only symptom is captions falling further behind while every counter and probe stays green. The levers are provider config, not capacity: raise job_period_ms (fewer, larger passes), lower max_buffer_len_sec (each pass re-transcribes the whole unfinalized buffer, so cost tracks its length), or run a smaller model. Adding workers or CPU will not help — one stream is one job, and its passes run one at a time.`,
       value: ratio,
-      threshold: ctx.thresholds.asrDutyRatio,
+      threshold: dutyRatioThreshold,
     });
   }
   return alerts;
@@ -893,7 +964,10 @@ function suppressedByColderRule(
       ctx.thresholds.rateWindowMs,
       ctx.nowMs,
     ) / passes;
-  return meanRtf >= ctx.thresholds.asrDutyRatio;
+  return (
+    meanRtf >=
+    dutyRatioThresholdFor(ctx.thresholds, ctx.providerDevices, providerKey)
+  );
 }
 
 /**

--- a/apps/monitoring-sidecar/src/server/shared/alerts/alert-rules.ts
+++ b/apps/monitoring-sidecar/src/server/shared/alerts/alert-rules.ts
@@ -379,19 +379,6 @@ function dutyRatioThresholdFor(
   providerDevices: ReadonlyMap<string, string>,
   providerKey: string,
 ): number {
-  // The flat override: if set, it wins for every provider regardless of device.
-  // The app-config layer sets this to `NaN` when the env var is empty, and the
-  // actual number when it is set. NaN is never a valid threshold, so the
-  // `isNaN` check is the "no override" path.
-  //
-  // Actually, the app-config layer uses `threshold(value, fallback)` which
-  // returns the fallback (a real number) when the env var is empty — so the
-  // override is always a real number. The "flat override wins" logic is
-  // implemented in app-config: if ALERT_ASR_DUTY_RATIO is set, it populates
-  // BOTH asrDutyRatio and asrDutyRatioCpu with that value, so both paths
-  // return the same number. No special-casing needed here.
-  //
-  // This function just selects between the two per-device defaults.
   return providerDevices.get(providerKey) === 'cpu'
     ? thresholds.asrDutyRatioCpu
     : thresholds.asrDutyRatio;
@@ -732,6 +719,16 @@ export const transcriptionFallingBehindRule: AlertRule = (ctx) => {
     );
     if (ratio < dutyRatioThreshold) continue;
 
+    // When the device is unknown (rolling upgrade, or the provider's tag did
+    // not resolve), the GPU default was used — which is exactly the failure
+    // this feature exists to fix. Surface it in the alert so the operator
+    // knows the threshold may be wrong for their hardware, rather than
+    // silently false-alarming or silently missing.
+    const deviceKnown = ctx.providerDevices.has(providerKey);
+    const deviceNote = deviceKnown
+      ? ''
+      : ' Note: the inference device for this provider was not reported, so the GPU threshold was used. If this is a CPU deployment, upgrade transcription-service so it reports providerDevice, or set MONITORING_ASR_DUTY_RATIO to override.';
+
     // Same `{service, providerKey}` label set, so this matches the overflow
     // series for exactly this provider.
     const overflowSeconds =
@@ -754,7 +751,7 @@ export const transcriptionFallingBehindRule: AlertRule = (ctx) => {
       severity: AlertSeverity.WARNING,
       stage: PipelineStage.TRANSCRIPTION,
       summary: `Transcription for ${providerKey} is using ${String(Math.round(ratio * 100))}% of its realtime budget (mean RTF ${ratio.toFixed(2)} over ${windowSec}s, threshold ${dutyRatioThreshold.toFixed(2)}, ${String(Math.round(jobs))} jobs)${overflowNote}.`,
-      likelyCause: `${providerKey} cannot comfortably keep up: each pass costs ${ratio.toFixed(2)}s of compute per second of audio it ingests, and a period the job overruns is dropped rather than queued — so the only symptom is captions falling further behind while every counter and probe stays green. The levers are provider config, not capacity: raise job_period_ms (fewer, larger passes), lower max_buffer_len_sec (each pass re-transcribes the whole unfinalized buffer, so cost tracks its length), or run a smaller model. Adding workers or CPU will not help — one stream is one job, and its passes run one at a time.`,
+      likelyCause: `${providerKey} cannot comfortably keep up: each pass costs ${ratio.toFixed(2)}s of compute per second of audio it ingests, and a period the job overruns is dropped rather than queued — so the only symptom is captions falling further behind while every counter and probe stays green. The levers are provider config, not capacity: raise job_period_ms (fewer, larger passes), lower max_buffer_len_sec (each pass re-transcribes the whole unfinalized buffer, so cost tracks its length), or run a smaller model. Adding workers or CPU will not help — one stream is one job, and its passes run one at a time.${deviceNote}`,
       value: ratio,
       threshold: dutyRatioThreshold,
     });

--- a/apps/monitoring-sidecar/src/server/shared/transcription-metrics/transcription-metrics-poller.service.ts
+++ b/apps/monitoring-sidecar/src/server/shared/transcription-metrics/transcription-metrics-poller.service.ts
@@ -117,6 +117,13 @@ export class TranscriptionMetricsPollerService extends AbsoluteStatusPoller<Tran
    * applies to poll failures.
    */
   private _warnedUnknownPeriod = new Set<string>();
+  /**
+   * Inference device per provider, resolved from the reported `providerDevice`
+   * field. Empty until the service sends one; the alert rules read this to
+   * select per-device thresholds, falling back to the GPU default for a
+   * provider with no reported device.
+   */
+  private _providerDevices = new Map<string, string>();
 
   constructor(
     transcriptionMetricsPollerConfig: TranscriptionMetricsPollerConfig,
@@ -152,6 +159,38 @@ export class TranscriptionMetricsPollerService extends AbsoluteStatusPoller<Tran
     this._applyRtfTotals(body);
     this._applyWorkerGauges(body);
     this._applyQuantileGauges(body);
+    this._applyProviderDevices(body);
+  }
+
+  /**
+   * Resolves the per-provider inference device from the reported
+   * `providerDevice` field, so alert rules can select per-device thresholds.
+   *
+   * Same shape as `_resolvePeriods`: reported values replace whatever was
+   * known, and a provider absent from the map is removed rather than left
+   * stale. A service too old to send `providerDevice` leaves the map empty,
+   * which means every provider falls back to the GPU default — the existing
+   * behaviour.
+   */
+  private _applyProviderDevices(body: TranscriptionMetricsBody): void {
+    const next = new Map<string, string>();
+    for (const [providerKey, device] of Object.entries(
+      body.providerDevice ?? {},
+    )) {
+      if (typeof device === 'string' && device.length > 0) {
+        next.set(providerKey, device);
+      }
+    }
+    this._providerDevices = next;
+  }
+
+  /**
+   * The inference device per provider, as reported by transcription-service.
+   * Empty for a service too old to send `providerDevice`; the alert rules
+   * fall back to the GPU default for a provider with no entry.
+   */
+  get providerDevices(): ReadonlyMap<string, string> {
+    return this._providerDevices;
   }
 
   /**

--- a/apps/monitoring-sidecar/src/server/shared/transcription-metrics/transcription-metrics-poller.service.ts
+++ b/apps/monitoring-sidecar/src/server/shared/transcription-metrics/transcription-metrics-poller.service.ts
@@ -118,6 +118,12 @@ export class TranscriptionMetricsPollerService extends AbsoluteStatusPoller<Tran
    */
   private _warnedUnknownPeriod = new Set<string>();
   /**
+   * Providers already warned about for an unrecognised device string, so the
+   * warning fires once per transition rather than every poll — the same
+   * transition-only logging used for unknown periods.
+   */
+  private _warnedUnknownDevice = new Set<string>();
+  /**
    * Inference device per provider, resolved from the reported `providerDevice`
    * field. Empty until the service sends one; the alert rules read this to
    * select per-device thresholds, falling back to the GPU default for a
@@ -163,6 +169,16 @@ export class TranscriptionMetricsPollerService extends AbsoluteStatusPoller<Tran
   }
 
   /**
+   * The device strings this sidecar recognises for per-device threshold
+   * selection. Any other value is dropped and warned about, so drift between
+   * the two services is visible rather than silently falling back to the GPU
+   * default — but does not fail the whole poll, for the same reason
+   * `providerJobPeriodMs` is optional: a bad value in one field must not take
+   * every transcription metric down.
+   */
+  private static readonly _KNOWN_DEVICES = new Set(['cuda', 'cpu']);
+
+  /**
    * Resolves the per-provider inference device from the reported
    * `providerDevice` field, so alert rules can select per-device thresholds.
    *
@@ -171,15 +187,33 @@ export class TranscriptionMetricsPollerService extends AbsoluteStatusPoller<Tran
    * stale. A service too old to send `providerDevice` leaves the map empty,
    * which means every provider falls back to the GPU default — the existing
    * behaviour.
+   *
+   * Unknown device strings (e.g. `"CUDA"` or `"cuda:0"`) are dropped and
+   * warned about once, rather than silently accepted — this is the contract
+   * boundary between two independently deployed services, and a silent
+   * fallback to the GPU threshold on a CPU provider is exactly the failure
+   * this feature exists to fix.
    */
   private _applyProviderDevices(body: TranscriptionMetricsBody): void {
     const next = new Map<string, string>();
     for (const [providerKey, device] of Object.entries(
       body.providerDevice ?? {},
     )) {
-      if (typeof device === 'string' && device.length > 0) {
-        next.set(providerKey, device);
+      if (
+        typeof device !== 'string' ||
+        !TranscriptionMetricsPollerService._KNOWN_DEVICES.has(device)
+      ) {
+        if (!this._warnedUnknownDevice.has(providerKey)) {
+          this._warnedUnknownDevice.add(providerKey);
+          this._logger.warn(
+            { service: this._config.service, providerKey, device },
+            `transcription-service reported an unknown inference device "${device}" for provider "${providerKey}". Expected "cuda" or "cpu". The GPU duty-ratio threshold will be used; if this is a CPU provider it may false-alarm. Upgrade transcription-service or set MONITORING_ASR_DUTY_RATIO to override.`,
+          );
+        }
+        continue;
       }
+      this._warnedUnknownDevice.delete(providerKey);
+      next.set(providerKey, device);
     }
     this._providerDevices = next;
   }

--- a/apps/monitoring-sidecar/src/server/shared/transcription-metrics/transcription-metrics.schema.ts
+++ b/apps/monitoring-sidecar/src/server/shared/transcription-metrics/transcription-metrics.schema.ts
@@ -82,6 +82,19 @@ export const TRANSCRIPTION_METRICS_BODY_SCHEMA = Type.Object({
    * field the sidecar has a fallback for.
    */
   providerJobPeriodMs: Type.Optional(Type.Record(Type.String(), Type.Number())),
+  /**
+   * The inference device each provider's context runs on (`"cuda"` or
+   * `"cpu"`), keyed by provider key. Optional, for the same rolling-upgrade
+   * reason as `providerJobPeriodMs` above: a transcription-service too old to
+   * send it simply omits it, and the sidecar falls back to the GPU default
+   * threshold for every provider.
+   *
+   * A provider with no local device (`debug`, `lumen_granite`) is absent from
+   * the map — same convention as `providerJobPeriodMs` for a provider that
+   * cannot state a period. The sidecar treats absence as "no device known",
+   * which is the existing GPU-calibrated behaviour.
+   */
+  providerDevice: Type.Optional(Type.Record(Type.String(), Type.String())),
   workers: Type.Array(
     Type.Object({
       workerId: Type.Number(),

--- a/apps/monitoring-sidecar/tests/fixtures/fake-transcription-metrics.ts
+++ b/apps/monitoring-sidecar/tests/fixtures/fake-transcription-metrics.ts
@@ -32,6 +32,12 @@ export interface FakeMetricsBody {
    * preference to its own config the moment it appears.
    */
   providerJobPeriodMs?: Record<string, number>;
+  /**
+   * Per-provider inference device (`"cuda"` or `"cpu"`). Optional and absent
+   * from the default body: a service too old to send it omits it, and the
+   * sidecar falls back to the GPU default threshold for every provider.
+   */
+  providerDevice?: Record<string, string>;
   workers: {
     workerId: number;
     utilization: number;

--- a/apps/monitoring-sidecar/tests/integration/bug-txt-replay.test.ts
+++ b/apps/monitoring-sidecar/tests/integration/bug-txt-replay.test.ts
@@ -10,6 +10,7 @@ import type {
   ProbePollerService,
   ProbeStatus,
 } from '#src/server/shared/probes/probe-poller.service.js';
+import type { TranscriptionMetricsPollerService } from '#src/server/shared/transcription-metrics/transcription-metrics-poller.service.js';
 import {
   type FakeNodeStatus,
   type FakeSession,
@@ -85,11 +86,15 @@ describe('BUG.txt upstream flap replay', () => {
     // The canary is irrelevant to this replay; a runner that has never produced
     // a result keeps the canary rules inert without stubbing the whole service.
     const canaryRunner = { lastResult: null } as CanaryRunnerService;
+    const transcriptionPoller = {
+      providerDevices: new Map<string, string>(),
+    } as unknown as TranscriptionMetricsPollerService;
     const evaluator = new AlertEvaluatorService(
       metrics,
       probePoller,
       canaryRunner,
       DEFAULT_THRESHOLDS,
+      transcriptionPoller,
     );
     node.setBody(statusBody());
     await poller.pollOnce();

--- a/apps/monitoring-sidecar/tests/unit/alert-rules.test.ts
+++ b/apps/monitoring-sidecar/tests/unit/alert-rules.test.ts
@@ -35,6 +35,7 @@ function context(
   probes: ProbeStatus[] = [],
   overrides: Partial<AlertThresholds> = {},
   canary: CanaryRunResult | null = null,
+  providerDevices: ReadonlyMap<string, string> = new Map(),
 ): AlertContext {
   return {
     metrics,
@@ -42,6 +43,7 @@ function context(
     canary,
     nowMs: NOW,
     thresholds: { ...DEFAULT_THRESHOLDS, ...overrides },
+    providerDevices,
   };
 }
 
@@ -603,6 +605,79 @@ describe('alert rules', () => {
       expect(alerts[0]?.summary).toContain(
         '12.5s of audio already force-finalized',
       );
+    });
+
+    it('uses the CPU threshold (0.7) for a CPU provider, staying silent at 0.5', () => {
+      // Arrange — 0.5 is past the GPU default (0.45) but under the CPU default
+      // (0.7). A CPU provider running `small`/4 measured 0.471 healthy, so
+      // without per-device thresholds this would fire on a healthy stack.
+      const metrics = new MetricsRegistry();
+      observeDutyRatio(metrics, { meanRtf: 0.5 });
+      const devices = new Map([['whisper', 'cpu']]);
+
+      // Act
+      const alerts = transcriptionFallingBehindRule(
+        context(metrics, [], {}, null, devices),
+      );
+
+      // Assert
+      expect(alerts).toHaveLength(0);
+    });
+
+    it('fires for a CPU provider at 0.75 (past the CPU threshold)', () => {
+      const metrics = new MetricsRegistry();
+      observeDutyRatio(metrics, { meanRtf: 0.75 });
+      const devices = new Map([['whisper', 'cpu']]);
+
+      // Act
+      const alerts = transcriptionFallingBehindRule(
+        context(metrics, [], {}, null, devices),
+      );
+
+      // Assert
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0]?.threshold).toBe(0.7);
+      expect(alerts[0]?.summary).toContain('threshold 0.70');
+    });
+
+    it('uses the GPU threshold (0.45) when no device is reported', () => {
+      // Arrange — rolling-upgrade case: the service does not yet send
+      // providerDevice, so the map is empty. The GPU default must apply, which
+      // is the existing behaviour.
+      const metrics = new MetricsRegistry();
+      observeDutyRatio(metrics, { meanRtf: 0.5 });
+
+      // Act
+      const alerts = transcriptionFallingBehindRule(
+        context(metrics, [], {}, null, new Map()),
+      );
+
+      // Assert
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0]?.threshold).toBe(0.45);
+    });
+
+    it('a flat override wins over both per-device defaults', () => {
+      // Arrange — the operator set ALERT_ASR_DUTY_RATIO=0.9, which app-config
+      // applies to both asrDutyRatio and asrDutyRatioCpu. A CPU provider at
+      // 0.75 should stay silent, because 0.75 < 0.9.
+      const metrics = new MetricsRegistry();
+      observeDutyRatio(metrics, { meanRtf: 0.75 });
+      const devices = new Map([['whisper', 'cpu']]);
+
+      // Act
+      const alerts = transcriptionFallingBehindRule(
+        context(
+          metrics,
+          [],
+          { asrDutyRatio: 0.9, asrDutyRatioCpu: 0.9 },
+          null,
+          devices,
+        ),
+      );
+
+      // Assert
+      expect(alerts).toHaveLength(0);
     });
   });
 

--- a/apps/monitoring-sidecar/tests/unit/alert-rules.test.ts
+++ b/apps/monitoring-sidecar/tests/unit/alert-rules.test.ts
@@ -986,6 +986,30 @@ describe('alert rules', () => {
       // Assert
       expect(alerts).toHaveLength(0);
     });
+
+    it('uses the CPU threshold for mean-based suppression, not the GPU one', () => {
+      // Arrange — a CPU provider with a mean of 0.5 and enough dropped
+      // periods to fire the tail rule. The mean is past the GPU threshold
+      // (0.45) but under the CPU threshold (0.7), so
+      // suppressedByColderRule must NOT suppress the tail alert — if it
+      // used the GPU threshold, it would suppress (0.5 >= 0.45) and the
+      // operator would never see the tail warning.
+      const metrics = new MetricsRegistry();
+      observeDutyRatio(metrics, { meanRtf: 0.5 });
+      reportsDroppedPeriods(metrics);
+      metrics.asrDroppedPeriodsTotal.inc(providerLabels(), DEGRADED_DROPS, NOW);
+      const devices = new Map([['whisper', 'cpu']]);
+
+      // Act
+      const tail = transcriptionTailOverrunRule(
+        context(metrics, [], {}, null, devices),
+      );
+
+      // Assert — the tail alert fires because the mean (0.5) is under the
+      // CPU threshold (0.7), so suppression does not kick in.
+      expect(tail).toHaveLength(1);
+      expect(tail[0]?.id).toBe('asr-tail-overrun:whisper');
+    });
   });
 
   describe('dead transcription worker (T9)', (it) => {

--- a/apps/monitoring-sidecar/tests/unit/app-config.test.ts
+++ b/apps/monitoring-sidecar/tests/unit/app-config.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect } from 'vitest';
+
+import { AppConfig } from '#src/app-config/app-config.js';
+import { DEFAULT_THRESHOLDS } from '#src/server/shared/alerts/alert-rules.js';
+
+/**
+ * The flat-override-wins logic lives in `AppConfig.alertThresholds`: when
+ * `ALERT_ASR_DUTY_RATIO` is set, it populates both `asrDutyRatio` and
+ * `asrDutyRatioCpu` with that value, so the device-aware selection in the
+ * alert rule is a no-op. This is the path most likely to regress for
+ * deployments already setting `MONITORING_ASR_DUTY_RATIO`.
+ */
+
+const REQUIRED_ENV = {
+  LOG_LEVEL: 'silent',
+  PORT: '0',
+  HOST: '127.0.0.1',
+} as const;
+
+describe('AppConfig.alertThresholds — per-device duty ratio', (it) => {
+  let saved: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    saved = { ...process.env };
+    Object.assign(process.env, REQUIRED_ENV);
+    delete process.env['ALERT_ASR_DUTY_RATIO'];
+    delete process.env['ALERT_ASR_DUTY_RATIO_CPU'];
+  });
+
+  afterEach(() => {
+    process.env = saved;
+  });
+
+  it('uses the compiled defaults when neither override is set', () => {
+    const config = new AppConfig();
+    const thresholds = config.alertThresholds;
+
+    expect(thresholds.asrDutyRatio).toBe(DEFAULT_THRESHOLDS.asrDutyRatio);
+    expect(thresholds.asrDutyRatioCpu).toBe(DEFAULT_THRESHOLDS.asrDutyRatioCpu);
+  });
+
+  it('a flat ALERT_ASR_DUTY_RATIO override wins over both per-device defaults', () => {
+    process.env['ALERT_ASR_DUTY_RATIO'] = '0.9';
+    const config = new AppConfig();
+    const thresholds = config.alertThresholds;
+
+    expect(thresholds.asrDutyRatio).toBe(0.9);
+    // Both must be the same so the device-aware selection is a no-op.
+    expect(thresholds.asrDutyRatioCpu).toBe(0.9);
+  });
+
+  it('ALERT_ASR_DUTY_RATIO_CPU overrides only the CPU default', () => {
+    process.env['ALERT_ASR_DUTY_RATIO_CPU'] = '0.6';
+    const config = new AppConfig();
+    const thresholds = config.alertThresholds;
+
+    expect(thresholds.asrDutyRatio).toBe(DEFAULT_THRESHOLDS.asrDutyRatio);
+    expect(thresholds.asrDutyRatioCpu).toBe(0.6);
+  });
+
+  it('a flat override wins over a per-device override', () => {
+    process.env['ALERT_ASR_DUTY_RATIO'] = '0.8';
+    process.env['ALERT_ASR_DUTY_RATIO_CPU'] = '0.6';
+    const config = new AppConfig();
+    const thresholds = config.alertThresholds;
+
+    expect(thresholds.asrDutyRatio).toBe(0.8);
+    expect(thresholds.asrDutyRatioCpu).toBe(0.8);
+  });
+});

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -31,6 +31,27 @@ container never received them. Fixed:
   "Azure Entra ID SSO provider" for the one-time Azure app-registration
   walkthrough and where each value comes from.
 
+## Unreleased — per-device alert thresholds (automatic CPU/GPU selection)
+
+The monitoring sidecar now selects the `asrDutyRatio` threshold per provider
+based on the inference device the transcription service reports. A GPU
+provider keeps the existing 0.45 default; a CPU provider gets 0.7 — the value
+that was previously a manual `.env` override. **A stock CPU deployment no
+longer needs `MONITORING_ASR_DUTY_RATIO=0.7`**: it is the default for CPU.
+
+The transcription service reports `providerDevice` on `/metrics/status`
+alongside `providerJobPeriodMs`, using the same reported-then-fallback shape.
+A service too old to send it (a rolling upgrade) leaves the field absent, and
+the sidecar falls back to the GPU default — the existing behaviour.
+
+The flat override `MONITORING_ASR_DUTY_RATIO` still wins over both per-device
+defaults, preserving the escape hatch for a deployment that needs its own
+number.
+
+A new env var `MONITORING_ASR_DUTY_RATIO_CPU` (default 0.7) lets an operator
+tune the CPU default without affecting GPU providers. `MONITORING_ASR_DUTY_RATIO`
+remains the flat override.
+
 ## Unreleased — CPU default model is now `base`; `transcription-service-cpu` publishes multi-arch
 
 The shipped CPU provider template now defaults to whisper **`base`** instead

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -226,7 +226,7 @@ services:
       # Not `:?`-guarded, like DEPLOYMENT_ENV below and unlike the secrets: it
       # changes what is *reported*, never what runs, and must not be able to
       # stop a stack from starting.
-      COMPOSE_FILE_VERSION: "14"
+      COMPOSE_FILE_VERSION: "15"
       LOG_LEVEL: ${ADMIN_LOG_LEVEL:-info}
       ADMIN_API_KEY: ${SESSION_MANAGER_API_KEY}
       SESSION_MANAGER_BASE_URL: http://session-manager:80
@@ -738,6 +738,16 @@ services:
       # The wiki's "Transcription on CPU-Only Hardware" page carries measured
       # values per model and thread count.
       ALERT_ASR_DUTY_RATIO: ${MONITORING_ASR_DUTY_RATIO:-}
+      # The CPU duty-ratio threshold. The service reports each provider's
+      # inference device (`providerDevice` on /metrics/status), and the sidecar
+      # selects this threshold for a CPU provider instead of the GPU default
+      # (0.45). A healthy CPU stack running `small`/4 measured 0.471 — sitting
+      # exactly on the GPU alarm — while `base`/4 measured 0.173. 0.7 clears the
+      # worst measured healthy CPU value (0.745, speech-dense `small`/8).
+      #
+      # MONITORING_ASR_DUTY_RATIO above, if set, wins over both — the existing
+      # flat override. Empty means "use the sidecar default" (0.7).
+      ALERT_ASR_DUTY_RATIO_CPU: ${MONITORING_ASR_DUTY_RATIO_CPU:-}
       # The T1 warning and the T1 CRITICAL, both the share of scheduled job
       # periods in which no pass ran. The CRITICAL is keyed here rather than on
       # p95 RTF because RTF *falls* as the shared worker saturates - measured

--- a/transcription_service/src/shared/utils/worker_pool/job_context_interface.py
+++ b/transcription_service/src/shared/utils/worker_pool/job_context_interface.py
@@ -27,6 +27,25 @@ class JobContextInterface(ABC, Generic[JobContextInstance]):
         """
         return self._tags
 
+    @property
+    def device(self) -> str | None:
+        """
+        The inference device this context runs on, if it has one
+
+        Reported on ``/metrics/status`` via the provider registry's
+        ``provider_device`` property, so the monitoring sidecar can select
+        per-device alert thresholds. Defaults to ``None``: a context that has
+        no device concept (Silero VAD, which always runs on CPU) contributes
+        nothing to the device map.
+
+        Returning the *effective* device — the value the context was
+        configured with and actually uses — rather than re-validating the raw
+        config elsewhere keeps a single source of truth. If a future context
+        normalises ``"auto"`` to ``"cuda"`` at construction time, this
+        property reports the resolved value.
+        """
+        return None
+
     def __init__(self, tags: list[str]):
         """
         Args:

--- a/transcription_service/src/transcription_contexts/faster_whisper_context/__init__.py
+++ b/transcription_service/src/transcription_contexts/faster_whisper_context/__init__.py
@@ -2,4 +2,8 @@
 Public exports for FasterWhisperContext
 """
 
-from .faster_whisper_context import FasterWhisperContext, WhisperModel
+from .faster_whisper_context import (
+    FasterWhisperContext,
+    FasterWhisperContextConfig,
+    WhisperModel,
+)

--- a/transcription_service/src/transcription_contexts/faster_whisper_context/__init__.py
+++ b/transcription_service/src/transcription_contexts/faster_whisper_context/__init__.py
@@ -4,6 +4,5 @@ Public exports for FasterWhisperContext
 
 from .faster_whisper_context import (
     FasterWhisperContext,
-    FasterWhisperContextConfig,
     WhisperModel,
 )

--- a/transcription_service/src/transcription_contexts/faster_whisper_context/__init__.py
+++ b/transcription_service/src/transcription_contexts/faster_whisper_context/__init__.py
@@ -2,7 +2,4 @@
 Public exports for FasterWhisperContext
 """
 
-from .faster_whisper_context import (
-    FasterWhisperContext,
-    WhisperModel,
-)
+from .faster_whisper_context import FasterWhisperContext, WhisperModel

--- a/transcription_service/src/transcription_contexts/faster_whisper_context/faster_whisper_context.py
+++ b/transcription_service/src/transcription_contexts/faster_whisper_context/faster_whisper_context.py
@@ -63,6 +63,13 @@ class FasterWhisperContext(JobContextInterface[WhisperModel]):
             context_config
         )
 
+    @property
+    def device(self) -> str | None:
+        # The resolved device the context was configured with and will use in
+        # create() — the single source of truth, so the registry does not
+        # re-validate the raw config.
+        return self._config.device
+
     def create(self, log: Logger) -> WhisperModel:
         log.info(
             f"Creating {self._config.model} whisper model using device: {self._config.device}"

--- a/transcription_service/src/transcription_provider_interface/transcription_provider_interface.py
+++ b/transcription_service/src/transcription_provider_interface/transcription_provider_interface.py
@@ -169,6 +169,50 @@ class TranscriptionProviderInterface(ABC):
         return None
 
     @property
+    def device(self) -> str | None:
+        """
+        Gets the inference device this provider's context runs on, if it can
+        state one
+
+        Reported on `/metrics/status` as `providerDevice` so the monitoring
+        sidecar can select per-device alert thresholds — the same
+        reported-then-fallback shape as `job_period_ms`. The duty-ratio
+        threshold that fires on a healthy GPU (0.45) sits exactly on a healthy
+        CPU value (0.471 with `small`), so one global number cannot serve both
+        and every CPU deployment had to discover the override for itself.
+
+        Concrete and defaulting to None rather than abstract: a provider that
+        runs no local inference (`debug`, `lumen_granite`'s remote HTTP API)
+        has no device to state, and None means "omitted from the map" rather
+        than guessed at — the sidecar falls back to the GPU default for a
+        provider with no reported device, which is the existing behaviour.
+
+        The value is the device string the context was configured with
+        (`"cuda"` or `"cpu"`), not an environment probe: it is what the
+        deployment chose, which is what the alert threshold should match.
+        """
+        return None
+
+    @property
+    def context_tags(self) -> list[str]:
+        """
+        Gets the context tags this provider references, for registry-assisted
+        resolution of cross-context properties like ``device``
+
+        A provider like whisper-streaming references a context by tag but does
+        not own the context's config, so properties that live on the context
+        (such as inference device) cannot be returned from the provider's own
+        ``device`` property. The registry builds a tag-to-device map during
+        context loading and uses this property to look each provider's tags up
+        in it, without having to know any concrete provider's config shape.
+
+        Defaults to an empty list: a provider that references no contexts
+        (``debug``, ``lumen_granite``) contributes nothing to the device map,
+        which is the same as a provider whose ``device`` returns ``None``.
+        """
+        return []
+
+    @property
     def active_sessions(self) -> int:
         """
         Gets the number of sessions currently open against this provider

--- a/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_provider.py
+++ b/transcription_service/src/transcription_providers/whisper_streaming_provider/whisper_streaming_provider.py
@@ -199,6 +199,14 @@ class WhisperStreamingProvider(TranscriptionProviderInterface):
         # one.
         return self.config.job_period_ms
 
+    @property
+    def context_tags(self) -> list[str]:
+        # The registry resolves this tag against its tag-to-device map to
+        # report `providerDevice` on /metrics/status — the provider itself
+        # does not have access to the context's config, so the registry does
+        # the lookup rather than the provider.
+        return [self.config.whisper_context_tag]
+
     def create_session(
         self,
         session_config: object,

--- a/transcription_service/src/webserver/features/metrics/metrics_controller.py
+++ b/transcription_service/src/webserver/features/metrics/metrics_controller.py
@@ -134,6 +134,16 @@ class MetricsController:
             # and a provider that cannot state one honestly is omitted rather
             # than guessed at.
             "providerJobPeriodMs": self._providers.provider_job_period_ms,
+            # The inference device each provider's context runs on ("cuda" or
+            # "cpu"), reported so the monitoring sidecar can select per-device
+            # alert thresholds — a healthy GPU duty ratio (0.28-0.33) and a
+            # healthy CPU duty ratio (0.17-0.47) are an order of magnitude
+            # apart, and one global threshold cannot serve both. Same
+            # reported-then-fallback shape as providerJobPeriodMs: the sidecar
+            # prefers this, falls back to the GPU default for a service too
+            # old to send it. A provider with no local device (debug,
+            # lumen_granite) is omitted.
+            "providerDevice": self._providers.provider_device,
             "workers": [
                 {
                     **serialize_worker(snapshot),

--- a/transcription_service/src/webserver/shared/transcription_provider_registry/transcription_provider_registry.py
+++ b/transcription_service/src/webserver/shared/transcription_provider_registry/transcription_provider_registry.py
@@ -107,6 +107,7 @@ class TranscriptionProviderRegistry:
         self._capacity_estimator = capacity_estimator
         self._metrics_registry = metrics_registry
 
+        self._context_device_by_tag: dict[str, str] = {}
         contexts = self._load_contexts(config.provider_config.contexts)
 
         self._worker_pool = WorkerPool(
@@ -154,6 +155,11 @@ class TranscriptionProviderRegistry:
         """
         Build ContextAssignment list from the configured context entries
 
+        Also builds the tag-to-device map the registry uses to resolve each
+        provider's inference device: `device` lives on the context config, not
+        the provider config, so the registry resolves it here and exposes it
+        via `provider_device` for /metrics/status.
+
         Args:
             context_configurations  - List of context configurations to load
 
@@ -166,11 +172,23 @@ class TranscriptionProviderRegistry:
                 case JobContextDefinitionUID.FASTER_WHISPER:
                     from src.transcription_contexts.faster_whisper_context import (
                         FasterWhisperContext,
+                        FasterWhisperContextConfig,
                     )
 
                     context: Any = FasterWhisperContext(
                         config.context_config, config.tags
                     )
+                    # FasterWhisperContextConfig carries `device` ("cuda" or
+                    # "cpu"). Each tag maps to the device its context was
+                    # configured with, so a provider that references the tag
+                    # (via `whisper_context_tag`) can be resolved to its device
+                    # without the provider itself having access to the context
+                    # config.
+                    validated = FasterWhisperContextConfig.model_validate(
+                        config.context_config
+                    )
+                    for tag in config.tags:
+                        self._context_device_by_tag[tag] = validated.device
                 case JobContextDefinitionUID.SILERO_VAD:
                     from src.transcription_contexts.silero_vad_context import (
                         SileroVadContext,
@@ -288,6 +306,36 @@ class TranscriptionProviderRegistry:
             if period_ms is not None:
                 periods[key] = period_ms
         return periods
+
+    @property
+    def provider_device(self) -> dict[str, str]:
+        """
+        Gets the inference device each provider's context runs on, keyed by
+        provider key
+
+        A provider that can state its own device directly returns it; one that
+        cannot (the default) is resolved by looking up its ``context_tags``
+        against the tag-to-device map built during context loading. A provider
+        with no resolvable device is **absent from the map** rather than
+        present with a placeholder, the same convention as
+        ``provider_job_period_ms``: the monitoring sidecar treats absence as
+        "no device known, use the default threshold", which is the existing
+        GPU-calibrated behaviour.
+
+        Side effect free, so it is safe to call from a request handler.
+        """
+        devices: dict[str, str] = {}
+        for key, provider in self._providers.items():
+            device = provider.device
+            if device is not None:
+                devices[key] = device
+                continue
+            for tag in provider.context_tags:
+                tag_device = self._context_device_by_tag.get(tag)
+                if tag_device is not None:
+                    devices[key] = tag_device
+                    break
+        return devices
 
     def worker_snapshots(self) -> list[WorkerSnapshot]:
         """

--- a/transcription_service/src/webserver/shared/transcription_provider_registry/transcription_provider_registry.py
+++ b/transcription_service/src/webserver/shared/transcription_provider_registry/transcription_provider_registry.py
@@ -172,23 +172,11 @@ class TranscriptionProviderRegistry:
                 case JobContextDefinitionUID.FASTER_WHISPER:
                     from src.transcription_contexts.faster_whisper_context import (
                         FasterWhisperContext,
-                        FasterWhisperContextConfig,
                     )
 
                     context: Any = FasterWhisperContext(
                         config.context_config, config.tags
                     )
-                    # FasterWhisperContextConfig carries `device` ("cuda" or
-                    # "cpu"). Each tag maps to the device its context was
-                    # configured with, so a provider that references the tag
-                    # (via `whisper_context_tag`) can be resolved to its device
-                    # without the provider itself having access to the context
-                    # config.
-                    validated = FasterWhisperContextConfig.model_validate(
-                        config.context_config
-                    )
-                    for tag in config.tags:
-                        self._context_device_by_tag[tag] = validated.device
                 case JobContextDefinitionUID.SILERO_VAD:
                     from src.transcription_contexts.silero_vad_context import (
                         SileroVadContext,
@@ -197,6 +185,18 @@ class TranscriptionProviderRegistry:
                     context = SileroVadContext(
                         config.context_config, config.tags
                     )
+
+            # Record the context's device under each of its tags, so a
+            # provider that references the tag (via `whisper_context_tag`)
+            # can be resolved to its device without the provider itself
+            # having access to the context's config. Asks the constructed
+            # context for its device rather than re-validating the raw
+            # config, so there is one source of truth — if the context ever
+            # normalises "auto" to "cuda" at construction time, this reports
+            # the resolved value.
+            if context.device is not None:
+                for tag in config.tags:
+                    self._context_device_by_tag[tag] = context.device
 
             assignments.append(
                 ContextAssignment(

--- a/transcription_service/tests/integration/metrics/metrics_test.py
+++ b/transcription_service/tests/integration/metrics/metrics_test.py
@@ -201,6 +201,11 @@ def test_reports_workers_and_capacity(test_client: TestClient):
     # provider_config field, which is why the value is asked of the provider
     # instead of read off its config.
     assert body["providerJobPeriodMs"] == {"debug": DEBUG_JOB_PERIOD_MS}
+    # debug has no local device (no model, no inference), so it is omitted
+    # from providerDevice — same convention as providerJobPeriodMs for a
+    # provider that cannot state one. The sidecar falls back to the GPU
+    # default for a provider with no reported device.
+    assert body["providerDevice"] == {}
     assert len(body["workers"]) == NUM_WORKERS
     assert [worker["workerId"] for worker in body["workers"]] == [0, 1]
     for worker in body["workers"]:


### PR DESCRIPTION
## Summary

The `asrDutyRatio` alert threshold was GPU-calibrated (0.45). A healthy CPU stack running `small`/4 measured 0.471 — sitting exactly on the alarm. Every CPU deployment had to discover the `MONITORING_ASR_DUTY_RATIO=0.7` override for itself. This PR makes the selection automatic: the service reports its device, the sidecar picks the threshold.

### How it works

Same shape as `providerJobPeriodMs`:
1. **Transcription service** reports `providerDevice` on `/metrics/status` — the registry resolves each provider's device from its context's config (`"cuda"` or `"cpu"`). Providers with no local device (`debug`, `lumen_granite`) are omitted.
2. **Sidecar** consumes `providerDevice` in the poller, stores a `Map<providerKey, device>`, and passes it to the alert rules via `AlertContext.providerDevices`.
3. **Alert rules** select `asrDutyRatioCpu` (0.7) for a CPU provider, `asrDutyRatio` (0.45) for GPU or unknown. The flat override `ALERT_ASR_DUTY_RATIO` still wins over both.

### Precedence

```
ALERT_ASR_DUTY_RATIO set → wins for every provider (existing escape hatch)
elif device == "cpu"     → ALERT_ASR_DUTY_RATIO_CPU (default 0.7)
else                     → ALERT_ASR_DUTY_RATIO (default 0.45, existing GPU default)
```

A rolling upgrade where device is not yet reported falls back to the GPU default — the existing behaviour.

### Scope: only `asrDutyRatio` needs per-device defaults

The drop-share thresholds measured fine on both devices (CPU is actually *lower*). The legacy RTF fallbacks (`rtfP95`, `asrTailP99Rtf`) are device-independent by construction. So the scope is `asrDutyRatio` alone.

### Files

**Transcription service (Python):**
- `transcription_provider_interface.py` — `device` and `context_tags` properties (default `None`/`[]`)
- `whisper_streaming_provider.py` — overrides `context_tags` to return `[whisper_context_tag]`
- `transcription_provider_registry.py` — builds tag→device map in `_load_contexts`; `provider_device` property resolves provider→tag→device
- `metrics_controller.py` — `providerDevice` on `/metrics/status`

**Sidecar (TypeScript):**
- `transcription-metrics.schema.ts` — `providerDevice` field (optional)
- `transcription-metrics-poller.service.ts` — consumes `providerDevice`, stores in `_providerDevices`, exposes via getter
- `alert-rules.ts` — `asrDutyRatioCpu` threshold; `dutyRatioThresholdFor()` helper; `AlertContext.providerDevices`
- `alert-evaluator.service.ts` — passes poller's device map into context
- `app-config.ts` — `ALERT_ASR_DUTY_RATIO_CPU` env var; flat-override-wins logic

**Deployment:**
- `compose.yml` v15 — `ALERT_ASR_DUTY_RATIO_CPU` passthrough
- `.env.example`, `UPGRADING.md` — documented

Design: `2026-08-02-03-PLAN-PerDeviceAlertThresholds.md`
Supersedes: `2026-07-26-02-NEXTSTEPS-CPU-Whisper.md` §3, `2026-07-27-01-NEXTSTEPS-TestAudio-and-Alerts.md` §5

## Test plan

- [x] Python unit tests: 536 passed
- [x] Python integration tests: 31 passed, 12 skipped (asserts `providerDevice == {}` for debug-only config)
- [x] Sidecar unit tests: 143 passed (4 new per-device threshold tests)
- [x] Sidecar integration tests: 96 passed
- [x] Admin-server unit tests: 235 passed (compose hash re-pinned, version bumped to 15)
- [x] Full repo `npm run build` / `lint` / `format` clean
- [x] Python `make format` / `make lint` clean (10.00/10 on src)
- [ ] Live verification: a CPU stack with no `MONITORING_ASR_DUTY_RATIO` override reports `{"alerts":[]}` (needs a running stack)