### PR TITLE
fix(visible-errors): rate limits, frozen telemetry, node diagnostics, empty-vs-failed

### DIFF
--- a/.changeset/admin-empty-vs-failed.md
+++ b/.changeset/admin-empty-vs-failed.md
@@ -1,0 +1,57 @@
+---
+'@scribear/admin-webapp': minor
+---
+
+The console stops claiming the deployment is empty when it simply could not
+load.
+
+`useAsyncList`'s catch set `error` but left `items` at `[]`, and every page
+branched `loading ? spinner : items.length === 0 ? "No X found." : rows`. So a
+reload while the backend was down stated, in plain text and permanently, that
+there are **no rooms** — with the only contrary signal a toast that auto-hid
+after five seconds. On the audit page the same shape asserted that nobody had
+done anything.
+
+Fixed in the hook first, so it cannot come back: the first-page load is a
+discriminated `loading | ok | unavailable`, and `items` exist **only** inside
+`ok`. "No rooms found." is now unreachable from a failure by construction
+rather than by discipline, which is what the plan asked for. The shape
+deliberately matches the alerts hook so the codebase has one idiom. A failed
+*append* is reported separately and never blanks rows already on screen — the
+mirror image of the original bug.
+
+`useAsyncData` gains the same union **additively**, because a dozen pages
+outside this change read its existing `data`/`loading`/`error`. That matters
+because only two of the five pages the plan named actually used
+`useAsyncList` — audit and sessions-overview use `useAsyncData`, and fixing
+just the named hook would have left them broken while looking complete.
+
+A shared `<ErrorState>` replaces the hand-rolled `errorMessage` copies and
+renders cause, next action, and **`requestId`** — which was captured on
+`ApiError` and displayed nowhere, so an operator filing a ticket could not
+quote the correlation id the server had already generated. It is given
+prominence only because the chain was traced end to end:
+`setGenReqId(randomUUID)` → the request-scoped logger's `reqId` → the
+`X-Request-ID` header → the error envelope → the `request_id` audit row → the
+console's own Audit column. It is correctly absent for a network failure,
+where the request never reached a server, and the block is omitted rather than
+rendered blank.
+
+**Retry appears only when retrying can work.** An expired session gets "sign in
+again"; a wrong `ADMIN_API_KEY` gets "check `ADMIN_API_KEY`". Offering Retry
+there would be advice already known to be wrong — the same defect as "Please
+try again" on a rate limit.
+
+The plan's own example turned out to be misdiagnosed, and the real bug was
+worse. "No devices assigned to this room." is not reachable from a failed load
+— the page early-returns first — but its `!detail` fallback said **"Room not
+found."** for a network drop, a dead session-manager, a 429 or a bad API key.
+Not "this room is empty" but "this room does not exist". Fixed there instead.
+
+Four best-effort catches that rendered nothing are also fixed: a failed room
+search now says so instead of reading as "no matches"; the kiosk wizard's step
+3 stops waiting forever behind a spinner and says it cannot tell after three
+consecutive failed polls, noting the activation is recorded on the device and
+nothing is lost; and `health-indicator` distinguishes "Checking…" from
+"Unreachable" instead of showing one grey "Unknown" for both a dead admin
+server and a healthy one with a hung probe.

--- a/.changeset/admin-frozen-fleet-and-node-diagnostics.md
+++ b/.changeset/admin-frozen-fleet-and-node-diagnostics.md
@@ -1,0 +1,65 @@
+---
+'@scribear/admin-webapp': minor
+---
+
+The fleet grid can no longer freeze while looking live, and the node
+diagnostics the browser was already receiving are finally rendered.
+
+**A frozen fleet says so.** `use-fleet` handled `TELEMETRY_UNAVAILABLE` and let
+`TELEMETRY_DEGRADED` fall through, keeping the last good snapshot with no chip,
+no toast and no staleness marker — while the only visible chip,
+`reconnecting…`, described the SSE stream rather than the poll. An operator
+watched a plausible, motionless fleet and believed it was current. Every other
+gap in this area *fails to inform*; this one **actively misinforms during an
+incident**, which is the exact "looks live but isn't" failure the poll's own
+comment says it exists to prevent. It also got worse the day an alerts panel
+landed beside it: a correct, green alerts panel lends credibility to a frozen
+grid.
+
+The snapshot is kept rather than blanked — mid-incident the last known fleet is
+evidence, and an empty grid beside a green alerts panel would read as "nothing
+running, nothing wrong" — but the marking is made unmissable and text-bearing,
+never colour alone: the heading becomes "Live fleet — last known state", an age
+chip reads `not updating · 2m 14s old`, an assertive banner names the cause and
+the absolute time of the last successful read and offers a retry, and the grid
+itself is fenced with a caption saying everything below is frozen. Severity
+follows the age of the *data*, not merely whether a request threw — a hung
+request never rejects and a hidden tab pauses the poll, and both used to leave
+a stale snapshot looking healthy. It escalates to `error` past three poll
+intervals, chosen because `AUDIO_STATS_TTL_MS` is 10 s, so beyond 15 s every
+audio reading on screen has certainly expired server-side.
+
+Two smaller honesty fixes come with it: a failed first load no longer renders
+"Loading fleet…" over a request that is not coming, and a frozen empty fleet
+says "No active sessions **as of 14:03:22** — this is the frozen snapshot"
+rather than asserting there are none.
+
+**Node diagnostics are rendered.** `GET /api/node-server/v1/status` publishes
+close-code tallies with their `initiator`, auth failures by reason, handshake
+totals and provider-key rejects, and shipped all of it to the browser every
+five seconds — where `grep "snapshot.nodes"` matched nothing. The findings that
+answer a question sit outside the accordion, always visible, each as cause plus
+next action: a **signing-key mismatch** between session-manager and node-server
+is now named as such, with the variable to compare, gated on "has never
+accepted a token" rather than a ratio because these are lifetime totals; a
+device acting on a stale schedule and a room pointed at a provider key no host
+serves are both newly nameable.
+
+Close codes are grouped by role and every row states `initiator` **in words** —
+"the far end closed it" / "node-server closed it" — with a caption explaining
+that a server-chosen reason is authoritative while a peer reason collapses to
+`other` unless allowlisted, so `other` means *unlabelled*, not a specific
+fault. That is what makes "it keeps dropping" distinguishable from "it never
+connected".
+
+Deliberately left out: latency series, the upstream-transition matrix,
+clock-skew counters, and **any derived rate** — differencing a 5 s poll would
+make most windows all-zero, and a wrong rate presented as current is the bug
+class this work exists to remove. Every counter is labelled as a total since
+process start, with its counting epoch shown.
+
+Also corrects the browser's `NodeSnapshot` mirror, which had drifted from its
+producer: `binaryBeforeAuthDropsTotal` and `endedSessionRegistrationsTotal`
+were being published and were entirely untyped here. They render as "not
+reported" when absent, never as `0` — "this publisher predates the field" is a
+different fact from "it counted nothing".

--- a/.changeset/admin-rate-limited-not-wrong-password.md
+++ b/.changeset/admin-rate-limited-not-wrong-password.md
@@ -1,0 +1,43 @@
+---
+'@scribear/admin-server': minor
+'@scribear/admin-webapp': minor
+---
+
+An operator rate-limited by the admin server is no longer told their password
+is wrong.
+
+admin-server registers `@fastify/rate-limit` with `global: true`, so every
+admin route can answer 429 — and the login route tightens the limit further.
+It already had an `errorResponseBuilder`, so the body was well-formed all
+along; what was wrong was the rendering. The console showed the server's
+log-facing string, *"Too many requests. Please retry after 1 minute."*, at
+`error` severity, in the same red slot as *"Invalid credentials."* A rate
+limit is transient and self-clearing, and telling someone their sign-in was
+rejected when it was merely deferred is the worst version of that mistake.
+
+It now renders as a `warning`, says a rate limit is what happened, says nothing
+was changed (the limiter rejects in `onRequest`, before any handler runs), and
+does not imply an automatic retry, because nothing in the console retries.
+
+`Retry-After` reaches the browser for the first time. It is set as a header,
+which the console cannot read, but `@fastify/rate-limit`'s `context.after` is
+already display copy — `"1 minute"`, `"45 seconds"` — so it moves into
+`details.retryAfter` on the error envelope and the wording can name the actual
+wait.
+
+**No schema change**, which is the opposite of what this looked like from the
+outside. It would be natural to add 429 to `STANDARD_ERROR_REPLIES`, on the
+grounds that admin-server's `global: true` is the mirror image of
+session-manager's `global: false`. It is not: admin-server declares **no**
+`response` map at all — it is a BFF with its own `{ok, error}` envelope — and
+`admin-webapp` does not use `createEndpointClient`. All 46 spread sites belong
+to session-manager and node-server, both `global: false`, so the change would
+have added an unreachable arm to 46 schemas and done nothing for admin. A note
+in `error-reply.schema.ts` records why, so the next reader does not have to
+re-derive it.
+
+Along the way, twelve hand-rolled copies of
+`err instanceof ApiError ? err.message : fallback` collapse into one shared
+helper, and `ToastSeverity`'s `'warning'` — which had existed in the type and
+carried a WCAG contrast override in the provider, but which no caller could
+reach — finally has a producer.

--- a/.changeset/client-kiosk-name-the-failure.md
+++ b/.changeset/client-kiosk-name-the-failure.md
@@ -1,0 +1,45 @@
+---
+'@scribear/client-webapp': minor
+'@scribear/kiosk-webapp': minor
+---
+
+The viewer and the kiosk now say which kind of failure happened, and stop
+burning their retry budget on a rate limit in under five seconds.
+
+**`InvalidResponseBodyError` has consumers.** It was introduced so a caller
+could tell "there was no structured error body at all" from "the body was JSON
+but failed the declared schema", and nothing branched on it, so both rendered
+the same generic fallback.
+
+Splitting it exactly two ways would have been wrong, though, and the reason is
+worth recording. nginx's `location /api/session-manager/` sets no
+`proxy_intercept_errors` and no `error_page`, so when the upstream is down
+nginx's own 502/503/504 arrive as **undeclared** statuses — which
+`createEndpointClient` short-circuits into a plain `UnexpectedResponseError`
+*before* it ever tries to parse a body. Under a literal two-way rule, the most
+common infrastructure-down signal in this deployment would have been labelled
+*"this app may be out of date, reload the page"*: advice that cannot help,
+aimed at the wrong party, while the service is simply down. Gateway statuses
+are therefore folded in with `InvalidResponseBodyError` as
+`SERVICE_UNREACHABLE`, and `VERSION_MISMATCH` is reserved for genuine contract
+drift. The same distinction carries into the refresh path, so the terminal
+message after the budget is spent says which of the two occurred.
+
+**The refresh backoff is rate-limit aware.** `@fastify/rate-limit`'s bundled
+`LocalStore` is a **fixed** window — it resets the whole bucket at
+`iterationStartMs + timeWindow` rather than decaying — so the useful client
+behaviour is to spread retries across roughly one window, not to pace at the
+limit rate. A rate-limited viewer was spending its entire five-attempt budget
+in about 4.5 seconds and going terminal, advising a reload that landed in the
+same overload. Rate-limited retries are now spaced 15 seconds apart, spending
+the same bounded budget over about 60 seconds, which gives the window a real
+chance to roll over. Every other failure cause keeps the fast exponential
+schedule.
+
+`Retry-After` is deliberately not read — `createEndpointClient` returns
+`{status, data}` and discards headers — and the window is referenced as a
+shipped default rather than scraped, since those numbers now live in
+session-manager's `AppConfig`.
+
+Also corrects two kiosk comments that blamed `exchange-device-token` for a 429
+it cannot structurally produce: that route has no rate limiter at all.

--- a/.changeset/session-auth-rate-limit-recalibration.md
+++ b/.changeset/session-auth-rate-limit-recalibration.md
@@ -1,0 +1,60 @@
+---
+'@scribear/session-manager': minor
+---
+
+Recalibrate the session-auth rate limits, and add the anti-guessing control the
+old limit was pretending to be.
+
+`exchange-join-code` and `refresh-session-token` were limited at a hard-coded
+100 requests / 60 s per client IP. That number was set as if it were a
+credential-guessing defence, and it is not one: join codes are 8 characters from
+a 36-character alphabet (~2.8×10¹² possibilities) rotating every 5 minutes, and
+refresh tokens are 256-bit secrets checked against the database, so brute force
+is hopeless at 100/min and equally hopeless at 100,000/min. What it did instead
+was fire on ordinary traffic. Session tokens live 5 minutes and the client
+refreshes at 50% of remaining lifetime, so each viewer refreshes about every
+150 s; `N` viewers behind one NAT produce `N/150` refreshes per second, which
+crosses `100/60 s` at **N ≈ 250**. A 250-seat hall behind one campus NAT was
+429ing continuously in steady state with nobody doing anything unusual, and
+`exchange-join-code` tripped earlier still.
+
+The limits now live in `AppConfig` (`SESSION_AUTH_RATE_LIMIT_*`), as
+admin-server's already do, with the calibration argument written down beside
+them:
+
+- **`refresh-session-token`: 1,000 / 60 s.** Covers ~2,500 viewers behind one
+  egress IP in steady state. Raised rather than exempted, because this is the
+  most expensive unauthenticated call in the service — one bcrypt cost-12
+  compare, measured at 154 ms of libuv threadpool, against a service-wide
+  ceiling of ~25 compares/s with the default 4-thread pool — and because a
+  single client has already been seen hammering it in an unbounded ~1 s loop
+  (the reason `REFRESH_MAX_CONSECUTIVE_FAILURES` exists in client-webapp).
+  1,000 / 60 s is ~17× that runaway rate and ~2.5× the largest lecture hall.
+- **`exchange-join-code`: 600 / 60 s.** A generous volumetric cap: a 1,000-seat
+  hall can join inside ~100 s without touching it, while 600 *successful* joins
+  a minute is ~1.5 of the 4 bcrypt threads held by one source.
+- **New: 100 failed exchanges / 60 s.** The actual anti-guessing control, and
+  the operator's signal that guessing is happening (blocks are logged with the
+  client IP).
+
+The failed-attempt cap is keyed on the **client IP, never on the submitted join
+code** — keying a limiter on the credential being guessed hands the guesser a
+fresh bucket per guess, which is worse than having no limiter. It counts only
+404 `JOIN_CODE_NOT_FOUND`; a successful join never spends from it, so a full
+hall cannot lock itself out by joining normally. `@fastify/rate-limit` cannot do
+outcome-conditional counting through `config.rateLimit`, so this uses
+`fastify.createRateLimit()` (v11's manual API): a `preHandler` peeks with
+`{ increment: false }` and an `onSend` hook charges with `{ increment: true }`
+only on a 404. `onSend` rather than `onResponse`, so a burst of concurrent
+guesses cannot all clear the peek before any of them is charged.
+
+410 `JOIN_CODE_EXPIRED` is deliberately **not** charged: a guesser essentially
+never produces one, whereas a stale code left on a projector makes a whole room
+produce one at the same instant, and charging that would lock the room out of
+joining even after the display is fixed.
+
+The 429 declarations and user-facing wording added alongside them are unchanged
+and remain accurate. Because the limits are now config, the rate-limit
+integration suite configures a tiny limit instead of spending 100 real requests
+per route to reach a hard-coded ceiling and then leaving both routes limited for
+the remainder of a real 60-second window.

--- a/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
+++ b/apps/admin-server/src/server/features/deployment-versions/deployment-versions.service.ts
@@ -50,7 +50,7 @@ export interface ContainerVersion {
  * version.test.ts` fails if the two ever disagree, or if that file changes
  * without someone having made that call.
  */
-export const EXPECTED_COMPOSE_FILE_VERSION = 15;
+export const EXPECTED_COMPOSE_FILE_VERSION = 16;
 
 /**
  * How the running `compose.yml` compares to the one this image was built for.

--- a/apps/admin-server/src/server/plugins/rate-limit.plugin.ts
+++ b/apps/admin-server/src/server/plugins/rate-limit.plugin.ts
@@ -1,6 +1,6 @@
 import fastifyRateLimit from '@fastify/rate-limit';
 
-import { HttpError } from '@scribear/base-fastify-server';
+import { BaseHttpError } from '@scribear/base-fastify-server';
 import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
 
 export interface RateLimitConfig {
@@ -18,6 +18,12 @@ export interface RateLimitConfig {
  * The login route tightens this via per-route `config.rateLimit` (see the auth
  * router); probes opt out via `config.rateLimit: false` so container health
  * checks are never throttled.
+ *
+ * Because this is `global: true`, EVERY admin route can answer 429 — unlike
+ * session-manager, where the limiter is `global: false` and only two routes
+ * opt in. Anything that renders an admin API failure must therefore be able to
+ * explain a rate limit; see `errorMessage`/`errorSeverity` in admin-webapp's
+ * `lib/api-error.ts`.
  */
 export async function registerRateLimit(
   fastify: BaseFastifyInstance,
@@ -29,9 +35,21 @@ export async function registerRateLimit(
     timeWindow: config.globalWindowMs,
     // The plugin THROWS whatever this returns, so return a BaseHttpError; the
     // admin error handler then serializes it as a `RATE_LIMITED` envelope.
+    //
+    // Constructed directly rather than via `HttpError.rateLimited(...)` because
+    // that helper takes no `details`, and `details.retryAfter` is the only way
+    // the wait ever reaches the browser: the plugin also sets a `retry-after`
+    // header, but `AdminApiClient` (like `createEndpointClient`) returns only
+    // status + body and discards headers entirely. Carrying it in the body is
+    // what lets the console say "wait 1 minute" instead of "wait a moment".
     errorResponseBuilder: (_req, context) =>
-      HttpError.rateLimited(
+      new BaseHttpError(
+        429,
+        'RATE_LIMITED',
         `Too many requests. Please retry after ${context.after}.`,
+        // Human-readable duration from `@fastify/rate-limit` ("1 minute",
+        // "45 seconds"), not a number of seconds — it is display copy.
+        { retryAfter: context.after },
       ),
   });
 }

--- a/apps/admin-server/tests/integration/rate-limit.routes.test.ts
+++ b/apps/admin-server/tests/integration/rate-limit.routes.test.ts
@@ -1,0 +1,174 @@
+import { Type } from 'typebox';
+import { Value } from 'typebox/value';
+import { describe, expect } from 'vitest';
+
+import { TEST_USERNAME, useServer } from '#tests/utils/use-server.js';
+
+const BASE = '/api/admin/v1';
+
+/**
+ * What the admin console actually parses out of a 429.
+ *
+ * Deliberately NOT `RATE_LIMITED_REPLY_SCHEMA` from `@scribear/base-schema`:
+ * admin-server is a BFF and overrides the base error handler so every failure
+ * is the `{ ok: false, error: { … } }` envelope the SPA expects, rather than a
+ * bare `ErrorReply`. Nothing in admin-server declares a `response` map for its
+ * error statuses, so this schema is the only executable statement of the
+ * contract — `AdminApiClient._request` and `ApiError` in admin-webapp read
+ * exactly these fields, and `rateLimitMessage` reads `details.retryAfter`.
+ *
+ * `Value.Check` here is the same check `createEndpointClient` runs against a
+ * declared response schema in the services that use one.
+ */
+const RATE_LIMITED_ENVELOPE_SCHEMA = Type.Object(
+  {
+    ok: Type.Literal(false),
+    error: Type.Object({
+      code: Type.Literal('RATE_LIMITED'),
+      message: Type.String({ minLength: 1 }),
+      requestId: Type.String({ minLength: 1 }),
+      details: Type.Object({
+        // Display copy from `@fastify/rate-limit` ("1 minute", "45 seconds"),
+        // not a number of seconds. The console renders it verbatim.
+        retryAfter: Type.String({ minLength: 1 }),
+      }),
+    }),
+  },
+  { additionalProperties: false },
+);
+
+describe('Global rate limiting', () => {
+  // `global: true` in rate-limit.plugin.ts, so a route that declares no
+  // `config.rateLimit` of its own is still limited. Two requests, then 429.
+  const server = useServer({
+    rateLimitConfig: { globalMax: 2, globalWindowMs: 60_000 },
+  });
+
+  describe('a route with no rate limit of its own', (it) => {
+    it('is limited anyway, because the limiter is registered globally', async () => {
+      // Act — /auth/config carries no `config.rateLimit`; only the global one
+      // can throttle it.
+      const codes: number[] = [];
+      for (let i = 0; i < 3; i++) {
+        const res = await server.fastify.inject({
+          method: 'GET',
+          url: `${BASE}/auth/config`,
+        });
+        codes.push(res.statusCode);
+      }
+
+      // Assert
+      expect(codes).toEqual([200, 200, 429]);
+    });
+  });
+});
+
+describe('Rate-limited response body', () => {
+  const server = useServer({
+    rateLimitConfig: { globalMax: 1, globalWindowMs: 60_000 },
+  });
+
+  describe('the 429 an admin route emits', (it) => {
+    it('is the canonical admin error envelope, with a retryAfter the console can render', async () => {
+      // Arrange — burn the single allowed request.
+      await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/config`,
+      });
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/config`,
+      });
+
+      // Assert — the shape admin-webapp parses, checked the way
+      // `createEndpointClient` checks a declared schema.
+      expect(res.statusCode).toBe(429);
+      const body: unknown = res.json();
+      expect(Value.Check(RATE_LIMITED_ENVELOPE_SCHEMA, body)).toBe(true);
+      expect(body).toMatchObject({
+        ok: false,
+        error: {
+          code: 'RATE_LIMITED',
+          details: { retryAfter: '1 minute' },
+        },
+      });
+      // The header is set too, but no client in this repo can read it — which
+      // is why the value is duplicated into `details.retryAfter`.
+      expect(res.headers['retry-after']).toBeDefined();
+    });
+  });
+});
+
+describe('Probe routes opt out of rate limiting', () => {
+  const server = useServer({
+    rateLimitConfig: { globalMax: 1, globalWindowMs: 60_000 },
+  });
+
+  describe('GET /probes/liveness', (it) => {
+    it('still answers 200 after the global window is exhausted', async () => {
+      // Arrange — exhaust the global bucket on a route that is limited.
+      await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/config`,
+      });
+      const limited = await server.fastify.inject({
+        method: 'GET',
+        url: `${BASE}/auth/config`,
+      });
+      expect(limited.statusCode).toBe(429);
+
+      // Act — `config: { rateLimit: false }` on the probe router.
+      const codes: number[] = [];
+      for (let i = 0; i < 3; i++) {
+        const res = await server.fastify.inject({
+          method: 'GET',
+          url: `${BASE}/probes/liveness`,
+        });
+        codes.push(res.statusCode);
+      }
+
+      // Assert
+      expect(codes).toEqual([200, 200, 200]);
+    });
+  });
+});
+
+describe('Login rate limiting body', () => {
+  // The tighter per-route limit — the realistic trigger, since an operator
+  // mistyping a password reaches it in seconds.
+  const server = useServer({
+    rateLimitConfig: { loginMax: 1, loginWindowMs: 60_000 },
+  });
+
+  describe('POST /auth/login', (it) => {
+    it('answers RATE_LIMITED, not INVALID_CREDENTIALS, once the login limit is spent', async () => {
+      // Arrange — one allowed (failing) attempt.
+      const first = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/auth/login`,
+        payload: { username: TEST_USERNAME, password: 'wrong' },
+      });
+      expect(first.statusCode).toBe(401);
+      expect(first.json<{ error: { code: string } }>().error.code).toBe(
+        'INVALID_CREDENTIALS',
+      );
+
+      // Act
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${BASE}/auth/login`,
+        payload: { username: TEST_USERNAME, password: 'wrong' },
+      });
+
+      // Assert — the console distinguishes these two by `status`, so the 429
+      // must not arrive wearing the credential error's code.
+      expect(res.statusCode).toBe(429);
+      expect(Value.Check(RATE_LIMITED_ENVELOPE_SCHEMA, res.json())).toBe(true);
+      expect(res.json<{ error: { code: string } }>().error.code).toBe(
+        'RATE_LIMITED',
+      );
+    });
+  });
+});

--- a/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
+++ b/apps/admin-server/tests/unit/features/deployment-versions/compose-file-version.test.ts
@@ -34,7 +34,7 @@ const COMPOSE_FILE = 'deployment/compose.yml';
  * which of the two remedies applies.
  */
 const COMPOSE_FILE_SHA256 =
-  '6c53fd7b35282bc8c796e26b41f5f8fca98b6cb410787f9a3d0bd9d7e1bfeacc';
+  '72170e47cf283ef18fc64448435463cb5bf51c3421f359ab172ae3bcee2b2a4c';
 
 /** Walks up from the working directory, which differs by how vitest was run. */
 function repoFile(relative: string): string {

--- a/apps/admin-webapp/src/components/error-state.tsx
+++ b/apps/admin-webapp/src/components/error-state.tsx
@@ -1,0 +1,101 @@
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+import { CopyIconButton } from '#src/components/copy-icon-button';
+import { describeApiFailure } from '#src/lib/api-failure';
+
+export interface ErrorStateProps {
+  /**
+   * What failed, in the page's own words — "Could not load rooms." Doubles as
+   * the fallback cause when the error is not an `ApiError`.
+   */
+  title: string;
+  /** The rejection value from `adminApi`. */
+  error: unknown;
+  /**
+   * Re-runs the load. Rendered only when retrying could plausibly succeed:
+   * offering "Retry" for an expired session or a wrong ADMIN_API_KEY would be
+   * advice we know is wrong (PLAN-VisibleErrors §1).
+   */
+  onRetry?: () => void;
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * The one error surface for admin pages (PLAN-VisibleErrors §10.1), replacing
+ * the hand-rolled `errorMessage(err, fallback)` + auto-hiding toast pairs.
+ *
+ * Renders three things a toast could not: the **cause**, the **next action**,
+ * and the server's **`requestId`** — which `ApiError` has carried since it was
+ * written and which nothing displayed. It is `severity="error"` (§10.4:
+ * action required), never `warning`; MUI gives that an icon and `role="alert"`,
+ * so colour is not the only signal (WCAG SC 1.4.1) and the failure is
+ * announced once when it appears. It is deliberately *not* inside an
+ * `aria-live` region of its own — these mount on a load failure, not on a
+ * poll.
+ */
+export const ErrorState = ({ title, error, onRetry, sx }: ErrorStateProps) => {
+  const { cause, nextAction, retryable, requestId } = describeApiFailure(
+    error,
+    title,
+  );
+  const showRetry = onRetry !== undefined && retryable;
+
+  return (
+    <Alert
+      severity="error"
+      sx={sx}
+      action={
+        showRetry ? (
+          <Button color="inherit" size="small" onClick={onRetry}>
+            Retry
+          </Button>
+        ) : undefined
+      }
+    >
+      <AlertTitle>{title}</AlertTitle>
+      {/* For a rejection that is not an `ApiError` the cause falls back to the
+          title; printing the same sentence twice reads like a rendering bug. */}
+      {cause !== title && <Typography variant="body2">{cause}</Typography>}
+      {nextAction !== null && (
+        <Typography variant="body2" sx={{ mt: 0.5 }}>
+          {nextAction}
+        </Typography>
+      )}
+      {requestId !== undefined && (
+        <>
+          <Typography variant="caption" sx={{ display: 'block', mt: 1 }}>
+            {/* Verified end to end, not assumed: admin-server sets
+                `genReqId: () => randomUUID()` in `create-base-server.ts`, logs
+                it as `reqId` on every line for the request via the
+                `scope-logger` hook, echoes it as the `X-Request-ID` response
+                header, puts it in the error envelope this string comes from,
+                and stores it on the audit row (`audit.repository.ts`) that the
+                console's own Audit log renders. Same string in all five
+                places. */}
+            Request ID — quote this when reporting the problem. It appears in
+            the admin server&apos;s logs and in this console&apos;s Audit log.
+          </Typography>
+          <Stack
+            direction="row"
+            spacing={0.5}
+            sx={{ alignItems: 'center', mt: 0.5 }}
+          >
+            <Typography
+              variant="caption"
+              component="code"
+              sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}
+            >
+              {requestId}
+            </Typography>
+            <CopyIconButton value={requestId} label="request ID" />
+          </Stack>
+        </>
+      )}
+    </Alert>
+  );
+};

--- a/apps/admin-webapp/src/components/health-indicator.tsx
+++ b/apps/admin-webapp/src/components/health-indicator.tsx
@@ -17,12 +17,10 @@ const POLL_MS = 30_000;
  * hardcoded three names and would have reported "Healthy" while a newly-added
  * dependency was down.
  */
-function overall(report: HealthReport | null): {
+function overall(report: HealthReport): {
   color: 'success' | 'warning' | 'error' | 'default';
   label: string;
 } {
-  if (!report) return { color: 'default', label: 'Unknown' };
-
   // 'not-configured' components (e.g. redis with REDIS_URL unset) are an
   // intentional deployment choice, not a fault — excluded here so an operator
   // who never configured an optional dependency still sees "Healthy".
@@ -39,10 +37,27 @@ function overall(report: HealthReport | null): {
 }
 
 /**
+ * The three things this chip can honestly say, as a discriminated state —
+ * same `loading | ok | unavailable` vocabulary as `useAlerts` and
+ * `useAsyncList`.
+ *
+ * It replaces a single `HealthReport | null`, under which a dead admin server
+ * and a console that had simply not polled yet were both rendered as the same
+ * grey "Unknown" chip (PLAN-VisibleErrors §5). Worse, a *successful* first
+ * poll followed by failures reverted to "Unknown" — the console silently
+ * downgraded from knowing to not knowing, in the one widget an operator
+ * glances at to decide whether anything is wrong.
+ */
+type HealthState =
+  | { status: 'loading' }
+  | { status: 'ok'; report: HealthReport }
+  | { status: 'unavailable' };
+
+/**
  * Compact health chip that polls the BFF `/health` rollup. Hover for detail.
  */
 export const HealthIndicator = () => {
-  const [report, setReport] = useState<HealthReport | null>(null);
+  const [state, setState] = useState<HealthState>({ status: 'loading' });
 
   useEffect(() => {
     let cancelled = false;
@@ -50,10 +65,14 @@ export const HealthIndicator = () => {
       adminApi
         .health()
         .then((r) => {
-          if (!cancelled) setReport(r);
+          if (!cancelled) setState({ status: 'ok', report: r });
         })
         .catch(() => {
-          if (!cancelled) setReport(null);
+          // Not swallowed: `/health` is unauthenticated-adjacent and cheap, so
+          // a rejection means the admin server (or the network to it) is down.
+          // That is a harder fact than anything in the report, and the chip
+          // says so rather than reverting to grey.
+          if (!cancelled) setState({ status: 'unavailable' });
         });
     };
     poll();
@@ -64,21 +83,30 @@ export const HealthIndicator = () => {
     };
   }, []);
 
-  const { color, label } = overall(report);
-  const tip = report
-    ? [
-        `BFF: ${report.bff}`,
-        ...report.components.map((c) => {
-          // The cause beats the latency: a red "session-manager: fail" tells an
-          // operator nothing the detail ("database: fail") does not tell better.
-          const suffix =
-            c.detail !== undefined && c.detail !== ''
-              ? ` — ${c.detail}`
-              : ` (${String(c.latencyMs)}ms)`;
-          return `${c.name}: ${c.status}${suffix}`;
-        }),
-      ].join(' · ')
-    : 'Health unknown';
+  const { color, label } =
+    state.status === 'ok'
+      ? overall(state.report)
+      : state.status === 'loading'
+        ? ({ color: 'default', label: 'Checking…' } as const)
+        : ({ color: 'error', label: 'Unreachable' } as const);
+
+  const tip =
+    state.status === 'ok'
+      ? [
+          `BFF: ${state.report.bff}`,
+          ...state.report.components.map((c) => {
+            // The cause beats the latency: a red "session-manager: fail" tells an
+            // operator nothing the detail ("database: fail") does not tell better.
+            const suffix =
+              c.detail !== undefined && c.detail !== ''
+                ? ` — ${c.detail}`
+                : ` (${String(c.latencyMs)}ms)`;
+            return `${c.name}: ${c.status}${suffix}`;
+          }),
+        ].join(' · ')
+      : state.status === 'loading'
+        ? 'Reading the deployment health rollup…'
+        : 'Could not reach the admin server, so nothing here is known to be healthy. Check that the admin-server container is running and that this browser can reach it.';
 
   return (
     <Tooltip title={tip}>

--- a/apps/admin-webapp/src/features/audit/audit-page.tsx
+++ b/apps/admin-webapp/src/features/audit/audit-page.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
-import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -18,36 +17,20 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 
+import { ErrorState } from '#src/components/error-state';
 import { TimezoneNote } from '#src/components/timezone-note';
 import { adminApi } from '#src/lib/admin-api';
-import { ApiError, isApiErrorCode } from '#src/lib/api-error';
-import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 
 const LIMIT_OPTIONS = [50, 100, 200] as const;
 
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof ApiError ? err.message : fallback;
-}
-
 export const AuditPage = () => {
-  const { showError } = useToast();
   const [limit, setLimit] = useState<number>(50);
 
-  const { data, loading, error } = useAsyncData(
+  const { state, reload } = useAsyncData(
     () => adminApi.listAudit(limit),
     [limit],
   );
-  const items = data?.items ?? [];
-  const misconfigured = isApiErrorCode(error, 'BACKEND_MISCONFIGURATION');
-
-  // Any load failure that isn't misconfiguration is surfaced as a toast.
-  useEffect(() => {
-    if (error !== null && !isApiErrorCode(error, 'BACKEND_MISCONFIGURATION')) {
-      showError(errorMessage(error, 'Failed to load audit log.'));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
-  }, [error]);
 
   return (
     <Box>
@@ -80,12 +63,6 @@ export const AuditPage = () => {
           </Select>
         </FormControl>
       </Box>
-      {misconfigured && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          Admin backend misconfiguration — an operator must check the
-          server&apos;s ADMIN_API_KEY.
-        </Alert>
-      )}
       <TimezoneNote />
       <TableContainer component={Paper}>
         <Table size="small">
@@ -102,13 +79,25 @@ export const AuditPage = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {loading ? (
+            {/* Three outcomes, never two: an unread audit log is not an
+                empty one (PLAN-VisibleErrors §5). */}
+            {state.status === 'loading' ? (
               <TableRow>
                 <TableCell colSpan={8} align="center" sx={{ py: 4 }}>
                   <CircularProgress size={28} />
                 </TableCell>
               </TableRow>
-            ) : items.length === 0 ? (
+            ) : state.status === 'unavailable' ? (
+              <TableRow>
+                <TableCell colSpan={8} sx={{ py: 2 }}>
+                  <ErrorState
+                    title="Could not load the audit log."
+                    error={state.error}
+                    onRetry={reload}
+                  />
+                </TableCell>
+              </TableRow>
+            ) : state.data.items.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={8} align="center" sx={{ py: 4 }}>
                   <Typography
@@ -121,7 +110,7 @@ export const AuditPage = () => {
                 </TableCell>
               </TableRow>
             ) : (
-              items.map((row) => {
+              state.data.items.map((row) => {
                 const isSuccess = row.result.toLowerCase() === 'success';
                 return (
                   <TableRow key={row.id}>

--- a/apps/admin-webapp/src/features/audit/audit-page.tsx
+++ b/apps/admin-webapp/src/features/audit/audit-page.tsx
@@ -20,18 +20,14 @@ import Typography from '@mui/material/Typography';
 
 import { TimezoneNote } from '#src/components/timezone-note';
 import { adminApi } from '#src/lib/admin-api';
-import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { isApiErrorCode } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 
 const LIMIT_OPTIONS = [50, 100, 200] as const;
 
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof ApiError ? err.message : fallback;
-}
-
 export const AuditPage = () => {
-  const { showError } = useToast();
+  const { showApiError } = useToast();
   const [limit, setLimit] = useState<number>(50);
 
   const { data, loading, error } = useAsyncData(
@@ -44,7 +40,7 @@ export const AuditPage = () => {
   // Any load failure that isn't misconfiguration is surfaced as a toast.
   useEffect(() => {
     if (error !== null && !isApiErrorCode(error, 'BACKEND_MISCONFIGURATION')) {
-      showError(errorMessage(error, 'Failed to load audit log.'));
+      showApiError(error, 'Failed to load audit log.');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [error]);

--- a/apps/admin-webapp/src/features/auth/login-page.tsx
+++ b/apps/admin-webapp/src/features/auth/login-page.tsx
@@ -13,7 +13,11 @@ import { useSearchParams } from 'react-router-dom';
 import { Navigate, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '#src/features/auth/auth-context';
-import { ApiError } from '#src/lib/api-error';
+import {
+  type ErrorSeverity,
+  errorSeverity,
+  loginErrorMessage,
+} from '#src/lib/api-error';
 
 export const LoginPage = () => {
   const { status, config, configError, login } = useAuth();
@@ -21,7 +25,15 @@ export const LoginPage = () => {
   const [searchParams] = useSearchParams();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
+  // Severity travels with the message: the login route is rate limited to 5
+  // attempts a minute, so the most likely repeat failure here is a 429 — which
+  // is transient and self-clearing, and must not be shown in the same red
+  // alert as "Invalid credentials." or the operator will keep guessing at a
+  // password that was never the problem.
+  const [error, setError] = useState<{
+    message: string;
+    severity: ErrorSeverity;
+  } | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const ssoError = searchParams.get('sso_error');
@@ -50,11 +62,10 @@ export const LoginPage = () => {
         void navigate('/', { replace: true });
       })
       .catch((err: unknown) => {
-        setError(
-          err instanceof ApiError
-            ? err.message
-            : 'Sign in failed. Please try again.',
-        );
+        setError({
+          message: loginErrorMessage(err),
+          severity: errorSeverity(err),
+        });
       })
       .finally(() => {
         setSubmitting(false);
@@ -87,8 +98,8 @@ export const LoginPage = () => {
           </Typography>
 
           {error && (
-            <Alert severity="error" sx={{ mb: 2 }}>
-              {error}
+            <Alert severity={error.severity} sx={{ mb: 2 }}>
+              {error.message}
             </Alert>
           )}
 

--- a/apps/admin-webapp/src/features/config-check/config-check-page.tsx
+++ b/apps/admin-webapp/src/features/config-check/config-check-page.tsx
@@ -25,7 +25,6 @@ import type {
   ConfigFinding,
 } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
-import { ApiError } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 
@@ -74,10 +73,6 @@ const ENVIRONMENT_COLOR: Record<
   staging: 'info',
   production: 'error',
 };
-
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof ApiError ? err.message : fallback;
-}
 
 /**
  * One finding.
@@ -178,7 +173,7 @@ const FindingCard = ({
  * requests to redraw an identical page.
  */
 export const ConfigCheckPage = () => {
-  const { showError } = useToast();
+  const { showApiError } = useToast();
   const {
     data: report,
     loading,
@@ -200,16 +195,14 @@ export const ConfigCheckPage = () => {
   // A failed run is surfaced as a toast; `report` keeps its last value (or null).
   useEffect(() => {
     if (error !== null) {
-      showError(errorMessage(error, 'Failed to run the config check.'));
+      showApiError(error, 'Failed to run the config check.');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [error]);
 
   useEffect(() => {
     if (versionsError !== null) {
-      showError(
-        errorMessage(versionsError, 'Failed to read the container versions.'),
-      );
+      showApiError(versionsError, 'Failed to read the container versions.');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [versionsError]);

--- a/apps/admin-webapp/src/features/dashboard/alerts-panel.tsx
+++ b/apps/admin-webapp/src/features/dashboard/alerts-panel.tsx
@@ -115,7 +115,7 @@ export const AlertsPanel = () => {
 
   if (state.status === 'unavailable') {
     return (
-      <Alert severity="error" sx={{ mb: 3 }}>
+      <Alert severity={state.severity} sx={{ mb: 3 }}>
         Could not read monitoring-sidecar alerts — this is not the same as "no
         alerts firing"; the pipeline&apos;s health is currently unknown.{' '}
         {state.message}

--- a/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
+++ b/apps/admin-webapp/src/features/dashboard/fleet-panel.tsx
@@ -1,9 +1,11 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import HelpOutlineIcon from '@mui/icons-material/HelpOutlined';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardActionArea from '@mui/material/CardActionArea';
 import CardContent from '@mui/material/CardContent';
@@ -53,6 +55,8 @@ import {
   sourceThroughputSeconds,
   useFilteredSessions,
 } from './fleet-status';
+import { NodeDiagnosticsPanel } from './node-diagnostics-panel';
+import { deriveFreshness, freshnessChipLabel } from './telemetry-freshness';
 import { useFleet } from './use-fleet';
 
 const STATUS_COLOR: Record<FleetStatus, StatusColor> = {
@@ -70,6 +74,24 @@ const PROVIDER_STATUS_COLOR: Record<MergedProvider['status'], StatusColor> = {
 
 const STATUS_ORDER: FleetStatus[] = ['crit', 'warn', 'good', 'idle'];
 const AUDIO_STATUS_ORDER: AudioStatus[] = ['crit', 'warn', 'unknown', 'good'];
+
+/**
+ * How often the panel re-derives the age of the snapshot it is showing.
+ *
+ * A dedicated ticker rather than relying on the poll's own re-renders: the two
+ * states that most need marking are exactly the two that produce no re-render.
+ * A request that hangs never resolves or rejects, and a tab left hidden pauses
+ * the poll entirely — in both cases the last render happened when the data was
+ * fresh, and without a clock of its own this panel would keep displaying that
+ * moment's verdict indefinitely.
+ */
+const FRESHNESS_TICK_MS = 1_000;
+
+const FRESHNESS_CHIP_COLOR = {
+  ok: 'default',
+  warning: 'warning',
+  error: 'error',
+} as const;
 
 /**
  * Audio conventions the roll-up must label on the surface
@@ -675,10 +697,27 @@ const FleetAudioRollup = ({
  * session-centric telemetry — see `fleet-status.ts`).
  */
 export const FleetPanel = () => {
-  const { snapshot, sessionEvents, connected, available } = useFleet();
+  const { snapshot, sessionEvents, connected, available, poll, refresh } =
+    useFleet();
   const [filter, setFilter] = useState<FleetFilter>({
     status: ['crit', 'warn'],
   });
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setNow(Date.now());
+    }, FRESHNESS_TICK_MS);
+    return () => {
+      window.clearInterval(id);
+    };
+  }, []);
+
+  const freshness = deriveFreshness(poll, now);
+  const frozenAtLabel =
+    freshness.lastSuccessAt === null
+      ? null
+      : new Date(freshness.lastSuccessAt).toLocaleTimeString();
 
   const sessions = snapshot?.sessions ?? [];
   const audioMap = useMemo(() => audioBySession(snapshot), [snapshot]);
@@ -720,41 +759,147 @@ export const FleetPanel = () => {
     <Box sx={{ mb: 3 }}>
       <Stack
         direction="row"
+        useFlexGap
         sx={{
           justifyContent: 'space-between',
           alignItems: 'center',
+          flexWrap: 'wrap',
+          rowGap: 0.5,
           mb: 1,
         }}
       >
+        {/*
+          The heading itself changes when the data is stale. A chip alone is
+          missable and a banner can be scrolled past; the title of the thing an
+          operator is reading cannot be either, and this is the one signal that
+          travels with the grid wherever it sits on the page.
+        */}
         <Typography variant="h6" component="h2">
-          Live fleet
+          {freshness.stale ? 'Live fleet — last known state' : 'Live fleet'}
         </Typography>
-        {!connected && (
-          <Chip size="small" label="reconnecting…" color="warning" />
-        )}
+        <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: 'wrap' }}>
+          {/*
+            Not inside any live region: this ticks once a second, and a live
+            region that re-announced the age every second would be unusable.
+            The one-off state change is announced by the banner below instead.
+          */}
+          <Chip
+            size="small"
+            label={freshnessChipLabel(freshness)}
+            color={FRESHNESS_CHIP_COLOR[freshness.severity]}
+            variant={freshness.stale ? 'filled' : 'outlined'}
+          />
+          {/*
+            Explicitly "stream", because this chip has only ever described the
+            SSE connection. Labelled "reconnecting…" beside a frozen grid it
+            read as a complete account of the panel's health, which is exactly
+            how a dead poll stayed invisible (PLAN-VisibleErrors §4.4).
+          */}
+          {!connected && (
+            <Chip
+              size="small"
+              label="live stream reconnecting…"
+              color="warning"
+              variant="outlined"
+            />
+          )}
+        </Stack>
       </Stack>
+      {freshness.headline !== null && (
+        <Alert
+          severity={freshness.severity === 'error' ? 'error' : 'warning'}
+          sx={{ mb: 2 }}
+          action={
+            <Button color="inherit" size="small" onClick={refresh}>
+              Retry now
+            </Button>
+          }
+        >
+          <AlertTitle>
+            {freshness.severity === 'error'
+              ? 'This is not the live fleet'
+              : 'This may be behind the live fleet'}
+          </AlertTitle>
+          {freshness.headline}
+          {frozenAtLabel !== null &&
+            ` Last successful update: ${frozenAtLabel}.`}
+          {freshness.cause !== null && ` Reported cause: ${freshness.cause}`}{' '}
+          {freshness.nextAction}
+        </Alert>
+      )}
       <Box sx={{ mb: 2 }}>
         <ProviderStatusRow providers={snapshot?.providers ?? []} />
       </Box>
       <ProviderCapacityRow providers={snapshot?.providers ?? []} />
+      <NodeDiagnosticsPanel
+        nodes={snapshot?.nodes ?? []}
+        hosts={snapshot?.transcriptionHosts ?? []}
+      />
       {snapshot === null ? (
-        <Typography
-          sx={{
-            color: 'text.secondary',
-          }}
-        >
-          Loading fleet…
-        </Typography>
+        // "Loading fleet…" is only true while a read is genuinely in flight.
+        // Once one has failed, the banner above is the whole story and this
+        // would be a spinner-shaped lie about a request that is not coming.
+        poll.status === 'degraded' ? null : (
+          <Typography
+            sx={{
+              color: 'text.secondary',
+            }}
+          >
+            Loading fleet…
+          </Typography>
+        )
       ) : sessions.length === 0 ? (
         <Typography
           sx={{
             color: 'text.secondary',
           }}
         >
-          No active sessions.
+          {/*
+            "No active sessions." is a claim about the fleet. From a frozen
+            snapshot it is only a claim about a moment that has passed, and
+            saying it flatly is the same mistake as "No rooms found." over a
+            failed load (PLAN-VisibleErrors §5).
+          */}
+          {freshness.stale
+            ? `No active sessions as of ${frozenAtLabel ?? 'the last update'} — this is the frozen snapshot, not the fleet now.`
+            : 'No active sessions.'}
         </Typography>
       ) : (
-        <>
+        // While stale, the grid is fenced and captioned in place. The banner
+        // above states the situation once; this keeps it attached to the data
+        // itself, for an operator who scrolled straight to a room's card.
+        <Box
+          sx={
+            freshness.stale
+              ? {
+                  border: 2,
+                  borderColor:
+                    freshness.severity === 'error'
+                      ? 'error.main'
+                      : 'warning.main',
+                  borderRadius: 1,
+                  p: 1.5,
+                }
+              : undefined
+          }
+        >
+          {freshness.stale && (
+            <Typography
+              variant="body2"
+              sx={{
+                fontWeight: 'bold',
+                mb: 1,
+                color:
+                  freshness.severity === 'error'
+                    ? 'error.main'
+                    : 'warning.main',
+              }}
+            >
+              Frozen snapshot — everything below is as of{' '}
+              {frozenAtLabel ?? 'the last successful update'} and is not
+              updating.
+            </Typography>
+          )}
           <FleetAudioRollup sessions={sessions} audioMap={audioMap} />
           <FleetFilterBar
             filter={filter}
@@ -778,7 +923,7 @@ export const FleetPanel = () => {
               ))}
             </Grid>
           )}
-        </>
+        </Box>
       )}
     </Box>
   );

--- a/apps/admin-webapp/src/features/dashboard/node-diagnostics-panel.tsx
+++ b/apps/admin-webapp/src/features/dashboard/node-diagnostics-panel.tsx
@@ -1,0 +1,518 @@
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+
+import type {
+  NodeSnapshot,
+  TranscriptionHostSnapshot,
+} from '#src/lib/admin-api';
+import { browserTimeZone, formatInTimeZone } from '#src/lib/timezone';
+
+import type { NodeFinding } from './node-diagnostics';
+import {
+  AUTH_FAILURE_REASON_HELP,
+  CLOSE_INITIATOR_LABEL,
+  CONNECTION_ROLE_LABEL,
+  deriveCloseGroups,
+  deriveDiagnosticsRollup,
+  deriveHandshakeTally,
+  deriveHostFindings,
+  deriveNodeFindings,
+} from './node-diagnostics';
+
+/**
+ * Sentence appended wherever a counter is shown, because every counter on this
+ * panel is a lifetime total since the publishing process started and reading
+ * one as "what is happening now" is the exact mistake this whole plan is about.
+ */
+const EPOCH_NOTE =
+  'All counts are totals since the process started, not rates. A restart returns them to zero.';
+
+const PEER_REASON_NOTE =
+  'A close the far end performed carries remote-supplied text, which node-server normalises to “other” unless it matches a reason it knows — so “other” on a far-end row means “unlabelled”, not a specific fault. A close node-server performed carries a reason it chose, and that one is authoritative.';
+
+/** One finding, rendered as cause → next action. Colour is never the only cue:
+ *  the severity word is in the `AlertTitle`'s own icon and the text states the
+ *  problem outright, matching `AlertsPanel`'s card. */
+const FindingAlert = ({ finding }: { finding: NodeFinding }) => (
+  <Alert severity={finding.level} sx={{ mb: 1 }}>
+    <AlertTitle>{finding.headline}</AlertTitle>
+    <Typography variant="body2" sx={{ mb: 0.5 }}>
+      {finding.cause}
+    </Typography>
+    <Typography variant="body2">
+      <Box component="strong">Next: </Box>
+      {finding.nextAction}
+    </Typography>
+  </Alert>
+);
+
+/**
+ * Handshake outcomes for one node (PLAN-VisibleErrors §4.1, runbook question
+ * 4).
+ *
+ * Accepted, rejected and timed-out are three separate figures rather than a
+ * pass/fail pair because node-server counts them separately and they mean
+ * different things: a rejection is a credential this node looked at and
+ * refused, a timeout is a socket that never presented one at all. The
+ * per-reason rows name the failure instead of totalling it — "3 auth failures"
+ * cannot be acted on, "3 invalid-token" can.
+ */
+const HandshakeSection = ({ node }: { node: NodeSnapshot }) => {
+  const auth = deriveHandshakeTally(node);
+
+  return (
+    <Box sx={{ mt: 1.5 }}>
+      <Typography variant="subtitle2" component="h4">
+        Session-token handshakes
+      </Typography>
+      <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: 'wrap' }}>
+        <Chip
+          size="small"
+          variant="outlined"
+          label={`accepted: ${String(auth.successTotal)}`}
+          color={auth.successTotal > 0 ? 'success' : 'default'}
+        />
+        <Chip
+          size="small"
+          variant="outlined"
+          label={`rejected: ${String(auth.failureTotal)}`}
+          color={auth.failureTotal > 0 ? 'warning' : 'default'}
+        />
+        <Chip
+          size="small"
+          variant="outlined"
+          label={`never authenticated: ${String(auth.timeoutsTotal)}`}
+          color={auth.timeoutsTotal > 0 ? 'warning' : 'default'}
+        />
+      </Stack>
+      {auth.byReason.length === 0 ? (
+        <Typography
+          variant="caption"
+          sx={{ color: 'text.secondary', display: 'block', mt: 0.5 }}
+        >
+          {auth.successTotal === 0 && auth.timeoutsTotal === 0
+            ? 'No connection has ever presented a session token to this node — nothing has tried to connect, as distinct from trying and being refused.'
+            : 'No credential has been rejected by this node.'}
+        </Typography>
+      ) : (
+        <TableContainer sx={{ mt: 0.5 }}>
+          <Table
+            size="small"
+            aria-label={`Rejected handshakes on ${node.nodeInstanceId}`}
+          >
+            <TableHead>
+              <TableRow>
+                <TableCell>Reason</TableCell>
+                <TableCell align="right">Count</TableCell>
+                <TableCell>What it means</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {auth.byReason.map((row) => (
+                <TableRow key={row.reason}>
+                  <TableCell sx={{ fontFamily: 'monospace' }}>
+                    {row.reason}
+                  </TableCell>
+                  <TableCell
+                    align="right"
+                    sx={{ fontVariantNumeric: 'tabular-nums' }}
+                  >
+                    {row.count}
+                  </TableCell>
+                  <TableCell>
+                    {/* An unrecognised reason is shown with no gloss rather
+                        than a guess: `authFailures[].reason` is an open set and
+                        a newer node-server may name one this console predates. */}
+                    {AUTH_FAILURE_REASON_HELP[row.reason] ?? '—'}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+      <Typography
+        variant="caption"
+        sx={{ color: 'text.secondary', display: 'block', mt: 0.5 }}
+      >
+        “Never authenticated” counts sockets that opened and never sent a token
+        inside the watchdog window; node-server records those separately, so
+        they are not part of the rejected total above.
+      </Typography>
+    </Box>
+  );
+};
+
+/**
+ * Socket closes for one node, grouped by role and always labelled with
+ * `initiator` (PLAN-VisibleErrors §4.1, runbook question 3).
+ *
+ * The grouping is what makes "the source keeps dropping" separable from "the
+ * source never connected": a role with no rows at all has never had a socket
+ * close, and a role whose rows are overwhelmingly far-end closes is flapping.
+ * Both readings are impossible from an undifferentiated code tally, which is
+ * what this data looked like before anything rendered it.
+ */
+const CloseSection = ({ node }: { node: NodeSnapshot }) => {
+  const groups = deriveCloseGroups(node);
+
+  if (groups.length === 0) {
+    return (
+      <Box sx={{ mt: 1.5 }}>
+        <Typography variant="subtitle2" component="h4">
+          Socket closes
+        </Typography>
+        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+          No transcription-stream socket has closed on this node since it
+          started — neither a source nor a viewer has connected and gone away.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ mt: 1.5 }}>
+      <Typography variant="subtitle2" component="h4">
+        Socket closes
+      </Typography>
+      {groups.map((group) => (
+        <Box key={group.role} sx={{ mt: 1 }}>
+          <Typography variant="body2">
+            {CONNECTION_ROLE_LABEL[group.role]} — {group.total} close
+            {group.total === 1 ? '' : 's'}: {group.peerTotal} by the far end,{' '}
+            {group.serverTotal} by node-server.
+          </Typography>
+          <TableContainer sx={{ mt: 0.5 }}>
+            <Table
+              size="small"
+              aria-label={`${CONNECTION_ROLE_LABEL[group.role]} closes on ${node.nodeInstanceId}`}
+            >
+              <TableHead>
+                <TableRow>
+                  <TableCell>Code</TableCell>
+                  <TableCell>Reason</TableCell>
+                  <TableCell>Who closed it</TableCell>
+                  <TableCell align="right">Count</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {group.rows.map((row) => (
+                  <TableRow
+                    key={`${String(row.code)}:${row.reason}:${row.initiator}`}
+                  >
+                    <TableCell sx={{ fontVariantNumeric: 'tabular-nums' }}>
+                      {row.code}
+                    </TableCell>
+                    <TableCell sx={{ fontFamily: 'monospace' }}>
+                      {row.reason === '' ? '(none)' : row.reason}
+                    </TableCell>
+                    <TableCell>
+                      {CLOSE_INITIATOR_LABEL[row.initiator]}
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{ fontVariantNumeric: 'tabular-nums' }}
+                    >
+                      {row.count}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Box>
+      ))}
+      <Typography
+        variant="caption"
+        sx={{ color: 'text.secondary', display: 'block', mt: 0.5 }}
+      >
+        {PEER_REASON_NOTE}
+      </Typography>
+    </Box>
+  );
+};
+
+/** Frame-level drops and uplink churn — the counters that explain a session
+ *  whose source is connected while nothing reaches the ASR. */
+const ThroughputSection = ({ node }: { node: NodeSnapshot }) => {
+  const { summary } = node;
+  return (
+    <Box sx={{ mt: 1.5 }}>
+      <Typography variant="subtitle2" component="h4">
+        Dropped frames and uplink churn
+      </Typography>
+      <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: 'wrap' }}>
+        <Chip
+          size="small"
+          variant="outlined"
+          label={`malformed frames dropped: ${String(summary.decodeDropsTotal)}`}
+          color={summary.decodeDropsTotal > 0 ? 'warning' : 'default'}
+        />
+        <Chip
+          size="small"
+          variant="outlined"
+          // `undefined` means this publisher does not report the field at all
+          // (it is optional on the wire for rolling-deploy safety), which is a
+          // different fact from zero and must not be rendered as one.
+          label={
+            summary.binaryBeforeAuthDropsTotal === undefined
+              ? 'pre-auth audio dropped: not reported'
+              : `pre-auth audio dropped: ${String(summary.binaryBeforeAuthDropsTotal)}`
+          }
+          color={
+            (summary.binaryBeforeAuthDropsTotal ?? 0) > 0
+              ? 'warning'
+              : 'default'
+          }
+        />
+        <Chip
+          size="small"
+          variant="outlined"
+          label={`ASR uplink reconnects: ${String(summary.upstreamChurnTotal)}`}
+          color={summary.upstreamChurnTotal > 0 ? 'warning' : 'default'}
+        />
+        <Chip
+          size="small"
+          variant="outlined"
+          label={`orchestrator failures: ${String(summary.orchestratorFailuresTotal)}`}
+          color={summary.orchestratorFailuresTotal > 0 ? 'error' : 'default'}
+        />
+      </Stack>
+    </Box>
+  );
+};
+
+const NodeCard = ({ node }: { node: NodeSnapshot }) => {
+  const zone = browserTimeZone();
+  return (
+    <Card variant="outlined" sx={{ mb: 1 }}>
+      <CardContent>
+        <Stack
+          direction="row"
+          spacing={1}
+          useFlexGap
+          sx={{ alignItems: 'center', flexWrap: 'wrap' }}
+        >
+          <Typography
+            variant="subtitle1"
+            component="h3"
+            sx={{ fontFamily: 'monospace' }}
+          >
+            {node.nodeInstanceId}
+          </Typography>
+          <Chip
+            size="small"
+            variant="outlined"
+            label={`${String(node.summary.activeSessionCount)} active session${node.summary.activeSessionCount === 1 ? '' : 's'}`}
+          />
+          <Chip
+            size="small"
+            variant="outlined"
+            label={`counting since ${formatInTimeZone(node.processStartedAt, zone)}`}
+          />
+        </Stack>
+        <HandshakeSection node={node} />
+        <CloseSection node={node} />
+        <ThroughputSection node={node} />
+      </CardContent>
+    </Card>
+  );
+};
+
+/**
+ * Transcription Service host inventory (PLAN-VisibleErrors §4.2).
+ *
+ * The provider keys column is the reason this table exists rather than a bare
+ * `invalidProviderKeyRejects` number: the rejection only becomes actionable
+ * next to the list of keys the host would have accepted.
+ */
+const HostTable = ({ hosts }: { hosts: TranscriptionHostSnapshot[] }) => {
+  const zone = browserTimeZone();
+  return (
+    <TableContainer sx={{ mt: 1 }}>
+      <Table size="small" aria-label="Transcription Service hosts">
+        <TableHead>
+          <TableRow>
+            <TableCell>Host</TableCell>
+            <TableCell align="right">Workers</TableCell>
+            <TableCell>Provider keys served</TableCell>
+            <TableCell align="right">Unknown-key refusals</TableCell>
+            <TableCell>Counting since</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {hosts.map((host) => {
+            const keys = Object.keys(host.providers).sort();
+            return (
+              <TableRow key={host.transcriptionHost}>
+                <TableCell sx={{ fontFamily: 'monospace' }}>
+                  {host.transcriptionHost}
+                </TableCell>
+                <TableCell
+                  align="right"
+                  sx={{ fontVariantNumeric: 'tabular-nums' }}
+                >
+                  {host.numWorkers}
+                </TableCell>
+                <TableCell sx={{ fontFamily: 'monospace' }}>
+                  {keys.length > 0 ? keys.join(', ') : 'none configured'}
+                </TableCell>
+                <TableCell
+                  align="right"
+                  sx={{
+                    fontVariantNumeric: 'tabular-nums',
+                    color:
+                      host.invalidProviderKeyRejects > 0
+                        ? 'error.main'
+                        : 'text.primary',
+                  }}
+                >
+                  {host.invalidProviderKeyRejects}
+                </TableCell>
+                <TableCell>
+                  {formatInTimeZone(host.processStartedAt, zone)}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export interface NodeDiagnosticsPanelProps {
+  nodes: NodeSnapshot[];
+  hosts: TranscriptionHostSnapshot[];
+}
+
+/**
+ * Renders the node-server and Transcription Service counters that
+ * `FleetSnapshot` has been carrying to the browser every 5 seconds and that
+ * nothing read (PLAN-VisibleErrors §4.1, §4.2). It answers two runbook
+ * questions the console could not previously answer at all: "is the source
+ * dropping or did it never connect" and "is this a signing-key mismatch".
+ *
+ * Shape follows what an operator does with it. Findings — the named diagnoses —
+ * sit outside the accordion and are always visible, because a collapsed
+ * section is a section nobody opens during an incident. The tables behind them
+ * are collapsed by default: they are the evidence for a finding, not a thing to
+ * scan, and a permanently-expanded wall of counters is its own kind of
+ * unreadable.
+ *
+ * **Live-region discipline** (LESSONSLEARNED, "a polled list must not be a live
+ * region"): this whole panel re-renders on the fleet panel's 5 s poll, so the
+ * tables sit outside any live region and only the counts rollup is
+ * `aria-live="polite"`. Because the underlying counters are monotonic and only
+ * move when something actually happens, that rollup announces exactly when
+ * there is news — which is the behaviour a live region is for.
+ */
+export const NodeDiagnosticsPanel = ({
+  nodes,
+  hosts,
+}: NodeDiagnosticsPanelProps) => {
+  if (nodes.length === 0 && hosts.length === 0) return null;
+
+  const findings = [
+    ...nodes.flatMap((node) => deriveNodeFindings(node)),
+    ...hosts.flatMap((host) => deriveHostFindings(host)),
+  ];
+  const rollup = deriveDiagnosticsRollup(nodes, hosts);
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      {findings.map((finding) => (
+        <FindingAlert key={finding.id} finding={finding} />
+      ))}
+      {/*
+        Outside the Accordion, not inside its summary: ARIA treats the content
+        of a button as presentational, so a live region nested in an
+        `AccordionSummary` would never announce — the same trap `SessionCard`'s
+        audio strip documents for `role="progressbar"` inside a
+        `CardActionArea`. Keeping it a sibling also means the headline counts
+        stay readable while the detail is collapsed.
+      */}
+      <Stack
+        direction="row"
+        spacing={1}
+        useFlexGap
+        sx={{ flexWrap: 'wrap', mb: 1 }}
+        aria-live="polite"
+        aria-label="Connection diagnostics summary"
+      >
+        <Chip
+          size="small"
+          variant="outlined"
+          label={`${String(rollup.nodeCount)} node-server, ${String(rollup.hostCount)} transcription host${rollup.hostCount === 1 ? '' : 's'}`}
+        />
+        <Chip
+          size="small"
+          variant="outlined"
+          label={`handshakes ${String(rollup.authSuccessTotal)} accepted / ${String(rollup.authFailureTotal)} rejected`}
+          color={
+            rollup.authFailureTotal > 0 && rollup.authSuccessTotal === 0
+              ? 'error'
+              : rollup.authFailureTotal > 0
+                ? 'warning'
+                : 'default'
+          }
+        />
+        <Chip
+          size="small"
+          variant="outlined"
+          label={`source closes ${String(rollup.sourceClosesTotal)} · viewer closes ${String(rollup.clientClosesTotal)}`}
+        />
+      </Stack>
+      <Accordion variant="outlined" disableGutters>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          {/*
+            `component="span"`, not the `h6` MUI's `subtitle2` variant mapping
+            would otherwise emit: this label lives inside the accordion's
+            button, where a heading is both wrong semantically and — because
+            the panel sits under the fleet panel's `h2` — a three-level jump
+            that axe flags. Caught by the a11y test, not by eye.
+          */}
+          <Typography variant="subtitle2" component="span">
+            Connection diagnostics — node-server handshakes, socket closes and
+            transcription hosts
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Typography
+            variant="caption"
+            sx={{ color: 'text.secondary', display: 'block', mb: 1 }}
+          >
+            {EPOCH_NOTE}
+          </Typography>
+          {nodes.map((node) => (
+            <NodeCard key={node.processUid} node={node} />
+          ))}
+          {hosts.length > 0 && (
+            <>
+              <Typography variant="subtitle2" component="h3" sx={{ mt: 2 }}>
+                Transcription Service hosts
+              </Typography>
+              <HostTable hosts={hosts} />
+            </>
+          )}
+        </AccordionDetails>
+      </Accordion>
+    </Box>
+  );
+};

--- a/apps/admin-webapp/src/features/dashboard/node-diagnostics.ts
+++ b/apps/admin-webapp/src/features/dashboard/node-diagnostics.ts
@@ -1,0 +1,304 @@
+import type {
+  CloseInitiator,
+  ConnectionRole,
+  NodeSnapshot,
+  TranscriptionHostSnapshot,
+  WsCloseTally,
+} from '#src/lib/admin-api';
+
+/**
+ * Node-server and Transcription Service counter derivations for the fleet
+ * panel (PLAN-VisibleErrors §4.1, §4.2). Every number these read has been
+ * arriving in the browser on `FleetSnapshot.nodes` / `.transcriptionHosts`
+ * every 5 s since the fleet view shipped, and nothing rendered any of it.
+ *
+ * **All of it is monotonic since the publishing process started.** Nothing here
+ * is a rate and nothing here describes "now"; the rendering layer's job is to
+ * keep saying so. Deriving a rate in the browser was considered and rejected —
+ * see the note on {@link NodeFinding} — so every verdict below is phrased so it
+ * stays true of a lifetime total.
+ */
+
+/**
+ * What each `authFailures[].reason` from node-server's `verifyAuth` actually
+ * means, in operator language. Sourced from
+ * `apps/node-server/src/server/features/transcription-stream/transcription-stream.auth.ts`
+ * and `session-token.service.ts`, not from the names.
+ *
+ * An **open set**: a reason that is not in here is rendered verbatim with no
+ * gloss, which is the correct behaviour for a new reason shipped by a
+ * node-server newer than this console.
+ */
+export const AUTH_FAILURE_REASON_HELP: Record<string, string> = {
+  'invalid-token':
+    'The token’s HMAC did not verify, or its payload failed the schema check. This is what a SESSION_TOKEN_SIGNING_KEY mismatch between session-manager and node-server looks like — session-manager is minting tokens node-server cannot verify.',
+  'token-expired':
+    'The token’s expiry had already passed when the socket authenticated — a client sitting on an old token, or clock skew between session-manager and node-server.',
+  'session-mismatch':
+    'The token was minted for a different session than the URL it was presented on.',
+  'missing-scope':
+    'The token lacks the scope this role requires — SEND_AUDIO for a source, RECEIVE_TRANSCRIPTIONS for a viewer.',
+};
+
+/** Operator-facing name for each `wsCloses[].role`. */
+export const CONNECTION_ROLE_LABEL: Record<ConnectionRole, string> = {
+  source: 'Source uplinks (the room’s microphone)',
+  client: 'Viewer connections',
+};
+
+/**
+ * Operator-facing name for each `wsCloses[].initiator`. Spelled out as words
+ * rather than shown as a colour or an icon: `initiator` is the label the whole
+ * tally exists for, and the two values mean genuinely different things about
+ * who is at fault.
+ */
+export const CLOSE_INITIATOR_LABEL: Record<CloseInitiator, string> = {
+  server: 'node-server closed it',
+  peer: 'the far end closed it',
+};
+
+export interface HandshakeTally {
+  /** Successful WebSocket auth handshakes since process start. */
+  successTotal: number;
+  /** Credential rejections, summed across reasons. Excludes timeouts. */
+  failureTotal: number;
+  /**
+   * Connections that never sent `auth` inside the watchdog window. Counted by
+   * `recordAuthTimeout` only — node-server does **not** also record these in
+   * `authFailures[]`, so they are a separate fact rather than a subset, and a
+   * surface that folds them in makes its own numbers stop adding up.
+   */
+  timeoutsTotal: number;
+  /** Rejections by reason, highest count first. */
+  byReason: { reason: string; count: number }[];
+  /**
+   * `failureTotal / (failureTotal + successTotal)`, or null when nothing has
+   * ever presented a credential. The ratio, not the count, is the signal
+   * node-server's own `authSuccessTotal` doc comment says to read: a handful
+   * of failures is normal, all of them failing is config drift.
+   */
+  rejectRatio: number | null;
+}
+
+export function deriveHandshakeTally(node: NodeSnapshot): HandshakeTally {
+  const byReason = [...node.authFailures].sort((a, b) => b.count - a.count);
+  const failureTotal = byReason.reduce((sum, r) => sum + r.count, 0);
+  const successTotal = node.summary.authSuccessTotal;
+  const attempts = failureTotal + successTotal;
+  return {
+    successTotal,
+    failureTotal,
+    timeoutsTotal: node.summary.authTimeoutsTotal,
+    byReason,
+    rejectRatio: attempts === 0 ? null : failureTotal / attempts,
+  };
+}
+
+/** One role's close tally on one node. */
+export interface CloseGroup {
+  role: ConnectionRole;
+  /** Rows for this role, highest count first. */
+  rows: WsCloseTally[];
+  /** Closes node-server decided on. Its `reason` is authoritative. */
+  serverTotal: number;
+  /** Closes the far end performed. Its `reason` is remote text. */
+  peerTotal: number;
+  total: number;
+}
+
+/**
+ * Groups one node's `wsCloses[]` by role, preserving `initiator` on every row.
+ *
+ * Grouping by role rather than by code is the point: the runbook question is
+ * about one room's microphone uplink, and a viewer's close tally is a different
+ * subject that would otherwise be summed into the same number.
+ */
+export function deriveCloseGroups(node: NodeSnapshot): CloseGroup[] {
+  const roles: ConnectionRole[] = ['source', 'client'];
+  return roles
+    .map((role) => {
+      const rows = node.wsCloses
+        .filter((c) => c.role === role)
+        .sort((a, b) => b.count - a.count);
+      const serverTotal = rows
+        .filter((r) => r.initiator === 'server')
+        .reduce((sum, r) => sum + r.count, 0);
+      const peerTotal = rows
+        .filter((r) => r.initiator === 'peer')
+        .reduce((sum, r) => sum + r.count, 0);
+      return {
+        role,
+        rows,
+        serverTotal,
+        peerTotal,
+        total: serverTotal + peerTotal,
+      };
+    })
+    .filter((g) => g.rows.length > 0);
+}
+
+/**
+ * A named diagnosis, in the PLAN §1 shape: a **cause**, an **audience** (this
+ * panel's is always an operator), and a **next action**.
+ *
+ * Every finding is phrased to stay true of a lifetime total, because that is
+ * what the underlying counters are. That constraint is why the strongest
+ * verdict below keys on `successTotal === 0` — "this node has never accepted a
+ * handshake" is a statement a monotonic counter can support without a window,
+ * whereas "authentication is failing right now" is not. Differencing successive
+ * polls to synthesise a rate was considered and deliberately not done: the poll
+ * is 5 s, most windows would be all-zero, and a wrong rate presented as current
+ * is precisely the class of bug this plan exists to remove.
+ */
+export interface NodeFinding {
+  /** Stable key for React and for tests. */
+  id: string;
+  level: 'warning' | 'error';
+  headline: string;
+  cause: string;
+  nextAction: string;
+}
+
+/** Fraction of rejected handshakes above which the ratio is worth naming. */
+export const AUTH_REJECT_WARN_RATIO = 0.5;
+
+/**
+ * Diagnoses one node-server instance from its counters.
+ *
+ * Returns an empty array when nothing is worth saying — the healthy state of
+ * this surface is the absence of a finding, not a green banner, for the same
+ * reason the sidecar's alert list has no `info` tier.
+ */
+export function deriveNodeFindings(node: NodeSnapshot): NodeFinding[] {
+  const findings: NodeFinding[] = [];
+  const auth = deriveHandshakeTally(node);
+  const invalidToken =
+    auth.byReason.find((r) => r.reason === 'invalid-token')?.count ?? 0;
+
+  if (auth.failureTotal > 0 && auth.successTotal === 0) {
+    // The unambiguous case, and the one PLAN §8 question 4 asks for. A node
+    // that has rejected every credential ever presented to it is not looking at
+    // a handful of stale clients.
+    const dominant = auth.byReason[0];
+    const keyMismatch = invalidToken === auth.failureTotal;
+    findings.push({
+      id: `${node.nodeInstanceId}:auth-never-succeeded`,
+      level: 'error',
+      headline: keyMismatch
+        ? `${node.nodeInstanceId} has never accepted a session token: all ${String(auth.failureTotal)} handshakes were rejected as invalid-token.`
+        : `${node.nodeInstanceId} has never accepted a session token: all ${String(auth.failureTotal)} handshakes were rejected${dominant ? ` (mostly ${dominant.reason})` : ''}.`,
+      cause: keyMismatch
+        ? 'A token whose HMAC does not verify is the signature of a signing-key mismatch: session-manager is minting tokens with one SESSION_TOKEN_SIGNING_KEY and node-server is verifying them with another. Neither service logs this as an error — each believes it is behaving correctly.'
+        : (AUTH_FAILURE_REASON_HELP[dominant?.reason ?? ''] ??
+          'Every credential presented to this node has been rejected.'),
+      nextAction: keyMismatch
+        ? 'Compare SESSION_TOKEN_SIGNING_KEY on session-manager and on node-server; they must be byte-identical. Until they agree, no source or viewer can connect to this node and every room it owns stays silent.'
+        : 'Read the per-reason breakdown below — the reason names which half of the handshake contract is being broken.',
+    });
+  } else if (
+    auth.rejectRatio !== null &&
+    auth.rejectRatio >= AUTH_REJECT_WARN_RATIO &&
+    auth.failureTotal > 0
+  ) {
+    findings.push({
+      id: `${node.nodeInstanceId}:auth-reject-ratio`,
+      level: 'warning',
+      headline: `${node.nodeInstanceId} has rejected ${String(Math.round(auth.rejectRatio * 100))}% of the session tokens presented to it (${String(auth.failureTotal)} rejected, ${String(auth.successTotal)} accepted since it started).`,
+      cause:
+        'These are totals since the process started, so this does not mean authentication is failing at this moment — but a majority-rejected node has something systematically wrong with its tokens rather than a few unlucky clients.',
+      nextAction:
+        'Check the per-reason breakdown below: invalid-token points at a signing-key mismatch, token-expired at clock skew or clients reusing old tokens, missing-scope at a token minted for the wrong role.',
+    });
+  }
+
+  const endedRegistrations = node.summary.endedSessionRegistrationsTotal ?? 0;
+  if (endedRegistrations > 0) {
+    findings.push({
+      id: `${node.nodeInstanceId}:ended-session-registrations`,
+      level: 'warning',
+      headline: `${node.nodeInstanceId} refused ${String(endedRegistrations)} source registration(s) for sessions that had already ended.`,
+      cause:
+        'A device connected and asked to send audio for a session past its scheduled end. It is acting on a schedule it has not been able to refresh — most often a kiosk whose mySchedule long-poll has been failing silently.',
+      nextAction:
+        'Check that device’s presence and its last-seen time on the device page; a kiosk in this state shows a room as scheduled while sending audio nowhere.',
+    });
+  }
+
+  return findings;
+}
+
+/**
+ * §4.2's counterpart on the Transcription Service side.
+ *
+ * `invalidProviderKeyRejects` is not a capacity refusal and not transient: the
+ * registry raises it when the requested key is not in the host's configured
+ * providers, so nothing about retrying or waiting will fix it. Rendering the
+ * count alongside the keys the host *does* serve is what turns the number into
+ * a diagnosis.
+ */
+export function deriveHostFindings(
+  host: TranscriptionHostSnapshot,
+): NodeFinding[] {
+  if (host.invalidProviderKeyRejects <= 0) return [];
+  const configured = Object.keys(host.providers).sort();
+  return [
+    {
+      id: `${host.transcriptionHost}:invalid-provider-key`,
+      level: 'error',
+      headline: `${host.transcriptionHost} refused ${String(host.invalidProviderKeyRejects)} session(s) for a provider key it does not have configured.`,
+      cause: `A session asked this host for a transcription provider it does not load. The keys it serves are: ${configured.length > 0 ? configured.join(', ') : '(none configured)'}. This is a naming disagreement, not a load problem — the session gets no captions at all, and no amount of retrying changes that.`,
+      nextAction:
+        'Compare the provider key configured on the room or session against the keys listed above, then fix whichever side is wrong. A room pointed at a key no host serves is silent every time it runs.',
+    },
+  ];
+}
+
+/** Fleet-wide counts for the panel's one polite live-region rollup. */
+export interface DiagnosticsRollup {
+  nodeCount: number;
+  hostCount: number;
+  authSuccessTotal: number;
+  authFailureTotal: number;
+  authTimeoutsTotal: number;
+  sourceClosesTotal: number;
+  clientClosesTotal: number;
+  findingCount: number;
+}
+
+export function deriveDiagnosticsRollup(
+  nodes: NodeSnapshot[],
+  hosts: TranscriptionHostSnapshot[],
+): DiagnosticsRollup {
+  let authSuccessTotal = 0;
+  let authFailureTotal = 0;
+  let authTimeoutsTotal = 0;
+  let sourceClosesTotal = 0;
+  let clientClosesTotal = 0;
+  let findingCount = 0;
+
+  for (const node of nodes) {
+    const auth = deriveHandshakeTally(node);
+    authSuccessTotal += auth.successTotal;
+    authFailureTotal += auth.failureTotal;
+    authTimeoutsTotal += auth.timeoutsTotal;
+    for (const close of node.wsCloses) {
+      if (close.role === 'source') sourceClosesTotal += close.count;
+      else clientClosesTotal += close.count;
+    }
+    findingCount += deriveNodeFindings(node).length;
+  }
+  for (const host of hosts) {
+    findingCount += deriveHostFindings(host).length;
+  }
+
+  return {
+    nodeCount: nodes.length,
+    hostCount: hosts.length,
+    authSuccessTotal,
+    authFailureTotal,
+    authTimeoutsTotal,
+    sourceClosesTotal,
+    clientClosesTotal,
+    findingCount,
+  };
+}

--- a/apps/admin-webapp/src/features/dashboard/telemetry-freshness.ts
+++ b/apps/admin-webapp/src/features/dashboard/telemetry-freshness.ts
@@ -1,0 +1,196 @@
+import { FLEET_POLL_INTERVAL_MS } from '#src/lib/admin-api';
+
+import type { FleetPollState } from './use-fleet';
+
+/**
+ * How old the last successful `/fleet` read may get before what is on screen
+ * stops being "a moment behind" and becomes "no longer describing the fleet".
+ *
+ * Three poll intervals, chosen against the publisher rather than by feel: the
+ * backplane expires session audio-stats keys after `AUDIO_STATS_TTL_MS`
+ * (10 s — `infra/scribear-redis/src/telemetry/telemetry-timing.ts`), so once a
+ * snapshot is 15 s old *every* audio reading drawn from it has certainly
+ * outlived its own TTL server-side. Before that point the numbers are merely
+ * late; after it they are expired, and the difference is worth an escalation.
+ */
+export const FLEET_STALE_AFTER_MS = 3 * FLEET_POLL_INTERVAL_MS;
+
+/**
+ * Severity of the freshness state, in the PLAN §10 vocabulary: `ok` maps to
+ * "waiting/expected, no action"; `warning` to "degraded, retrying, no action
+ * yet"; `error` to "what is on screen is not the fleet, stop reading it as
+ * such".
+ */
+export type FreshnessSeverity = 'ok' | 'warning' | 'error';
+
+export interface TelemetryFreshness {
+  severity: FreshnessSeverity;
+  /** Age of the newest successful read, or null when there has never been one. */
+  ageMs: number | null;
+  /**
+   * Epoch ms of the newest successful read, or null when there has never been
+   * one. An absolute clock time derived from this is what belongs in the
+   * assertive banner — unlike {@link ageMs} it changes only when a read
+   * actually lands, so it does not re-announce itself once per second.
+   */
+  lastSuccessAt: number | null;
+  /** True while the panel is showing a snapshot it knows is not current. */
+  stale: boolean;
+  /**
+   * Cause + audience, as one **stable** sentence. Deliberately carries no
+   * relative age: this string lands in an assertive `role="alert"` region, and
+   * a ticking "2m 14s" inside one would re-announce itself to a screen-reader
+   * user every second. The ticking readout lives in the chip, outside any live
+   * region; the absolute clock time comes from {@link lastSuccessAt}, which
+   * changes only when a read actually succeeds.
+   */
+  headline: string | null;
+  /** Verbatim cause from the failed read, when there was one. */
+  cause: string | null;
+  /** What the operator should do. Never null when `headline` is non-null. */
+  nextAction: string | null;
+}
+
+/**
+ * Human age, coarse on purpose: an operator reads this to decide whether to
+ * trust the grid, not to time anything. Sub-minute resolves to seconds, past
+ * an hour it stops counting seconds entirely.
+ */
+export function formatAge(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  if (totalSeconds < 60) return `${String(totalSeconds)}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) return `${String(minutes)}m ${String(seconds)}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${String(hours)}h ${String(minutes % 60)}m`;
+}
+
+const RETRY_NOTE = `The console keeps retrying every ${String(
+  Math.round(FLEET_POLL_INTERVAL_MS / 1000),
+)} seconds.`;
+
+const CHECK_NOTE =
+  'If it does not clear on its own, check that admin-server can reach the Redis telemetry backplane (REDIS_URL) and that the node-server and transcription-service publishers are running.';
+
+/**
+ * Classifies how much of the fleet panel can still be believed.
+ *
+ * Severity is driven by the **age of the data**, not only by whether the last
+ * request threw. That matters for two states a status-only rule gets wrong: a
+ * request that hangs rather than rejecting never produces a failure yet leaves
+ * the panel just as frozen, and a tab that has been hidden for an hour returns
+ * with `status: 'ok'` and an hour-old snapshot on screen. Both are stale, and
+ * an operator glancing at the grid cannot tell either from live.
+ *
+ * @param poll Poll state from `useFleet`.
+ * @param now Current epoch ms — injected so this is testable without fake timers.
+ */
+export function deriveFreshness(
+  poll: FleetPollState,
+  now: number,
+): TelemetryFreshness {
+  if (poll.status === 'unavailable') {
+    return {
+      severity: 'error',
+      ageMs: null,
+      lastSuccessAt: null,
+      stale: false,
+      headline: null,
+      cause: poll.message,
+      nextAction: null,
+    };
+  }
+
+  if (poll.status === 'loading') {
+    return {
+      severity: 'ok',
+      ageMs: null,
+      lastSuccessAt: null,
+      stale: false,
+      headline: null,
+      cause: null,
+      nextAction: null,
+    };
+  }
+
+  // Both remaining variants carry it; `ok` narrows it to a number.
+  const lastSuccessAt: number | null = poll.lastSuccessAt;
+  const ageMs =
+    lastSuccessAt === null ? null : Math.max(0, now - lastSuccessAt);
+
+  if (poll.status === 'degraded' && ageMs === null) {
+    // Never had a good read and the current one failed. There is nothing on
+    // screen to mark as stale — the honest statement is that the view is empty
+    // because the read failed, not because the fleet is idle (PLAN §5's bug,
+    // in the one place it would be least noticed).
+    return {
+      severity: 'error',
+      ageMs: null,
+      lastSuccessAt: null,
+      stale: false,
+      headline:
+        'Live fleet telemetry could not be read, so this view has never had any data. An empty fleet panel here does not mean the fleet is idle.',
+      cause: poll.message,
+      nextAction: `${RETRY_NOTE} ${CHECK_NOTE}`,
+    };
+  }
+
+  const age = ageMs ?? 0;
+  const beyondThreshold = age >= FLEET_STALE_AFTER_MS;
+
+  if (poll.status === 'degraded') {
+    return {
+      severity: beyondThreshold ? 'error' : 'warning',
+      ageMs: age,
+      lastSuccessAt,
+      stale: true,
+      headline: beyondThreshold
+        ? 'Live fleet telemetry has stopped updating. Every session, audio level and capacity figure below is frozen at the time shown and no longer describes the fleet — do not read this grid as current.'
+        : 'Live fleet telemetry missed its last update. What is below is the most recent snapshot that arrived, not the current state of the fleet.',
+      cause: poll.message,
+      nextAction: beyondThreshold
+        ? `${RETRY_NOTE} ${CHECK_NOTE} Until it clears, treat the alerts panel and the per-room pages as the current picture rather than this grid.`
+        : RETRY_NOTE,
+    };
+  }
+
+  // status === 'ok', but the newest read may still be old: a hidden tab pauses
+  // the poll, and a hung request never rejects.
+  if (beyondThreshold) {
+    return {
+      severity: 'warning',
+      ageMs: age,
+      lastSuccessAt,
+      stale: true,
+      headline:
+        'The newest fleet snapshot is older than one poll cycle, so the grid below may lag the fleet. No read has failed — the poll pauses while this tab is hidden and a request can hang without erroring.',
+      cause: null,
+      nextAction: 'It refreshes as soon as the next read lands.',
+    };
+  }
+
+  return {
+    severity: 'ok',
+    ageMs: age,
+    lastSuccessAt,
+    stale: false,
+    headline: null,
+    cause: null,
+    nextAction: null,
+  };
+}
+
+/**
+ * Text for the age chip beside the panel heading. Always carries a word as
+ * well as an age, so the chip's colour is never the only thing distinguishing
+ * "fresh" from "frozen" (SC 1.4.1) — the same rule `CapacityMeterBar`'s
+ * "N / N*" readout follows.
+ */
+export function freshnessChipLabel(freshness: TelemetryFreshness): string {
+  const { ageMs, stale } = freshness;
+  if (ageMs === null) return stale ? 'no data' : 'waiting for first update';
+  return stale
+    ? `not updating · ${formatAge(ageMs)} old`
+    : `updated ${formatAge(ageMs)} ago`;
+}

--- a/apps/admin-webapp/src/features/dashboard/use-alerts.ts
+++ b/apps/admin-webapp/src/features/dashboard/use-alerts.ts
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react';
 
 import type { MonitoringAlert } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
-import { ApiError } from '#src/lib/api-error';
+import {
+  type ErrorSeverity,
+  errorMessage,
+  errorSeverity,
+} from '#src/lib/api-error';
 
 /**
  * How often the dashboard re-reads `/alerts`. Independent of
@@ -21,7 +25,10 @@ export const ALERTS_POLL_INTERVAL_MS = 15_000;
 export type AlertsState =
   | { status: 'loading' }
   | { status: 'ok'; alerts: MonitoringAlert[]; generatedAt: string }
-  | { status: 'unavailable'; message: string };
+  /** `severity` travels with the message because admin-server rate limits
+   *  every route: a 429 here means "ask again shortly", not "the pipeline is
+   *  broken", and must not be painted the same red. */
+  | { status: 'unavailable'; message: string; severity: ErrorSeverity };
 
 export interface UseAlertsResult {
   state: AlertsState;
@@ -57,10 +64,8 @@ export function useAlerts(): UseAlertsResult {
         if (!alive.current) return;
         setState({
           status: 'unavailable',
-          message:
-            err instanceof ApiError
-              ? err.message
-              : 'Could not reach the admin server.',
+          message: errorMessage(err, 'Could not reach the admin server.'),
+          severity: errorSeverity(err),
         });
       });
 

--- a/apps/admin-webapp/src/features/dashboard/use-fleet.ts
+++ b/apps/admin-webapp/src/features/dashboard/use-fleet.ts
@@ -6,7 +6,44 @@ import {
   FLEET_STREAM_URL,
   adminApi,
 } from '#src/lib/admin-api';
-import { isApiErrorCode } from '#src/lib/api-error';
+import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+
+/**
+ * Health of the `/fleet` **poll**, which is a different question from the SSE
+ * connection `connected` reports (PLAN-VisibleErrors §4.4). The poll is what
+ * refreshes every number on the fleet panel; the stream only carries
+ * per-session connectivity deltas. Before this existed the two were conflated,
+ * so a dead poll could sit behind a healthy-looking `reconnecting…` chip while
+ * the grid froze at its last good snapshot.
+ *
+ * `lastSuccessAt` is stamped from the **browser's** clock when a read resolves,
+ * deliberately not taken from `FleetSnapshot.generatedAt` (the admin-server's
+ * clock): the question this answers is "how long since we last heard from the
+ * server", and comparing a server timestamp against a local `Date.now()` would
+ * render clock skew as staleness and vice versa.
+ */
+export type FleetPollState =
+  /** No read has resolved yet, successfully or otherwise. */
+  | { status: 'loading' }
+  | { status: 'ok'; lastSuccessAt: number }
+  /**
+   * A read failed — `TELEMETRY_DEGRADED` from admin-server, or a network/BFF
+   * error. `lastSuccessAt` is retained across the failure precisely because the
+   * caller keeps rendering that snapshot; it is what makes the age of what is
+   * on screen statable.
+   */
+  | {
+      status: 'degraded';
+      /** Envelope error code when there was one, e.g. `TELEMETRY_DEGRADED`. */
+      code: string | null;
+      message: string;
+      lastSuccessAt: number | null;
+      consecutiveFailures: number;
+    }
+  /** Telemetry is not configured at all (`REDIS_URL` unset) — a deployment
+   *  fact rather than a transient, so the poll stops rather than retrying it
+   *  every 5 s for as long as the tab is open. */
+  | { status: 'unavailable'; message: string };
 
 export interface FleetState {
   /** Null until the first successful `/fleet` read. */
@@ -20,11 +57,17 @@ export interface FleetState {
    */
   sessionEvents: Map<string, SessionStatusEvent>;
   /** True once the SSE connection has been established at least once and
-   *  hasn't since dropped. The browser retries a drop on its own. */
+   *  hasn't since dropped. The browser retries a drop on its own.
+   *
+   *  Says nothing about whether `snapshot` is current — see {@link poll}. */
   connected: boolean;
   /** False when telemetry isn't configured at all (`REDIS_URL` unset) — as
-   *  opposed to a transient read failure, which leaves this true. */
+   *  opposed to a transient read failure, which leaves this true.
+   *  Derived from {@link poll}; kept as its own field because it is the one
+   *  state where there is nothing to render at all. */
   available: boolean;
+  /** Health and freshness of the `/fleet` poll. @see {@link FleetPollState} */
+  poll: FleetPollState;
   /** Re-fetch `/fleet` on demand, e.g. for a manual "retry" affordance. */
   refresh: () => void;
 }
@@ -46,7 +89,7 @@ export function useFleet(): FleetState {
     Map<string, SessionStatusEvent>
   >(() => new Map());
   const [connected, setConnected] = useState(false);
-  const [available, setAvailable] = useState(true);
+  const [poll, setPoll] = useState<FleetPollState>({ status: 'loading' });
   const [refreshNonce, setRefreshNonce] = useState(0);
 
   useEffect(() => {
@@ -55,13 +98,47 @@ export function useFleet(): FleetState {
     adminApi
       .fleet()
       .then((s) => {
-        if (alive.current) setSnapshot(s);
+        if (!alive.current) return;
+        setSnapshot(s);
+        setPoll({ status: 'ok', lastSuccessAt: Date.now() });
       })
       .catch((err: unknown) => {
         if (!alive.current) return;
-        if (isApiErrorCode(err, 'TELEMETRY_UNAVAILABLE')) setAvailable(false);
-        // TELEMETRY_DEGRADED and network errors: leave the prior snapshot (if
-        // any) in place rather than clearing it out from under the caller.
+        if (isApiErrorCode(err, 'TELEMETRY_UNAVAILABLE')) {
+          setPoll({
+            status: 'unavailable',
+            message:
+              err instanceof ApiError
+                ? err.message
+                : 'Live fleet telemetry is not configured.',
+          });
+          return;
+        }
+        // TELEMETRY_DEGRADED and network errors: the prior snapshot (if any)
+        // is deliberately left in place rather than cleared out from under the
+        // caller — mid-incident, the last known fleet is evidence, and blanking
+        // it substitutes one lie ("nothing is running") for another. What was
+        // missing until PLAN-VisibleErrors §4.4 is the other half of that
+        // bargain: the failure is now *stated*, and `lastSuccessAt` is carried
+        // through it so the caller can say how old what it is showing is. A
+        // retained snapshot without a staleness marker is the "looks live but
+        // isn't" failure this hook's poll exists to prevent.
+        setPoll((prev) => ({
+          status: 'degraded',
+          code: err instanceof ApiError ? err.code : null,
+          message:
+            err instanceof ApiError
+              ? err.message
+              : 'Could not reach the admin server.',
+          lastSuccessAt:
+            prev.status === 'ok'
+              ? prev.lastSuccessAt
+              : prev.status === 'degraded'
+                ? prev.lastSuccessAt
+                : null,
+          consecutiveFailures:
+            prev.status === 'degraded' ? prev.consecutiveFailures + 1 : 1,
+        }));
       });
 
     return () => {
@@ -116,13 +193,23 @@ export function useFleet(): FleetState {
   // only on reconnect) is worse than none — it looks live. The timer is
   // gated on `document.hidden` so an operator with the dashboard parked on a
   // second monitor does not poll all night.
+  //
+  // The effect below depends on this primitive rather than on `poll` itself:
+  // it owns the interval, and depending on the whole state object would tear
+  // the timer down and rebuild it on every poll result — resetting the cadence
+  // each time and, once degraded, on every failure too. Only `unavailable` may
+  // stop the timer.
+  const pollDisabled = poll.status === 'unavailable';
+
   useEffect(() => {
     // Nothing to poll for when the backplane is not configured at all.
-    // `available` only goes false on TELEMETRY_UNAVAILABLE, which is a
-    // deployment fact rather than a transient — without this guard the hook
-    // would re-request `/fleet` every 5 s forever and swallow the identical
-    // error each time, for the whole time a tab is left open.
-    if (!available) return;
+    // TELEMETRY_UNAVAILABLE is a deployment fact rather than a transient —
+    // without this guard the hook would re-request `/fleet` every 5 s forever
+    // and swallow the identical error each time, for the whole time a tab is
+    // left open. A TELEMETRY_DEGRADED failure deliberately does NOT stop the
+    // timer: it is exactly the case that recovers on its own, and an operator
+    // watching a degraded panel needs it to un-degrade without a reload.
+    if (pollDisabled) return;
 
     const poll = () => {
       setRefreshNonce((n) => n + 1);
@@ -145,11 +232,18 @@ export function useFleet(): FleetState {
       window.clearInterval(id);
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };
-  }, [available]);
+  }, [pollDisabled]);
 
   const refresh = () => {
     setRefreshNonce((n) => n + 1);
   };
 
-  return { snapshot, sessionEvents, connected, available, refresh };
+  return {
+    snapshot,
+    sessionEvents,
+    connected,
+    available: poll.status !== 'unavailable',
+    poll,
+    refresh,
+  };
 }

--- a/apps/admin-webapp/src/features/devices/device-detail-page.tsx
+++ b/apps/admin-webapp/src/features/devices/device-detail-page.tsx
@@ -33,10 +33,6 @@ import { useSettings } from '#src/lib/settings-context';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof ApiError ? err.message : fallback;
-}
-
 interface RenameDeviceDialogProps {
   open: boolean;
   currentName: string;
@@ -52,7 +48,7 @@ const RenameDeviceDialog = ({
   onRenamed,
   deviceUid,
 }: RenameDeviceDialogProps) => {
-  const { showSuccess, showError } = useToast();
+  const { showSuccess, showApiError } = useToast();
   const [name, setName] = useState(currentName);
   const [submitting, setSubmitting] = useState(false);
   const [misconfigured, setMisconfigured] = useState(false);
@@ -70,7 +66,7 @@ const RenameDeviceDialog = ({
         if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
           setMisconfigured(true);
         } else {
-          showError(errorMessage(err, 'Failed to rename device.'));
+          showApiError(err, 'Failed to rename device.');
         }
       })
       .finally(() => {
@@ -148,7 +144,7 @@ const ReregisterResultDialog = ({
 export const DeviceDetailPage = () => {
   const { deviceUid } = useParams<{ deviceUid: string }>();
   const navigate = useNavigate();
-  const { showSuccess, showError } = useToast();
+  const { showSuccess, showError, showApiError } = useToast();
   const { showUuids } = useSettings();
 
   const {
@@ -194,7 +190,7 @@ export const DeviceDetailPage = () => {
       !isApiErrorCode(error, 'BACKEND_MISCONFIGURATION') &&
       !(error instanceof ApiError && error.status === 404)
     ) {
-      showError(errorMessage(error, 'Failed to load device.'));
+      showApiError(error, 'Failed to load device.');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [error]);
@@ -214,7 +210,7 @@ export const DeviceDetailPage = () => {
             "Can't delete: this device is a room's source. Reassign the source first.",
           );
         } else {
-          showError(errorMessage(err, 'Failed to delete device.'));
+          showApiError(err, 'Failed to delete device.');
         }
       })
       .finally(() => {
@@ -234,7 +230,7 @@ export const DeviceDetailPage = () => {
         setReregisterConfirmOpen(false);
       })
       .catch((err: unknown) => {
-        showError(errorMessage(err, 'Failed to re-register device.'));
+        showApiError(err, 'Failed to re-register device.');
       })
       .finally(() => {
         setReregistering(false);

--- a/apps/admin-webapp/src/features/devices/devices-list-page.tsx
+++ b/apps/admin-webapp/src/features/devices/devices-list-page.tsx
@@ -36,7 +36,7 @@ import { NameWithUid } from '#src/components/name-with-uid';
 import { TimezoneNote } from '#src/components/timezone-note';
 import type { RegisterDeviceResult } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
-import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { isApiErrorCode } from '#src/lib/api-error';
 import { useSettings } from '#src/lib/settings-context';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncList } from '#src/lib/use-async-list';
@@ -46,10 +46,6 @@ const PAGE_LIMIT = 25;
 
 type StatusFilter = 'all' | 'active' | 'pending';
 type RoomFilter = 'all' | 'unassigned';
-
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof ApiError ? err.message : fallback;
-}
 
 interface RegisterDeviceDialogProps {
   open: boolean;
@@ -67,7 +63,7 @@ const RegisterDeviceDialog = ({
   onClose,
   onRegistered,
 }: RegisterDeviceDialogProps) => {
-  const { showSuccess, showError } = useToast();
+  const { showSuccess, showApiError } = useToast();
   const [name, setName] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [misconfigured, setMisconfigured] = useState(false);
@@ -87,7 +83,7 @@ const RegisterDeviceDialog = ({
         if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
           setMisconfigured(true);
         } else {
-          showError(errorMessage(err, 'Failed to register device.'));
+          showApiError(err, 'Failed to register device.');
         }
       })
       .finally(() => {
@@ -157,7 +153,7 @@ const RegisterDeviceDialog = ({
 
 export const DevicesListPage = () => {
   const navigate = useNavigate();
-  const { showError } = useToast();
+  const { showApiError } = useToast();
   const { showUuids } = useSettings();
   const roomNames = useRoomNameLookup();
   const [search, setSearch] = useState('');
@@ -199,7 +195,7 @@ export const DevicesListPage = () => {
   // Any non-misconfiguration load failure is surfaced as a toast, once per error.
   useEffect(() => {
     if (error !== null && !isApiErrorCode(error, 'BACKEND_MISCONFIGURATION')) {
-      showError(errorMessage(error, 'Failed to load devices.'));
+      showApiError(error, 'Failed to load devices.');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [error]);

--- a/apps/admin-webapp/src/features/devices/devices-list-page.tsx
+++ b/apps/admin-webapp/src/features/devices/devices-list-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import AddIcon from '@mui/icons-material/Add';
 import Alert from '@mui/material/Alert';
@@ -31,12 +31,14 @@ import type { Device } from '@scribear/session-manager-schema';
 
 import { ActivationCodeDisplay } from '#src/components/activation-code-display';
 import { DevicePresenceChip } from '#src/components/device-presence-chip';
+import { ErrorState } from '#src/components/error-state';
 import { KioskUrlInstructions } from '#src/components/kiosk-url-instructions';
 import { NameWithUid } from '#src/components/name-with-uid';
 import { TimezoneNote } from '#src/components/timezone-note';
 import type { RegisterDeviceResult } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
-import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { isApiErrorCode } from '#src/lib/api-error';
+import { errorMessage } from '#src/lib/api-failure';
 import { useSettings } from '#src/lib/settings-context';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncList } from '#src/lib/use-async-list';
@@ -46,10 +48,6 @@ const PAGE_LIMIT = 25;
 
 type StatusFilter = 'all' | 'active' | 'pending';
 type RoomFilter = 'all' | 'unassigned';
-
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof ApiError ? err.message : fallback;
-}
 
 interface RegisterDeviceDialogProps {
   open: boolean;
@@ -157,7 +155,6 @@ const RegisterDeviceDialog = ({
 
 export const DevicesListPage = () => {
   const navigate = useNavigate();
-  const { showError } = useToast();
   const { showUuids } = useSettings();
   const roomNames = useRoomNameLookup();
   const [search, setSearch] = useState('');
@@ -181,28 +178,11 @@ export const DevicesListPage = () => {
     return query;
   };
 
-  const {
-    items: devices,
-    loading,
-    loadingMore,
-    error,
-    hasMore,
-    loadMore,
-    reload,
-  } = useAsyncList<Device>(
-    (cursor) => adminApi.listDevices(buildQuery(cursor)),
-    [search, statusFilter, roomFilter],
-  );
-
-  const misconfigured = isApiErrorCode(error, 'BACKEND_MISCONFIGURATION');
-
-  // Any non-misconfiguration load failure is surfaced as a toast, once per error.
-  useEffect(() => {
-    if (error !== null && !isApiErrorCode(error, 'BACKEND_MISCONFIGURATION')) {
-      showError(errorMessage(error, 'Failed to load devices.'));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
-  }, [error]);
+  const { state, loadingMore, loadMoreError, hasMore, loadMore, reload } =
+    useAsyncList<Device>(
+      (cursor) => adminApi.listDevices(buildQuery(cursor)),
+      [search, statusFilter, roomFilter],
+    );
 
   const renderRoomCell = (roomUid: string | null) => {
     if (roomUid === null) return 'Unassigned';
@@ -236,12 +216,6 @@ export const DevicesListPage = () => {
         </Button>
         <TimezoneNote />
       </Box>
-      {misconfigured && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          Admin backend misconfiguration — an operator must check the
-          server&apos;s ADMIN_API_KEY.
-        </Alert>
-      )}
       <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
         <TextField
           label="Search devices"
@@ -294,13 +268,25 @@ export const DevicesListPage = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {loading ? (
+            {/* Three outcomes, never two — "No devices found." is reachable
+                only from `ok` (PLAN-VisibleErrors §5). */}
+            {state.status === 'loading' ? (
               <TableRow>
                 <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
                   <CircularProgress size={28} />
                 </TableCell>
               </TableRow>
-            ) : devices.length === 0 ? (
+            ) : state.status === 'unavailable' ? (
+              <TableRow>
+                <TableCell colSpan={5} sx={{ py: 2 }}>
+                  <ErrorState
+                    title="Could not load devices."
+                    error={state.error}
+                    onRetry={reload}
+                  />
+                </TableCell>
+              </TableRow>
+            ) : state.items.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
                   <Typography
@@ -313,7 +299,7 @@ export const DevicesListPage = () => {
                 </TableCell>
               </TableRow>
             ) : (
-              devices.map((device) => (
+              state.items.map((device) => (
                 <TableRow
                   key={device.uid}
                   hover
@@ -366,7 +352,15 @@ export const DevicesListPage = () => {
           </TableBody>
         </Table>
       </TableContainer>
-      {hasMore && !loading && (
+      {loadMoreError !== null && (
+        <ErrorState
+          title="Could not load the next page of devices."
+          error={loadMoreError}
+          onRetry={loadMore}
+          sx={{ mt: 2 }}
+        />
+      )}
+      {state.status === 'ok' && hasMore && (
         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
           <Button onClick={loadMore} disabled={loadingMore}>
             {loadingMore ? 'Loading…' : 'Load more'}

--- a/apps/admin-webapp/src/features/kiosk-setup/kiosk-wizard-page.tsx
+++ b/apps/admin-webapp/src/features/kiosk-setup/kiosk-wizard-page.tsx
@@ -30,7 +30,7 @@ import { ActivationCodeDisplay } from '#src/components/activation-code-display';
 import { KioskUrlInstructions } from '#src/components/kiosk-url-instructions';
 import { ScheduleStep } from '#src/features/kiosk-setup/schedule-step';
 import { adminApi } from '#src/lib/admin-api';
-import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { isApiErrorCode } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 
@@ -39,10 +39,6 @@ const POLL_MS = 3000;
 const STEPS = ['Device', 'Room', 'Schedule', 'Verify'];
 
 type RoomChoice = 'new' | 'existing';
-
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof ApiError ? err.message : fallback;
-}
 
 interface DeviceStepProps {
   deviceName: string;
@@ -341,7 +337,7 @@ const VerifyStep = ({ deviceUid, roomUid, deviceActive }: VerifyStepProps) => {
  * the kiosk has activated using the code.
  */
 export const KioskWizardPage = () => {
-  const { showSuccess, showError } = useToast();
+  const { showSuccess, showApiError } = useToast();
   const [activeStep, setActiveStep] = useState(0);
 
   // Step 0: device
@@ -408,7 +404,7 @@ export const KioskWizardPage = () => {
         if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
           setDeviceMisconfigured(true);
         } else {
-          showError(errorMessage(err, 'Failed to register device.'));
+          showApiError(err, 'Failed to register device.');
         }
       })
       .finally(() => {
@@ -427,7 +423,7 @@ export const KioskWizardPage = () => {
         showSuccess('New activation code generated.');
       })
       .catch((err: unknown) => {
-        showError(errorMessage(err, 'Failed to re-register device.'));
+        showApiError(err, 'Failed to re-register device.');
       })
       .finally(() => {
         setReregistering(false);
@@ -441,7 +437,7 @@ export const KioskWizardPage = () => {
       existingRoomsError !== null &&
       !isApiErrorCode(existingRoomsError, 'BACKEND_MISCONFIGURATION')
     ) {
-      showError(errorMessage(existingRoomsError, 'Failed to load rooms.'));
+      showApiError(existingRoomsError, 'Failed to load rooms.');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [existingRoomsError]);
@@ -465,7 +461,7 @@ export const KioskWizardPage = () => {
         if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
           setRoomMisconfigured(true);
         } else {
-          showError(errorMessage(err, 'Failed to create room.'));
+          showApiError(err, 'Failed to create room.');
         }
       })
       .finally(() => {
@@ -496,7 +492,7 @@ export const KioskWizardPage = () => {
         if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
           setRoomMisconfigured(true);
         } else {
-          showError(errorMessage(err, 'Failed to add device to room.'));
+          showApiError(err, 'Failed to add device to room.');
         }
       })
       .finally(() => {

--- a/apps/admin-webapp/src/features/kiosk-setup/kiosk-wizard-page.tsx
+++ b/apps/admin-webapp/src/features/kiosk-setup/kiosk-wizard-page.tsx
@@ -30,19 +30,22 @@ import { ActivationCodeDisplay } from '#src/components/activation-code-display';
 import { KioskUrlInstructions } from '#src/components/kiosk-url-instructions';
 import { ScheduleStep } from '#src/features/kiosk-setup/schedule-step';
 import { adminApi } from '#src/lib/admin-api';
-import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { isApiErrorCode } from '#src/lib/api-error';
+import { errorMessage } from '#src/lib/api-failure';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 
 const DEFAULT_TIMEZONE = 'America/Chicago';
 const POLL_MS = 3000;
+/**
+ * Consecutive failed activation polls before the wizard says so. One failure
+ * is a blip on a 3 s timer; three in a row (~9 s) is a problem the operator is
+ * otherwise given no way to notice.
+ */
+const POLL_FAILURES_BEFORE_WARNING = 3;
 const STEPS = ['Device', 'Room', 'Schedule', 'Verify'];
 
 type RoomChoice = 'new' | 'existing';
-
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof ApiError ? err.message : fallback;
-}
 
 interface DeviceStepProps {
   deviceName: string;
@@ -285,9 +288,16 @@ interface VerifyStepProps {
   deviceUid: string | null;
   roomUid: string | null;
   deviceActive: boolean;
+  /** True once the activation poll has failed repeatedly — see `POLL_FAILURES_BEFORE_WARNING`. */
+  pollStalled: boolean;
 }
 
-const VerifyStep = ({ deviceUid, roomUid, deviceActive }: VerifyStepProps) => {
+const VerifyStep = ({
+  deviceUid,
+  roomUid,
+  deviceActive,
+  pollStalled,
+}: VerifyStepProps) => {
   if (deviceActive) {
     return (
       <Stack
@@ -323,7 +333,9 @@ const VerifyStep = ({ deviceUid, roomUid, deviceActive }: VerifyStepProps) => {
         py: 4,
       }}
     >
-      <CircularProgress aria-label="Waiting for the kiosk to activate" />
+      {!pollStalled && (
+        <CircularProgress aria-label="Waiting for the kiosk to activate" />
+      )}
       <Typography
         sx={{
           color: 'text.secondary',
@@ -331,6 +343,14 @@ const VerifyStep = ({ deviceUid, roomUid, deviceActive }: VerifyStepProps) => {
       >
         Waiting for the kiosk to activate…
       </Typography>
+      {pollStalled && (
+        <Alert severity="error" sx={{ width: '100%' }}>
+          Cannot tell whether the kiosk has activated — the admin server has not
+          answered the last few checks. The kiosk may well have activated
+          already. Check the admin server, then reload this page; the activation
+          itself is recorded on the device, so nothing is lost.
+        </Alert>
+      )}
     </Stack>
   );
 };
@@ -392,6 +412,7 @@ export const KioskWizardPage = () => {
 
   // Step 3: verify
   const [deviceActive, setDeviceActive] = useState(false);
+  const [pollStalled, setPollStalled] = useState(false);
 
   const handleRegister = () => {
     setRegistering(true);
@@ -507,14 +528,27 @@ export const KioskWizardPage = () => {
   useEffect(() => {
     if (activeStep !== 3 || deviceUid === null || deviceActive) return;
     const alive = { current: true };
+    let consecutiveFailures = 0;
     const poll = () => {
       adminApi
         .getDevice(deviceUid)
         .then((d) => {
-          if (alive.current && d.active) setDeviceActive(true);
+          if (!alive.current) return;
+          consecutiveFailures = 0;
+          setPollStalled(false);
+          if (d.active) setDeviceActive(true);
         })
         .catch(() => {
-          /* transient poll failure — try again on the next tick */
+          // A single failure is genuinely transient and is swallowed. A run of
+          // them is not: this step's whole UI is a spinner reading "Waiting for
+          // the kiosk to activate…", so without this the wizard waits forever
+          // and blames the kiosk for the admin server being down
+          // (PLAN-VisibleErrors §5, §10.5).
+          if (!alive.current) return;
+          consecutiveFailures += 1;
+          if (consecutiveFailures >= POLL_FAILURES_BEFORE_WARNING) {
+            setPollStalled(true);
+          }
         });
     };
     poll();
@@ -621,6 +655,7 @@ export const KioskWizardPage = () => {
             deviceUid={deviceUid}
             roomUid={roomUid}
             deviceActive={deviceActive}
+            pollStalled={pollStalled}
           />
         )}
       </Paper>

--- a/apps/admin-webapp/src/features/kiosk-setup/schedule-step.tsx
+++ b/apps/admin-webapp/src/features/kiosk-setup/schedule-step.tsx
@@ -41,7 +41,7 @@ import type {
   SessionScope,
 } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
-import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { isApiErrorCode } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
 
 import type { CommonFormState } from './schedule-form-utils';
@@ -77,10 +77,6 @@ const FREQUENCIES: readonly ScheduleFrequency[] = [
   'BIWEEKLY',
 ];
 const RANGE_DAYS = 90;
-
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof ApiError ? err.message : fallback;
-}
 
 interface ScheduleFormState extends CommonFormState {
   name: string;
@@ -387,7 +383,7 @@ export const ScheduleStep = ({
   roomTimezone,
   onCreated,
 }: ScheduleStepProps) => {
-  const { showSuccess, showError } = useToast();
+  const { showSuccess, showError, showApiError } = useToast();
   const [mode, setMode] = useState<Mode>('none');
   const [scheduleForm, setScheduleForm] =
     useState<ScheduleFormState>(emptyScheduleForm);
@@ -438,7 +434,7 @@ export const ScheduleStep = ({
         if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
           setMisconfigured(true);
         } else {
-          showError(errorMessage(err, "Failed to load the room's schedules."));
+          showApiError(err, "Failed to load the room's schedules.");
         }
       })
       .finally(() => {
@@ -517,7 +513,7 @@ export const ScheduleStep = ({
         if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
           setMisconfigured(true);
         } else {
-          showError(errorMessage(err, 'Failed to create schedule.'));
+          showApiError(err, 'Failed to create schedule.');
         }
       })
       .finally(() => {
@@ -573,11 +569,9 @@ export const ScheduleStep = ({
             return null;
           })
           .catch((err: unknown) => {
-            showError(
-              errorMessage(
-                err,
-                'Open hours saved, but auto-sessions could not be enabled for the room.',
-              ),
+            showApiError(
+              err,
+              'Open hours saved, but auto-sessions could not be enabled for the room.',
             );
             return null;
           });
@@ -592,7 +586,7 @@ export const ScheduleStep = ({
         if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
           setMisconfigured(true);
         } else {
-          showError(errorMessage(err, 'Failed to save open hours.'));
+          showApiError(err, 'Failed to save open hours.');
         }
       })
       .finally(() => {

--- a/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
+++ b/apps/admin-webapp/src/features/rooms/room-detail-page.tsx
@@ -37,6 +37,7 @@ import type { Device, Room, Session } from '@scribear/session-manager-schema';
 
 import { ConfirmDialog } from '#src/components/confirm-dialog';
 import { DevicePresenceChip } from '#src/components/device-presence-chip';
+import { ErrorState } from '#src/components/error-state';
 import { NameWithUid } from '#src/components/name-with-uid';
 import { TimezoneNote } from '#src/components/timezone-note';
 import type { RoomDetail } from '#src/lib/admin-api';
@@ -448,12 +449,27 @@ export const RoomDetailPage = () => {
   }
 
   if (!detail) {
-    return misconfigured ? (
-      <Alert severity="error">
-        Admin backend misconfiguration — an operator must check the
-        server&apos;s ADMIN_API_KEY.
-      </Alert>
-    ) : (
+    // "Room not found." is a statement about the deployment, so it is reserved
+    // for the one error that actually means it: a 404. Every other failure —
+    // session-manager down, a wrong ADMIN_API_KEY, a rate limit, no network —
+    // used to render the same sentence, which is the §5 bug one level up from
+    // the lists (PLAN-VisibleErrors §5; the plan located it in the devices
+    // table below, but that table is unreachable without `detail`).
+    // Keyed on the status, not the code: admin-server passes an upstream 404
+    // through with whatever `code` Session Manager sent.
+    if (
+      error !== null &&
+      !(error instanceof ApiError && error.status === 404)
+    ) {
+      return (
+        <ErrorState
+          title="Could not load this room."
+          error={error}
+          onRetry={reload}
+        />
+      );
+    }
+    return (
       <Typography
         sx={{
           color: 'text.secondary',

--- a/apps/admin-webapp/src/features/rooms/rooms-list-page.tsx
+++ b/apps/admin-webapp/src/features/rooms/rooms-list-page.tsx
@@ -30,10 +30,11 @@ import { useNavigate } from 'react-router-dom';
 import { DEMO_SOURCE_DEVICE_UID } from '@scribear/session-manager-schema';
 import type { Device, Room } from '@scribear/session-manager-schema';
 
+import { ErrorState } from '#src/components/error-state';
 import { NameWithUid } from '#src/components/name-with-uid';
 import { TimezoneNote } from '#src/components/timezone-note';
 import { adminApi } from '#src/lib/admin-api';
-import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { ApiError } from '#src/lib/api-error';
 import { useSettings } from '#src/lib/settings-context';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncList } from '#src/lib/use-async-list';
@@ -213,42 +214,22 @@ const CreateRoomDialog = ({ onClose, onCreated }: CreateRoomDialogProps) => {
 
 export const RoomsListPage = () => {
   const navigate = useNavigate();
-  const { showError } = useToast();
   const { showUuids } = useSettings();
   const [search, setSearch] = useState('');
   const [createOpen, setCreateOpen] = useState(false);
 
-  const {
-    items: rooms,
-    loading,
-    loadingMore,
-    error,
-    hasMore,
-    loadMore,
-    reload,
-  } = useAsyncList<Room>(
-    (cursor) => {
-      const query: { search?: string; cursor?: string; limit: number } = {
-        limit: PAGE_LIMIT,
-      };
-      if (search !== '') query.search = search;
-      if (cursor !== undefined) query.cursor = cursor;
-      return adminApi.listRooms(query);
-    },
-    [search],
-  );
-
-  const misconfigured = isApiErrorCode(error, 'BACKEND_MISCONFIGURATION');
-
-  // Any non-misconfiguration load failure is surfaced as a toast, once per error.
-  useEffect(() => {
-    if (error !== null && !isApiErrorCode(error, 'BACKEND_MISCONFIGURATION')) {
-      showError(
-        error instanceof ApiError ? error.message : 'Failed to load rooms.',
-      );
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
-  }, [error]);
+  const { state, loadingMore, loadMoreError, hasMore, loadMore, reload } =
+    useAsyncList<Room>(
+      (cursor) => {
+        const query: { search?: string; cursor?: string; limit: number } = {
+          limit: PAGE_LIMIT,
+        };
+        if (search !== '') query.search = search;
+        if (cursor !== undefined) query.cursor = cursor;
+        return adminApi.listRooms(query);
+      },
+      [search],
+    );
 
   const handleCreated = () => {
     setCreateOpen(false);
@@ -279,12 +260,6 @@ export const RoomsListPage = () => {
         </Button>
       </Box>
       <TimezoneNote />
-      {misconfigured && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          Admin backend misconfiguration — an operator must check the
-          server&apos;s ADMIN_API_KEY.
-        </Alert>
-      )}
       <TextField
         label="Search rooms"
         value={search}
@@ -306,13 +281,26 @@ export const RoomsListPage = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {loading ? (
+            {/* Three outcomes, never two: "No rooms found." is reachable only
+                from `ok`, so a failed load can no longer state that the
+                deployment has no rooms (PLAN-VisibleErrors §5). */}
+            {state.status === 'loading' ? (
               <TableRow>
                 <TableCell colSpan={4} align="center" sx={{ py: 4 }}>
                   <CircularProgress size={28} />
                 </TableCell>
               </TableRow>
-            ) : rooms.length === 0 ? (
+            ) : state.status === 'unavailable' ? (
+              <TableRow>
+                <TableCell colSpan={4} sx={{ py: 2 }}>
+                  <ErrorState
+                    title="Could not load rooms."
+                    error={state.error}
+                    onRetry={reload}
+                  />
+                </TableCell>
+              </TableRow>
+            ) : state.items.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={4} align="center" sx={{ py: 4 }}>
                   <Typography
@@ -325,7 +313,7 @@ export const RoomsListPage = () => {
                 </TableCell>
               </TableRow>
             ) : (
-              rooms.map((room) => (
+              state.items.map((room) => (
                 <TableRow
                   key={room.uid}
                   hover
@@ -359,7 +347,15 @@ export const RoomsListPage = () => {
           </TableBody>
         </Table>
       </TableContainer>
-      {hasMore && !loading && (
+      {loadMoreError !== null && (
+        <ErrorState
+          title="Could not load the next page of rooms."
+          error={loadMoreError}
+          onRetry={loadMore}
+          sx={{ mt: 2 }}
+        />
+      )}
+      {state.status === 'ok' && hasMore && (
         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
           <Button onClick={loadMore} disabled={loadingMore}>
             {loadingMore ? 'Loading…' : 'Load more'}

--- a/apps/admin-webapp/src/features/scheduling/auto-window-dialog.tsx
+++ b/apps/admin-webapp/src/features/scheduling/auto-window-dialog.tsx
@@ -33,7 +33,6 @@ import {
   DAYS_OF_WEEK,
   SCOPES,
   diffAutoWindowUpdate,
-  errorMessage,
   isoToLocalInput,
   localInputToIso,
 } from './scheduling-form-helpers';
@@ -93,7 +92,7 @@ export const AutoWindowDialog = ({
   onClose,
   onSaved,
 }: AutoWindowDialogProps) => {
-  const { showSuccess, showError } = useToast();
+  const { showSuccess, showError, showApiError } = useToast();
   const [form, setForm] = useState<AutoWindowFormState>(() =>
     autoWindow
       ? windowToFormState(autoWindow)
@@ -201,11 +200,9 @@ export const AutoWindowDialog = ({
           .updateRoomScheduleConfig({ roomUid, autoSessionEnabled: true })
           .then(() => null)
           .catch((err: unknown) => {
-            showError(
-              errorMessage(
-                err,
-                'Window saved, but auto-sessions could not be enabled for the room.',
-              ),
+            showApiError(
+              err,
+              'Window saved, but auto-sessions could not be enabled for the room.',
             );
             return null;
           });
@@ -222,13 +219,9 @@ export const AutoWindowDialog = ({
         if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
           setMisconfigured(true);
         } else {
-          showError(
-            errorMessage(
-              err,
-              creating
-                ? 'Failed to create window.'
-                : 'Failed to update window.',
-            ),
+          showApiError(
+            err,
+            creating ? 'Failed to create window.' : 'Failed to update window.',
           );
         }
       })

--- a/apps/admin-webapp/src/features/scheduling/on-demand-dialog.tsx
+++ b/apps/admin-webapp/src/features/scheduling/on-demand-dialog.tsx
@@ -17,7 +17,7 @@ import { isApiErrorCode } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
 
 import { JsonConfigField, MultiSelectField } from './scheduling-form-fields';
-import { SCOPES, errorMessage } from './scheduling-form-helpers';
+import { SCOPES } from './scheduling-form-helpers';
 
 interface OnDemandFormState {
   name: string;
@@ -37,7 +37,7 @@ export const OnDemandDialog = ({
   onClose,
   onCreated,
 }: OnDemandDialogProps) => {
-  const { showSuccess, showError } = useToast();
+  const { showSuccess, showApiError } = useToast();
   const [form, setForm] = useState<OnDemandFormState>({
     name: '',
     joinCodeScopes: ['SEND_AUDIO', 'RECEIVE_TRANSCRIPTIONS'],
@@ -76,7 +76,7 @@ export const OnDemandDialog = ({
         if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
           setMisconfigured(true);
         } else {
-          showError(errorMessage(err, 'Failed to start session.'));
+          showApiError(err, 'Failed to start session.');
         }
       })
       .finally(() => {

--- a/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
+++ b/apps/admin-webapp/src/features/scheduling/room-scheduling-page.tsx
@@ -39,7 +39,7 @@ import type {
 import { ConfirmDialog } from '#src/components/confirm-dialog';
 import { TimezoneNote } from '#src/components/timezone-note';
 import { adminApi } from '#src/lib/admin-api';
-import { ApiError, isApiErrorCode } from '#src/lib/api-error';
+import { ApiError, errorMessage, isApiErrorCode } from '#src/lib/api-error';
 import { formatInTimeZone } from '#src/lib/timezone';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
@@ -67,14 +67,10 @@ const LOOKBACK_DAYS = 7;
 // in the effect below.
 const SESSION_POLL_MS = 15_000;
 
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof ApiError ? err.message : fallback;
-}
-
 export const RoomSchedulingPage = () => {
   const { roomUid } = useParams<{ roomUid: string }>();
   const navigate = useNavigate();
-  const { showSuccess, showError } = useToast();
+  const { showSuccess, showApiError } = useToast();
 
   const [autoToggling, setAutoToggling] = useState(false);
 
@@ -213,7 +209,7 @@ export const RoomSchedulingPage = () => {
       roomError !== null &&
       !isApiErrorCode(roomError, 'BACKEND_MISCONFIGURATION')
     ) {
-      showError(errorMessage(roomError, 'Failed to load room.'));
+      showApiError(roomError, 'Failed to load room.');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [roomError]);
@@ -222,7 +218,7 @@ export const RoomSchedulingPage = () => {
       schedulesError !== null &&
       !isApiErrorCode(schedulesError, 'BACKEND_MISCONFIGURATION')
     ) {
-      showError(errorMessage(schedulesError, 'Failed to load schedules.'));
+      showApiError(schedulesError, 'Failed to load schedules.');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [schedulesError]);
@@ -231,9 +227,7 @@ export const RoomSchedulingPage = () => {
       windowsError !== null &&
       !isApiErrorCode(windowsError, 'BACKEND_MISCONFIGURATION')
     ) {
-      showError(
-        errorMessage(windowsError, 'Failed to load auto-session windows.'),
-      );
+      showApiError(windowsError, 'Failed to load auto-session windows.');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [windowsError]);
@@ -252,7 +246,7 @@ export const RoomSchedulingPage = () => {
     const message = errorMessage(sessionsError, 'Failed to load sessions.');
     if (lastSessionsErrorRef.current === message) return;
     lastSessionsErrorRef.current = message;
-    showError(message);
+    showApiError(sessionsError, 'Failed to load sessions.');
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [sessionsError]);
 
@@ -268,7 +262,7 @@ export const RoomSchedulingPage = () => {
         );
       })
       .catch((err: unknown) => {
-        showError(errorMessage(err, 'Failed to update auto-session setting.'));
+        showApiError(err, 'Failed to update auto-session setting.');
       })
       .finally(() => {
         setAutoToggling(false);
@@ -285,7 +279,7 @@ export const RoomSchedulingPage = () => {
         reloadSchedules();
       })
       .catch((err: unknown) => {
-        showError(errorMessage(err, 'Failed to delete schedule.'));
+        showApiError(err, 'Failed to delete schedule.');
       })
       .finally(() => {
         setDeletingSchedule(false);
@@ -303,7 +297,7 @@ export const RoomSchedulingPage = () => {
         reloadWindows();
       })
       .catch((err: unknown) => {
-        showError(errorMessage(err, 'Failed to delete window.'));
+        showApiError(err, 'Failed to delete window.');
       })
       .finally(() => {
         setDeletingWindow(false);

--- a/apps/admin-webapp/src/features/scheduling/schedule-dialog.tsx
+++ b/apps/admin-webapp/src/features/scheduling/schedule-dialog.tsx
@@ -37,7 +37,6 @@ import {
   DAYS_OF_WEEK,
   SCOPES,
   diffScheduleUpdate,
-  errorMessage,
   isoToLocalInput,
   localInputToIso,
 } from './scheduling-form-helpers';
@@ -100,7 +99,7 @@ export const ScheduleDialog = ({
   onClose,
   onSaved,
 }: ScheduleDialogProps) => {
-  const { showSuccess, showError } = useToast();
+  const { showSuccess, showError, showApiError } = useToast();
   const [form, setForm] = useState<ScheduleFormState>(() =>
     schedule
       ? scheduleToFormState(schedule)
@@ -187,7 +186,7 @@ export const ScheduleDialog = ({
           if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
             setMisconfigured(true);
           } else {
-            showError(errorMessage(err, 'Failed to create schedule.'));
+            showApiError(err, 'Failed to create schedule.');
           }
         })
         .finally(() => {
@@ -219,7 +218,7 @@ export const ScheduleDialog = ({
           if (isApiErrorCode(err, 'BACKEND_MISCONFIGURATION')) {
             setMisconfigured(true);
           } else {
-            showError(errorMessage(err, 'Failed to update schedule.'));
+            showApiError(err, 'Failed to update schedule.');
           }
         })
         .finally(() => {

--- a/apps/admin-webapp/src/features/scheduling/scheduling-form-helpers.ts
+++ b/apps/admin-webapp/src/features/scheduling/scheduling-form-helpers.ts
@@ -10,7 +10,6 @@ import type {
   UpdateAutoWindowBody,
   UpdateScheduleBody,
 } from '#src/lib/admin-api';
-import { ApiError } from '#src/lib/api-error';
 
 export const DAYS_OF_WEEK: readonly DayOfWeek[] = [
   'SUN',
@@ -25,10 +24,6 @@ export const SCOPES: readonly SessionScope[] = [
   'SEND_AUDIO',
   'RECEIVE_TRANSCRIPTIONS',
 ];
-
-export function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof ApiError ? err.message : fallback;
-}
 
 export function formatInRoomTz(iso: string, timezone: string): string {
   try {

--- a/apps/admin-webapp/src/features/sessions/room-calendar-page.tsx
+++ b/apps/admin-webapp/src/features/sessions/room-calendar-page.tsx
@@ -29,7 +29,6 @@ import { useAsyncData } from '#src/lib/use-async-data';
 import { AutoWindowDialog } from '../scheduling/auto-window-dialog';
 import { OnDemandDialog } from '../scheduling/on-demand-dialog';
 import { ScheduleDialog } from '../scheduling/schedule-dialog';
-import { errorMessage } from '../scheduling/scheduling-form-helpers';
 import {
   type CalendarColumn,
   SessionCalendarGrid,
@@ -77,7 +76,7 @@ export const RoomCalendarPage = () => {
   const { roomUid } = useParams<{ roomUid: string }>();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { showError } = useToast();
+  const { showApiError } = useToast();
   const { showUuids } = useSettings();
 
   const [view, setView] = useState<ViewMode>('week');
@@ -138,7 +137,7 @@ export const RoomCalendarPage = () => {
       roomError !== null &&
       !isApiErrorCode(roomError, 'BACKEND_MISCONFIGURATION')
     ) {
-      showError(errorMessage(roomError, 'Failed to load room.'));
+      showApiError(roomError, 'Failed to load room.');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [roomError]);
@@ -147,7 +146,7 @@ export const RoomCalendarPage = () => {
       sessionsError !== null &&
       !isApiErrorCode(sessionsError, 'BACKEND_MISCONFIGURATION')
     ) {
-      showError(errorMessage(sessionsError, 'Failed to load sessions.'));
+      showApiError(sessionsError, 'Failed to load sessions.');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [sessionsError]);

--- a/apps/admin-webapp/src/features/sessions/room-picker.tsx
+++ b/apps/admin-webapp/src/features/sessions/room-picker.tsx
@@ -21,16 +21,24 @@ export interface RoomPickerProps {
 export const RoomPicker = ({ selected, onChange }: RoomPickerProps) => {
   const [inputValue, setInputValue] = useState('');
   const [options, setOptions] = useState<Room[]>([]);
+  const [searchFailed, setSearchFailed] = useState(false);
 
   useEffect(() => {
     const alive = { current: true };
     adminApi
       .listRooms({ search: inputValue, limit: 25 })
       .then((res) => {
-        if (alive.current) setOptions(res.items);
+        if (!alive.current) return;
+        setSearchFailed(false);
+        setOptions(res.items);
       })
       .catch(() => {
-        // Best-effort; leave options as-is on error.
+        // The error object itself is not kept: this is a search-as-you-type
+        // control, and the only thing the operator can do about any cause is
+        // type again. What they must NOT see is the previous "no rooms match"
+        // wording, which would report a failed search as an empty result —
+        // so the flag below rewrites the empty-list text and marks the field.
+        if (alive.current) setSearchFailed(true);
       });
     return () => {
       alive.current = false;
@@ -57,8 +65,25 @@ export const RoomPicker = ({ selected, onChange }: RoomPickerProps) => {
           return <Chip key={key} label={room.name} {...itemProps} />;
         })
       }
+      noOptionsText={
+        searchFailed
+          ? 'Could not search rooms — the admin server did not answer.'
+          : 'No rooms match.'
+      }
       renderInput={(params) => (
-        <TextField {...params} label="Rooms" placeholder="Search rooms…" />
+        <TextField
+          {...params}
+          label="Rooms"
+          placeholder="Search rooms…"
+          error={searchFailed}
+          // Not colour alone (WCAG SC 1.4.1): the helper text says it, and it
+          // names the next action rather than leaving a silently stale list.
+          helperText={
+            searchFailed
+              ? 'Could not search rooms — the admin server did not answer. Any rooms listed are from an earlier search. Edit your search to try again.'
+              : undefined
+          }
+        />
       )}
     />
   );

--- a/apps/admin-webapp/src/features/sessions/session-detail-page.tsx
+++ b/apps/admin-webapp/src/features/sessions/session-detail-page.tsx
@@ -77,10 +77,6 @@ import { useAsyncData } from '#src/lib/use-async-data';
 // page refresh — mirrors the demo-room card's poll cadence.
 const JOIN_CODE_POLL_MS = 120_000;
 
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof ApiError ? err.message : fallback;
-}
-
 function formatDateTime(
   iso: string | null,
   timeZone: string | undefined,
@@ -886,7 +882,7 @@ const AudioHealthSection = ({ session }: { session: Session }) => {
 
 export const SessionDetailPage = () => {
   const { sessionUid } = useParams<{ sessionUid: string }>();
-  const { showSuccess, showError } = useToast();
+  const { showSuccess, showError, showApiError } = useToast();
 
   const {
     data: session,
@@ -963,7 +959,7 @@ export const SessionDetailPage = () => {
       !isApiErrorCode(error, 'BACKEND_MISCONFIGURATION') &&
       !(error instanceof ApiError && error.status === 404)
     ) {
-      showError(errorMessage(error, 'Failed to load session.'));
+      showApiError(error, 'Failed to load session.');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [error]);
@@ -978,7 +974,7 @@ export const SessionDetailPage = () => {
         reload();
       })
       .catch((err: unknown) => {
-        showError(errorMessage(err, 'Failed to start session early.'));
+        showApiError(err, 'Failed to start session early.');
       })
       .finally(() => {
         setStarting(false);
@@ -996,7 +992,7 @@ export const SessionDetailPage = () => {
         reload();
       })
       .catch((err: unknown) => {
-        showError(errorMessage(err, 'Failed to end session early.'));
+        showApiError(err, 'Failed to end session early.');
       })
       .finally(() => {
         setEnding(false);
@@ -1025,7 +1021,7 @@ export const SessionDetailPage = () => {
                     "Can't undo — another session now occupies this time.",
                   );
                 } else {
-                  showError(errorMessage(err, 'Failed to undo cancellation.'));
+                  showApiError(err, 'Failed to undo cancellation.');
                 }
               });
           },
@@ -1033,7 +1029,7 @@ export const SessionDetailPage = () => {
         reload();
       })
       .catch((err: unknown) => {
-        showError(errorMessage(err, 'Failed to cancel session.'));
+        showApiError(err, 'Failed to cancel session.');
       })
       .finally(() => {
         setCancelling(false);

--- a/apps/admin-webapp/src/features/sessions/sessions-overview-page.tsx
+++ b/apps/admin-webapp/src/features/sessions/sessions-overview-page.tsx
@@ -29,7 +29,6 @@ import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 import { useSelectedRooms } from '#src/lib/use-selected-rooms';
 
-import { errorMessage } from '../scheduling/scheduling-form-helpers';
 import { RoomPicker } from './room-picker';
 import {
   type CalendarColumn,
@@ -47,7 +46,7 @@ function startOfLocalDay(d: Date): Date {
 
 export const SessionsOverviewPage = () => {
   const navigate = useNavigate();
-  const { showError } = useToast();
+  const { showApiError } = useToast();
   const { showUuids } = useSettings();
 
   const [selectedRooms, setSelectedRooms] = useSelectedRooms();
@@ -133,7 +132,7 @@ export const SessionsOverviewPage = () => {
       sessionsError !== null &&
       !isApiErrorCode(sessionsError, 'BACKEND_MISCONFIGURATION')
     ) {
-      showError(errorMessage(sessionsError, 'Failed to load sessions.'));
+      showApiError(sessionsError, 'Failed to load sessions.');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [sessionsError]);

--- a/apps/admin-webapp/src/features/sessions/sessions-overview-page.tsx
+++ b/apps/admin-webapp/src/features/sessions/sessions-overview-page.tsx
@@ -16,8 +16,8 @@ import { useNavigate } from 'react-router-dom';
 
 import type { Session } from '@scribear/session-manager-schema';
 
+import { ErrorState } from '#src/components/error-state';
 import { adminApi } from '#src/lib/admin-api';
-import { isApiErrorCode } from '#src/lib/api-error';
 import {
   GRID_MAX_COLUMNS,
   defaultRoomSelection,
@@ -25,11 +25,9 @@ import {
   nextHourRangeIndex,
 } from '#src/lib/session-rules';
 import { useSettings } from '#src/lib/settings-context';
-import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 import { useSelectedRooms } from '#src/lib/use-selected-rooms';
 
-import { errorMessage } from '../scheduling/scheduling-form-helpers';
 import { RoomPicker } from './room-picker';
 import {
   type CalendarColumn,
@@ -47,7 +45,6 @@ function startOfLocalDay(d: Date): Date {
 
 export const SessionsOverviewPage = () => {
   const navigate = useNavigate();
-  const { showError } = useToast();
   const { showUuids } = useSettings();
 
   const [selectedRooms, setSelectedRooms] = useSelectedRooms();
@@ -61,6 +58,11 @@ export const SessionsOverviewPage = () => {
   );
   const [anchorDate, setAnchorDate] = useState(() => new Date());
   const [hourRangeIndex, setHourRangeIndex] = useState(0);
+  // Non-null once the default-selection fetch below has failed. Kept so the
+  // page can say why the picker is empty instead of telling the operator to
+  // select rooms from a list that could not be read.
+  const [defaultSelectionError, setDefaultSelectionError] =
+    useState<unknown>(null);
 
   const rangeStart = startOfLocalDay(anchorDate);
   const rangeEnd = new Date(rangeStart.getTime() + MS_PER_DAY);
@@ -74,23 +76,35 @@ export const SessionsOverviewPage = () => {
 
   // On first load with no persisted selection, default to "show everything"
   // for small deployments, or nothing for large ones (§4.5) — run once.
-  useEffect(() => {
-    if (defaultApplied) return;
-    const alive = { current: true };
+  //
+  // Also used as the "Retry" handler for the failure branch, so the operator
+  // has a way out that does not require reloading the whole console.
+  const applyDefaultSelection = (alive: { current: boolean }) => {
     adminApi
       .listRooms({ limit: GRID_MAX_COLUMNS + 1 })
       .then((res) => {
         if (!alive.current) return;
+        setDefaultSelectionError(null);
         setSelectedRooms(
           defaultRoomSelection(res.items, res.nextCursor !== null),
         );
       })
-      .catch(() => {
-        // Best-effort default; leave selection empty on error.
+      .catch((err: unknown) => {
+        // NOT swallowed (PLAN-VisibleErrors §10.5): with no selection and no
+        // message the page would show "Select rooms above to view their
+        // calendar." over a picker whose own search is failing for the same
+        // reason. The failure branch below states that instead.
+        if (alive.current) setDefaultSelectionError(err);
       })
       .finally(() => {
         if (alive.current) setDefaultApplied(true);
       });
+  };
+
+  useEffect(() => {
+    if (defaultApplied) return;
+    const alive = { current: true };
+    applyDefaultSelection(alive);
     return () => {
       alive.current = false;
     };
@@ -99,11 +113,9 @@ export const SessionsOverviewPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, []);
 
-  const {
-    data: sessionsData,
-    loading: sessionsLoading,
-    error: sessionsError,
-  } = useAsyncData<Session[]>(
+  const { state: sessionsState, reload: reloadSessions } = useAsyncData<
+    Session[]
+  >(
     () =>
       selectedRooms.length === 0
         ? Promise.resolve([])
@@ -116,27 +128,15 @@ export const SessionsOverviewPage = () => {
             .then((res) => res.items),
     [selectedRoomsKey, rangeStartMs, rangeEndMs],
   );
-  const sessions = sessionsData ?? [];
-  const misconfigured = isApiErrorCode(
-    sessionsError,
-    'BACKEND_MISCONFIGURATION',
-  );
+  // Only ever the sessions we actually read. A failed load reaches the
+  // `unavailable` branch below instead of rendering "No sessions today." in
+  // every room card (PLAN-VisibleErrors §5).
+  const sessions = sessionsState.status === 'ok' ? sessionsState.data : [];
   const sessionsOutsideHours = isGridMode
     ? sessions.filter((s) =>
         isOutsideHourWindow(s, hourRange.startHour, hourRange.endHour),
       ).length
     : 0;
-
-  // Non-misconfiguration load failures are surfaced as a toast, once per error.
-  useEffect(() => {
-    if (
-      sessionsError !== null &&
-      !isApiErrorCode(sessionsError, 'BACKEND_MISCONFIGURATION')
-    ) {
-      showError(errorMessage(sessionsError, 'Failed to load sessions.'));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
-  }, [sessionsError]);
 
   const navigateDate = (direction: -1 | 0 | 1) => {
     setAnchorDate(
@@ -174,12 +174,6 @@ export const SessionsOverviewPage = () => {
           Sessions
         </Typography>
       </Stack>
-      {misconfigured && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          Admin backend misconfiguration — an operator must check the
-          server&apos;s ADMIN_API_KEY.
-        </Alert>
-      )}
       <Box sx={{ mb: 2, maxWidth: 600 }}>
         <RoomPicker selected={selectedRooms} onChange={setSelectedRooms} />
       </Box>
@@ -248,7 +242,15 @@ export const SessionsOverviewPage = () => {
           {sessionsOutsideHours === 1 ? 'it' : 'them'}.
         </Alert>
       )}
-      {selectedRooms.length === 0 ? (
+      {selectedRooms.length === 0 && defaultSelectionError !== null ? (
+        <ErrorState
+          title="Could not load the room list."
+          error={defaultSelectionError}
+          onRetry={() => {
+            applyDefaultSelection({ current: true });
+          }}
+        />
+      ) : selectedRooms.length === 0 ? (
         <Paper variant="outlined" sx={{ p: 4, textAlign: 'center' }}>
           <Typography
             sx={{
@@ -258,10 +260,16 @@ export const SessionsOverviewPage = () => {
             Select rooms above to view their calendar.
           </Typography>
         </Paper>
-      ) : sessionsLoading ? (
+      ) : sessionsState.status === 'loading' ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
           <CircularProgress size={28} />
         </Box>
+      ) : sessionsState.status === 'unavailable' ? (
+        <ErrorState
+          title="Could not load sessions."
+          error={sessionsState.error}
+          onRetry={reloadSessions}
+        />
       ) : isGridMode ? (
         <SessionCalendarGrid
           columns={columns}

--- a/apps/admin-webapp/src/features/test-audio/use-test-audio.ts
+++ b/apps/admin-webapp/src/features/test-audio/use-test-audio.ts
@@ -7,7 +7,6 @@ import type {
   TestAudioParamsPatch,
 } from '#src/lib/admin-api';
 import { adminApi } from '#src/lib/admin-api';
-import { ApiError } from '#src/lib/api-error';
 import { useToast } from '#src/lib/toast-context';
 import { useAsyncData } from '#src/lib/use-async-data';
 
@@ -102,10 +101,6 @@ export interface DeviceRunControls {
   retune: (patch: TestAudioParamsPatch) => void;
 }
 
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof ApiError ? err.message : fallback;
-}
-
 /**
  * The three mutations for one device, with their toasts and their in-flight
  * flag. Deliberately knows nothing about the shape of `params` — the two
@@ -116,7 +111,7 @@ export function useDeviceRun(
   deviceId: TestAudioDeviceId,
   refresh: () => void,
 ): DeviceRunControls {
-  const { showSuccess, showError } = useToast();
+  const { showSuccess, showApiError } = useToast();
   const [busy, setBusy] = useState(false);
 
   const run = (
@@ -130,7 +125,7 @@ export function useDeviceRun(
         showSuccess(success);
       })
       .catch((err: unknown) => {
-        showError(errorMessage(err, failure));
+        showApiError(err, failure);
       })
       .finally(() => {
         setBusy(false);
@@ -161,9 +156,7 @@ export function useDeviceRun(
       // still needs saying — silently ignoring it would leave the operator
       // watching a meter for an effect that was never applied.
       adminApi.updateTestAudioParams(deviceId, patch).catch((err: unknown) => {
-        showError(
-          errorMessage(err, `Failed to retune the ${deviceId} source.`),
-        );
+        showApiError(err, `Failed to retune the ${deviceId} source.`);
       });
     },
   };

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -335,7 +335,45 @@ export interface SessionSnapshot {
   processUid: string;
 }
 
-/** One node-server instance's own counters, excluding its session list. */
+/** Which end of a transcription-stream socket performed the close. */
+export type CloseInitiator = 'server' | 'peer';
+
+/** Which side of a session a transcription-stream socket serves. */
+export type ConnectionRole = 'source' | 'client';
+
+/**
+ * One transcription-stream close, labelled.
+ *
+ * `initiator` is the load-bearing label and the reason this record is not just
+ * a code tally: `server` means node-server decided to close and its `reason` is
+ * authoritative (`transcription-stream.controller.ts`'s `closeWith`), while
+ * `peer` means the far end went away — a device navigating, losing Wi-Fi or
+ * being killed — and its `reason` is remote-supplied text normalised against
+ * node-server's known-reason allowlist, collapsing to `other` when it matches
+ * nothing (`node-server-metrics.service.ts`'s `recordWsClose`). Without the
+ * split, a flapping source uplink is indistinguishable from an auth rejection.
+ *
+ * Every count is monotonic since the publishing process started; a label
+ * combination that has never occurred is omitted rather than reported as zero.
+ */
+export interface WsCloseTally {
+  code: number;
+  reason: string;
+  role: ConnectionRole;
+  initiator: CloseInitiator;
+  count: number;
+}
+
+/**
+ * One node-server instance's own counters, excluding its session list.
+ *
+ * **Every `*Total` here is monotonic since `processStartedAt`, not a rate and
+ * not a window.** `processUid` is regenerated on every boot, so a change in it
+ * means the counters restarted from zero — a consumer differencing successive
+ * reads must compare it first. Any surface rendering these numbers has to say
+ * which epoch they count from, or it is presenting a lifetime total as if it
+ * described the present.
+ */
 export interface NodeSnapshot {
   processUid: string;
   processStartedAt: string;
@@ -343,11 +381,27 @@ export interface NodeSnapshot {
   summary: {
     activeSessionCount: number;
     decodeDropsTotal: number;
+    /**
+     * Binary frames a source sent before its AUTH handshake completed, dropped
+     * rather than closed on. Optional on the wire
+     * (`STATUS_PROCESS_SCHEMA.summary.binaryBeforeAuthDropsTotal`) so a
+     * publisher predating it does not fail the strict `Value.Check` on the
+     * read side and vanish from the fleet for a whole rolling deploy — so
+     * `undefined` here means "this publisher does not report it", never zero.
+     */
+    binaryBeforeAuthDropsTotal?: number;
     pendingChunkEvictionsTotal: number;
     upstreamChurnTotal: number;
     authSuccessTotal: number;
     authTimeoutsTotal: number;
     orchestratorFailuresTotal: number;
+    /**
+     * Source registrations refused because the session was already past its
+     * `effectiveEnd` — the only signal that a device is acting on a stale
+     * schedule. Optional for the same backward-compat reason as
+     * `binaryBeforeAuthDropsTotal` above.
+     */
+    endedSessionRegistrationsTotal?: number;
     latencySamplesTotal: number;
     latencyE2eUnavailableTotal: number;
     latencyE2eNegativeTotal: number;
@@ -358,14 +412,14 @@ export interface NodeSnapshot {
     to: UpstreamState;
     count: number;
   }[];
-  wsCloses: {
-    code: number;
-    reason: string;
-    role: 'source' | 'client';
-    initiator: 'server' | 'peer';
-    count: number;
-  }[];
+  wsCloses: WsCloseTally[];
   latency: LatencySeries[];
+  /**
+   * Credential rejections from `verifyAuth`, by reason. **Auth *timeouts* are
+   * not in here** — a connection that never sent `auth` at all is counted only
+   * in `summary.authTimeoutsTotal` — so these two must be presented as separate
+   * facts or the numbers will not add up for whoever reads them.
+   */
   authFailures: { reason: string; count: number }[];
   updatedAt: number;
   nodeInstanceId: string;
@@ -422,6 +476,17 @@ export interface TranscriptionHostSnapshot {
   processUid: string;
   processStartedAt: string;
   numWorkers: number;
+  /**
+   * Sessions this host refused because the requested provider key is not one
+   * it has configured (`TranscriptionProviderRegistry.create_session` raising
+   * `Invalid Provider Key`). Not a capacity refusal and not a transient: it is
+   * a naming disagreement between whoever chose the session's provider key and
+   * the keys this host actually loads, so the fix is a configuration change,
+   * not a retry.
+   *
+   * Monotonic since `processStartedAt` and reset to zero by a restart, so a
+   * consumer differencing successive reads must compare `processUid` first.
+   */
   invalidProviderKeyRejects: number;
   workers: TranscriptionWorker[];
   /** Keyed by configured provider key, verbatim. */

--- a/apps/admin-webapp/src/lib/admin-api.ts
+++ b/apps/admin-webapp/src/lib/admin-api.ts
@@ -804,7 +804,14 @@ interface EnvelopeOk<T> {
 }
 interface EnvelopeErr {
   ok: false;
-  error: { code: string; message: string; requestId?: string };
+  error: {
+    code: string;
+    message: string;
+    requestId?: string;
+    /** Per-code context. `RATE_LIMITED` carries `retryAfter` here — see
+     *  `rateLimitMessage` in `./api-error`. */
+    details?: Record<string, unknown>;
+  };
 }
 
 type QueryValue = string | number | boolean | null | undefined | string[];
@@ -893,11 +900,17 @@ export class AdminApiClient {
       );
     }
 
-    const err =
+    const err: EnvelopeErr['error'] =
       json && !json.ok
         ? json.error
         : { code: 'UNKNOWN', message: 'The request failed.' };
-    throw new ApiError(err.code, err.message, res.status, err.requestId);
+    throw new ApiError(
+      err.code,
+      err.message,
+      res.status,
+      err.requestId,
+      err.details,
+    );
   }
 
   // ---- Auth ----

--- a/apps/admin-webapp/src/lib/api-error.ts
+++ b/apps/admin-webapp/src/lib/api-error.ts
@@ -7,22 +7,102 @@ export class ApiError extends Error {
   readonly code: string;
   readonly status: number;
   readonly requestId: string | undefined;
+  /** The envelope's `error.details`, when the server sent any. */
+  readonly details: Record<string, unknown> | undefined;
 
   constructor(
     code: string,
     message: string,
     status: number,
     requestId?: string,
+    details?: Record<string, unknown>,
   ) {
     super(message);
     this.name = 'ApiError';
     this.code = code;
     this.status = status;
     this.requestId = requestId;
+    this.details = details;
   }
 }
 
 /** True when the error is an ApiError with the given code. */
 export function isApiErrorCode(err: unknown, code: string): boolean {
   return err instanceof ApiError && err.code === code;
+}
+
+/**
+ * How a failure should be rendered. Follows the house convention: `warning` =
+ * degraded or transient, no operator action required beyond waiting; `error` =
+ * terminal, the operator has to do something.
+ */
+export type ErrorSeverity = 'error' | 'warning';
+
+/**
+ * True for a 429 from the admin BFF. admin-server registers
+ * `@fastify/rate-limit` with `global: true`, so **every** admin route can
+ * answer 429 — this is not a per-route special case, and any surface that
+ * renders an API failure has to be able to hit it.
+ */
+export function isRateLimited(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 429;
+}
+
+/**
+ * The wait the limiter reported, as display copy ("1 minute", "45 seconds"),
+ * or null when the server did not say. Comes from `error.details.retryAfter`
+ * rather than the `Retry-After` header: `AdminApiClient` returns only status
+ * and body, so no caller in this app can read a response header.
+ */
+function retryAfterText(err: unknown): string | null {
+  if (!(err instanceof ApiError)) return null;
+  const after = err.details?.['retryAfter'];
+  return typeof after === 'string' && after !== '' ? after : null;
+}
+
+/**
+ * Copy for a rate-limited request. `kind` picks the audience: `'sign-in'` is
+ * the login form, where the operator's next guess is that their password is
+ * wrong and it is important to say that it is not.
+ *
+ * Both variants name the cause, say nothing was changed (the limiter rejects
+ * on `onRequest`, before any handler runs, so no admin mutation ever
+ * half-applied), and give the one next action there is — wait, then retry.
+ * Nothing in this app auto-retries, so the wording must not imply it will.
+ */
+export function rateLimitMessage(
+  err: unknown,
+  kind: 'request' | 'sign-in' = 'request',
+): string {
+  const wait = retryAfterText(err) ?? 'a moment';
+  return kind === 'sign-in'
+    ? `Too many sign-in attempts. This is a rate limit, not a rejected password — wait ${wait}, then sign in again.`
+    : `Too many requests — the admin server is rate limiting this browser. Nothing was changed; wait ${wait}, then try again.`;
+}
+
+/**
+ * The message to show for a failed admin API call. Shared by every admin page:
+ * this used to be copy-pasted into nine of them, which is why a 429 was
+ * rendered nowhere despite being reachable everywhere.
+ */
+export function errorMessage(err: unknown, fallback: string): string {
+  if (isRateLimited(err)) return rateLimitMessage(err);
+  return err instanceof ApiError ? err.message : fallback;
+}
+
+/** As {@link errorMessage}, but for the login form's audience. */
+export function loginErrorMessage(err: unknown): string {
+  if (isRateLimited(err)) return rateLimitMessage(err, 'sign-in');
+  return err instanceof ApiError
+    ? err.message
+    : 'Sign in failed. Please try again.';
+}
+
+/**
+ * Severity to render {@link errorMessage} at. A rate limit is transient and
+ * clears on its own, so it is a `warning`; everything else needs the operator
+ * to act and stays an `error`.
+ */
+export function errorSeverity(err: unknown): ErrorSeverity {
+  return isRateLimited(err) ? 'warning' : 'error';
 }

--- a/apps/admin-webapp/src/lib/api-failure.ts
+++ b/apps/admin-webapp/src/lib/api-failure.ts
@@ -1,0 +1,165 @@
+import { ApiError } from './api-error';
+
+/**
+ * A failed request described the way PLAN-VisibleErrors §1 requires: a
+ * **cause**, an **audience** (the operator reading this console), and a
+ * **next action** — or `null` when we cannot honestly name one, rather than
+ * implying a retry that cannot work.
+ */
+export interface ApiFailure {
+  /** What went wrong, in the operator's terms. Never "Something went wrong." */
+  cause: string;
+  /** What to do about it, or null when no action of the reader's can help. */
+  nextAction: string | null;
+  /** True when re-issuing the same request could plausibly succeed. */
+  retryable: boolean;
+  /**
+   * admin-server's per-request correlation id, when the failure reached the
+   * server. `undefined` for failures that never got a reply (offline, DNS,
+   * nginx down) — see {@link describeApiFailure}.
+   */
+  requestId: string | undefined;
+}
+
+/**
+ * The `errorMessage(err, fallback)` helper that was copy-pasted verbatim into
+ * at least eight page modules. One copy, here, so a change to what the console
+ * shows for an unknown error is a change in one place.
+ */
+export function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof ApiError ? err.message : fallback;
+}
+
+const CHECK_LOGS = 'Retry. If it keeps failing, check the admin server logs';
+
+/**
+ * Maps an error thrown by `adminApi` onto a cause / next action pair.
+ *
+ * The branches mirror what admin-server can actually emit for these routes —
+ * verified by reading `session-manager-gateway.service.ts#classify`
+ * (`BACKEND_MISCONFIGURATION` 502 / `UPSTREAM_UNREACHABLE` 503 /
+ * `UPSTREAM_ERROR` 502 / `RATE_LIMITED` 429), `require-session.hook.ts`
+ * (`UNAUTHENTICATED` 401), `require-role.hook.ts` (`FORBIDDEN` 403),
+ * `rate-limit.plugin.ts` (a *global* limiter, so any list load can 429),
+ * `error-handler.plugin.ts` (`INTERNAL_ERROR` 500), and the two codes
+ * `admin-api.ts` mints client-side (`NETWORK`, `INVALID_RESPONSE`).
+ * Collapsing those into one "Something went wrong. Retry." would be the
+ * distinct-causes-collapsed-to-one-message mode from §0 all over again: an
+ * expired session, a rate limit, a dead session-manager and a wrong
+ * ADMIN_API_KEY need four different next actions.
+ */
+export function describeApiFailure(err: unknown, fallback: string): ApiFailure {
+  if (!(err instanceof ApiError)) {
+    return {
+      cause: fallback,
+      nextAction: `${CHECK_LOGS}.`,
+      retryable: true,
+      requestId: undefined,
+    };
+  }
+
+  // Present only when the server replied with an error envelope; `admin-api.ts`
+  // reads it from `error.requestId`.
+  const requestId = err.requestId;
+
+  switch (err.code) {
+    case 'NETWORK':
+      return {
+        cause:
+          'Could not reach the admin server — the request never completed, so nothing is known about the data below.',
+        nextAction:
+          'Check that you are still connected and that the admin server is running, then retry.',
+        retryable: true,
+        requestId,
+      };
+
+    case 'BACKEND_MISCONFIGURATION':
+      return {
+        cause:
+          "Admin backend misconfiguration — Session Manager rejected the admin server's credentials.",
+        nextAction:
+          "An operator must check that the admin server's ADMIN_API_KEY matches Session Manager's. Retrying will not help until it is fixed.",
+        retryable: false,
+        requestId,
+      };
+
+    case 'UPSTREAM_UNREACHABLE':
+      return {
+        cause: 'The admin server could not reach Session Manager.',
+        nextAction:
+          'Check that the session-manager service is running and reachable from the admin server, then retry.',
+        retryable: true,
+        requestId,
+      };
+
+    case 'RATE_LIMITED':
+      return {
+        // The server's own message carries the window ("retry after N").
+        cause: err.message,
+        nextAction:
+          'Wait for that window to pass, then retry — nothing on this page retries on its own.',
+        retryable: true,
+        requestId,
+      };
+
+    case 'UNAUTHENTICATED':
+      return {
+        cause: 'Your admin session has expired.',
+        nextAction:
+          'Sign in again — the console is returning you to the login page.',
+        retryable: false,
+        requestId,
+      };
+
+    case 'FORBIDDEN':
+      return {
+        cause: err.message,
+        nextAction:
+          'Ask an administrator to grant your account the role this page needs. Retrying as you are will not help.',
+        retryable: false,
+        requestId,
+      };
+
+    case 'INVALID_RESPONSE':
+      return {
+        cause:
+          'The admin server returned a response this console could not read.',
+        nextAction:
+          'Reload the page. If it persists just after a deployment, this browser tab may be running an outdated console build.',
+        retryable: true,
+        requestId,
+      };
+
+    default:
+      break;
+  }
+
+  if (err.status === 404) {
+    return {
+      cause: err.message,
+      nextAction:
+        'It may have been deleted since this page was opened — reload to see the current state.',
+      retryable: true,
+      requestId,
+    };
+  }
+
+  if (err.status >= 500) {
+    return {
+      cause: err.message,
+      nextAction:
+        requestId === undefined
+          ? `${CHECK_LOGS}.`
+          : `${CHECK_LOGS} for the request id below.`,
+      retryable: true,
+      requestId,
+    };
+  }
+
+  return {
+    cause: err.message,
+    nextAction: `${CHECK_LOGS}.`,
+    retryable: true,
+    requestId,
+  };
+}

--- a/apps/admin-webapp/src/lib/toast-context.ts
+++ b/apps/admin-webapp/src/lib/toast-context.ts
@@ -11,6 +11,16 @@ export interface ToastApi {
   showSuccess: (message: string, action?: ToastAction) => void;
   showError: (message: string) => void;
   showInfo: (message: string) => void;
+  showWarning: (message: string) => void;
+  /**
+   * Renders a failed admin API call at the severity its cause deserves.
+   * Prefer this over hand-rolling `showError(...)` from an error's message:
+   * admin-server rate
+   * limits every route, and a 429 is transient — showing it in the same red
+   * toast as a real failure tells the operator to act when the only action is
+   * to wait. See `errorMessage`/`errorSeverity` in `./api-error`.
+   */
+  showApiError: (err: unknown, fallback: string) => void;
 }
 
 export const ToastContext = createContext<ToastApi | null>(null);

--- a/apps/admin-webapp/src/lib/toast-provider.tsx
+++ b/apps/admin-webapp/src/lib/toast-provider.tsx
@@ -6,6 +6,7 @@ import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Snackbar from '@mui/material/Snackbar';
 
+import { errorMessage, errorSeverity } from './api-error';
 import {
   type ToastAction,
   type ToastApi,
@@ -51,6 +52,12 @@ export const ToastProvider = ({ children }: React.PropsWithChildren) => {
       },
       showInfo: (m) => {
         show(m, 'info');
+      },
+      showWarning: (m) => {
+        show(m, 'warning');
+      },
+      showApiError: (err, fallback) => {
+        show(errorMessage(err, fallback), errorSeverity(err));
       },
     }),
     [show],

--- a/apps/admin-webapp/src/lib/use-async-data.ts
+++ b/apps/admin-webapp/src/lib/use-async-data.ts
@@ -1,8 +1,30 @@
 import type { DependencyList } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 
+/**
+ * The fetch's outcome as a discriminated union — the single-value sibling of
+ * {@link AsyncListLoad} (PLAN-VisibleErrors §10.2), with the same
+ * `loading | ok | unavailable` vocabulary `useAlerts` uses. `data` is reachable
+ * **only** through `ok`, so a page cannot describe a failed load with the
+ * wording it uses for an empty one.
+ *
+ * Additive: `data` / `loading` / `error` below are unchanged and still
+ * supported, because a dozen pages read them and most are outside the scope of
+ * the change that introduced this. New branches should prefer `state`.
+ */
+export type AsyncDataLoad<T> =
+  | { status: 'loading' }
+  | { status: 'ok'; data: T }
+  | { status: 'unavailable'; error: unknown };
+
 export interface AsyncDataState<T> {
-  /** Latest successful result, or null before the first success. */
+  /** Discriminated view of the same fetch. Prefer this over the three fields below. */
+  state: AsyncDataLoad<T>;
+  /**
+   * Latest successful result, or null before the first success. Retained
+   * across a later failure — check `error`/`state` before describing it as
+   * current.
+   */
   data: T | null;
   /** True while a fetch is in flight (including re-fetches). */
   loading: boolean;
@@ -30,7 +52,10 @@ export function useAsyncData<T>(
   fetcher: () => Promise<T>,
   deps: DependencyList,
 ): AsyncDataState<T> {
-  const [data, setData] = useState<T | null>(null);
+  // Boxed rather than stored bare so `T` may itself be null (several callers
+  // fetch `Session | null`) without "resolved with null" and "never resolved"
+  // becoming the same state.
+  const [result, setResult] = useState<{ value: T } | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<unknown>(null);
   // Bumping this re-runs the effect without changing the caller's `deps`.
@@ -47,8 +72,8 @@ export function useAsyncData<T>(
     // eslint-disable-next-line @eslint-react/set-state-in-effect -- see above
     setError(null);
     fetcher()
-      .then((result) => {
-        if (alive.current) setData(result);
+      .then((value) => {
+        if (alive.current) setResult({ value });
       })
       .catch((err: unknown) => {
         if (alive.current) setError(err);
@@ -63,5 +88,17 @@ export function useAsyncData<T>(
     // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
   }, [...deps, reloadNonce]);
 
-  return { data, loading, error, reload };
+  // Derived, not stored, so `state` and the three legacy fields can never
+  // disagree. The final `loading` branch is unreachable in practice (the
+  // effect settles into exactly one of `result`/`error`); it is what the type
+  // needs for the window before the first settle.
+  const state: AsyncDataLoad<T> = loading
+    ? { status: 'loading' }
+    : error !== null
+      ? { status: 'unavailable', error }
+      : result !== null
+        ? { status: 'ok', data: result.value }
+        : { status: 'loading' };
+
+  return { state, data: result?.value ?? null, loading, error, reload };
 }

--- a/apps/admin-webapp/src/lib/use-async-list.ts
+++ b/apps/admin-webapp/src/lib/use-async-list.ts
@@ -8,15 +8,32 @@ export interface AsyncListPage<T> {
   nextCursor: string | null;
 }
 
+/**
+ * The first page's outcome, as a discriminated union (PLAN-VisibleErrors
+ * §10.2). `items` exist **only** in `ok`, so "the deployment has no rooms" and
+ * "we could not ask" cannot be rendered by the same branch — which is exactly
+ * what the previous `{ items: [], error }` shape let five pages do.
+ *
+ * `unavailable` (rather than `failed`/`error`) matches `useAlerts`'
+ * `loading | ok | unavailable`, so the console has one idiom for this.
+ */
+export type AsyncListLoad<T> =
+  | { status: 'loading' }
+  | { status: 'ok'; items: T[] }
+  | { status: 'unavailable'; error: unknown };
+
 export interface AsyncListState<T> {
-  /** All items loaded so far (first page plus any appended pages). */
-  items: T[];
-  /** True while the first page (mount / `deps` change / `reload`) is loading. */
-  loading: boolean;
+  /** First-page state. Callers must branch on `status` to reach `items`. */
+  state: AsyncListLoad<T>;
   /** True while a subsequent page is being appended via `loadMore`. */
   loadingMore: boolean;
-  /** Error from the most recent page load, else null. */
-  error: unknown;
+  /**
+   * Error from the most recent failed `loadMore`, else null. Kept separate
+   * from `state`: a failed *append* must not blank the pages already loaded,
+   * so the list stays `ok` and the caller reports the append failure beside
+   * the rows it already has.
+   */
+  loadMoreError: unknown;
   /** True when another page is available. */
   hasMore: boolean;
   /** Append the next page. No-op when exhausted or already appending. */
@@ -28,9 +45,7 @@ export interface AsyncListState<T> {
 /**
  * Cursor-paginated sibling of {@link useAsyncData}. Loads the first page on
  * mount and whenever `deps` change (replacing the list), and appends further
- * pages on `loadMore` (accumulating). Owns the mounted-guard and the two
- * loading flags; callers derive any branch (misconfiguration, ...) from
- * `error` during render.
+ * pages on `loadMore` (accumulating).
  *
  * `fetchPage` is called with `undefined` for the first page and with the prior
  * page's `nextCursor` for each subsequent page. It should read the current
@@ -44,29 +59,29 @@ export function useAsyncList<T>(
   fetchPage: (cursor: string | undefined) => Promise<AsyncListPage<T>>,
   deps: DependencyList,
 ): AsyncListState<T> {
-  const [items, setItems] = useState<T[]>([]);
+  const [state, setState] = useState<AsyncListLoad<T>>({ status: 'loading' });
   const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [error, setError] = useState<unknown>(null);
+  const [loadMoreError, setLoadMoreError] = useState<unknown>(null);
   const [reloadNonce, setReloadNonce] = useState(0);
 
   useEffect(() => {
     const alive = { current: true };
-    // eslint-disable-next-line react-hooks/set-state-in-effect, @eslint-react/set-state-in-effect -- first-page loading flag before an async fetch; consolidated here so per-site suppressions aren't needed. See REVIEW-EFFECT-SETState.md.
-    setLoading(true);
+    // eslint-disable-next-line react-hooks/set-state-in-effect, @eslint-react/set-state-in-effect -- first-page loading state before an async fetch; consolidated here so per-site suppressions aren't needed. See REVIEW-EFFECT-SETState.md.
+    setState({ status: 'loading' });
     fetchPage(undefined)
       .then((page) => {
         if (!alive.current) return;
-        setError(null);
-        setItems(page.items);
+        setLoadMoreError(null);
+        setState({ status: 'ok', items: page.items });
         setNextCursor(page.nextCursor);
       })
       .catch((err: unknown) => {
-        if (alive.current) setError(err);
-      })
-      .finally(() => {
-        if (alive.current) setLoading(false);
+        if (!alive.current) return;
+        // No `items: []` fallback: the caller cannot reach an empty list from
+        // here, so it cannot say "No X found." about a load that failed.
+        setState({ status: 'unavailable', error: err });
+        setNextCursor(null);
       });
     return () => {
       alive.current = false;
@@ -80,12 +95,18 @@ export function useAsyncList<T>(
     setLoadingMore(true);
     fetchPage(nextCursor)
       .then((page) => {
-        setError(null);
-        setItems((prev) => [...prev, ...page.items]);
+        setLoadMoreError(null);
+        setState((prev) =>
+          // A first-page reload may have superseded this append; only extend a
+          // list that is still `ok`.
+          prev.status === 'ok'
+            ? { status: 'ok', items: [...prev.items, ...page.items] }
+            : prev,
+        );
         setNextCursor(page.nextCursor);
       })
       .catch((err: unknown) => {
-        setError(err);
+        setLoadMoreError(err);
       })
       .finally(() => {
         setLoadingMore(false);
@@ -97,10 +118,9 @@ export function useAsyncList<T>(
   };
 
   return {
-    items,
-    loading,
+    state,
     loadingMore,
-    error,
+    loadMoreError,
     hasMore: nextCursor !== null,
     loadMore,
     reload,

--- a/apps/admin-webapp/tests/components/error-state.test.tsx
+++ b/apps/admin-webapp/tests/components/error-state.test.tsx
@@ -1,0 +1,125 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, vi } from 'vitest';
+
+import { ErrorState } from '#src/components/error-state';
+import { ApiError } from '#src/lib/api-error';
+
+import { renderWithProviders } from '../utils/render-with-providers';
+
+describe('ErrorState', (it) => {
+  it('renders the cause, the next action and the requestId', async () => {
+    // Arrange & Act
+    renderWithProviders(
+      <ErrorState
+        title="Could not load rooms."
+        error={
+          new ApiError(
+            'INTERNAL_ERROR',
+            'Server encountered an unexpected error.',
+            500,
+            '7b1f2c3d-0000-4000-8000-abcdefabcdef',
+          )
+        }
+      />,
+    );
+
+    // Assert
+    expect(screen.getByText('Could not load rooms.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Server encountered an unexpected error.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/check the admin server logs/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('7b1f2c3d-0000-4000-8000-abcdefabcdef'),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Copy request ID' }),
+    ).toBeInTheDocument();
+  });
+
+  it('omits the requestId block entirely when the request never reached a server', () => {
+    // Arrange & Act - `admin-api.ts` mints NETWORK with no requestId; a
+    // "Request ID: undefined" line would be worse than none.
+    renderWithProviders(
+      <ErrorState
+        title="Could not load rooms."
+        error={new ApiError('NETWORK', 'Could not reach the admin server.', 0)}
+      />,
+    );
+
+    // Assert
+    expect(screen.queryByText(/Request ID/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Copy request ID' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls onRetry when the failure is one a retry could fix', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+    renderWithProviders(
+      <ErrorState
+        title="Could not load rooms."
+        error={new ApiError('UPSTREAM_UNREACHABLE', 'down', 503)}
+        onRetry={onRetry}
+      />,
+    );
+
+    // Act
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    // Assert
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides Retry when retrying cannot help, even if a handler was passed', () => {
+    // Arrange & Act - offering "Retry" for a 403 is advice we know is wrong
+    // (PLAN-VisibleErrors §1: never imply an action that cannot work).
+    renderWithProviders(
+      <ErrorState
+        title="Could not load rooms."
+        error={new ApiError('FORBIDDEN', 'You do not have permission.', 403)}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    // Assert
+    expect(
+      screen.queryByRole('button', { name: 'Retry' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/ask an administrator/i)).toBeInTheDocument();
+  });
+
+  it('announces itself as an alert and has no axe violations', async () => {
+    // Arrange & Act - severity is `error` per §10.4, and MUI gives that an
+    // icon plus role="alert", so colour is not the only signal (SC 1.4.1).
+    const { container } = renderWithProviders(
+      <ErrorState
+        title="Could not load rooms."
+        error={new ApiError('UPSTREAM_ERROR', 'boom', 502, 'req-1')}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    // Assert - the scaffolding rules disabled here fire because this is a
+    // bare component under test rather than the full app shell, same set the
+    // devices-list a11y test disables.
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    const results = await axe(container, {
+      rules: {
+        region: { enabled: false },
+        'landmark-one-main': { enabled: false },
+        'page-has-heading-one': { enabled: false },
+        'html-has-lang': { enabled: false },
+        'document-title': { enabled: false },
+        bypass: { enabled: false },
+      },
+    });
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/apps/admin-webapp/tests/components/health-indicator.test.tsx
+++ b/apps/admin-webapp/tests/components/health-indicator.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, vi } from 'vitest';
+
+import { HealthIndicator } from '#src/components/health-indicator';
+import type { HealthReport } from '#src/lib/admin-api';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
+
+vi.mock('#src/lib/admin-api', () => ({
+  adminApi: { health: vi.fn() },
+}));
+
+function buildReport(overrides: Partial<HealthReport> = {}): HealthReport {
+  return {
+    bff: 'ok',
+    components: [{ name: 'session-manager', status: 'ok', latencyMs: 4 }],
+    checkedAt: '2026-08-02T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('HealthIndicator', (it) => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('says it is still checking before the first poll answers', () => {
+    // Arrange
+    vi.mocked(adminApi.health).mockReturnValue(
+      new Promise(() => {
+        /* never resolves */
+      }),
+    );
+
+    // Act
+    render(<HealthIndicator />);
+
+    // Assert
+    expect(screen.getByText('Checking…')).toBeInTheDocument();
+  });
+
+  it('reports the rollup once it has one', async () => {
+    // Arrange
+    vi.mocked(adminApi.health).mockResolvedValue(buildReport());
+
+    // Act
+    render(<HealthIndicator />);
+
+    // Assert
+    expect(await screen.findByText('Healthy')).toBeInTheDocument();
+  });
+
+  it('says "Unreachable", not "Checking…", when the admin server is down', async () => {
+    // Arrange - a dead admin server and a console that has not polled yet used
+    // to render the same grey "Unknown" chip (PLAN-VisibleErrors §5).
+    vi.mocked(adminApi.health).mockRejectedValue(
+      new ApiError('NETWORK', 'Could not reach the admin server.', 0),
+    );
+
+    // Act
+    render(<HealthIndicator />);
+
+    // Assert
+    expect(await screen.findByText('Unreachable')).toBeInTheDocument();
+    expect(screen.queryByText('Checking…')).not.toBeInTheDocument();
+    // The word carries the state, not just the colour (WCAG SC 1.4.1).
+    await waitFor(() => {
+      expect(screen.queryByText('Unknown')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/admin-webapp/tests/features/audit/audit-page.test.tsx
+++ b/apps/admin-webapp/tests/features/audit/audit-page.test.tsx
@@ -1,0 +1,114 @@
+import { screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, vi } from 'vitest';
+
+import { AuditPage } from '#src/features/audit/audit-page';
+import type { AuditRow } from '#src/lib/admin-api';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
+
+import { renderWithProviders } from '../../utils/render-with-providers';
+
+vi.mock('#src/lib/admin-api', () => ({
+  adminApi: { listAudit: vi.fn() },
+}));
+
+function buildRow(overrides: Partial<AuditRow> = {}): AuditRow {
+  return {
+    id: 'audit-1',
+    actorSubject: 'admin',
+    actorProvider: 'local',
+    action: 'create-room',
+    target: 'room-1',
+    paramsSummary: {},
+    result: 'success',
+    statusCode: 200,
+    requestId: 'req-1',
+    createdAt: '2026-08-02T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+async function waitForLoad() {
+  await waitFor(() => {
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+}
+
+describe('AuditPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('loading', (it) => {
+    it('shows a spinner and neither the empty nor the failed wording', () => {
+      // Arrange
+      vi.mocked(adminApi.listAudit).mockReturnValue(
+        new Promise(() => {
+          /* never resolves */
+        }),
+      );
+
+      // Act
+      renderWithProviders(<AuditPage />);
+
+      // Assert
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(
+        screen.queryByText('No audit entries found.'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', (it) => {
+    it('says "No audit entries found." only when the log really is empty', async () => {
+      // Arrange
+      vi.mocked(adminApi.listAudit).mockResolvedValue({ items: [] });
+
+      // Act
+      renderWithProviders(<AuditPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(screen.getByText('No audit entries found.')).toBeInTheDocument();
+    });
+  });
+
+  describe('failed state', (it) => {
+    it('never says "No audit entries found." when the load failed', async () => {
+      // Arrange - an unread audit log is not an empty one; on this page in
+      // particular the difference is "nobody did anything" vs "we cannot say".
+      vi.mocked(adminApi.listAudit).mockRejectedValue(
+        new ApiError('UPSTREAM_UNREACHABLE', 'unreachable', 503, 'req-77'),
+      );
+
+      // Act
+      renderWithProviders(<AuditPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText('Could not load the audit log.'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('No audit entries found.'),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('req-77')).toBeInTheDocument();
+    });
+  });
+
+  describe('rows', (it) => {
+    it('renders a row from the API', async () => {
+      // Arrange
+      vi.mocked(adminApi.listAudit).mockResolvedValue({
+        items: [buildRow({ action: 'delete-room' })],
+      });
+
+      // Act
+      renderWithProviders(<AuditPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(screen.getByText('delete-room')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/admin-webapp/tests/features/auth/login-page.test.tsx
+++ b/apps/admin-webapp/tests/features/auth/login-page.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, vi } from 'vitest';
+
+import { AuthProvider } from '#src/features/auth/auth-provider';
+import { LoginPage } from '#src/features/auth/login-page';
+import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
+
+vi.mock('#src/lib/admin-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('#src/lib/admin-api')>();
+  return {
+    ...actual,
+    adminApi: {
+      getAuthConfig: vi.fn(),
+      me: vi.fn(),
+      setOnUnauthorized: vi.fn(),
+      setCsrfToken: vi.fn(),
+      login: vi.fn(),
+      logout: vi.fn(),
+    },
+  };
+});
+
+function renderLoginPage() {
+  return render(
+    <MemoryRouter initialEntries={['/login']}>
+      <AuthProvider>
+        <LoginPage />
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+async function submitCredentials() {
+  const user = userEvent.setup();
+  await user.type(await screen.findByLabelText('Username'), 'engrit');
+  await user.type(screen.getByLabelText('Password'), 'hunter2');
+  await user.click(screen.getByRole('button', { name: 'Sign in' }));
+}
+
+describe('LoginPage sign-in failures', () => {
+  beforeEach(() => {
+    vi.mocked(adminApi.getAuthConfig).mockResolvedValue({
+      local: true,
+      sso: false,
+    });
+    vi.mocked(adminApi.me).mockRejectedValue(
+      new ApiError('UNAUTHORIZED', 'no session', 401),
+    );
+  });
+
+  describe('when the login route rate limits the operator', (it) => {
+    it('says the password was not rejected, and says it as a warning', async () => {
+      // Arrange - admin-server limits POST /auth/login to 5 attempts a minute,
+      // so an operator who mistyped a few times gets this, not a 401. Before
+      // this fix the server's terse "Too many requests." landed in the same red
+      // alert as "Invalid credentials.", so the operator kept guessing.
+      vi.mocked(adminApi.login).mockRejectedValue(
+        new ApiError(
+          'RATE_LIMITED',
+          'Too many requests. Please retry after 1 minute.',
+          429,
+          'req-1',
+          { retryAfter: '1 minute' },
+        ),
+      );
+
+      // Act
+      renderLoginPage();
+      await submitCredentials();
+
+      // Assert
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent(
+        'Too many sign-in attempts. This is a rate limit, not a rejected password — wait 1 minute, then sign in again.',
+      );
+      // MUI renders the severity as a class; `warning` not `error`, because a
+      // rate limit clears on its own and needs no action but waiting.
+      expect(alert.className).toContain('MuiAlert-colorWarning');
+      expect(alert.className).not.toContain('MuiAlert-colorError');
+    });
+  });
+
+  describe('when the password really is wrong', (it) => {
+    it('keeps the credential message at error severity', async () => {
+      // Arrange
+      vi.mocked(adminApi.login).mockRejectedValue(
+        new ApiError('INVALID_CREDENTIALS', 'Invalid credentials.', 401),
+      );
+
+      // Act
+      renderLoginPage();
+      await submitCredentials();
+
+      // Assert - the 429 handling must not soften a genuine rejection.
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent('Invalid credentials.');
+      expect(alert.className).toContain('MuiAlert-colorError');
+    });
+  });
+
+  describe('when the request never reached the server', (it) => {
+    it('falls back to the generic sign-in message at error severity', async () => {
+      // Arrange
+      vi.mocked(adminApi.login).mockRejectedValue(new TypeError('boom'));
+
+      // Act
+      renderLoginPage();
+      await submitCredentials();
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(
+          'Sign in failed. Please try again.',
+        );
+      });
+      expect(screen.getByRole('alert').className).toContain(
+        'MuiAlert-colorError',
+      );
+    });
+  });
+});

--- a/apps/admin-webapp/tests/features/dashboard/alerts-panel.test.tsx
+++ b/apps/admin-webapp/tests/features/dashboard/alerts-panel.test.tsx
@@ -49,6 +49,7 @@ describe('AlertsPanel', (it) => {
       status: 'unavailable',
       message:
         "monitoring-sidecar's /api/monitoring/v1/alerts answered HTTP 500.",
+      severity: 'error',
     });
 
     const alert = screen.getByRole('alert');
@@ -135,10 +136,28 @@ describe('AlertsPanel', (it) => {
     expect(results.violations).toHaveLength(0);
   });
 
+  it('renders a rate-limited read as a warning, not as a broken pipeline', () => {
+    // admin-server rate limits every route globally, and this panel polls
+    // /alerts every 15 s — so a 429 here is "ask again shortly", not "the
+    // pipeline's health is unknown because something is broken".
+    mount({
+      status: 'unavailable',
+      message:
+        'Too many requests — the admin server is rate limiting this browser. Nothing was changed; wait 1 minute, then try again.',
+      severity: 'warning',
+    });
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/wait 1 minute, then try again/);
+    expect(alert.className).toContain('MuiAlert-colorWarning');
+    expect(alert.className).not.toContain('MuiAlert-colorError');
+  });
+
   it('has no a11y violations in the unavailable state', async () => {
     const container = mount({
       status: 'unavailable',
       message: 'did not answer within 3000ms.',
+      severity: 'error',
     });
 
     const results = await axe(container);

--- a/apps/admin-webapp/tests/features/dashboard/fleet-panel.test.tsx
+++ b/apps/admin-webapp/tests/features/dashboard/fleet-panel.test.tsx
@@ -3,6 +3,8 @@ import { axe } from 'jest-axe';
 import { beforeEach, describe, expect, vi } from 'vitest';
 
 import { FleetPanel } from '#src/features/dashboard/fleet-panel';
+import { FLEET_STALE_AFTER_MS } from '#src/features/dashboard/telemetry-freshness';
+import type { FleetState } from '#src/features/dashboard/use-fleet';
 import { useFleet } from '#src/features/dashboard/use-fleet';
 import type {
   AudioLevelStats,
@@ -92,6 +94,7 @@ function mountFleet(
     sessionEvents,
     connected: true,
     available: true,
+    poll: { status: 'ok', lastSuccessAt: Date.now() },
     refresh: vi.fn(),
   });
   return renderWithProviders(<FleetPanel />).container;
@@ -611,6 +614,211 @@ describe('FleetPanel a11y', (it) => {
       [visibleSession({ sessionUid: 'session-1' })],
       [buildThroughputOnlySnapshot({ sessionUid: 'session-1' })],
     );
+
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
+  });
+});
+
+/**
+ * PLAN-VisibleErrors §4.4 at the surface. The bug was never that the panel
+ * kept a stale snapshot — mid-incident that snapshot is evidence — it was that
+ * it kept one while looking exactly like a live one.
+ */
+describe('FleetPanel stale telemetry', (it) => {
+  beforeEach(() => {
+    vi.mocked(useFleet).mockReset();
+  });
+
+  function mountStale(
+    poll: FleetState['poll'],
+    sessions: SessionSnapshot[] = [visibleSession({ sessionUid: 'session-1' })],
+  ): HTMLElement {
+    const snapshot: FleetSnapshot = {
+      generatedAt: 1,
+      nodes: [],
+      sessions,
+      transcriptionHosts: [],
+      providers: [],
+      sessionAudio: [],
+    };
+    vi.mocked(useFleet).mockReturnValue({
+      snapshot,
+      sessionEvents: new Map(),
+      connected: true,
+      available: true,
+      poll,
+      refresh: vi.fn(),
+    });
+    return renderWithProviders(<FleetPanel />).container;
+  }
+
+  it('marks the heading, the chip and the grid itself when the poll degrades', () => {
+    mountStale({
+      status: 'degraded',
+      code: 'TELEMETRY_DEGRADED',
+      message: 'Could not read live fleet telemetry.',
+      lastSuccessAt: Date.now() - 4_000,
+      consecutiveFailures: 1,
+    });
+
+    // Three independent, text-bearing signals — none of them colour alone, and
+    // none of them dependent on the operator scrolling to the same place.
+    expect(
+      screen.getByRole('heading', { name: /last known state/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/not updating · 4s old/)).toBeInTheDocument();
+    expect(screen.getByText(/frozen snapshot/i)).toBeInTheDocument();
+  });
+
+  it('states the cause and the next action, not just that something is wrong', () => {
+    // No sessions: with any, the audio roll-up's own "metering unavailable"
+    // notice is a second `role="alert"` and `getByRole` would be ambiguous.
+    mountStale(
+      {
+        status: 'degraded',
+        code: 'TELEMETRY_DEGRADED',
+        message: 'Could not read live fleet telemetry.',
+        lastSuccessAt: Date.now() - 2_000,
+        consecutiveFailures: 1,
+      },
+      [],
+    );
+
+    const banner = screen.getByRole('alert');
+    expect(banner).toHaveTextContent(/not the current state of the fleet/i);
+    expect(banner).toHaveTextContent(/Could not read live fleet telemetry/);
+    expect(banner).toHaveTextContent(/keeps retrying/i);
+    expect(
+      screen.getByRole('button', { name: /retry now/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('escalates to an error banner once the snapshot outlives the stale threshold', () => {
+    mountStale(
+      {
+        status: 'degraded',
+        code: 'TELEMETRY_DEGRADED',
+        message: 'Could not read live fleet telemetry.',
+        lastSuccessAt: Date.now() - FLEET_STALE_AFTER_MS - 1_000,
+        consecutiveFailures: 4,
+      },
+      [],
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /this is not the live fleet/i,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /do not read this grid as current/i,
+    );
+  });
+
+  it('keeps the ticking age out of the announced banner', () => {
+    // The banner is assertive and the age ticks once a second; a relative age
+    // inside it would re-announce itself indefinitely to a screen-reader user.
+    mountStale(
+      {
+        status: 'degraded',
+        code: 'TELEMETRY_DEGRADED',
+        message: 'Could not read live fleet telemetry.',
+        lastSuccessAt: Date.now() - 134_000,
+        consecutiveFailures: 20,
+      },
+      [],
+    );
+
+    expect(screen.getByRole('alert')).not.toHaveTextContent('2m 14s');
+    // …while the chip, which is in no live region, carries it.
+    expect(screen.getByText(/not updating · 2m 14s old/)).toBeInTheDocument();
+  });
+
+  it('does not present a frozen empty fleet as "No active sessions."', () => {
+    mountStale(
+      {
+        status: 'degraded',
+        code: 'TELEMETRY_DEGRADED',
+        message: 'Could not read live fleet telemetry.',
+        lastSuccessAt: Date.now() - 2_000,
+        consecutiveFailures: 1,
+      },
+      [],
+    );
+
+    expect(
+      screen.getByText(/this is the frozen snapshot/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('No active sessions.')).not.toBeInTheDocument();
+  });
+
+  it('says the SSE chip is about the stream, not about the data', () => {
+    vi.mocked(useFleet).mockReturnValue({
+      snapshot: {
+        generatedAt: 1,
+        nodes: [],
+        sessions: [],
+        transcriptionHosts: [],
+        providers: [],
+        sessionAudio: [],
+      },
+      sessionEvents: new Map(),
+      connected: false,
+      available: true,
+      poll: { status: 'ok', lastSuccessAt: Date.now() },
+      refresh: vi.fn(),
+    });
+    renderWithProviders(<FleetPanel />);
+
+    // A bare "reconnecting…" beside a frozen grid read as a complete account
+    // of the panel's health; it never was.
+    expect(screen.getByText('live stream reconnecting…')).toBeInTheDocument();
+    expect(screen.getByText(/updated \d+s ago/)).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('does not say "Loading fleet…" once a read has already failed', () => {
+    // A spinner-shaped lie about a request that is not coming.
+    vi.mocked(useFleet).mockReturnValue({
+      snapshot: null,
+      sessionEvents: new Map(),
+      connected: false,
+      available: true,
+      poll: {
+        status: 'degraded',
+        code: 'TELEMETRY_DEGRADED',
+        message: 'Could not read live fleet telemetry.',
+        lastSuccessAt: null,
+        consecutiveFailures: 2,
+      },
+      refresh: vi.fn(),
+    });
+    renderWithProviders(<FleetPanel />);
+
+    expect(screen.queryByText('Loading fleet…')).not.toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /does not mean the fleet is idle/i,
+    );
+  });
+
+  it('shows no staleness marking at all while the poll is healthy', () => {
+    mountStale({ status: 'ok', lastSuccessAt: Date.now() - 1_000 }, []);
+
+    expect(
+      screen.getByRole('heading', { name: 'Live fleet' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/frozen snapshot/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('has no a11y violations while stale', async () => {
+    const container = mountStale({
+      status: 'degraded',
+      code: 'TELEMETRY_DEGRADED',
+      message: 'Could not read live fleet telemetry.',
+      lastSuccessAt: Date.now() - FLEET_STALE_AFTER_MS - 1_000,
+      consecutiveFailures: 4,
+    });
 
     const results = await axe(container);
 

--- a/apps/admin-webapp/tests/features/dashboard/node-diagnostics-panel.test.tsx
+++ b/apps/admin-webapp/tests/features/dashboard/node-diagnostics-panel.test.tsx
@@ -1,0 +1,256 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect } from 'vitest';
+
+import { NodeDiagnosticsPanel } from '#src/features/dashboard/node-diagnostics-panel';
+import type {
+  NodeSnapshot,
+  TranscriptionHostSnapshot,
+} from '#src/lib/admin-api';
+
+import { renderWithProviders } from '../../utils/render-with-providers';
+import { buildHost, buildNode } from './node-fixtures';
+
+function mount(
+  nodes: NodeSnapshot[],
+  hosts: TranscriptionHostSnapshot[] = [],
+): HTMLElement {
+  return renderWithProviders(
+    <NodeDiagnosticsPanel nodes={nodes} hosts={hosts} />,
+  ).container;
+}
+
+/** The detail tables live behind a collapsed accordion by default. */
+async function expandDetail(): Promise<void> {
+  await userEvent.click(
+    screen.getByRole('button', { name: /connection diagnostics/i }),
+  );
+}
+
+describe('NodeDiagnosticsPanel', (it) => {
+  it('renders nothing when the snapshot carries no nodes or hosts', () => {
+    const container = mount([], []);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('names a signing-key mismatch without needing the detail opened', async () => {
+    // PLAN §8 question 4. A finding an operator has to expand an accordion to
+    // discover is a finding nobody sees during an incident.
+    mount([
+      buildNode({
+        summary: { ...buildNode().summary, authSuccessTotal: 0 },
+        authFailures: [{ reason: 'invalid-token', count: 47 }],
+      }),
+    ]);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/never accepted a session token/i);
+    expect(alert).toHaveTextContent(/signing-key mismatch/i);
+    expect(alert).toHaveTextContent(/SESSION_TOKEN_SIGNING_KEY/);
+  });
+
+  it('raises no finding for a healthy node', () => {
+    mount([buildNode()]);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('preserves initiator as words on every close row', async () => {
+    // `initiator` is the whole reason the tally is labelled: a flapping source
+    // uplink must not read as an auth failure.
+    mount([
+      buildNode({
+        wsCloses: [
+          {
+            code: 1006,
+            reason: '',
+            role: 'source',
+            initiator: 'peer',
+            count: 41,
+          },
+          {
+            code: 1008,
+            reason: 'invalid-token',
+            role: 'source',
+            initiator: 'server',
+            count: 2,
+          },
+        ],
+      }),
+    ]);
+    await expandDetail();
+
+    expect(screen.getByText('the far end closed it')).toBeInTheDocument();
+    expect(screen.getByText('node-server closed it')).toBeInTheDocument();
+    // And the split is stated in prose too, so the pattern is legible without
+    // reading every row.
+    expect(
+      screen.getByText(/41 by the far end, 2 by node-server/i),
+    ).toBeInTheDocument();
+  });
+
+  it('distinguishes "nothing ever connected" from "it keeps dropping"', async () => {
+    // Runbook question 3, the half that a close tally alone cannot express:
+    // an absent label combination means it never happened.
+    mount([
+      buildNode({
+        summary: { ...buildNode().summary, authSuccessTotal: 0 },
+      }),
+    ]);
+    await expandDetail();
+
+    expect(
+      screen.getByText(/no transcription-stream socket has closed/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/has ever presented a session token to this node/i),
+    ).toBeInTheDocument();
+  });
+
+  it('breaks rejections out by reason and explains each one', async () => {
+    mount([
+      buildNode({
+        authFailures: [
+          { reason: 'invalid-token', count: 3 },
+          { reason: 'missing-scope', count: 1 },
+        ],
+      }),
+    ]);
+    await expandDetail();
+
+    expect(screen.getByText('invalid-token')).toBeInTheDocument();
+    expect(screen.getByText('missing-scope')).toBeInTheDocument();
+    expect(screen.getByText(/HMAC did not verify/i)).toBeInTheDocument();
+    expect(screen.getByText(/SEND_AUDIO for a source/i)).toBeInTheDocument();
+  });
+
+  it('renders an unrecognised reason verbatim rather than guessing at it', async () => {
+    // `authFailures[].reason` is an open set — a newer node-server may name a
+    // reason this console predates.
+    mount([
+      buildNode({ authFailures: [{ reason: 'brand-new-reason', count: 2 }] }),
+    ]);
+    await expandDetail();
+
+    expect(screen.getByText('brand-new-reason')).toBeInTheDocument();
+  });
+
+  it('keeps auth timeouts visible as their own figure, not folded into rejections', async () => {
+    mount([
+      buildNode({
+        summary: { ...buildNode().summary, authTimeoutsTotal: 5 },
+      }),
+    ]);
+    await expandDetail();
+
+    expect(screen.getByText('never authenticated: 5')).toBeInTheDocument();
+    expect(screen.getByText('rejected: 0')).toBeInTheDocument();
+  });
+
+  it('says "not reported" for an optional counter an older publisher omits', async () => {
+    mount([buildNode()]);
+    await expandDetail();
+
+    // Not "0": the publisher not carrying the field is a different fact from
+    // it having counted nothing.
+    expect(
+      screen.getByText('pre-auth audio dropped: not reported'),
+    ).toBeInTheDocument();
+  });
+
+  it('names the provider keys a host serves beside its unknown-key refusals', async () => {
+    mount([], [buildHost({ invalidProviderKeyRejects: 3 })]);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/refused 3 session\(s\)/i);
+    expect(alert).toHaveTextContent(/whisper/);
+
+    await expandDetail();
+    expect(screen.getByText('ts-1')).toBeInTheDocument();
+  });
+
+  it('puts only the counts rollup in a live region, never the polled tables', async () => {
+    // LESSONSLEARNED: "a polled list must not be a live region" — this panel
+    // re-renders on the fleet panel's 5 s poll.
+    const container = mount([
+      buildNode({
+        wsCloses: [
+          {
+            code: 1006,
+            reason: '',
+            role: 'source',
+            initiator: 'peer',
+            count: 4,
+          },
+        ],
+      }),
+    ]);
+    await expandDetail();
+
+    const rollup = screen.getByLabelText('Connection diagnostics summary');
+    expect(rollup).toHaveAttribute('aria-live', 'polite');
+    expect(rollup).toHaveTextContent('handshakes 10 accepted / 0 rejected');
+    expect(rollup).toHaveTextContent('source closes 4');
+
+    for (const table of container.querySelectorAll('table')) {
+      expect(rollup.contains(table)).toBe(false);
+    }
+    expect(container.querySelectorAll('[aria-live]')).toHaveLength(1);
+  });
+
+  it('states the counting epoch, so a lifetime total is not read as "now"', async () => {
+    mount([buildNode()]);
+    await expandDetail();
+
+    expect(
+      screen.getByText(/totals since the process started/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/counting since/i)).toBeInTheDocument();
+  });
+
+  it('has no a11y violations with findings and the detail expanded', async () => {
+    // Rendered under stand-in page headings: in the app this panel sits inside
+    // `FleetPanel`, whose "Live fleet" is an `h2`, and its own `h3`/`h4`
+    // sections are numbered against that. Mounted bare, the first heading
+    // would be an `h3` with nothing above it and axe would flag the jump —
+    // a defect of the harness, not of the component.
+    const { container } = renderWithProviders(
+      <>
+        <h1>Dashboard</h1>
+        <h2>Live fleet</h2>
+        <NodeDiagnosticsPanel
+          nodes={[
+            buildNode({
+              summary: { ...buildNode().summary, authSuccessTotal: 0 },
+              authFailures: [{ reason: 'invalid-token', count: 47 }],
+              wsCloses: [
+                {
+                  code: 1006,
+                  reason: '',
+                  role: 'source',
+                  initiator: 'peer',
+                  count: 41,
+                },
+                {
+                  code: 1001,
+                  reason: '',
+                  role: 'client',
+                  initiator: 'peer',
+                  count: 2,
+                },
+              ],
+            }),
+          ]}
+          hosts={[buildHost({ invalidProviderKeyRejects: 1 })]}
+        />
+      </>,
+    );
+    await expandDetail();
+
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/apps/admin-webapp/tests/features/dashboard/node-diagnostics.test.ts
+++ b/apps/admin-webapp/tests/features/dashboard/node-diagnostics.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect } from 'vitest';
+
+import {
+  deriveCloseGroups,
+  deriveDiagnosticsRollup,
+  deriveHandshakeTally,
+  deriveHostFindings,
+  deriveNodeFindings,
+} from '#src/features/dashboard/node-diagnostics';
+
+import { buildHost, buildNode } from './node-fixtures';
+
+describe('deriveHandshakeTally', (it) => {
+  it('keeps timeouts out of the rejection total', () => {
+    // node-server's `recordAuthTimeout` does not also call
+    // `recordAuthFailure`, so folding the two would make the panel's own
+    // numbers stop adding up.
+    const tally = deriveHandshakeTally(
+      buildNode({
+        summary: {
+          ...buildNode().summary,
+          authSuccessTotal: 8,
+          authTimeoutsTotal: 5,
+        },
+        authFailures: [{ reason: 'invalid-token', count: 2 }],
+      }),
+    );
+
+    expect(tally.failureTotal).toBe(2);
+    expect(tally.timeoutsTotal).toBe(5);
+    expect(tally.successTotal).toBe(8);
+  });
+
+  it('sorts reasons by count so the dominant failure is first', () => {
+    const tally = deriveHandshakeTally(
+      buildNode({
+        authFailures: [
+          { reason: 'token-expired', count: 1 },
+          { reason: 'invalid-token', count: 9 },
+          { reason: 'missing-scope', count: 4 },
+        ],
+      }),
+    );
+
+    expect(tally.byReason.map((r) => r.reason)).toEqual([
+      'invalid-token',
+      'missing-scope',
+      'token-expired',
+    ]);
+  });
+
+  it('reports a null ratio when no credential has ever been presented', () => {
+    const tally = deriveHandshakeTally(
+      buildNode({
+        summary: { ...buildNode().summary, authSuccessTotal: 0 },
+      }),
+    );
+
+    // Not zero: "nothing has tried" and "nothing has failed" are different
+    // answers to the runbook's dropping-vs-never-connected question.
+    expect(tally.rejectRatio).toBeNull();
+  });
+
+  it('computes the ratio against successes, the denominator node-server ships for it', () => {
+    const tally = deriveHandshakeTally(
+      buildNode({
+        summary: { ...buildNode().summary, authSuccessTotal: 1 },
+        authFailures: [{ reason: 'invalid-token', count: 3 }],
+      }),
+    );
+
+    expect(tally.rejectRatio).toBe(0.75);
+  });
+});
+
+describe('deriveCloseGroups', (it) => {
+  it('groups by role and splits each group by initiator', () => {
+    const groups = deriveCloseGroups(
+      buildNode({
+        wsCloses: [
+          {
+            code: 1006,
+            reason: '',
+            role: 'source',
+            initiator: 'peer',
+            count: 41,
+          },
+          {
+            code: 1008,
+            reason: 'invalid-token',
+            role: 'source',
+            initiator: 'server',
+            count: 2,
+          },
+          {
+            code: 1001,
+            reason: '',
+            role: 'client',
+            initiator: 'peer',
+            count: 7,
+          },
+        ],
+      }),
+    );
+
+    expect(groups.map((g) => g.role)).toEqual(['source', 'client']);
+    const source = groups[0];
+    expect(source?.peerTotal).toBe(41);
+    expect(source?.serverTotal).toBe(2);
+    expect(source?.total).toBe(43);
+    // The rows keep `initiator` — the label the tally exists for.
+    expect(source?.rows[0]).toMatchObject({ initiator: 'peer', count: 41 });
+  });
+
+  it('omits a role with no closes rather than showing it as zero', () => {
+    // An absent label combination has never occurred; node-server omits it,
+    // and rendering an empty "Viewer connections — 0 closes" row would invent
+    // a fact about viewers that have simply never connected.
+    const groups = deriveCloseGroups(
+      buildNode({
+        wsCloses: [
+          {
+            code: 1000,
+            reason: 'session-ended',
+            role: 'source',
+            initiator: 'server',
+            count: 3,
+          },
+        ],
+      }),
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.role).toBe('source');
+  });
+});
+
+describe('deriveNodeFindings', (it) => {
+  it('names a signing-key mismatch when every handshake was rejected as invalid-token', () => {
+    // PLAN §8 question 4. `verifyAuth` returns `invalid-token` when
+    // `SessionTokenService.verify` fails the HMAC, which is exactly what a
+    // SESSION_TOKEN_SIGNING_KEY disagreement produces.
+    const findings = deriveNodeFindings(
+      buildNode({
+        summary: { ...buildNode().summary, authSuccessTotal: 0 },
+        authFailures: [{ reason: 'invalid-token', count: 47 }],
+      }),
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.level).toBe('error');
+    expect(findings[0]?.headline).toMatch(/never accepted a session token/i);
+    expect(findings[0]?.cause).toMatch(/signing-key mismatch/i);
+    expect(findings[0]?.nextAction).toMatch(/SESSION_TOKEN_SIGNING_KEY/);
+  });
+
+  it('does not claim a key mismatch when the rejections are a different reason', () => {
+    const findings = deriveNodeFindings(
+      buildNode({
+        summary: { ...buildNode().summary, authSuccessTotal: 0 },
+        authFailures: [{ reason: 'token-expired', count: 6 }],
+      }),
+    );
+
+    expect(findings[0]?.level).toBe('error');
+    expect(findings[0]?.cause).not.toMatch(/signing-key mismatch/i);
+    expect(findings[0]?.cause).toMatch(/expiry had already passed/i);
+  });
+
+  it('warns without claiming currency when most, but not all, handshakes were rejected', () => {
+    const findings = deriveNodeFindings(
+      buildNode({
+        summary: { ...buildNode().summary, authSuccessTotal: 2 },
+        authFailures: [{ reason: 'invalid-token', count: 8 }],
+      }),
+    );
+
+    expect(findings[0]?.level).toBe('warning');
+    expect(findings[0]?.headline).toMatch(/80%/);
+    // These are lifetime totals; saying "authentication is failing now" would
+    // be the exact class of bug this panel exists to remove.
+    expect(findings[0]?.cause).toMatch(/totals since the process started/i);
+  });
+
+  it('says nothing at all about a node whose handshakes are healthy', () => {
+    expect(deriveNodeFindings(buildNode())).toEqual([]);
+  });
+
+  it('flags a device acting on a stale schedule', () => {
+    const findings = deriveNodeFindings(
+      buildNode({
+        summary: {
+          ...buildNode().summary,
+          endedSessionRegistrationsTotal: 4,
+        },
+      }),
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.headline).toMatch(/already ended/i);
+    expect(findings[0]?.cause).toMatch(/mySchedule long-poll/i);
+  });
+
+  it('treats an absent optional counter as unreported, not as zero activity', () => {
+    // `endedSessionRegistrationsTotal` is optional on the wire so an older
+    // publisher does not fail the strict read-side check.
+    expect(deriveNodeFindings(buildNode())).toEqual([]);
+  });
+});
+
+describe('deriveHostFindings', (it) => {
+  it('names the keys the host does serve alongside the refusal count', () => {
+    const findings = deriveHostFindings(
+      buildHost({ invalidProviderKeyRejects: 3 }),
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.level).toBe('error');
+    expect(findings[0]?.cause).toMatch(/whisper/);
+    // Not a capacity problem, so "wait and retry" would be wrong advice.
+    expect(findings[0]?.cause).toMatch(/no amount of retrying/i);
+  });
+
+  it('is silent when the host has refused nothing', () => {
+    expect(deriveHostFindings(buildHost())).toEqual([]);
+  });
+});
+
+describe('deriveDiagnosticsRollup', (it) => {
+  it('sums handshakes and closes across nodes and counts findings', () => {
+    const rollup = deriveDiagnosticsRollup(
+      [
+        buildNode({
+          nodeInstanceId: 'node-a',
+          wsCloses: [
+            {
+              code: 1006,
+              reason: '',
+              role: 'source',
+              initiator: 'peer',
+              count: 4,
+            },
+          ],
+        }),
+        buildNode({
+          nodeInstanceId: 'node-b',
+          processUid: 'proc-2',
+          summary: { ...buildNode().summary, authSuccessTotal: 0 },
+          authFailures: [{ reason: 'invalid-token', count: 5 }],
+          wsCloses: [
+            {
+              code: 1001,
+              reason: '',
+              role: 'client',
+              initiator: 'peer',
+              count: 9,
+            },
+          ],
+        }),
+      ],
+      [buildHost({ invalidProviderKeyRejects: 1 })],
+    );
+
+    expect(rollup.authSuccessTotal).toBe(10);
+    expect(rollup.authFailureTotal).toBe(5);
+    expect(rollup.sourceClosesTotal).toBe(4);
+    expect(rollup.clientClosesTotal).toBe(9);
+    expect(rollup.findingCount).toBe(2);
+  });
+});

--- a/apps/admin-webapp/tests/features/dashboard/node-fixtures.ts
+++ b/apps/admin-webapp/tests/features/dashboard/node-fixtures.ts
@@ -1,0 +1,76 @@
+import type {
+  NodeSnapshot,
+  ProviderHealth,
+  TranscriptionHostSnapshot,
+} from '#src/lib/admin-api';
+
+/**
+ * A healthy node-server instance: handshakes accepted, nothing rejected, no
+ * socket has closed. Overrides are shallow, so a case changing one `summary`
+ * counter spreads `buildNode().summary` itself.
+ */
+export function buildNode(overrides: Partial<NodeSnapshot> = {}): NodeSnapshot {
+  return {
+    processUid: 'proc-1',
+    processStartedAt: '2026-08-02T14:02:00.000Z',
+    generatedAt: '2026-08-02T17:13:00.000Z',
+    summary: {
+      activeSessionCount: 1,
+      decodeDropsTotal: 0,
+      pendingChunkEvictionsTotal: 0,
+      upstreamChurnTotal: 0,
+      authSuccessTotal: 10,
+      authTimeoutsTotal: 0,
+      orchestratorFailuresTotal: 0,
+      latencySamplesTotal: 0,
+      latencyE2eUnavailableTotal: 0,
+      latencyE2eNegativeTotal: 0,
+      latencyUnmatchedChunkTotal: 0,
+    },
+    upstreamStateTransitions: [],
+    wsCloses: [],
+    latency: [],
+    authFailures: [],
+    updatedAt: 1_000,
+    nodeInstanceId: 'node-a',
+    ...overrides,
+  };
+}
+
+/**
+ * A Transcription Service host serving one provider key and refusing nothing.
+ * `binaryBeforeAuthDropsTotal` and `endedSessionRegistrationsTotal` are
+ * deliberately absent from {@link buildNode} for the same reason they are
+ * optional on the wire: the default fixture is an older publisher, so a
+ * consumer that treats "not reported" as zero fails here rather than in
+ * production during a rolling deploy.
+ */
+export function buildHost(
+  overrides: Partial<TranscriptionHostSnapshot> = {},
+): TranscriptionHostSnapshot {
+  const provider: ProviderHealth = {
+    providerUid: 'p-1',
+    kind: 'local',
+    status: 'ok',
+    activeSessions: 0,
+    sessionsRefusedCapacityTotal: 0,
+    model: 'base',
+    modelLoaded: true,
+    owningWorkers: [],
+    endpoint: null,
+    reachable: null,
+    probeLatencyMs: null,
+    detail: null,
+  };
+  return {
+    updatedAt: 1_000,
+    transcriptionHost: 'ts-1',
+    processUid: 'ts-proc-1',
+    processStartedAt: '2026-08-02T14:00:00.000Z',
+    numWorkers: 2,
+    invalidProviderKeyRejects: 0,
+    workers: [],
+    providers: { whisper: provider },
+    ...overrides,
+  };
+}

--- a/apps/admin-webapp/tests/features/dashboard/telemetry-freshness.test.ts
+++ b/apps/admin-webapp/tests/features/dashboard/telemetry-freshness.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect } from 'vitest';
+
+import {
+  FLEET_STALE_AFTER_MS,
+  deriveFreshness,
+  formatAge,
+  freshnessChipLabel,
+} from '#src/features/dashboard/telemetry-freshness';
+import type { FleetPollState } from '#src/features/dashboard/use-fleet';
+
+const NOW = 1_700_000_000_000;
+
+function degraded(
+  overrides: Partial<Extract<FleetPollState, { status: 'degraded' }>> = {},
+) {
+  return {
+    status: 'degraded' as const,
+    code: 'TELEMETRY_DEGRADED',
+    message: 'Could not read live fleet telemetry.',
+    lastSuccessAt: NOW - 4_000,
+    consecutiveFailures: 1,
+    ...overrides,
+  };
+}
+
+describe('formatAge', (it) => {
+  it('resolves to whole seconds under a minute', () => {
+    expect(formatAge(0)).toBe('0s');
+    expect(formatAge(3_400)).toBe('3s');
+    expect(formatAge(59_999)).toBe('59s');
+  });
+
+  it('switches to minutes and seconds, then to hours and minutes', () => {
+    expect(formatAge(60_000)).toBe('1m 0s');
+    expect(formatAge(134_000)).toBe('2m 14s');
+    expect(formatAge(3_600_000)).toBe('1h 0m');
+    expect(formatAge(7_500_000)).toBe('2h 5m');
+  });
+});
+
+describe('deriveFreshness', (it) => {
+  it('says nothing at all while the very first read is in flight', () => {
+    // The "waiting" case must not borrow the vocabulary of a fault
+    // (PLAN §10.4): a panel that has not loaded yet is not degraded.
+    const freshness = deriveFreshness({ status: 'loading' }, NOW);
+
+    expect(freshness.severity).toBe('ok');
+    expect(freshness.stale).toBe(false);
+    expect(freshness.headline).toBeNull();
+  });
+
+  it('is ok, and not stale, for a read that landed within the threshold', () => {
+    const freshness = deriveFreshness(
+      { status: 'ok', lastSuccessAt: NOW - 2_000 },
+      NOW,
+    );
+
+    expect(freshness.severity).toBe('ok');
+    expect(freshness.stale).toBe(false);
+    expect(freshness.ageMs).toBe(2_000);
+    expect(freshness.headline).toBeNull();
+  });
+
+  it('warns and marks stale on a degraded read, keeping the snapshot age', () => {
+    // The §4.4 regression in one assertion: TELEMETRY_DEGRADED used to fall
+    // through with no chip, no toast and no staleness marker at all.
+    const freshness = deriveFreshness(degraded(), NOW);
+
+    expect(freshness.severity).toBe('warning');
+    expect(freshness.stale).toBe(true);
+    expect(freshness.ageMs).toBe(4_000);
+    expect(freshness.lastSuccessAt).toBe(NOW - 4_000);
+    expect(freshness.headline).toMatch(/not the current state of the fleet/i);
+    expect(freshness.cause).toBe('Could not read live fleet telemetry.');
+    expect(freshness.nextAction).not.toBeNull();
+  });
+
+  it('escalates a degraded read to error once the data outlives the stale threshold', () => {
+    const freshness = deriveFreshness(
+      degraded({ lastSuccessAt: NOW - FLEET_STALE_AFTER_MS }),
+      NOW,
+    );
+
+    expect(freshness.severity).toBe('error');
+    expect(freshness.stale).toBe(true);
+    expect(freshness.headline).toMatch(/do not read this grid as current/i);
+  });
+
+  it('treats an old snapshot as stale even when no read has failed', () => {
+    // A hidden tab pauses the poll and a hung request never rejects, so a
+    // status-only rule would call both of these live.
+    const freshness = deriveFreshness(
+      { status: 'ok', lastSuccessAt: NOW - 10 * FLEET_STALE_AFTER_MS },
+      NOW,
+    );
+
+    expect(freshness.severity).toBe('warning');
+    expect(freshness.stale).toBe(true);
+    expect(freshness.headline).toMatch(/older than one poll cycle/i);
+  });
+
+  it('reports an error, not an empty panel, when no read has ever succeeded', () => {
+    const freshness = deriveFreshness(
+      degraded({ lastSuccessAt: null, consecutiveFailures: 3 }),
+      NOW,
+    );
+
+    expect(freshness.severity).toBe('error');
+    // Nothing is on screen to mark as stale — the point is that the emptiness
+    // is a failure, not an idle fleet.
+    expect(freshness.stale).toBe(false);
+    expect(freshness.ageMs).toBeNull();
+    expect(freshness.headline).toMatch(/does not mean the fleet is idle/i);
+  });
+
+  it('keeps the ticking age out of the announced sentence', () => {
+    // The banner is assertive; a relative age inside it would re-announce
+    // itself every second to a screen-reader user.
+    const freshness = deriveFreshness(degraded(), NOW);
+
+    expect(freshness.headline).not.toMatch(/\d+s\b/);
+    expect(freshness.headline).not.toMatch(/\d+m /);
+  });
+
+  it('carries the unavailable message without inventing a staleness claim', () => {
+    const freshness = deriveFreshness(
+      { status: 'unavailable', message: 'REDIS_URL unset.' },
+      NOW,
+    );
+
+    expect(freshness.stale).toBe(false);
+    expect(freshness.ageMs).toBeNull();
+    expect(freshness.cause).toBe('REDIS_URL unset.');
+  });
+});
+
+describe('freshnessChipLabel', (it) => {
+  it('says how fresh the data is in words, never by colour alone', () => {
+    const fresh = deriveFreshness(
+      { status: 'ok', lastSuccessAt: NOW - 3_000 },
+      NOW,
+    );
+
+    expect(freshnessChipLabel(fresh)).toBe('updated 3s ago');
+  });
+
+  it('says the data is not updating, and how old it is, when stale', () => {
+    const stale = deriveFreshness(
+      degraded({ lastSuccessAt: NOW - 134_000 }),
+      NOW,
+    );
+
+    expect(freshnessChipLabel(stale)).toBe('not updating · 2m 14s old');
+  });
+
+  it('distinguishes "no data yet" from "no data at all"', () => {
+    expect(
+      freshnessChipLabel(deriveFreshness({ status: 'loading' }, NOW)),
+    ).toBe('waiting for first update');
+  });
+});

--- a/apps/admin-webapp/tests/features/dashboard/use-alerts.test.ts
+++ b/apps/admin-webapp/tests/features/dashboard/use-alerts.test.ts
@@ -91,6 +91,35 @@ describe('useAlerts', (it) => {
     expect(result.current.state).toEqual({
       status: 'unavailable',
       message: 'sidecar did not answer',
+      severity: 'error',
+    });
+  });
+
+  it('classifies a 429 as a warning with retry copy, not as an unavailable pipeline', async () => {
+    // admin-server's limiter is `global: true` and this hook polls every 15 s,
+    // so a 429 is a reachable state here. It means "ask again shortly" — the
+    // sidecar was never asked, and nothing about the pipeline is known to be
+    // wrong.
+    vi.mocked(adminApi.alerts).mockRejectedValue(
+      new ApiError(
+        'RATE_LIMITED',
+        'Too many requests. Please retry after 1 minute.',
+        429,
+        'req-1',
+        { retryAfter: '1 minute' },
+      ),
+    );
+
+    const { result } = renderHook(() => useAlerts());
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('unavailable');
+    });
+    expect(result.current.state).toEqual({
+      status: 'unavailable',
+      message:
+        'Too many requests — the admin server is rate limiting this browser. Nothing was changed; wait 1 minute, then try again.',
+      severity: 'warning',
     });
   });
 
@@ -105,6 +134,7 @@ describe('useAlerts', (it) => {
     expect(result.current.state).toEqual({
       status: 'unavailable',
       message: 'Could not reach the admin server.',
+      severity: 'error',
     });
   });
 

--- a/apps/admin-webapp/tests/features/dashboard/use-fleet.test.ts
+++ b/apps/admin-webapp/tests/features/dashboard/use-fleet.test.ts
@@ -10,6 +10,7 @@ import {
   FLEET_STREAM_URL,
   adminApi,
 } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
 
 vi.mock('#src/lib/admin-api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('#src/lib/admin-api')>();
@@ -256,5 +257,195 @@ describe('useFleet poll timer', (it) => {
 
     // Assert: no additional fetches after unmount
     expect(vi.mocked(adminApi.fleet).mock.calls.length).toBe(fetchesAfterMount);
+  });
+});
+
+/**
+ * PLAN-VisibleErrors §4.4. `TELEMETRY_DEGRADED` used to fall through this
+ * hook's catch entirely: the last good snapshot stayed on screen with no chip,
+ * no toast and no staleness marker, behind a `reconnecting…` chip that only
+ * ever described the SSE connection. These pin both halves of the replacement —
+ * the snapshot is still kept, and the failure is now stated.
+ */
+describe('useFleet degraded telemetry', (it) => {
+  let originalEventSource: typeof globalThis.EventSource | undefined;
+  let originalHidden: boolean;
+
+  const populatedSnapshot: FleetSnapshot = {
+    ...emptySnapshot,
+    generatedAt: 42,
+  };
+
+  function degradedError(): ApiError {
+    return new ApiError(
+      'TELEMETRY_DEGRADED',
+      'Could not read live fleet telemetry.',
+      503,
+    );
+  }
+
+  /** Lets the mocked fetch's microtasks settle under fake timers. */
+  async function flush(): Promise<void> {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.EventSource = FakeEventSource as any;
+    vi.useFakeTimers();
+    originalHidden = document.hidden;
+    Object.defineProperty(document, 'hidden', {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalEventSource) {
+      globalThis.EventSource = originalEventSource;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (globalThis as any).EventSource;
+    }
+    Object.defineProperty(document, 'hidden', {
+      value: originalHidden,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('keeps the last good snapshot and reports the poll as degraded', async () => {
+    // Arrange: one good read, then the backplane read starts failing.
+    vi.mocked(adminApi.fleet)
+      .mockResolvedValueOnce(populatedSnapshot)
+      .mockRejectedValue(degradedError());
+    const { result } = renderHook(() => useFleet());
+    await flush();
+    expect(result.current.poll.status).toBe('ok');
+
+    // Act
+    act(() => {
+      vi.advanceTimersByTime(FLEET_POLL_INTERVAL_MS);
+    });
+    await flush();
+
+    // Assert: stale-but-marked, not hidden — the snapshot survives, and the
+    // hook now says out loud that it is no longer being refreshed.
+    expect(result.current.snapshot).toBe(populatedSnapshot);
+    expect(result.current.poll).toMatchObject({
+      status: 'degraded',
+      code: 'TELEMETRY_DEGRADED',
+      message: 'Could not read live fleet telemetry.',
+      consecutiveFailures: 1,
+    });
+    // `available` stays true: a degraded read is not an unconfigured backplane.
+    expect(result.current.available).toBe(true);
+  });
+
+  it('retains the age of the snapshot it is still showing', async () => {
+    vi.mocked(adminApi.fleet)
+      .mockResolvedValueOnce(populatedSnapshot)
+      .mockRejectedValue(degradedError());
+    const { result } = renderHook(() => useFleet());
+    await flush();
+    const successAt =
+      result.current.poll.status === 'ok'
+        ? result.current.poll.lastSuccessAt
+        : null;
+    expect(successAt).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(FLEET_POLL_INTERVAL_MS);
+    });
+    await flush();
+
+    // Carried through the failure — it is what makes "how old is what I am
+    // looking at" a statable question rather than a guess.
+    expect(
+      result.current.poll.status === 'degraded'
+        ? result.current.poll.lastSuccessAt
+        : null,
+    ).toBe(successAt);
+  });
+
+  it('keeps polling while degraded and counts consecutive failures', async () => {
+    vi.mocked(adminApi.fleet).mockRejectedValue(degradedError());
+    const { result } = renderHook(() => useFleet());
+    await flush();
+    const callsAfterMount = vi.mocked(adminApi.fleet).mock.calls.length;
+
+    act(() => {
+      vi.advanceTimersByTime(FLEET_POLL_INTERVAL_MS * 2);
+    });
+    await flush();
+
+    // A degraded read is exactly the case that recovers on its own, so the
+    // timer must survive it — unlike TELEMETRY_UNAVAILABLE below.
+    expect(vi.mocked(adminApi.fleet).mock.calls.length).toBeGreaterThan(
+      callsAfterMount,
+    );
+    expect(
+      result.current.poll.status === 'degraded'
+        ? result.current.poll.consecutiveFailures
+        : 0,
+    ).toBeGreaterThan(1);
+  });
+
+  it('recovers to ok, dropping the degraded state, once a read lands again', async () => {
+    vi.mocked(adminApi.fleet)
+      .mockRejectedValueOnce(degradedError())
+      .mockResolvedValue(populatedSnapshot);
+    const { result } = renderHook(() => useFleet());
+    await flush();
+    expect(result.current.poll.status).toBe('degraded');
+
+    act(() => {
+      vi.advanceTimersByTime(FLEET_POLL_INTERVAL_MS);
+    });
+    await flush();
+
+    expect(result.current.poll.status).toBe('ok');
+    expect(result.current.snapshot).toBe(populatedSnapshot);
+  });
+
+  it('stops polling for an unconfigured backplane, unlike a degraded one', async () => {
+    vi.mocked(adminApi.fleet).mockRejectedValue(
+      new ApiError(
+        'TELEMETRY_UNAVAILABLE',
+        'Live fleet telemetry is not configured (REDIS_URL unset).',
+        503,
+      ),
+    );
+    const { result } = renderHook(() => useFleet());
+    await flush();
+    const callsAfterMount = vi.mocked(adminApi.fleet).mock.calls.length;
+
+    act(() => {
+      vi.advanceTimersByTime(FLEET_POLL_INTERVAL_MS * 4);
+    });
+    await flush();
+
+    expect(result.current.available).toBe(false);
+    expect(result.current.poll.status).toBe('unavailable');
+    expect(vi.mocked(adminApi.fleet).mock.calls.length).toBe(callsAfterMount);
+  });
+
+  it('treats a bare network failure the same as TELEMETRY_DEGRADED, with no code', async () => {
+    vi.mocked(adminApi.fleet).mockRejectedValue(new TypeError('fetch failed'));
+    const { result } = renderHook(() => useFleet());
+    await flush();
+
+    expect(result.current.poll).toMatchObject({
+      status: 'degraded',
+      code: null,
+      message: 'Could not reach the admin server.',
+    });
   });
 });

--- a/apps/admin-webapp/tests/features/devices/devices-list-page.test.tsx
+++ b/apps/admin-webapp/tests/features/devices/devices-list-page.test.tsx
@@ -69,8 +69,10 @@ describe('DevicesListPage', () => {
     });
   });
 
-  describe('error state', (it) => {
-    it('shows a toast and falls back to the empty state on a non-ApiError rejection', async () => {
+  describe('failed state', (it) => {
+    // PLAN-VisibleErrors §5: "No devices found." is a claim about the
+    // deployment and must be unreachable when the load failed.
+    it('never says "No devices found." when the load failed', async () => {
       // Arrange
       vi.mocked(adminApi.listDevices).mockRejectedValue(
         new Error('network down'),
@@ -82,14 +84,42 @@ describe('DevicesListPage', () => {
 
       // Assert
       expect(
-        await screen.findByText('Failed to load devices.'),
+        await screen.findByText('Could not load devices.'),
       ).toBeInTheDocument();
-      expect(screen.getByText('No devices found.')).toBeInTheDocument();
+      expect(screen.queryByText('No devices found.')).not.toBeInTheDocument();
+    });
+
+    it('names the cause and the next action for an unreachable Session Manager', async () => {
+      // Arrange - what admin-server sends when session-manager is down
+      // (`session-manager-gateway.service.ts#classify`).
+      vi.mocked(adminApi.listDevices).mockRejectedValue(
+        new ApiError(
+          'UPSTREAM_UNREACHABLE',
+          'The admin backend is currently unreachable.',
+          503,
+          'req-abc',
+        ),
+      );
+
+      // Act
+      renderWithProviders(<DevicesListPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText(
+          'The admin server could not reach Session Manager.',
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/session-manager service is running/),
+      ).toBeInTheDocument();
+      expect(screen.getByText('req-abc')).toBeInTheDocument();
     });
   });
 
   describe('BACKEND_MISCONFIGURATION', (it) => {
-    it('shows the ADMIN_API_KEY alert instead of a toast', async () => {
+    it('names ADMIN_API_KEY and offers no retry, because retrying cannot help', async () => {
       // Arrange
       vi.mocked(adminApi.listDevices).mockRejectedValue(
         new ApiError('BACKEND_MISCONFIGURATION', 'nope', 502),
@@ -103,6 +133,9 @@ describe('DevicesListPage', () => {
       expect(
         await screen.findByText(/admin backend misconfiguration/i),
       ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Retry' }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/apps/admin-webapp/tests/features/kiosk-setup/kiosk-wizard-page.test.tsx
+++ b/apps/admin-webapp/tests/features/kiosk-setup/kiosk-wizard-page.test.tsx
@@ -285,6 +285,39 @@ describe('KioskWizardPage', () => {
         callsAtUnmount,
       );
     }, 10_000);
+
+    it('says it cannot tell, rather than waiting forever, when the poll keeps failing', async () => {
+      // Arrange: same real-timer approach as above. Step 3's entire UI is a
+      // spinner reading "Waiting for the kiosk to activate…", and the poll's
+      // catch was empty — so a dead admin server left the wizard waiting
+      // forever and implicitly blaming the kiosk (PLAN-VisibleErrors §5).
+      const user = userEvent.setup();
+      vi.mocked(adminApi.getDevice).mockRejectedValue(
+        new Error('admin server down'),
+      );
+      renderWithProviders(<KioskWizardPage />);
+      await registerDevice(user);
+      await clickNext(user);
+      vi.mocked(adminApi.createRoom).mockResolvedValue(
+        buildRoom({ uid: 'room-1' }),
+      );
+      await user.type(screen.getByLabelText('Room name'), 'Room 101');
+      await user.click(screen.getByRole('button', { name: /create room/i }));
+      await screen.findByText('room-1', { selector: 'strong' });
+      await clickNext(user);
+      await clickNextOrSkip(user);
+
+      // Act: three consecutive failures at POLL_MS = 3000ms.
+      // Assert
+      await waitFor(
+        () => {
+          expect(
+            screen.getByText(/cannot tell whether the kiosk has activated/i),
+          ).toBeInTheDocument();
+        },
+        { timeout: 12_000, interval: 250 },
+      );
+    }, 20_000);
   });
 
   describe('kiosk URL', (it) => {

--- a/apps/admin-webapp/tests/features/rooms/room-detail-page.test.tsx
+++ b/apps/admin-webapp/tests/features/rooms/room-detail-page.test.tsx
@@ -226,8 +226,23 @@ describe('RoomDetailPage', () => {
   });
 
   describe('error / not-found state', (it) => {
-    it('shows a toast and a "Room not found." fallback on a non-ApiError rejection', async () => {
+    it('reserves "Room not found." for an actual 404', async () => {
       // Arrange
+      vi.mocked(adminApi.roomDetail).mockRejectedValue(
+        new ApiError('NOT_FOUND', 'No such room.', 404),
+      );
+
+      // Act
+      renderPage();
+      await waitForLoad();
+
+      // Assert
+      expect(screen.getByText('Room not found.')).toBeInTheDocument();
+    });
+
+    it('does not claim the room is missing when the load merely failed', async () => {
+      // Arrange - the §5 bug one level up from the lists: every failure used
+      // to render "Room not found.", i.e. a statement about the deployment.
       vi.mocked(adminApi.roomDetail).mockRejectedValue(
         new Error('network down'),
       );
@@ -238,9 +253,9 @@ describe('RoomDetailPage', () => {
 
       // Assert
       expect(
-        await screen.findByText('Failed to load room.'),
+        await screen.findByText('Could not load this room.'),
       ).toBeInTheDocument();
-      expect(screen.getByText('Room not found.')).toBeInTheDocument();
+      expect(screen.queryByText('Room not found.')).not.toBeInTheDocument();
     });
   });
 

--- a/apps/admin-webapp/tests/features/rooms/rooms-list-page.test.tsx
+++ b/apps/admin-webapp/tests/features/rooms/rooms-list-page.test.tsx
@@ -63,8 +63,10 @@ describe('RoomsListPage', () => {
     });
   });
 
-  describe('error state', (it) => {
-    it('shows a toast and falls back to the empty state on a non-ApiError rejection', async () => {
+  describe('failed state', (it) => {
+    // The whole point of PLAN-VisibleErrors §5: a failed load and a genuinely
+    // empty deployment must never render the same sentence.
+    it('never says "No rooms found." when the load failed', async () => {
       // Arrange
       vi.mocked(adminApi.listRooms).mockRejectedValue(
         new Error('network down'),
@@ -76,12 +78,12 @@ describe('RoomsListPage', () => {
 
       // Assert
       expect(
-        await screen.findByText('Failed to load rooms.'),
+        await screen.findByText('Could not load rooms.'),
       ).toBeInTheDocument();
-      expect(screen.getByText('No rooms found.')).toBeInTheDocument();
+      expect(screen.queryByText('No rooms found.')).not.toBeInTheDocument();
     });
 
-    it("shows the ApiError's own message in the toast for a non-misconfiguration ApiError", async () => {
+    it("shows the ApiError's own message as the cause", async () => {
       // Arrange
       vi.mocked(adminApi.listRooms).mockRejectedValue(
         new ApiError('SOME_OTHER_CODE', 'Something else went wrong.', 400),
@@ -96,10 +98,53 @@ describe('RoomsListPage', () => {
         await screen.findByText('Something else went wrong.'),
       ).toBeInTheDocument();
     });
+
+    it("shows the server's requestId so an operator can quote it", async () => {
+      // Arrange
+      vi.mocked(adminApi.listRooms).mockRejectedValue(
+        new ApiError(
+          'INTERNAL_ERROR',
+          'Server encountered an unexpected error.',
+          500,
+          '7b1f2c3d-0000-4000-8000-abcdefabcdef',
+        ),
+      );
+
+      // Act
+      renderWithProviders(<RoomsListPage />);
+      await waitForLoad();
+
+      // Assert
+      expect(
+        await screen.findByText('7b1f2c3d-0000-4000-8000-abcdefabcdef'),
+      ).toBeInTheDocument();
+    });
+
+    it('retries the load from the error state', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      vi.mocked(adminApi.listRooms)
+        .mockRejectedValueOnce(new Error('network down'))
+        .mockResolvedValueOnce({
+          items: [buildRoom({ uid: 'room-1', name: 'Room 101' })],
+          nextCursor: null,
+        });
+      renderWithProviders(<RoomsListPage />);
+      await screen.findByText('Could not load rooms.');
+
+      // Act
+      await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+      // Assert
+      expect(await screen.findByText('Room 101')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Could not load rooms.'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('BACKEND_MISCONFIGURATION', (it) => {
-    it('shows the ADMIN_API_KEY alert instead of a toast', async () => {
+    it('names ADMIN_API_KEY and offers no retry, because retrying cannot help', async () => {
       // Arrange
       vi.mocked(adminApi.listRooms).mockRejectedValue(
         new ApiError('BACKEND_MISCONFIGURATION', 'nope', 502),
@@ -113,6 +158,10 @@ describe('RoomsListPage', () => {
       expect(
         await screen.findByText(/admin backend misconfiguration/i),
       ).toBeInTheDocument();
+      expect(screen.getByText(/ADMIN_API_KEY/)).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Retry' }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/apps/admin-webapp/tests/features/sessions/room-picker.test.tsx
+++ b/apps/admin-webapp/tests/features/sessions/room-picker.test.tsx
@@ -44,6 +44,43 @@ describe('RoomPicker', () => {
     });
   });
 
+  it('reports a failed search instead of showing "No rooms match."', async () => {
+    // Arrange - the catch used to be silent, so a dead admin server rendered
+    // as "this deployment has no rooms matching that" (PLAN-VisibleErrors §5).
+    vi.mocked(adminApi.listRooms).mockRejectedValue(new Error('backend down'));
+    render(<RoomPicker selected={[]} onChange={() => undefined} />);
+
+    // Act
+    const input = screen.getByRole('combobox', { name: 'Rooms' });
+    fireEvent.change(input, { target: { value: 'Conf' } });
+
+    // Assert - said twice on purpose: in the field's helper text and in place
+    // of the "No rooms match." empty-list wording inside the open popup.
+    expect(
+      await screen.findAllByText(/could not search rooms/i),
+    ).not.toHaveLength(0);
+    expect(screen.queryByText('No rooms match.')).not.toBeInTheDocument();
+  });
+
+  it('clears the failure notice once a later search succeeds', async () => {
+    // Arrange
+    vi.mocked(adminApi.listRooms).mockRejectedValueOnce(
+      new Error('backend down'),
+    );
+    render(<RoomPicker selected={[]} onChange={() => undefined} />);
+    await screen.findAllByText(/could not search rooms/i);
+
+    // Act
+    fireEvent.change(screen.getByRole('combobox', { name: 'Rooms' }), {
+      target: { value: 'Room' },
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.queryAllByText(/could not search rooms/i)).toHaveLength(0);
+    });
+  });
+
   it('calls onChange when an option is selected', async () => {
     const onChange = vi.fn();
     render(<RoomPicker selected={[]} onChange={onChange} />);

--- a/apps/admin-webapp/tests/features/sessions/session-detail-page.test.tsx
+++ b/apps/admin-webapp/tests/features/sessions/session-detail-page.test.tsx
@@ -474,6 +474,7 @@ describe('SessionDetailPage', () => {
         sessionEvents: new Map(),
         connected: true,
         available: true,
+        poll: { status: 'ok', lastSuccessAt: Date.now() },
         refresh: vi.fn(),
       });
     }
@@ -787,6 +788,7 @@ describe('SessionDetailPage', () => {
         sessionEvents: new Map(),
         connected: true,
         available: true,
+        poll: { status: 'ok', lastSuccessAt: Date.now() },
         refresh: vi.fn(),
       });
     }

--- a/apps/admin-webapp/tests/features/sessions/sessions-overview-page.test.tsx
+++ b/apps/admin-webapp/tests/features/sessions/sessions-overview-page.test.tsx
@@ -5,6 +5,7 @@ import type { Room } from '@scribear/session-manager-schema';
 
 import { SessionsOverviewPage } from '#src/features/sessions/sessions-overview-page';
 import { adminApi } from '#src/lib/admin-api';
+import { ApiError } from '#src/lib/api-error';
 import { GRID_MAX_COLUMNS } from '#src/lib/session-rules';
 
 import { renderWithProviders } from '../../utils/render-with-providers';
@@ -57,5 +58,66 @@ describe('SessionsOverviewPage', () => {
         screen.getByRole('heading', { level: 2, name: room.name }),
       ).toBeInTheDocument();
     }
+  });
+
+  it('never says "No sessions today." in every room when the load failed', async () => {
+    // Arrange - the §5 shape on this page: a failed session load left
+    // `sessions` empty, so every room card reported a quiet day.
+    const rooms = manyRooms(GRID_MAX_COLUMNS + 1);
+    seedSelectedRooms(rooms);
+    vi.mocked(adminApi.listSessions).mockRejectedValue(
+      new ApiError('UPSTREAM_UNREACHABLE', 'unreachable', 503, 'req-42'),
+    );
+
+    // Act
+    renderWithProviders(<SessionsOverviewPage />);
+
+    // Assert
+    expect(
+      await screen.findByText('Could not load sessions.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('No sessions today.')).not.toBeInTheDocument();
+    expect(screen.getByText('req-42')).toBeInTheDocument();
+  });
+
+  it('still says "No sessions today." when the day really is empty', async () => {
+    // Arrange
+    const rooms = manyRooms(GRID_MAX_COLUMNS + 1);
+    seedSelectedRooms(rooms);
+    vi.mocked(adminApi.listSessions).mockResolvedValue({ items: [] });
+
+    // Act
+    renderWithProviders(<SessionsOverviewPage />);
+    await waitFor(() => {
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+
+    // Assert
+    expect(screen.queryAllByText('No sessions today.')).toHaveLength(
+      rooms.length,
+    );
+    expect(
+      screen.queryByText('Could not load sessions.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('explains an unusable picker instead of telling the operator to select rooms from it', async () => {
+    // Arrange - with no persisted selection the page fetches rooms to seed a
+    // default. That catch was silent, so a dead backend rendered "Select rooms
+    // above to view their calendar." above a picker that could not list any.
+    vi.mocked(adminApi.listRooms).mockRejectedValue(
+      new ApiError('UPSTREAM_UNREACHABLE', 'unreachable', 503),
+    );
+
+    // Act
+    renderWithProviders(<SessionsOverviewPage />);
+
+    // Assert
+    expect(
+      await screen.findByText('Could not load the room list.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Select rooms above to view their calendar.'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/admin-webapp/tests/lib/api-error.test.ts
+++ b/apps/admin-webapp/tests/lib/api-error.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect } from 'vitest';
+
+import {
+  ApiError,
+  errorMessage,
+  errorSeverity,
+  isRateLimited,
+  loginErrorMessage,
+} from '#src/lib/api-error';
+
+/**
+ * A 429 exactly as admin-server's rate-limit plugin serializes it. `null`
+ * models a 429 that carried no `details` at all.
+ */
+function rateLimited(retryAfter: string | null = '1 minute'): ApiError {
+  return new ApiError(
+    'RATE_LIMITED',
+    'Too many requests. Please retry after 1 minute.',
+    429,
+    'req-1',
+    retryAfter === null ? undefined : { retryAfter },
+  );
+}
+
+describe('isRateLimited', (it) => {
+  it('is true for any 429, since admin-server rate limits every route globally', () => {
+    // Arrange / Act / Assert - keyed on status, not on the route or the code,
+    // because `global: true` means there is no route-level allowlist to check.
+    expect(isRateLimited(rateLimited())).toBe(true);
+    expect(isRateLimited(new ApiError('CONFLICT', 'nope', 409))).toBe(false);
+    expect(isRateLimited(new TypeError('Failed to fetch'))).toBe(false);
+  });
+});
+
+describe('errorMessage', (it) => {
+  it('replaces the log-facing 429 text with copy naming cause, effect and next action', () => {
+    // Act
+    const message = errorMessage(rateLimited(), 'Failed to load rooms.');
+
+    // Assert - the server's own wording ("Please retry after 1 minute.") is
+    // a summary for logs; the console has to say what happened to the request.
+    expect(message).toBe(
+      'Too many requests — the admin server is rate limiting this browser. Nothing was changed; wait 1 minute, then try again.',
+    );
+  });
+
+  it('degrades to "a moment" when the server sent no retryAfter', () => {
+    // Arrange - an older admin-server image, or a 429 from a proxy in front.
+    // Act
+    const message = errorMessage(rateLimited(null), 'Failed to load.');
+
+    // Assert - never invents a duration it was not told.
+    expect(message).toContain('wait a moment, then try again');
+  });
+
+  it('still passes non-429 API errors through verbatim', () => {
+    // Act / Assert
+    expect(
+      errorMessage(
+        new ApiError('CONFLICT', 'Room name already in use.', 409),
+        'Failed to create room.',
+      ),
+    ).toBe('Room name already in use.');
+    expect(errorMessage(new TypeError('boom'), 'Failed to create room.')).toBe(
+      'Failed to create room.',
+    );
+  });
+});
+
+describe('loginErrorMessage', (it) => {
+  it('tells the operator a rate-limited sign-in is not a rejected password', () => {
+    // Arrange - the login route allows 5 attempts a minute, so this is what an
+    // operator who mistyped their password a few times actually sees.
+    // Act
+    const message = loginErrorMessage(rateLimited());
+
+    // Assert
+    expect(message).toBe(
+      'Too many sign-in attempts. This is a rate limit, not a rejected password — wait 1 minute, then sign in again.',
+    );
+  });
+
+  it('leaves a real credential rejection alone', () => {
+    // Act / Assert
+    expect(
+      loginErrorMessage(
+        new ApiError('INVALID_CREDENTIALS', 'Invalid credentials.', 401),
+      ),
+    ).toBe('Invalid credentials.');
+  });
+});
+
+describe('errorSeverity', (it) => {
+  it('rates a rate limit as warning and everything else as error', () => {
+    // Assert - house convention: `warning` = transient, no action but waiting;
+    // `error` = terminal, the operator has to do something.
+    expect(errorSeverity(rateLimited())).toBe('warning');
+    expect(
+      errorSeverity(new ApiError('INVALID_CREDENTIALS', 'Invalid.', 401)),
+    ).toBe('error');
+    expect(errorSeverity(new TypeError('boom'))).toBe('error');
+  });
+});

--- a/apps/admin-webapp/tests/lib/api-failure.test.ts
+++ b/apps/admin-webapp/tests/lib/api-failure.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect } from 'vitest';
+
+import { ApiError } from '#src/lib/api-error';
+import { describeApiFailure, errorMessage } from '#src/lib/api-failure';
+
+describe('errorMessage', (it) => {
+  it("uses the ApiError's own message", () => {
+    expect(errorMessage(new ApiError('X', 'boom', 400), 'fallback')).toBe(
+      'boom',
+    );
+  });
+
+  it('falls back for anything that is not an ApiError', () => {
+    expect(errorMessage(new Error('boom'), 'fallback')).toBe('fallback');
+  });
+});
+
+describe('describeApiFailure', (it) => {
+  it('does not offer a retry for an expired session', () => {
+    // Retrying a 401 just fails again; the action is to sign in.
+    const failure = describeApiFailure(
+      new ApiError('UNAUTHENTICATED', 'Authentication required.', 401, 'r-1'),
+      'Could not load rooms.',
+    );
+
+    expect(failure.retryable).toBe(false);
+    expect(failure.cause).toBe('Your admin session has expired.');
+    expect(failure.nextAction).toMatch(/sign in again/i);
+  });
+
+  it('does not offer a retry for a wrong ADMIN_API_KEY', () => {
+    const failure = describeApiFailure(
+      new ApiError('BACKEND_MISCONFIGURATION', 'nope', 502, 'r-2'),
+      'Could not load rooms.',
+    );
+
+    expect(failure.retryable).toBe(false);
+    expect(failure.nextAction).toMatch(/ADMIN_API_KEY/);
+  });
+
+  it('keeps the rate limiter’s own wording, which carries the window', () => {
+    // `rate-limit.plugin.ts` builds "Too many requests. Please retry after N."
+    const failure = describeApiFailure(
+      new ApiError(
+        'RATE_LIMITED',
+        'Too many requests. Please retry after 42 seconds.',
+        429,
+        'r-3',
+      ),
+      'Could not load rooms.',
+    );
+
+    expect(failure.cause).toContain('42 seconds');
+    expect(failure.retryable).toBe(true);
+    // The console does not auto-retry, so the copy must not imply it does.
+    expect(failure.nextAction).toMatch(
+      /nothing on this page retries on its own/,
+    );
+  });
+
+  it('distinguishes an unreachable Session Manager from a dead admin server', () => {
+    const upstream = describeApiFailure(
+      new ApiError('UPSTREAM_UNREACHABLE', 'unreachable', 503),
+      'Could not load rooms.',
+    );
+    const network = describeApiFailure(
+      new ApiError('NETWORK', 'Could not reach the admin server.', 0),
+      'Could not load rooms.',
+    );
+
+    expect(upstream.cause).toMatch(/could not reach Session Manager/);
+    expect(network.cause).toMatch(/never completed/);
+    expect(upstream.nextAction).not.toBe(network.nextAction);
+  });
+
+  it('carries the requestId when the server produced one, and not otherwise', () => {
+    // `admin-api.ts` mints the NETWORK error itself: the request never reached
+    // a server, so there is no correlation id to quote.
+    expect(
+      describeApiFailure(
+        new ApiError('INTERNAL_ERROR', 'boom', 500, 'req-9'),
+        'Could not load rooms.',
+      ).requestId,
+    ).toBe('req-9');
+    expect(
+      describeApiFailure(
+        new ApiError('NETWORK', 'Could not reach the admin server.', 0),
+        'Could not load rooms.',
+      ).requestId,
+    ).toBeUndefined();
+  });
+
+  it('falls back to the caller’s wording for a non-ApiError rejection', () => {
+    const failure = describeApiFailure(
+      new Error('TypeError: undefined is not a function'),
+      'Could not load rooms.',
+    );
+
+    expect(failure.cause).toBe('Could not load rooms.');
+    expect(failure.retryable).toBe(true);
+  });
+});

--- a/apps/admin-webapp/tests/lib/toast-provider.test.tsx
+++ b/apps/admin-webapp/tests/lib/toast-provider.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect } from 'vitest';
+
+import { ApiError } from '#src/lib/api-error';
+import { useToast } from '#src/lib/toast-context';
+import { ToastProvider } from '#src/lib/toast-provider';
+
+/** Stands in for the ~40 admin call sites that report a failed API call. */
+const Thrower = ({ err }: { err: unknown }) => {
+  const { showApiError } = useToast();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        showApiError(err, 'Failed to load rooms.');
+      }}
+    >
+      go
+    </button>
+  );
+};
+
+async function fire(err: unknown) {
+  const user = userEvent.setup();
+  render(
+    <ToastProvider>
+      <Thrower err={err} />
+    </ToastProvider>,
+  );
+  await user.click(screen.getByRole('button', { name: 'go' }));
+  return screen.findByRole('alert');
+}
+
+describe('ToastProvider.showApiError', () => {
+  describe('a rate-limited request', (it) => {
+    it('is a warning toast explaining the limit, not a red failure', async () => {
+      // Arrange - admin-server registers the limiter with `global: true`, so
+      // every one of these call sites can receive a 429.
+      // Act
+      const alert = await fire(
+        new ApiError(
+          'RATE_LIMITED',
+          'Too many requests. Please retry after 1 minute.',
+          429,
+          'req-1',
+          { retryAfter: '1 minute' },
+        ),
+      );
+
+      // Assert
+      expect(alert).toHaveTextContent(
+        'Too many requests — the admin server is rate limiting this browser. Nothing was changed; wait 1 minute, then try again.',
+      );
+      expect(alert.className).toContain('MuiAlert-colorWarning');
+    });
+  });
+
+  describe('any other API failure', (it) => {
+    it('keeps the server message at error severity', async () => {
+      // Act
+      const alert = await fire(
+        new ApiError('CONFLICT', 'Room name already in use.', 409),
+      );
+
+      // Assert
+      expect(alert).toHaveTextContent('Room name already in use.');
+      expect(alert.className).toContain('MuiAlert-colorError');
+    });
+  });
+
+  describe('a non-API failure', (it) => {
+    it('falls back to the caller-supplied message at error severity', async () => {
+      // Act
+      const alert = await fire(new TypeError('Failed to fetch'));
+
+      // Assert
+      expect(alert).toHaveTextContent('Failed to load rooms.');
+      expect(alert.className).toContain('MuiAlert-colorError');
+    });
+  });
+});

--- a/apps/admin-webapp/tests/lib/use-async-list.test.tsx
+++ b/apps/admin-webapp/tests/lib/use-async-list.test.tsx
@@ -1,0 +1,130 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, vi } from 'vitest';
+
+import type { AsyncListPage } from '#src/lib/use-async-list';
+import { useAsyncList } from '#src/lib/use-async-list';
+
+function page<T>(
+  items: T[],
+  nextCursor: string | null = null,
+): AsyncListPage<T> {
+  return { items, nextCursor };
+}
+
+describe('useAsyncList', (it) => {
+  it('starts in "loading", not in a premature empty "ok"', () => {
+    // Arrange
+    const fetchPage = vi.fn(
+      () => new Promise<AsyncListPage<string>>(() => undefined),
+    );
+
+    // Act
+    const { result } = renderHook(() => useAsyncList(fetchPage, []));
+
+    // Assert
+    expect(result.current.state).toEqual({ status: 'loading' });
+  });
+
+  it('moves to "ok" with an empty list when the deployment really has none', async () => {
+    // Arrange
+    const fetchPage = vi.fn(() => Promise.resolve(page<string>([])));
+
+    // Act
+    const { result } = renderHook(() => useAsyncList(fetchPage, []));
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.state).toEqual({ status: 'ok', items: [] });
+    });
+  });
+
+  it('moves to "unavailable" on a failure, with no items reachable at all', async () => {
+    // Arrange - this is the invariant PLAN-VisibleErrors §10.2 asks for: the
+    // failed state has no `items` field, so no caller can render "No X found."
+    // over an error even by accident.
+    const err = new Error('backend down');
+    const fetchPage = vi.fn(() => Promise.reject(err));
+
+    // Act
+    const { result } = renderHook(() => useAsyncList(fetchPage, []));
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.state).toEqual({
+        status: 'unavailable',
+        error: err,
+      });
+    });
+    expect(result.current.state).not.toHaveProperty('items');
+  });
+
+  it('reload() re-runs the first page and can recover from "unavailable"', async () => {
+    // Arrange
+    const fetchPage = vi
+      .fn<(cursor: string | undefined) => Promise<AsyncListPage<string>>>()
+      .mockRejectedValueOnce(new Error('backend down'))
+      .mockResolvedValueOnce(page(['a']));
+    const { result } = renderHook(() => useAsyncList(fetchPage, []));
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('unavailable');
+    });
+
+    // Act
+    act(() => {
+      result.current.reload();
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.state).toEqual({ status: 'ok', items: ['a'] });
+    });
+  });
+
+  it('appends a further page on loadMore()', async () => {
+    // Arrange
+    const fetchPage = vi
+      .fn<(cursor: string | undefined) => Promise<AsyncListPage<string>>>()
+      .mockResolvedValueOnce(page(['a'], 'cursor-1'))
+      .mockResolvedValueOnce(page(['b']));
+    const { result } = renderHook(() => useAsyncList(fetchPage, []));
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    // Act
+    act(() => {
+      result.current.loadMore();
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.state).toEqual({ status: 'ok', items: ['a', 'b'] });
+    });
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('keeps the loaded rows when an append fails, reporting it separately', async () => {
+    // Arrange - a failed *append* must not blank pages the operator can already
+    // see; that would be the mirror image of the bug being fixed.
+    const appendErr = new Error('page 2 failed');
+    const fetchPage = vi
+      .fn<(cursor: string | undefined) => Promise<AsyncListPage<string>>>()
+      .mockResolvedValueOnce(page(['a'], 'cursor-1'))
+      .mockRejectedValueOnce(appendErr);
+    const { result } = renderHook(() => useAsyncList(fetchPage, []));
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    // Act
+    act(() => {
+      result.current.loadMore();
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.loadMoreError).toBe(appendErr);
+    });
+    expect(result.current.state).toEqual({ status: 'ok', items: ['a'] });
+  });
+});

--- a/apps/client-webapp/src/features/session-provider/components/join-session-modal.tsx
+++ b/apps/client-webapp/src/features/session-provider/components/join-session-modal.tsx
@@ -47,6 +47,19 @@ const JOIN_ERROR_MESSAGES: Record<JoinError, string> = {
   // simultaneously, producing the next round of 429s.
   [JoinError.RATE_LIMITED]:
     'Too many people are joining at once. Wait a minute, then try the same join code again — this clears on its own.',
+  // Either no structured error body at all (session-manager failed partway
+  // through a response it had already started, or the connection dropped
+  // mid-body), or nginx's own 502/503/504 for a session-manager it couldn't
+  // reach - see `JoinError.SERVICE_UNREACHABLE`'s doc. Names the service, not
+  // the code, as the suspect.
+  [JoinError.SERVICE_UNREACHABLE]:
+    'Could not reach the session service. This is not a problem with your join code — try again in a moment.',
+  // A body that parsed as JSON but didn't match what this client expects, or
+  // some other status this build's schema doesn't recognize - session-manager
+  // answered, just not with anything this build understands. Usually a
+  // partial deploy; a reload can pick up a matching build.
+  [JoinError.VERSION_MISMATCH]:
+    'This app may be out of date with the session service. Reload the page and try again.',
   [JoinError.UNKNOWN]: 'Unable to join session. Please try again.',
 };
 
@@ -64,6 +77,12 @@ const JOIN_ERROR_SEVERITY: Record<JoinError, 'error' | 'warning'> = {
   [JoinError.JOIN_CODE_EXPIRED]: 'error',
   [JoinError.SESSION_NOT_CURRENTLY_ACTIVE]: 'error',
   [JoinError.RATE_LIMITED]: 'warning',
+  // Both name a next action (retry shortly / reload), same as NETWORK_ERROR,
+  // so they follow its precedent rather than RATE_LIMITED's: this isn't a
+  // self-clearing condition the whole room shares, so there's no reason to
+  // withhold the "something's wrong" framing the way RATE_LIMITED does.
+  [JoinError.SERVICE_UNREACHABLE]: 'error',
+  [JoinError.VERSION_MISMATCH]: 'error',
   [JoinError.UNKNOWN]: 'error',
 };
 

--- a/apps/client-webapp/src/features/session-provider/services/client-session-service-status.ts
+++ b/apps/client-webapp/src/features/session-provider/services/client-session-service-status.ts
@@ -72,5 +72,50 @@ export enum JoinError {
    * (see the severity convention on {@link JoinNotice}).
    */
   RATE_LIMITED = 'RATE_LIMITED',
+  /**
+   * `exchange-join-code` failed in a way that points at the path to
+   * session-manager rather than at this join code - two distinct
+   * `createEndpointClient` outcomes collapse here because, to a viewer, they
+   * mean the same thing ("try again shortly"):
+   *
+   * - `InvalidResponseBodyError`: a *declared* status arrived with no
+   *   structured body to read at all - most plausibly session-manager itself
+   *   failing partway through a response it had already started (a crash, an
+   *   OOM kill, an unhandled exception after headers were sent), or the
+   *   connection dropping mid-body.
+   * - A plain `UnexpectedResponseError` whose `status` is one of nginx's own
+   *   upstream-failure codes (502/503/504) - this deployment's
+   *   `infra/scribear-nginx/nginx.conf` proxies `/api/session-manager/` with
+   *   no `error_page`/`proxy_intercept_errors` override, so those three
+   *   statuses are nginx's own synthesized response when it cannot reach or
+   *   times out talking to session-manager, never declared by any route
+   *   schema, and therefore never even reach the JSON-parsing step that could
+   *   produce an `InvalidResponseBodyError` for them.
+   *
+   * Distinct from {@link JoinError.VERSION_MISMATCH} below: there,
+   * session-manager (not its gateway) answered with something concrete this
+   * build just doesn't recognize.
+   */
+  SERVICE_UNREACHABLE = 'SERVICE_UNREACHABLE',
+  /**
+   * `exchange-join-code` came back as a plain `UnexpectedResponseError` whose
+   * `status` is *not* one of the gateway codes above - a declared status
+   * whose body parsed as JSON but didn't match what this client was compiled
+   * against, or some other status this build's schema doesn't know at all.
+   * session-manager (or, for a status it never declared, its schema
+   * definition) is answering with something this specific build doesn't
+   * recognize - the usual cause is this client and the deployed service being
+   * out of sync after a partial deploy, which a reload can fix if a newer
+   * bundle is available.
+   */
+  VERSION_MISMATCH = 'VERSION_MISMATCH',
+  /**
+   * A declared status this switch doesn't otherwise map (e.g. a structured
+   * 500 whose body parsed and matched schema fine). Kept deliberately generic
+   * - unlike {@link JoinError.SERVICE_UNREACHABLE} and
+   * {@link JoinError.VERSION_MISMATCH}, session-manager both received the
+   * request and returned a well-formed reply, so there's no infrastructure or
+   * version story to tell.
+   */
   UNKNOWN = 'UNKNOWN',
 }

--- a/apps/client-webapp/src/features/session-provider/services/client-session-service.ts
+++ b/apps/client-webapp/src/features/session-provider/services/client-session-service.ts
@@ -1,6 +1,10 @@
 import EventEmitter from 'eventemitter3';
 
-import { NetworkError } from '@scribear/base-api-client';
+import {
+  InvalidResponseBodyError,
+  NetworkError,
+  UnexpectedResponseError,
+} from '@scribear/base-api-client';
 import {
   type WebSocketClient,
   SchemaValidationError as WsSchemaValidationError,
@@ -116,6 +120,69 @@ const REFRESH_RETRY_BASE_MS = 300;
 const REFRESH_RETRY_MAX_MS = 2000;
 
 /**
+ * session-manager rate-limits `refresh-session-token` (and `exchange-join-code`)
+ * per client IP using `@fastify/rate-limit`'s default store
+ * (`LocalStore.incr`, see the package's `store/LocalStore.js`), which is a
+ * **fixed window** counter, not a sliding one: a bucket starts on the IP's
+ * first request in a window and every request within `timeWindow` of that
+ * start counts against the same cap, however it's distributed in time. The
+ * bucket does not partially drain - it stays fully "spent" until
+ * `iterationStartMs + timeWindow` passes, at which point it resets all at
+ * once. This client cannot see `iterationStartMs`, so it cannot know how much
+ * of the current window is already behind it when a 429 first arrives.
+ *
+ * The window length itself is per-deployment config on the server
+ * (`SessionAuthRateLimitConfig.refreshSessionTokenWindowMs`, an env var read
+ * in session-manager's `app-config.ts`) - not a constant this client can read
+ * or a value worth copying, since it can be retuned independently of this
+ * code. What's stable enough to build a client-side heuristic on is the
+ * *shipped default*, 60 seconds, which is also the number this feature's own
+ * design doc uses when describing the limiter. Nothing here assumes a
+ * specific request *count* (that number changes independently of the window
+ * and this client never needs it).
+ *
+ * The generic exponential schedule above (300/600/1200/2000ms) burns the
+ * entire {@link REFRESH_MAX_CONSECUTIVE_FAILURES} budget in about 4.5
+ * seconds - many multiples faster than a fixed window still mid-cycle could
+ * ever clear, so an overloaded lecture hall always exhausted its budget
+ * within the *same* window it started in, then went terminal telling
+ * everyone to "wait a minute" after its own retry loop had already given up
+ * seconds earlier.
+ *
+ * Because the bucket's phase is unknown, no single wait can be timed
+ * precisely - so when the most recent failure was specifically a 429 (see
+ * `_refreshFailureCause`), retries are spread a quarter of the assumed
+ * window apart instead of firing in the first few seconds: four delays of
+ * {@link RATE_LIMIT_RETRY_DELAY_MS} spend the same 5-attempt budget across
+ * roughly one window's duration, so at least one attempt is likely to land
+ * after whatever reset boundary this IP's bucket actually has, rather than
+ * gambling the whole budget on the first few seconds of it.
+ *
+ * This cannot use the `Retry-After` header the limiter sets (which *would*
+ * name the real remaining time), because `createEndpointClient` returns only
+ * `{status, data}` and discards response headers entirely - reading it would
+ * require a `base-api-client` change. The default window length is the best
+ * available substitute.
+ */
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_RETRY_DELAY_MS = RATE_LIMIT_WINDOW_MS / 4;
+
+/**
+ * Statuses nginx synthesizes itself - never session-manager - when it cannot
+ * reach or times out talking to it. Verified against this deployment's own
+ * config: `infra/scribear-nginx/nginx.conf`'s `location /api/session-manager/`
+ * sets no `error_page` or `proxy_intercept_errors`, so on a connect failure or
+ * timeout nginx returns its own bare response under one of these three
+ * codes - none of which any route schema declares, so `createEndpointClient`
+ * reports them as a plain `UnexpectedResponseError` before ever attempting to
+ * read a body. A `status` in this set is the same "can't reach the service"
+ * story as `InvalidResponseBodyError`, just arriving through the
+ * undeclared-status branch instead of a body-parse failure - see
+ * `_causeFromError` for where the two are folded together.
+ */
+const GATEWAY_ERROR_STATUSES: ReadonlySet<number> = new Set([502, 503, 504]);
+
+/**
  * How many consecutive 1008 closes to tolerate before declaring the session
  * terminal, when the close reason isn't one we recognise as permanent. The
  * kiosk app already treats any 1008 as terminal; the client is a little more
@@ -140,6 +207,30 @@ const PERMANENT_AUTH_CLOSE_REASONS = new Set([
   'missing-scope',
   'session-mismatch',
 ]);
+
+/**
+ * Classify a `createEndpointClient` failure that is neither `null` nor a
+ * `NetworkError` into the two user-facing stories worth telling apart: the
+ * request never reached anything that could answer as session-manager
+ * (`'service-unreachable'`), or it reached something that answered with
+ * content this build doesn't recognize (`'version-mismatch'`). Shared between
+ * the join and refresh paths (see `joinSession` and `_refreshSessionToken`)
+ * so the two don't drift into different definitions of the same distinction.
+ *
+ * `InvalidResponseBodyError` (a declared status with no readable body) and an
+ * `UnexpectedResponseError` on one of {@link GATEWAY_ERROR_STATUSES} (an
+ * undeclared status nginx synthesizes itself) are both folded into
+ * `'service-unreachable'`: to a viewer they mean the same thing - try again
+ * shortly - even though one arrives via a body-parse failure and the other
+ * via the undeclared-status branch, before any body is even read.
+ */
+function classifyUnexpectedResponseError(
+  error: UnexpectedResponseError,
+): 'service-unreachable' | 'version-mismatch' {
+  if (error instanceof InvalidResponseBodyError) return 'service-unreachable';
+  if (GATEWAY_ERROR_STATUSES.has(error.status)) return 'service-unreachable';
+  return 'version-mismatch';
+}
 
 /**
  * Compute a uniform jitter offset in `[-jitter * base, +jitter * base]`.
@@ -254,14 +345,37 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
   private _authFailures = 0;
 
   /**
-   * Whether the most recent refresh failure was session-manager's per-IP rate
-   * limit (429). Only used to word the terminal message once the retry budget
-   * is spent: a rate-limited viewer must not be told to "join again with a new
-   * join code", because a new join code is exchanged over a rate-limited route
-   * too - the advice reproduces the problem, and does it from every seat in
-   * the room at once.
+   * Best-known cause of the most recent refresh failure. Reset on every
+   * success and whenever a fresh session becomes `ACTIVE`. Used for two
+   * things: choosing the terminal message once the retry budget is spent (see
+   * {@link _refreshTerminalMessage}), and - for `'rate-limited'` only -
+   * pacing the retry delay itself (see {@link RATE_LIMIT_RETRY_DELAY_MS}).
+   *
+   * - `'rate-limited'`: session-manager's per-IP limit (429) fired. Nothing
+   *   is wrong with the join code, the session, or this device - a lecture
+   *   hall behind one campus NAT shares a client IP and trips it collectively.
+   *   Self-clearing; the advice must not be "join again with a new join
+   *   code", because a new join code is exchanged over a rate-limited route
+   *   too, reproducing the problem from every seat in the room at once.
+   * - `'service-unreachable'`: see {@link classifyUnexpectedResponseError} -
+   *   either a declared status with no readable body (`InvalidResponseBodyError`),
+   *   or an undeclared status nginx synthesizes itself when it can't reach
+   *   session-manager ({@link GATEWAY_ERROR_STATUSES}). The same "join again"
+   *   trap applies: a new join code goes over the same broken path.
+   * - `'version-mismatch'`: everything else `classifyUnexpectedResponseError`
+   *   sees - a declared status whose body parsed but didn't match this
+   *   client's schema, or some other status this build's schema doesn't know
+   *   at all. Usually means this client and the deployed session-manager are
+   *   out of sync after a partial deploy - a reload can pick up a matching
+   *   build.
+   * - `'other'`: `NetworkError`, or anything not distinguished above. Keeps
+   *   the original "Lost access to this session…" wording.
    */
-  private _refreshRateLimited = false;
+  private _refreshFailureCause:
+    | 'rate-limited'
+    | 'service-unreachable'
+    | 'version-mismatch'
+    | 'other' = 'other';
 
   /**
    * Set once the session has been declared unrecoverable, to keep the
@@ -350,7 +464,12 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
       return;
     }
     if (error !== null) {
-      this.emit('joinError', JoinError.UNKNOWN);
+      this.emit(
+        'joinError',
+        classifyUnexpectedResponseError(error) === 'service-unreachable'
+          ? JoinError.SERVICE_UNREACHABLE
+          : JoinError.VERSION_MISMATCH,
+      );
       this._setLifecycle(ClientLifecycle.IDLE);
       return;
     }
@@ -412,7 +531,7 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
     const epoch = ++this._epoch;
     this._terminal = false;
     this._refreshFailures = 0;
-    this._refreshRateLimited = false;
+    this._refreshFailureCause = 'other';
     this._authFailures = 0;
     this._setLifecycle(ClientLifecycle.ACTIVE);
     this.emit('connectionStatus', SessionConnectionStatus.CONNECTING);
@@ -609,26 +728,46 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
       if (token !== null) return token;
 
       if (this._refreshFailures >= REFRESH_MAX_CONSECUTIVE_FAILURES) {
-        // The generic message sends the user to fetch a new join code. That is
-        // the wrong instruction after a rate limit and an actively harmful one
-        // when a whole room shares the IP that tripped it, so 429 gets its own
-        // wording: the credential is fine, the window just has to roll over.
-        this._enterTerminal(
-          this._refreshRateLimited
-            ? 'Too many people are reconnecting at once, so this session could not renew its access. Wait a minute, then reload this page — you do not need a new join code.'
-            : 'Lost access to this session and could not restore it. Leave the session and join again with a new join code.',
-        );
+        this._enterTerminal(this._refreshTerminalMessage());
         return null;
       }
 
-      const delayMs = Math.min(
-        REFRESH_RETRY_BASE_MS * 2 ** (this._refreshFailures - 1),
-        REFRESH_RETRY_MAX_MS,
-      );
+      // Every cause but a rate limit keeps the original fast exponential
+      // schedule - those are the failures a quick retry can plausibly clear.
+      // A 429 gets a schedule aligned with the limiter's own window instead
+      // of a faster one: see {@link RATE_LIMIT_RETRY_DELAY_MS} for why.
+      const delayMs =
+        this._refreshFailureCause === 'rate-limited'
+          ? RATE_LIMIT_RETRY_DELAY_MS
+          : Math.min(
+              REFRESH_RETRY_BASE_MS * 2 ** (this._refreshFailures - 1),
+              REFRESH_RETRY_MAX_MS,
+            );
       await sleep(delayMs + jitter(delayMs, TOKEN_REFRESH_JITTER));
       if (epoch !== this._epoch || generation !== this._authGeneration) {
         return null;
       }
+    }
+  }
+
+  /**
+   * Word the terminal message once the refresh retry budget is exhausted, by
+   * the cause of the most recent failure (see {@link _refreshFailureCause}).
+   * The generic "join again with a new join code" advice is actively harmful
+   * for the two infrastructure-shaped causes - `exchange-join-code` goes over
+   * the same rate limit, and the same broken proxy/gateway - so both get
+   * their own wording naming what to actually wait on.
+   */
+  private _refreshTerminalMessage(): string {
+    switch (this._refreshFailureCause) {
+      case 'rate-limited':
+        return 'Too many people are reconnecting at once, so this session could not renew its access. Wait a minute, then reload this page — you do not need a new join code.';
+      case 'service-unreachable':
+        return 'Could not reach the session service to renew access. This looks like a network or server problem rather than an issue with this session - wait a few minutes, then reload this page.';
+      case 'version-mismatch':
+        return 'This app could not understand the session service’s response, so it could not renew access. Reload the page to pick up a matching version.';
+      case 'other':
+        return 'Lost access to this session and could not restore it. Leave the session and join again with a new join code.';
     }
   }
 
@@ -638,10 +777,9 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
    * Any other failure returns `null` after charging the consecutive-failure
    * budget; retrying and giving up is {@link _refreshWithBackoff}'s job.
    *
-   * A 429 is charged like any other transient failure - the budget is what
-   * stops the loop hammering a server that is already telling us to slow down
-   * - but it is also recorded in {@link _refreshRateLimited}, because it is the
-   * one failure whose terminal advice has to differ.
+   * Every failure also updates {@link _refreshFailureCause}, because the
+   * budget alone can't say *why* it ran out - and "why" is what decides both
+   * the terminal wording and, for a 429, the retry pacing itself.
    */
   private async _refreshSessionToken(
     identity: SessionIdentity,
@@ -659,14 +797,21 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
     // only thing worth telling the user is the point at which retrying stops.
     if (error !== null) {
       this._refreshFailures++;
-      this._refreshRateLimited = false;
+      // NetworkError (fetch itself failed) has no further story to tell -
+      // 'other'. Everything else goes through the same classifier the join
+      // path uses, so the two don't independently decide what "service
+      // unreachable" vs. "version mismatch" means.
+      this._refreshFailureCause =
+        error instanceof NetworkError
+          ? 'other'
+          : classifyUnexpectedResponseError(error);
       return null;
     }
 
     switch (response.status) {
       case 200:
         this._refreshFailures = 0;
-        this._refreshRateLimited = false;
+        this._refreshFailureCause = 'other';
         return response.data.sessionToken;
       // 401 INVALID_REFRESH_TOKEN: refresh token is no longer usable. Drop
       // the stored identity and return to IDLE so the user can join a new
@@ -689,11 +834,11 @@ export class ClientSessionService extends EventEmitter<ClientSessionServiceEvent
       // user is told if the budget runs out first.
       case 429:
         this._refreshFailures++;
-        this._refreshRateLimited = true;
+        this._refreshFailureCause = 'rate-limited';
         return null;
       default:
         this._refreshFailures++;
-        this._refreshRateLimited = false;
+        this._refreshFailureCause = 'other';
         return null;
     }
   }

--- a/apps/client-webapp/tests/features/session-provider/components/join-session-modal.test.tsx
+++ b/apps/client-webapp/tests/features/session-provider/components/join-session-modal.test.tsx
@@ -110,6 +110,27 @@ describe('JoinSessionModal', () => {
     );
   });
 
+  it('names the service, not the join code, when the response had no readable body', () => {
+    renderIdleDialog({ joinError: JoinError.SERVICE_UNREACHABLE });
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/could not reach the session service/i);
+    expect(alert).toHaveTextContent(/not a problem with your join code/i);
+    expect(alert.className).toContain('MuiAlert-colorError');
+    expect(screen.getByLabelText('Join Code')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+
+  it('tells the user to reload, not just to retry, on a version mismatch', () => {
+    renderIdleDialog({ joinError: JoinError.VERSION_MISMATCH });
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/out of date/i);
+    expect(alert).toHaveTextContent(/reload the page/i);
+  });
+
   it('leaves a failed join attempt reading as an error', () => {
     renderIdleDialog({ joinError: JoinError.JOIN_CODE_NOT_FOUND });
 

--- a/apps/client-webapp/tests/features/session-provider/services/client-session-service.test.ts
+++ b/apps/client-webapp/tests/features/session-provider/services/client-session-service.test.ts
@@ -1,7 +1,11 @@
 import { EventEmitter } from 'eventemitter3';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { NetworkError } from '@scribear/base-api-client';
+import {
+  InvalidResponseBodyError,
+  NetworkError,
+  UnexpectedResponseError,
+} from '@scribear/base-api-client';
 import type { NodeServerClient } from '@scribear/node-server-client';
 import { createNodeServerClient } from '@scribear/node-server-client';
 import {
@@ -592,6 +596,10 @@ describe('ClientSessionService rate limiting', () => {
 
   it('does not tell a rate-limited viewer to fetch a new join code', async () => {
     vi.useFakeTimers();
+    // Zero out jitter so the 4 inter-attempt delays sum to exactly 60s
+    // (4 x 15s) - the point being tested is that they now span the limiter's
+    // own window instead of the ~4.5s the generic exponential schedule took.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
     refreshSessionToken.mockResolvedValue(rateLimited());
     const service = new ClientSessionService();
     const errors: (string | null)[] = [];
@@ -599,11 +607,20 @@ describe('ClientSessionService rate limiting', () => {
 
     service.start(IDENTITY);
     fakeSocket.emit('open');
-    await vi.advanceTimersByTimeAsync(30_000);
+
+    // Short of the new rate-limit-aware schedule's total (4 gaps x 15s: the
+    // 5th and final attempt lands at t=60s): the budget must still have one
+    // attempt left here, unlike the old ~4.5s schedule which would have
+    // already exhausted all 5.
+    await vi.advanceTimersByTimeAsync(50_000);
+    expect(refreshSessionToken).toHaveBeenCalledTimes(4);
+
+    await vi.advanceTimersByTimeAsync(15_000);
 
     // Still bounded - 429 is charged to the same budget as any other
     // transient failure, so the loop converges rather than hammering a server
-    // that is already asking it to stop.
+    // that is already asking it to stop, but now the budget is spent over
+    // roughly the limiter's 60s window instead of in ~4.5s.
     expect(refreshSessionToken).toHaveBeenCalledTimes(5);
     const terminal = errors.at(-1) ?? '';
     // The load-bearing assertion: a new join code is exchanged over a
@@ -614,10 +631,12 @@ describe('ClientSessionService rate limiting', () => {
     expect(terminal).toMatch(/you do not need a new join code/i);
     expect(terminal).toMatch(/too many people are reconnecting/i);
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('keeps the generic terminal wording when the last failure was not a rate limit', async () => {
     vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
     refreshSessionToken
       .mockResolvedValueOnce(rateLimited())
       .mockResolvedValueOnce(rateLimited())
@@ -628,12 +647,122 @@ describe('ClientSessionService rate limiting', () => {
 
     service.start(IDENTITY);
     fakeSocket.emit('open');
-    await vi.advanceTimersByTimeAsync(30_000);
+    // 2 rate-limit-paced gaps (15s each) + 2 fast exponential gaps once the
+    // cause switches to NetworkError (1.2s + 2s) = 33.2s worst case.
+    await vi.advanceTimersByTimeAsync(40_000);
 
     // The flag describes the most recent failure, not "a 429 happened once":
     // a session that started rate-limited and ended up genuinely offline must
     // not be told to wait for a limit window that is no longer the problem.
+    expect(refreshSessionToken).toHaveBeenCalledTimes(5);
     expect(errors.at(-1)).toMatch(/could not restore it/i);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('reports the session service as unreachable, not the join code, on a non-JSON error body', async () => {
+    exchangeJoinCode.mockResolvedValue([
+      null,
+      new InvalidResponseBodyError(
+        500,
+        new SyntaxError('Unexpected end of JSON input'),
+      ),
+    ]);
+    const service = new ClientSessionService();
+    const joinErrors: (JoinError | null)[] = [];
+    service.on('joinError', (error) => joinErrors.push(error));
+
+    await service.joinSession('JOINCODE');
+
+    // A declared status with no readable body - session-manager failing
+    // mid-response, or a dropped connection - is a service/infra symptom,
+    // not a bad join code, so it must not collapse into UNKNOWN.
+    expect(joinErrors).toEqual([null, JoinError.SERVICE_UNREACHABLE]);
+    expect(service.lifecycle).toBe(ClientLifecycle.IDLE);
+  });
+
+  it('also reports the gateway-synthesized statuses as unreachable, not a version mismatch', async () => {
+    // 502/503/504 are undeclared on every route, so `createEndpointClient`
+    // reports them as a plain UnexpectedResponseError without ever attempting
+    // to read a body - and per `infra/scribear-nginx/nginx.conf`'s
+    // `location /api/session-manager/` (no `error_page`/`proxy_intercept_errors`
+    // override), these three are exactly what nginx synthesizes itself when it
+    // cannot reach or times out talking to session-manager. That is a "can't
+    // reach the service" story, not "this build is out of date".
+    for (const status of [502, 503, 504]) {
+      exchangeJoinCode.mockResolvedValue([
+        null,
+        new UnexpectedResponseError(status),
+      ]);
+      const service = new ClientSessionService();
+      const joinErrors: (JoinError | null)[] = [];
+      service.on('joinError', (error) => joinErrors.push(error));
+
+      await service.joinSession('JOINCODE');
+
+      expect(joinErrors).toEqual([null, JoinError.SERVICE_UNREACHABLE]);
+    }
+  });
+
+  it('reports a schema-mismatched join reply as a version mismatch, not UNKNOWN', async () => {
+    // 501 is neither a gateway status nginx would synthesize nor one any
+    // route declares, standing in for "session-manager (or its schema)
+    // answered with something this build doesn't recognize".
+    exchangeJoinCode.mockResolvedValue([
+      null,
+      new UnexpectedResponseError(501),
+    ]);
+    const service = new ClientSessionService();
+    const joinErrors: (JoinError | null)[] = [];
+    service.on('joinError', (error) => joinErrors.push(error));
+
+    await service.joinSession('JOINCODE');
+
+    expect(joinErrors).toEqual([null, JoinError.VERSION_MISMATCH]);
+  });
+
+  it('tells a viewer the session service looked unreachable, not to fetch a new join code, once refresh gives up', async () => {
+    vi.useFakeTimers();
+    refreshSessionToken.mockResolvedValue([
+      null,
+      new InvalidResponseBodyError(500, new SyntaxError('boom')),
+    ]);
+    const service = new ClientSessionService();
+    const errors: (string | null)[] = [];
+    service.on('error', (message) => errors.push(message));
+
+    service.start(IDENTITY);
+    fakeSocket.emit('open');
+    // No rate-limit pacing applies here - InvalidResponseBodyError keeps the
+    // fast exponential schedule, same budget as the "gives up" test above.
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(refreshSessionToken).toHaveBeenCalledTimes(5);
+    const terminal = errors.at(-1) ?? '';
+    expect(terminal).not.toMatch(/join again with a new join code/i);
+    expect(terminal).toMatch(/network or server problem/i);
+    vi.useRealTimers();
+  });
+
+  it('tells a viewer to reload, not to fetch a new join code, when refresh keeps failing schema validation', async () => {
+    vi.useFakeTimers();
+    // 501: neither a gateway status nor one any route declares.
+    refreshSessionToken.mockResolvedValue([
+      null,
+      new UnexpectedResponseError(501),
+    ]);
+    const service = new ClientSessionService();
+    const errors: (string | null)[] = [];
+    service.on('error', (message) => errors.push(message));
+
+    service.start(IDENTITY);
+    fakeSocket.emit('open');
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(refreshSessionToken).toHaveBeenCalledTimes(5);
+    const terminal = errors.at(-1) ?? '';
+    expect(terminal).not.toMatch(/join again with a new join code/i);
+    expect(terminal).toMatch(/reload the page/i);
     vi.useRealTimers();
   });
 });

--- a/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
@@ -2,6 +2,7 @@ import EventEmitter from 'eventemitter3';
 
 import { ClockSync, encodeAudioFrame } from '@scribear/audio-frame-protocol';
 import {
+  InvalidResponseBodyError,
   NetworkError,
   UnexpectedResponseError,
 } from '@scribear/base-api-client';
@@ -306,8 +307,10 @@ function decodeSessionTokenExpiryMs(token: string): number | null {
  * Outcome of one `exchange-device-token` call. A failure always carries the
  * reason it failed and whether retrying could ever help - the previous
  * `string | null` return threw both away, which is why session-manager being
- * down, a 429 from a room full of devices, a 500, and a revoked device cookie
- * were indistinguishable to everyone including the operator.
+ * down, an unreachable gateway, a 500, and a revoked device cookie were
+ * indistinguishable to everyone including the operator. (`exchange-device-
+ * token` has no rate limiter - see `session-auth.router.ts` - so a 429 is not
+ * one of the outcomes this route can ever produce.)
  */
 type TokenFetchResult =
   | { token: string }
@@ -994,8 +997,8 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
 
       // Say which failure this is while it is still retrying. The banner's
       // generic "Connection lost. Reconnecting…" cannot distinguish
-      // session-manager being down from a 429 from a revoked device cookie,
-      // and those want three different people to do three different things.
+      // session-manager being unreachable from a revoked device cookie, and
+      // those want two different people to do two different things.
       this.emit('error', { severity: 'warning', message: result.message });
 
       const delayMs = Math.min(
@@ -1034,10 +1037,34 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
           message: 'Cannot reach the ScribeAR session service. Retrying…',
         };
       }
-      // The only other failure `createEndpointClient` reports is an
-      // undeclared status: a 429 from a room full of devices behind one NAT,
-      // or a 502/503/504 from the gateway. All transient by construction -
-      // everything permanent here is a declared status, handled below.
+      // Checked before the generic UnexpectedResponseError case below because
+      // InvalidResponseBodyError *is* one (subclass) - order matters. No
+      // structured body at all means a declared status arrived with nothing
+      // readable behind it - most plausibly session-manager itself failing
+      // partway through a response it had already started (a crash, an OOM
+      // kill, an exception after headers were sent), or the connection
+      // dropping mid-body. (Not nginx substituting its own error page: this
+      // deployment's `infra/scribear-nginx/nginx.conf` sets no `error_page`/
+      // `proxy_intercept_errors` on `/api/session-manager/`, so nginx only
+      // ever supplies its own body when it can't reach session-manager at
+      // all - and that arrives as an *undeclared* status, handled below,
+      // never reaching a body-parse step in the first place.)
+      if (error instanceof InvalidResponseBodyError) {
+        return {
+          token: null,
+          permanent: false,
+          message: `The session service is unreachable (HTTP ${error.status.toString()} with no readable response). Retrying…`,
+        };
+      }
+      // Everything else `createEndpointClient` reports here is an undeclared
+      // status: `exchange-device-token` has no rate limiter (see
+      // `session-auth.router.ts`), so this is never a 429 - either a genuine
+      // 502/503/504 that nginx synthesized itself because it could not reach
+      // session-manager, or a JSON body that parsed but didn't match this
+      // client's schema (version drift after a partial deploy). Both are
+      // transient by construction; everything permanent here is a declared
+      // status, handled below. A generic "could not issue credentials"
+      // message covers both without guessing which one it is.
       return {
         token: null,
         permanent: false,

--- a/apps/kiosk-webapp/tests/features/kiosk-provider/services/kiosk-service.test.ts
+++ b/apps/kiosk-webapp/tests/features/kiosk-provider/services/kiosk-service.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'eventemitter3';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  InvalidResponseBodyError,
   NetworkError,
   UnexpectedResponseError,
 } from '@scribear/base-api-client';
@@ -773,18 +774,41 @@ describe('KioskService session-token failures (2.4)', () => {
   });
 
   it('names the HTTP status when the session service refuses with an undeclared one', async () => {
+    // 502, not 429: `exchange-device-token` has no rate limiter (see
+    // `session-auth.router.ts`), so it can never produce a 429 - the only
+    // undeclared statuses that reach this branch are gateway codes like this
+    // one (nginx unable to reach session-manager) or a schema mismatch.
     exchangeDeviceToken.mockResolvedValue([
       null,
-      new UnexpectedResponseError(429),
+      new UnexpectedResponseError(502),
     ]);
     const service = await bringToIdle();
     const { faults } = observe(service);
 
     await deliverSchedule([activeSession()]);
 
-    // 429, 500 and "session-manager is down" used to be one indistinguishable
-    // silence; a room full of devices behind one NAT is a real 429 source.
-    expect(faults.at(-1)?.message).toMatch(/HTTP 429/);
+    // 502, 500 and "session-manager is down" used to be one indistinguishable
+    // silence.
+    expect(faults.at(-1)?.message).toMatch(/HTTP 502/);
+    expect(faults.at(-1)?.severity).toBe('warning');
+  });
+
+  it('names the service as unreachable, not just an HTTP status, on a non-JSON error body', async () => {
+    // A declared status (500) with nothing readable behind it - the fixed
+    // `createEndpointClient` bug this whole feature exists to consume. Before
+    // this, the promise chain would have escaped the `[response, error]`
+    // tuple entirely; now it reports a specific, distinguishable cause.
+    exchangeDeviceToken.mockResolvedValue([
+      null,
+      new InvalidResponseBodyError(500, new SyntaxError('boom')),
+    ]);
+    const service = await bringToIdle();
+    const { faults } = observe(service);
+
+    await deliverSchedule([activeSession()]);
+
+    expect(faults.at(-1)?.message).toMatch(/unreachable/i);
+    expect(faults.at(-1)?.message).toMatch(/HTTP 500/);
     expect(faults.at(-1)?.severity).toBe('warning');
   });
 

--- a/apps/session-manager/.env.example
+++ b/apps/session-manager/.env.example
@@ -75,3 +75,25 @@ DB_PASSWORD=CHANGEME
 #### Empty (the default) seeds nothing and leaves the canary switched off.
 #### Changing it and restarting rotates the credential.
 # CANARY_DEVICE_SECRET=
+
+#### Per-client-IP rate limits on the two unauthenticated credential-exchange
+#### routes. Every default and the reasoning behind it lives on
+#### SessionAuthRateLimitConfig in the session-auth router; the short version
+#### is that these are volumetric/CPU backstops plus one anti-guessing cap, not
+#### credential-guessing defences (an 8-character code from a 36-character
+#### alphabet is ~2.8e12 possibilities, so no per-minute number makes brute
+#### force meaningfully harder).
+####
+#### The values below ARE the defaults - leave them commented unless a
+#### deployment needs different ones. The one most likely to need raising is
+#### SESSION_AUTH_RATE_LIMIT_REFRESH_MAX, whose default is sized for ~2,500
+#### concurrent viewers behind a single egress IP; a campus that NATs more
+#### than that through one address, or that fronts nginx with a proxy without
+#### enabling set_real_ip_from (which makes every request look like it came
+#### from the proxy), should raise it.
+# SESSION_AUTH_RATE_LIMIT_JOIN_CODE_MAX=600
+# SESSION_AUTH_RATE_LIMIT_JOIN_CODE_WINDOW_SEC=60
+# SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_MAX=100
+# SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_WINDOW_SEC=60
+# SESSION_AUTH_RATE_LIMIT_REFRESH_MAX=1000
+# SESSION_AUTH_RATE_LIMIT_REFRESH_WINDOW_SEC=60

--- a/apps/session-manager/src/app-config/app-config.ts
+++ b/apps/session-manager/src/app-config/app-config.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_MATERIALIZATION_WORKER_CONFIG,
   type MaterializationWorkerConfig,
 } from '#src/server/features/schedule-management/materialization.worker.js';
+import type { SessionAuthRateLimitConfig } from '#src/server/features/session-auth/session-auth.router.js';
 import type { AdminAuthConfig } from '#src/server/shared/services/admin-auth.service.js';
 import type { DevicePresenceConfig } from '#src/server/shared/services/device-presence.service.js';
 import type { ServiceAuthConfig } from '#src/server/shared/services/service-auth.service.js';
@@ -112,6 +113,41 @@ const CONFIG_SCHEMA = Type.Object({
     minLength: 1,
     default: SHIPPED_TRANSCRIPTION_PROVIDER_IDS.join(','),
   }),
+
+  // Per-client-IP rate limits on the two unauthenticated credential-exchange
+  // routes. Every default and the reasoning behind it lives on
+  // `SessionAuthRateLimitConfig` in the session-auth router, next to the routes
+  // they apply to; the short version is that these are volumetric/CPU backstops
+  // and one anti-guessing cap, not credential-guessing defences.
+  //
+  // The one an operator is most likely to need: a deployment whose viewers all
+  // egress through a single campus NAT should raise
+  // SESSION_AUTH_RATE_LIMIT_REFRESH_MAX, which the shipped default sizes for
+  // ~2,500 concurrent viewers behind one IP.
+  SESSION_AUTH_RATE_LIMIT_JOIN_CODE_MAX: Type.Integer({
+    minimum: 1,
+    default: 600,
+  }),
+  SESSION_AUTH_RATE_LIMIT_JOIN_CODE_WINDOW_SEC: Type.Integer({
+    minimum: 1,
+    default: 60,
+  }),
+  SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_MAX: Type.Integer({
+    minimum: 1,
+    default: 100,
+  }),
+  SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_WINDOW_SEC: Type.Integer({
+    minimum: 1,
+    default: 60,
+  }),
+  SESSION_AUTH_RATE_LIMIT_REFRESH_MAX: Type.Integer({
+    minimum: 1,
+    default: 1_000,
+  }),
+  SESSION_AUTH_RATE_LIMIT_REFRESH_WINDOW_SEC: Type.Integer({
+    minimum: 1,
+    default: 60,
+  }),
 });
 
 export interface BaseConfig {
@@ -158,6 +194,12 @@ export interface CanaryRoomConfig {
    */
   deviceSecret: string;
 }
+
+/**
+ * Seconds-to-milliseconds, for the env vars that are expressed in seconds
+ * because that is the unit an operator thinks in.
+ */
+const SECOND_MS = 1_000;
 
 export class AppConfig {
   private _isDevelopment: boolean;
@@ -233,6 +275,22 @@ export class AppConfig {
       transcriptionProviderIds: this._env.TRANSCRIPTION_PROVIDER_IDS.split(',')
         .map((id) => id.trim())
         .filter((id) => id !== ''),
+    };
+  }
+
+  get sessionAuthRateLimitConfig(): SessionAuthRateLimitConfig {
+    return {
+      exchangeJoinCodeMax: this._env.SESSION_AUTH_RATE_LIMIT_JOIN_CODE_MAX,
+      exchangeJoinCodeWindowMs:
+        this._env.SESSION_AUTH_RATE_LIMIT_JOIN_CODE_WINDOW_SEC * SECOND_MS,
+      failedExchangeJoinCodeMax:
+        this._env.SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_MAX,
+      failedExchangeJoinCodeWindowMs:
+        this._env.SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_WINDOW_SEC *
+        SECOND_MS,
+      refreshSessionTokenMax: this._env.SESSION_AUTH_RATE_LIMIT_REFRESH_MAX,
+      refreshSessionTokenWindowMs:
+        this._env.SESSION_AUTH_RATE_LIMIT_REFRESH_WINDOW_SEC * SECOND_MS,
     };
   }
 

--- a/apps/session-manager/src/server/create-server.ts
+++ b/apps/session-manager/src/server/create-server.ts
@@ -35,7 +35,12 @@ async function createServer(config: AppConfig) {
 
   // Rate limiting is opt-in per route (`global: false`); only the
   // unauthenticated credential-exchange routes enable it (see session-auth
-  // router). Long-poll and admin/service routes are intentionally unlimited.
+  // router, whose `SessionAuthRateLimitConfig` documents every limit and how
+  // its default was derived). Long-poll and admin/service routes are
+  // intentionally unlimited. Registered before the routers because per-route
+  // `config.rateLimit` is applied by this plugin's `onRoute` hook, and because
+  // the session-auth router calls `fastify.createRateLimit()` at registration
+  // time for its failed-exchange cap.
   // Throw a BaseHttpError so the base error handler serializes it as 429.
   await fastify.register(fastifyRateLimit, {
     global: false,
@@ -49,7 +54,7 @@ async function createServer(config: AppConfig) {
   fastify.register(deviceManagementRouter);
   fastify.register(roomManagementRouter);
   fastify.register(scheduleManagementRouter);
-  fastify.register(sessionAuthRouter);
+  fastify.register(sessionAuthRouter, config.sessionAuthRateLimitConfig);
   fastify.register(demoRoomRouter);
   fastify.register(databaseRouter);
 

--- a/apps/session-manager/src/server/features/session-auth/session-auth.router.ts
+++ b/apps/session-manager/src/server/features/session-auth/session-auth.router.ts
@@ -1,3 +1,6 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { HttpError } from '@scribear/base-fastify-server';
 import type { BaseFastifyInstance } from '@scribear/base-fastify-server';
 import {
   ADMIN_FETCH_JOIN_CODE_ROUTE,
@@ -16,7 +19,154 @@ import resolveHandler from '#src/server/dependency-injection/resolve-handler.js'
 import { adminApiKeyHook } from '#src/server/hooks/admin-api-key.hook.js';
 import { deviceTokenHook } from '#src/server/hooks/device-token.hook.js';
 
-export function sessionAuthRouter(fastify: BaseFastifyInstance) {
+/**
+ * Per-client-IP limits for the two unauthenticated credential-exchange routes,
+ * plus the outcome-conditional cap on *failed* join-code exchanges. Supplied by
+ * `AppConfig.sessionAuthRateLimitConfig`; every value is an env var rather than
+ * a literal here, for the same two reasons admin-server moved its limits into
+ * config: the right number depends on how many viewers a deployment puts behind
+ * one egress IP, and a hard-coded limit forced the integration tests to spend a
+ * real 60-second window to reach it.
+ *
+ * MEASURED INPUTS the shipped defaults are derived from.
+ *
+ * - Session tokens live 5 minutes (`SESSION_TOKEN_LIFETIME_MS` in
+ *   `session-auth.service.ts`) and client-webapp re-refreshes at 50% of the
+ *   *remaining* lifetime (`TOKEN_REFRESH_FRACTION`, ±10% jitter), so one viewer
+ *   refreshes about every 150 s. N viewers behind one NAT therefore produce
+ *   `N/150` refreshes per second in steady state.
+ * - `refresh-session-token` runs one bcrypt cost-12 `compare` per call
+ *   (`HASH_SALT_ROUNDS = 12` in `hash.service.ts`). Measured on a 20-core dev
+ *   box: **154 ms per compare**, and **~25 compares/s** in aggregate with
+ *   node's default 4-thread libuv pool. A *successful* `exchange-join-code`
+ *   runs one bcrypt cost-12 `hash` (for the refresh token) at the same cost; a
+ *   *failed* one runs none — it is a single indexed SELECT.
+ * - Join codes are 8 characters drawn from a 36-character alphabet
+ *   (`generate-random-code.ts`), so ~2.8×10¹² codes, each valid for 5 minutes
+ *   (`JOIN_CODE_DURATION_MS`).
+ *
+ * WHY THE PREVIOUS 100 / 60 s WAS WRONG. It was calibrated as if it were a
+ * credential-guessing defence. It is not one and cannot be: with even a few
+ * thousand codes live at once a single guess lands with probability ~10⁻⁹, so
+ * one IP guessing flat out at 600/min needs ~16 days for a 1% chance of a
+ * single hit. Brute force is hopeless at 100/min and equally hopeless at
+ * 100,000/min. What 100 / 60 s *did* do was fire on ordinary traffic: refresh
+ * alone crosses it when `N/150 > 100/60`, i.e. at **N ≈ 250 viewers**, so a
+ * 250-seat hall behind one campus NAT 429s continuously in steady state with
+ * nobody doing anything unusual — and `exchange-join-code` trips earlier still,
+ * since 100 joins in the first minute of class is roughly a 150-person lecture.
+ *
+ * WHAT THESE LIMITS ARE FOR INSTEAD: bounding the CPU a single source can
+ * claim, and stopping a single runaway client. Note that none of them is a
+ * service-wide capacity control — that ceiling is the bcrypt threadpool
+ * (~25 calls/s in total, measured above) and it is global, not per-IP. Raising
+ * a per-IP limit does not raise it.
+ *
+ * WHO ACTUALLY CALLS THESE ROUTES. Only client-webapp viewers. The kiosk
+ * re-mints its token through `exchange-device-token` (`kiosk-service.ts`
+ * `_refreshSessionToken`), and the monitoring canary authenticates the same
+ * way; neither route is rate-limited, so neither shows up in the model above.
+ * Viewer count is therefore the whole of the legitimate load. The only repo
+ * tooling that spends from the failed-exchange budget is
+ * `tools/session-corner-cases`, which submits two deliberately bad join codes
+ * per run.
+ *
+ * WHAT "PER IP" ACTUALLY MEANS HERE. `create-server.ts` sets `trustProxy: 1`
+ * and `infra/scribear-nginx/nginx.conf` appends the peer address to
+ * `X-Forwarded-For`, so `req.ip` is the client address *as nginx saw it*, and
+ * nginx applies no `limit_req` of its own — these limits are the only rate
+ * control in the stack. But nginx's `set_real_ip_from` block is commented out
+ * by default, deliberately (see the reasoning in nginx.conf), so a deployment
+ * that puts a load balancer or CDN in front of that container without enabling
+ * it gives every request the front proxy's address, and these stop being
+ * per-client limits and become **deployment-wide** ones. That topology is the
+ * sharpest argument for the raised defaults: at the old 100 / 60 s it capped a
+ * whole deployment at ~250 concurrent viewers, not ~250 per NAT.
+ */
+export interface SessionAuthRateLimitConfig {
+  /**
+   * Volumetric per-IP cap on `exchange-join-code`, successful or not.
+   *
+   * Default 600 / 60 s. Sized so a 1,000-seat hall behind one NAT can all join
+   * inside ~100 s without touching it. The upper bound comes from the other
+   * side: 600 *successful* joins in a minute is 600 × 154 ms ≈ 92 CPU-seconds
+   * of bcrypt, i.e. ~1.5 of the 4 libuv threads held by a single IP, which is
+   * about the most one source should be able to take.
+   */
+  exchangeJoinCodeMax: number;
+  exchangeJoinCodeWindowMs: number;
+
+  /**
+   * Per-IP cap on join-code exchanges that come back **404
+   * `JOIN_CODE_NOT_FOUND`**. This is the actual anti-guessing control; the
+   * volumetric cap above is a load backstop.
+   *
+   * Default 100 / 60 s — 6× tighter than the volumetric cap, and roughly twice
+   * the worst legitimate burst modelled: a 250-seat hall joining at once with a
+   * (pessimistic) 20% first-attempt typo rate produces ~50 404s in the same
+   * minute. Its job is to bound and *surface* guessing (the block is logged
+   * with the client IP), not to prevent it — the 2.8×10¹² code space already
+   * does that, as the arithmetic above shows. Tighter would buy no security and
+   * would start locking real rooms out.
+   *
+   * KEYED ON THE CLIENT IP, NEVER ON THE SUBMITTED JOIN CODE. Keying a limiter
+   * on the credential being guessed hands the guesser a fresh bucket per guess,
+   * which is strictly worse than having no limiter at all.
+   *
+   * COUNTED ONLY ON THE FAILURE. `@fastify/rate-limit` cannot do
+   * outcome-conditional counting through `config.rateLimit` — that hook runs
+   * before the handler — so this uses `fastify.createRateLimit()`, the manual
+   * API added in v11: a `preHandler` peeks with `{ increment: false }` and an
+   * `onSend` hook charges the bucket with `{ increment: true }` only when the
+   * reply is a 404. A successful join never spends from this budget, so a full
+   * lecture hall never approaches it.
+   *
+   * 410 `JOIN_CODE_EXPIRED` is deliberately **not** charged. A guesser
+   * essentially never produces one — they would have had to guess a real code
+   * out of 2.8×10¹² to be told it had expired — whereas a stale code left on a
+   * projector makes an entire room produce one at the same instant. Charging
+   * that would lock the room out of joining even after the presenter fixes the
+   * display, which is the exact class of mistake this recalibration exists to
+   * remove.
+   */
+  failedExchangeJoinCodeMax: number;
+  failedExchangeJoinCodeWindowMs: number;
+
+  /**
+   * Volumetric per-IP cap on `refresh-session-token`.
+   *
+   * Default 1,000 / 60 s. This is the route that failed in steady state, and it
+   * is also the weakest guessing surface in the service — a refresh token is
+   * `{uuid}:{32 random bytes, base64url}`, i.e. 256 bits of secret checked
+   * against the DB, so guessing is not a threat model at any rate. 1,000 / 60 s
+   * covers 2,500 viewers behind one NAT in steady state (2500/150 ≈ 16.7/s),
+   * comfortably more than any single lecture hall, and absorbs a whole-hall
+   * reconnect burst for halls up to ~1,000 seats.
+   *
+   * NOT exempted altogether, for two reasons. First, this is the most expensive
+   * unauthenticated call in the service: one bcrypt cost-12 compare, 154 ms of
+   * libuv threadpool, measured. Second, this codebase has already seen a single
+   * client hammer this route in an unbounded ~1 s loop — see
+   * `REFRESH_MAX_CONSECUTIVE_FAILURES` in client-webapp's
+   * `client-session-service.ts`, which exists because of it. 1,000 / 60 s is
+   * ~17× that runaway rate, so the limit still catches the runaway while never
+   * firing on a lecture hall.
+   */
+  refreshSessionTokenMax: number;
+  refreshSessionTokenWindowMs: number;
+}
+
+/**
+ * The only reply status charged to the failed-join-code budget. See
+ * {@link SessionAuthRateLimitConfig.failedExchangeJoinCodeMax} for why 410 is
+ * excluded and 200 obviously is.
+ */
+const GUESSED_JOIN_CODE_STATUS = 404;
+
+export function sessionAuthRouter(
+  fastify: BaseFastifyInstance,
+  opts: SessionAuthRateLimitConfig,
+) {
   fastify.route({
     ...FETCH_JOIN_CODE_ROUTE,
     schema: FETCH_JOIN_CODE_SCHEMA,
@@ -38,9 +188,86 @@ export function sessionAuthRouter(fastify: BaseFastifyInstance) {
     handler: resolveHandler('sessionAuthController', 'exchangeDeviceToken'),
   });
 
+  // ONE limiter instance, invoked twice below with different `callOptions`.
+  // `createRateLimit` builds a fresh child store on every call, so calling it
+  // twice would give the peek and the charge separate buckets and the cap would
+  // never fire. The default key generator is `req.ip` - see
+  // `SessionAuthRateLimitConfig.failedExchangeJoinCodeMax` for why keying on the
+  // submitted join code would be actively harmful.
+  const failedJoinCodeLimit = fastify.createRateLimit({
+    max: opts.failedExchangeJoinCodeMax,
+    timeWindow: opts.failedExchangeJoinCodeWindowMs,
+  });
+
+  /**
+   * `preHandler`: reject the request when this IP has already spent its
+   * failed-exchange budget. Reads the counter without incrementing it, so the
+   * only thing that ever charges the budget is an actual 404.
+   */
+  async function rejectSuspectedJoinCodeGuessing(
+    req: FastifyRequest,
+    reply: FastifyReply,
+  ) {
+    const state = await failedJoinCodeLimit(req, { increment: false });
+    // `isAllowed: true` is the allow-list short circuit; there is no allow list
+    // configured, so in practice the other branch is always taken.
+    if (state.isAllowed || state.remaining > 0) return;
+
+    // Set for parity with the volumetric limiter's 429, which sets it by
+    // default. No client in this repo can read it yet - `createEndpointClient`
+    // discards response headers - so nothing may promise a countdown.
+    reply.header('retry-after', String(state.ttlInSeconds));
+
+    // The operational half of this control: guessing is far too slow to
+    // succeed, but it should not be invisible while it happens.
+    req.log.warn(
+      {
+        clientIp: req.ip,
+        max: state.max,
+        timeWindowMs: state.timeWindow,
+      },
+      'Blocking join-code exchange: failed-attempt budget exhausted for this client IP',
+    );
+
+    throw HttpError.rateLimited('Too many requests. Please retry shortly.');
+  }
+
+  /**
+   * `onSend`: charge the failed-exchange budget, and only then.
+   *
+   * `onSend` rather than `onResponse` on purpose. `onResponse` fires off the
+   * socket's `finish` event, so it is not ordered against the *next* request:
+   * a burst of concurrent guesses could all pass the `preHandler` peek before
+   * any of them had been charged, which is the one traffic shape this cap is
+   * supposed to stop. `onSend` is part of the awaited request lifecycle, so the
+   * charge has landed before the guesser is told anything. The store is
+   * in-memory and synchronous, so this adds no measurable latency.
+   */
+  async function chargeFailedJoinCodeExchange(
+    req: FastifyRequest,
+    reply: FastifyReply,
+    payload: unknown,
+  ) {
+    if (reply.statusCode !== GUESSED_JOIN_CODE_STATUS) return payload;
+    try {
+      await failedJoinCodeLimit(req, { increment: true });
+    } catch (err) {
+      // The reply is already built and the user sees the same 404 either way,
+      // so there is nothing to tell the client. But a store failure silently
+      // weakens the cap, so it must not be swallowed without a trace.
+      req.log.warn(
+        { err },
+        'Could not charge the failed-join-code rate limit; the cap is degraded',
+      );
+    }
+    return payload;
+  }
+
   // The next two routes are intentionally unauthenticated: the join code and
   // the refresh token themselves serve as the credential. They are the
-  // credential-guessing surface, so they are rate-limited per client IP.
+  // credential-guessing surface, so they are rate-limited per client IP - see
+  // `SessionAuthRateLimitConfig` above for what each limit is actually for and
+  // how its default was derived.
   //
   // These are the *only* rate-limited routes in this service - the plugin is
   // registered with `global: false` (see create-server.ts) - which is why 429
@@ -52,14 +279,26 @@ export function sessionAuthRouter(fastify: BaseFastifyInstance) {
   fastify.route({
     ...EXCHANGE_JOIN_CODE_ROUTE,
     schema: EXCHANGE_JOIN_CODE_SCHEMA,
-    config: { rateLimit: { max: 100, timeWindow: 60_000 } },
+    config: {
+      rateLimit: {
+        max: opts.exchangeJoinCodeMax,
+        timeWindow: opts.exchangeJoinCodeWindowMs,
+      },
+    },
+    preHandler: rejectSuspectedJoinCodeGuessing,
+    onSend: chargeFailedJoinCodeExchange,
     handler: resolveHandler('sessionAuthController', 'exchangeJoinCode'),
   });
 
   fastify.route({
     ...REFRESH_SESSION_TOKEN_ROUTE,
     schema: REFRESH_SESSION_TOKEN_SCHEMA,
-    config: { rateLimit: { max: 100, timeWindow: 60_000 } },
+    config: {
+      rateLimit: {
+        max: opts.refreshSessionTokenMax,
+        timeWindow: opts.refreshSessionTokenWindowMs,
+      },
+    },
     handler: resolveHandler('sessionAuthController', 'refreshSessionToken'),
   });
 }

--- a/apps/session-manager/tests/integration/features/session-auth/session-auth.rate-limit.routes.test.ts
+++ b/apps/session-manager/tests/integration/features/session-auth/session-auth.rate-limit.routes.test.ts
@@ -6,53 +6,74 @@ import {
   REFRESH_SESSION_TOKEN_SCHEMA,
 } from '@scribear/session-manager-schema';
 
-import { useServer } from '#tests/utils/use-server.js';
+import { useDb } from '#tests/utils/use-db.js';
+import { ADMIN_HEADER, useServer } from '#tests/utils/use-server.js';
 
+const DEVICE_BASE = '/api/session-manager/v1/device-management';
+const ROOM_BASE = '/api/session-manager/v1/room-management';
+const SCHEDULE_BASE = '/api/session-manager/v1/schedule-management';
 const SESSION_AUTH_BASE = '/api/session-manager/v1/session-auth';
 
 /**
- * Mirrors `config.rateLimit.max` on both credential-exchange routes in
- * `session-auth.router.ts`. Not imported from there: the router hard-codes it,
- * and the point of these tests is that the *declared contract* matches what
- * the limiter actually emits, so duplicating the number keeps the assertion
- * honest if someone changes one and not the other.
+ * Small enough to reach in a handful of requests. Before the limits moved into
+ * `AppConfig` these tests had to send 100 real requests per route to reach a
+ * hard-coded ceiling, and then left both routes limited for the remainder of a
+ * real 60-second window - which is why they lived in a file of their own with
+ * a warning attached. They still get their own `useServer` per scenario,
+ * because `@fastify/rate-limit`'s default store is in-memory and per-instance,
+ * so a fresh server is a fresh budget; but nothing here spends real time now.
+ *
+ * `useServer`'s defaults leave every limit effectively unlimited, so each
+ * `describe` below tightens exactly the one limit it is about and proves the
+ * others did not fire.
  */
-const RATE_LIMIT_MAX = 100;
+const TINY_MAX = 3;
+
+/** Long enough that no test can accidentally roll over into a fresh window. */
+const WINDOW_MS = 60_000;
+
+type Server = ReturnType<typeof useServer>;
+
+function post(server: Server, url: string, body: Record<string, unknown>) {
+  return server.fastify.inject({ method: 'POST', url, body });
+}
 
 /**
- * These tests deliberately burn a whole rate-limit window, which leaves both
- * routes limited for the remainder of the 60 s window. They therefore live in
- * their own file with their own `useServer()` - `@fastify/rate-limit`'s
- * default store is in-memory and per-instance, so a fresh server is a fresh
- * budget, and the main `session-auth.routes.test.ts` suite is unaffected.
+ * Spend `count` requests on `url`, asserting along the way that nothing 429s
+ * early (which would mean a previous test leaked into this one).
  */
+async function spend(
+  server: Server,
+  url: string,
+  body: Record<string, unknown>,
+  count: number,
+) {
+  for (let i = 0; i < count; i++) {
+    const res = await post(server, url, body);
+    expect(res.statusCode).not.toBe(429);
+  }
+}
+
 describe('Session Auth rate limiting', () => {
-  const server = useServer();
+  describe('POST /exchange-join-code - volumetric cap', (it) => {
+    const server = useServer({
+      sessionAuthRateLimitConfig: {
+        exchangeJoinCodeMax: TINY_MAX,
+        exchangeJoinCodeWindowMs: WINDOW_MS,
+      },
+    });
+    const url = `${SESSION_AUTH_BASE}/exchange-join-code`;
 
-  function post(url: string, body: Record<string, unknown>) {
-    return server.fastify.inject({ method: 'POST', url, body });
-  }
-
-  /**
-   * Spend the whole window on `url`, asserting along the way that nothing 429s
-   * early (which would mean a previous test leaked into this one).
-   */
-  async function exhaustWindow(url: string, body: Record<string, unknown>) {
-    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
-      const res = await post(url, body);
-      expect(res.statusCode).not.toBe(429);
-    }
-  }
-
-  describe('POST /exchange-join-code', (it) => {
     it('answers a rate-limited join with a 429 the route declares', async () => {
       // Arrange - an unknown join code 404s, which still counts against the
-      // limit. The limiter runs before the handler, so no fixtures are needed.
-      const url = `${SESSION_AUTH_BASE}/exchange-join-code`;
-      await exhaustWindow(url, { joinCode: 'NOPE0000' });
+      // volumetric limit. The limiter runs before the handler, so no fixtures
+      // are needed. (The *failed*-exchange cap is left unlimited by
+      // `useServer`'s defaults, so the 429 below can only be the volumetric
+      // one.)
+      await spend(server, url, { joinCode: 'NOPE0000' }, TINY_MAX);
 
       // Act
-      const res = await post(url, { joinCode: 'NOPE0000' });
+      const res = await post(server, url, { joinCode: 'NOPE0000' });
 
       // Assert - the body is the canonical ErrorReply shape, and it validates
       // against the schema the route declares for 429. That check is exactly
@@ -69,9 +90,7 @@ describe('Session Auth rate limiting', () => {
 
     it('sets retry-after on the 429, in seconds', async () => {
       // Arrange - the window from the previous test is still spent.
-      const res = await post(`${SESSION_AUTH_BASE}/exchange-join-code`, {
-        joinCode: 'NOPE0000',
-      });
+      const res = await post(server, url, { joinCode: 'NOPE0000' });
 
       // Assert - the header is real (so a future client that can read headers
       // has something to use), but it is never larger than the window, and
@@ -81,7 +100,7 @@ describe('Session Auth rate limiting', () => {
       const retryAfter = Number(res.headers['retry-after']);
       expect(Number.isNaN(retryAfter)).toBe(false);
       expect(retryAfter).toBeGreaterThan(0);
-      expect(retryAfter).toBeLessThanOrEqual(60);
+      expect(retryAfter).toBeLessThanOrEqual(WINDOW_MS / 1000);
     });
 
     it('does not limit routes that never opted in', async () => {
@@ -100,17 +119,24 @@ describe('Session Auth rate limiting', () => {
     });
   });
 
-  describe('POST /refresh-session-token', (it) => {
+  describe('POST /refresh-session-token - volumetric cap', (it) => {
+    const server = useServer({
+      sessionAuthRateLimitConfig: {
+        refreshSessionTokenMax: TINY_MAX,
+        refreshSessionTokenWindowMs: WINDOW_MS,
+      },
+    });
+    const url = `${SESSION_AUTH_BASE}/refresh-session-token`;
+
     it('answers a rate-limited refresh with a 429 the route declares', async () => {
       // Arrange - a malformed refresh token 401s without touching the DB,
-      // which is the cheapest way to spend the window on this route. Its
-      // budget is independent of exchange-join-code's: `@fastify/rate-limit`
-      // gives every route with its own `config.rateLimit` its own store.
-      const url = `${SESSION_AUTH_BASE}/refresh-session-token`;
-      await exhaustWindow(url, { sessionRefreshToken: 'not-a-real-token' });
+      // which is the cheapest way to spend the window on this route.
+      await spend(server, url, { sessionRefreshToken: 'not-a-real-token' }, 3);
 
       // Act
-      const res = await post(url, { sessionRefreshToken: 'not-a-real-token' });
+      const res = await post(server, url, {
+        sessionRefreshToken: 'not-a-real-token',
+      });
 
       // Assert
       expect(res.statusCode).toBe(429);
@@ -118,6 +144,193 @@ describe('Session Auth rate limiting', () => {
       expect(
         Value.Check(REFRESH_SESSION_TOKEN_SCHEMA.response[429], res.json()),
       ).toBe(true);
+    });
+
+    it('keeps a separate budget from exchange-join-code', async () => {
+      // Arrange - refresh is still exhausted from the previous test. Every
+      // route with its own `config.rateLimit` gets its own store, and the two
+      // limits are now separate config values as well; a shared bucket would
+      // mean tuning one silently retuned the other.
+      const res = await post(
+        server,
+        `${SESSION_AUTH_BASE}/exchange-join-code`,
+        {
+          joinCode: 'NOPE0000',
+        },
+      );
+
+      // 404 (no such code), emphatically not 429.
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('POST /exchange-join-code - failed-attempt cap', (it) => {
+    const server = useServer({
+      sessionAuthRateLimitConfig: {
+        failedExchangeJoinCodeMax: TINY_MAX,
+        failedExchangeJoinCodeWindowMs: WINDOW_MS,
+      },
+    });
+    const url = `${SESSION_AUTH_BASE}/exchange-join-code`;
+
+    it('blocks after the configured number of 404s, with the declared 429', async () => {
+      // Arrange - the volumetric cap is left unlimited by `useServer`'s
+      // defaults, so this 429 can only be the failed-attempt cap.
+      await spend(server, url, { joinCode: 'AAAA0000' }, TINY_MAX);
+
+      // Act
+      const res = await post(server, url, { joinCode: 'AAAA0000' });
+
+      // Assert
+      expect(res.statusCode).toBe(429);
+      expect(res.json<{ code: string }>().code).toBe('RATE_LIMITED');
+      expect(
+        Value.Check(EXCHANGE_JOIN_CODE_SCHEMA.response[429], res.json()),
+      ).toBe(true);
+      expect(Number(res.headers['retry-after'])).toBeGreaterThan(0);
+    });
+  });
+
+  describe('POST /exchange-join-code - failed-attempt cap keying', (it) => {
+    const server = useServer({
+      sessionAuthRateLimitConfig: {
+        failedExchangeJoinCodeMax: TINY_MAX,
+        failedExchangeJoinCodeWindowMs: WINDOW_MS,
+      },
+    });
+    const url = `${SESSION_AUTH_BASE}/exchange-join-code`;
+
+    it('counts guesses of DIFFERENT codes into the same per-IP bucket', async () => {
+      // This is the trap the design note in the router warns about: keying the
+      // limiter on the submitted join code would hand a guesser a fresh bucket
+      // per guess, making the control strictly worse than nothing. A guesser
+      // never repeats a code, so a per-code bucket would never fire - which is
+      // exactly what this asserts is not happening.
+      await spend(server, url, { joinCode: 'AAAA0001' }, 1);
+      await spend(server, url, { joinCode: 'BBBB0002' }, 1);
+      await spend(server, url, { joinCode: 'CCCC0003' }, 1);
+
+      const res = await post(server, url, { joinCode: 'DDDD0004' });
+
+      expect(res.statusCode).toBe(429);
+    });
+  });
+
+  describe('POST /exchange-join-code - what the failed-attempt cap ignores', (it) => {
+    const server = useServer({
+      sessionAuthRateLimitConfig: {
+        failedExchangeJoinCodeMax: TINY_MAX,
+        failedExchangeJoinCodeWindowMs: WINDOW_MS,
+      },
+    });
+    const dbContext = useDb([
+      'session_join_codes',
+      'session_refresh_tokens',
+      'sessions',
+      'rooms',
+      'devices',
+    ]);
+    const url = `${SESSION_AUTH_BASE}/exchange-join-code`;
+
+    /**
+     * A registered source device, a room, and a live on-demand session. The
+     * device is never activated: only the device-token routes need that, and
+     * nothing here calls one.
+     */
+    async function setupLiveSession(): Promise<string> {
+      const device = await server.fastify
+        .inject({
+          method: 'POST',
+          url: `${DEVICE_BASE}/register-device`,
+          headers: { authorization: ADMIN_HEADER },
+          body: { name: 'Rate Limit Source' },
+        })
+        .then((res) => res.json<{ deviceUid: string }>());
+
+      const roomUid = await server.fastify
+        .inject({
+          method: 'POST',
+          url: `${ROOM_BASE}/create-room`,
+          headers: { authorization: ADMIN_HEADER },
+          body: {
+            name: 'Rate Limit Room',
+            timezone: 'America/New_York',
+            autoSessionEnabled: false,
+            sourceDeviceUids: [device.deviceUid],
+          },
+        })
+        .then((res) => res.json<{ uid: string }>().uid);
+
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SCHEDULE_BASE}/create-on-demand-session`,
+        headers: { authorization: ADMIN_HEADER },
+        body: {
+          roomUid,
+          name: 'Rate Limit Session',
+          joinCodeScopes: ['RECEIVE_TRANSCRIPTIONS'],
+          transcriptionProviderId: 'whisper',
+          transcriptionStreamConfig: {},
+        },
+      });
+      // Asserted, not assumed: a fixture that quietly 400s would leave every
+      // test below exchanging against a session that does not exist, and they
+      // would all pass while proving nothing.
+      expect(res.statusCode).toBe(201);
+      return res.json<{ uid: string }>().uid;
+    }
+
+    async function mintJoinCode(sessionUid: string): Promise<string> {
+      const res = await server.fastify.inject({
+        method: 'POST',
+        url: `${SESSION_AUTH_BASE}/admin-fetch-join-code`,
+        headers: { authorization: ADMIN_HEADER },
+        body: { sessionUid },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{ status: string; joinCode: string | null }>();
+      expect(body.status).toBe('ok');
+      return body.joinCode!;
+    }
+
+    it('does not spend the budget on successful exchanges', async () => {
+      // Arrange - a real, live join code. A code is exchangeable any number of
+      // times within its window (each exchange mints a fresh clientId), so a
+      // lecture hall is a stream of 200s from one IP.
+      const sessionUid = await setupLiveSession();
+      const joinCode = await mintJoinCode(sessionUid);
+
+      // Act - more successful exchanges than the failed-attempt cap allows.
+      for (let i = 0; i < TINY_MAX + 2; i++) {
+        const res = await post(server, url, { joinCode });
+
+        // Assert - if 200s were charged, this would 429 partway through, and
+        // a full hall would lock itself out by joining normally.
+        expect(res.statusCode).toBe(200);
+      }
+    });
+
+    it('does not spend the budget on an expired code (410)', async () => {
+      // Arrange - a code whose window has already closed, which is what an
+      // entire room gets when a stale code is left on the projector. Charging
+      // that would lock the room out of joining even after the display is
+      // fixed, so 410 is deliberately excluded from the count.
+      const sessionUid = await setupLiveSession();
+      await dbContext.db
+        .insertInto('session_join_codes')
+        .values({
+          join_code: 'EXPIRED1',
+          session_uid: sessionUid,
+          valid_start: new Date(Date.now() - 10 * 60 * 1000),
+          valid_end: new Date(Date.now() - 5 * 60 * 1000),
+        })
+        .execute();
+
+      // Act / Assert - more expired exchanges than the cap allows, all 410.
+      for (let i = 0; i < TINY_MAX + 2; i++) {
+        const res = await post(server, url, { joinCode: 'EXPIRED1' });
+        expect(res.statusCode).toBe(410);
+      }
     });
   });
 });

--- a/apps/session-manager/tests/unit/app-config/app-config.test.ts
+++ b/apps/session-manager/tests/unit/app-config/app-config.test.ts
@@ -26,7 +26,16 @@ const VALID_ENV: Record<string, string> = {
  * cleared before each test so the defaults are what is exercised, and restored
  * afterwards like the rest.
  */
-const OPTIONAL_ENV_KEYS = ['DEMO_ROOM_ENABLED', 'DEMO_SESSION_UID'];
+const OPTIONAL_ENV_KEYS = [
+  'DEMO_ROOM_ENABLED',
+  'DEMO_SESSION_UID',
+  'SESSION_AUTH_RATE_LIMIT_JOIN_CODE_MAX',
+  'SESSION_AUTH_RATE_LIMIT_JOIN_CODE_WINDOW_SEC',
+  'SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_MAX',
+  'SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_WINDOW_SEC',
+  'SESSION_AUTH_RATE_LIMIT_REFRESH_MAX',
+  'SESSION_AUTH_RATE_LIMIT_REFRESH_WINDOW_SEC',
+];
 const ENV_KEYS = [...Object.keys(VALID_ENV), ...OPTIONAL_ENV_KEYS];
 
 // A path that does not exist, used to disable dotenv file loading so validation
@@ -184,6 +193,61 @@ describe('AppConfig', () => {
     it('rejects a non-boolean enable flag (only true/false are accepted)', () => {
       // Arrange - env-schema coerces "true"/"false" but not "1".
       process.env['DEMO_ROOM_ENABLED'] = '1';
+
+      // Act / Assert
+      expect(() => new AppConfig(NO_DOTENV_FILE)).toThrow();
+    });
+  });
+
+  describe('session-auth rate limit configuration', (it) => {
+    it('exposes the shipped defaults when nothing is set', () => {
+      // Act - every SESSION_AUTH_RATE_LIMIT_* var is absent.
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert - pinned rather than merely "some number", because these are
+      // the values a deployment gets by default and the calibration argument
+      // in `SessionAuthRateLimitConfig` is written against exactly these. A
+      // silent drift back towards the old 100/60 s would put a 250-seat hall
+      // behind one NAT into a permanent 429 again.
+      expect(config.sessionAuthRateLimitConfig).toStrictEqual({
+        exchangeJoinCodeMax: 600,
+        exchangeJoinCodeWindowMs: 60_000,
+        failedExchangeJoinCodeMax: 100,
+        failedExchangeJoinCodeWindowMs: 60_000,
+        refreshSessionTokenMax: 1_000,
+        refreshSessionTokenWindowMs: 60_000,
+      });
+    });
+
+    it('maps overrides and converts the windows from seconds to ms', () => {
+      // Arrange - windows are seconds in the env because that is the unit an
+      // operator thinks in; the router wants milliseconds.
+      process.env['SESSION_AUTH_RATE_LIMIT_JOIN_CODE_MAX'] = '11';
+      process.env['SESSION_AUTH_RATE_LIMIT_JOIN_CODE_WINDOW_SEC'] = '12';
+      process.env['SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_MAX'] = '13';
+      process.env['SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_WINDOW_SEC'] = '14';
+      process.env['SESSION_AUTH_RATE_LIMIT_REFRESH_MAX'] = '15';
+      process.env['SESSION_AUTH_RATE_LIMIT_REFRESH_WINDOW_SEC'] = '16';
+
+      // Act
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert
+      expect(config.sessionAuthRateLimitConfig).toStrictEqual({
+        exchangeJoinCodeMax: 11,
+        exchangeJoinCodeWindowMs: 12_000,
+        failedExchangeJoinCodeMax: 13,
+        failedExchangeJoinCodeWindowMs: 14_000,
+        refreshSessionTokenMax: 15,
+        refreshSessionTokenWindowMs: 16_000,
+      });
+    });
+
+    it('rejects a zero limit rather than silently blocking every request', () => {
+      // Arrange - `minimum: 1`. A max of 0 would 429 the first request of
+      // every window, which is a very expensive way to learn about a typo in
+      // an env file.
+      process.env['SESSION_AUTH_RATE_LIMIT_REFRESH_MAX'] = '0';
 
       // Act / Assert
       expect(() => new AppConfig(NO_DOTENV_FILE)).toThrow();

--- a/apps/session-manager/tests/utils/use-server.ts
+++ b/apps/session-manager/tests/utils/use-server.ts
@@ -14,6 +14,7 @@ import type {
 import type { DBClientConfig } from '#src/db/db-client.js';
 import createServer from '#src/server/create-server.js';
 import type { MaterializationWorkerConfig } from '#src/server/features/schedule-management/materialization.worker.js';
+import type { SessionAuthRateLimitConfig } from '#src/server/features/session-auth/session-auth.router.js';
 import type { AdminAuthConfig } from '#src/server/shared/services/admin-auth.service.js';
 import type { DevicePresenceConfig } from '#src/server/shared/services/device-presence.service.js';
 import type { ServiceAuthConfig } from '#src/server/shared/services/service-auth.service.js';
@@ -46,6 +47,7 @@ export interface TestAppConfigOverrides {
   testAudioRoomsConfig?: Partial<TestAudioRoomsConfig>;
   canaryRoomConfig?: Partial<CanaryRoomConfig>;
   scheduleManagementConfig?: Partial<ScheduleManagementConfig>;
+  sessionAuthRateLimitConfig?: Partial<SessionAuthRateLimitConfig>;
 }
 
 /**
@@ -129,6 +131,22 @@ export function buildTestAppConfig(
     scheduleManagementConfig: {
       transcriptionProviderIds: [...SHIPPED_TRANSCRIPTION_PROVIDER_IDS],
       ...overrides.scheduleManagementConfig,
+    },
+    // Effectively unlimited by default, so no ordinary suite can be made to
+    // 429 by an unrelated change to the shipped defaults. The suite that
+    // exercises the limiter overrides these with numbers small enough to reach
+    // in a handful of requests - which is the whole point of the limits living
+    // in config: the previous test spent 100 real requests per route to reach a
+    // hard-coded ceiling, and then left both routes limited for the rest of a
+    // real 60-second window.
+    sessionAuthRateLimitConfig: {
+      exchangeJoinCodeMax: 1_000_000,
+      exchangeJoinCodeWindowMs: 60_000,
+      failedExchangeJoinCodeMax: 1_000_000,
+      failedExchangeJoinCodeWindowMs: 60_000,
+      refreshSessionTokenMax: 1_000_000,
+      refreshSessionTokenWindowMs: 60_000,
+      ...overrides.sessionAuthRateLimitConfig,
     },
   } as unknown as AppConfig;
 }

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -154,6 +154,26 @@ REDIS_PASSWORD=CHANGEME
 # -- Session Manager --------
 SESSION_MANAGER_LOG_LEVEL=info
 SESSION_MANAGER_API_KEY=CHANGEME
+# Per-client-IP rate limits on the two unauthenticated credential-exchange
+# routes. The values below ARE the shipped defaults - uncomment only to change
+# them. See SessionAuthRateLimitConfig in session-auth.router.ts for how each
+# was derived; the short version is that the previous 100/60s fired on a
+# 250-seat lecture hall in steady state while doing nothing against guessing.
+#
+# FAILED_JOIN_CODE is the actual anti-guessing control: it counts only 404s
+# (not 410 expiries, which a whole room can produce at once from a stale code
+# left on a projector) and is keyed on the client IP, never the join code.
+#
+# "Per IP" means "per whatever the last hop reported". If you front this stack
+# with a load balancer or CDN, enable nginx's set_real_ip_from block too, or
+# every request arrives with the proxy's address and these become
+# deployment-wide limits.
+#SESSION_AUTH_RATE_LIMIT_JOIN_CODE_MAX=600
+#SESSION_AUTH_RATE_LIMIT_JOIN_CODE_WINDOW_SEC=60
+#SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_MAX=100
+#SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_WINDOW_SEC=60
+#SESSION_AUTH_RATE_LIMIT_REFRESH_MAX=1000
+#SESSION_AUTH_RATE_LIMIT_REFRESH_WINDOW_SEC=60
 
 # -- Node Server -----
 NODE_SERVER_LOG_LEVEL=info

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,46 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — session-auth rate limits are tunable and recalibrated (`compose.yml` v16)
+
+**Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. A
+stock deployment needs to do nothing else — all six new variables default to
+the new shipped values, and the defaults are what you want unless you have an
+unusual topology.
+
+The per-client-IP limit on join-code exchange and token refresh was
+`100 / 60 s`, hard-coded. That fired on ordinary traffic: token refresh alone
+crosses it at roughly **250 viewers behind one egress IP** in steady state,
+with nobody doing anything unusual, so a large lecture hall on campus NAT was
+rate-limited continuously. It also did essentially nothing against guessing —
+join codes are 8 characters from a 36-character alphabet and rotate every five
+minutes.
+
+New defaults: `600 / 60 s` for join-code exchange (a 1,000-seat hall joins
+inside ~100 s), `1000 / 60 s` for refresh (~2,500 viewers behind one IP). Both
+are now tunable:
+
+- **`SESSION_AUTH_RATE_LIMIT_JOIN_CODE_MAX`** / **`..._WINDOW_SEC`** — 600 / 60
+- **`SESSION_AUTH_RATE_LIMIT_REFRESH_MAX`** / **`..._WINDOW_SEC`** — 1000 / 60
+- **`SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_MAX`** / **`..._WINDOW_SEC`** —
+  100 / 60. This one is new behaviour, not a re-tune: a separate, tighter cap
+  counting **only** join-code exchanges that come back 404. Expired codes (410)
+  are deliberately not counted, because a stale code left on a projector makes
+  a whole room produce one at the same instant.
+
+**If you front this stack with a load balancer or CDN**, enable nginx's
+`set_real_ip_from` block as well. It is commented out by default, and without
+it every request arrives carrying the front proxy's address — which turns all
+of the above from per-client limits into deployment-wide ones. This was already
+true before this change; the raised defaults make it less likely to bite.
+
+Note the real service-wide ceiling is not any of these numbers: token refresh
+runs one bcrypt cost-12 comparison per call (~154 ms), so the binding
+constraint is the hashing threadpool, at roughly 25 refreshes per second across
+the whole service. Raising a per-IP limit does not raise that.
+
+---
+
 ## Unreleased — Azure Entra ID SSO reaches admin-server (`compose.yml` v14)
 
 **Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. A

--- a/deployment/compose.yml
+++ b/deployment/compose.yml
@@ -83,6 +83,21 @@ services:
       # offline between two writes.
       DEVICE_LAST_SEEN_WRITE_INTERVAL_SEC: ${DEVICE_LAST_SEEN_WRITE_SEC:-60}
       DEVICE_ONLINE_TTL_SEC: ${DEVICE_ONLINE_TTL_SEC:-180}
+      # Per-client-IP limits on the two unauthenticated credential-exchange
+      # routes, plus the outcome-conditional cap on *failed* join-code
+      # exchanges. The calibration argument (and the measured bcrypt cost that
+      # sets the real, global ceiling) lives on SessionAuthRateLimitConfig in
+      # session-auth.router.ts. Most likely to need raising:
+      # SESSION_AUTH_RATE_LIMIT_REFRESH_MAX, whose default is sized for ~2,500
+      # viewers behind one egress IP. Note "per IP" means "per whatever the
+      # last hop reported" - behind a load balancer with nginx's
+      # set_real_ip_from left commented out, these become deployment-wide.
+      SESSION_AUTH_RATE_LIMIT_JOIN_CODE_MAX: ${SESSION_AUTH_RATE_LIMIT_JOIN_CODE_MAX:-600}
+      SESSION_AUTH_RATE_LIMIT_JOIN_CODE_WINDOW_SEC: ${SESSION_AUTH_RATE_LIMIT_JOIN_CODE_WINDOW_SEC:-60}
+      SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_MAX: ${SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_MAX:-100}
+      SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_WINDOW_SEC: ${SESSION_AUTH_RATE_LIMIT_FAILED_JOIN_CODE_WINDOW_SEC:-60}
+      SESSION_AUTH_RATE_LIMIT_REFRESH_MAX: ${SESSION_AUTH_RATE_LIMIT_REFRESH_MAX:-1000}
+      SESSION_AUTH_RATE_LIMIT_REFRESH_WINDOW_SEC: ${SESSION_AUTH_RATE_LIMIT_REFRESH_WINDOW_SEC:-60}
       # Defaulted to the bundled container. Point them at a managed Postgres
       # to run the database outside this stack - see deployment/UPGRADING.md,
       # which also covers removing the bundled service and its depends_on.
@@ -226,7 +241,7 @@ services:
       # Not `:?`-guarded, like DEPLOYMENT_ENV below and unlike the secrets: it
       # changes what is *reported*, never what runs, and must not be able to
       # stop a stack from starting.
-      COMPOSE_FILE_VERSION: "15"
+      COMPOSE_FILE_VERSION: "16"
       LOG_LEVEL: ${ADMIN_LOG_LEVEL:-info}
       ADMIN_API_KEY: ${SESSION_MANAGER_API_KEY}
       SESSION_MANAGER_BASE_URL: http://session-manager:80

--- a/libs/schemas/base-schema/src/shared/error-reply.schema.ts
+++ b/libs/schemas/base-schema/src/shared/error-reply.schema.ts
@@ -198,6 +198,18 @@ export const INTERNAL_ERROR_REPLY_SCHEMA = Type.Object(
  * *is* service-owned (see {@link RATE_LIMITED_REPLY_SCHEMA}), but only routes
  * carrying a `config.rateLimit` can ever emit it, so it is declared per route
  * rather than globally.
+ *
+ * Not a counter-example: **admin-server registers its limiter with
+ * `global: true`**, so every one of its routes really can answer 429. Adding
+ * 429 here would still be wrong, and would not help it. This constant is
+ * spread by 92 route schemas, all of them in session-manager and node-server —
+ * services whose limiters are `global: false` — so widening it adds an
+ * unreachable arm to every one of their `EndpointResponse` unions. admin-server
+ * gains nothing either way: it is a BFF that declares no `response` map for any
+ * error status and serializes failures as its own
+ * `{ ok: false, error: { code, message, requestId, details } }` envelope, which
+ * `ErrorReply` does not describe. Its 429 contract is pinned by
+ * `apps/admin-server/tests/integration/rate-limit.routes.test.ts` instead.
  */
 export const STANDARD_ERROR_REPLIES = {
   400: VALIDATION_ERROR_REPLY_SCHEMA,


### PR DESCRIPTION
## Summary

Five independent items from `2026-08-01-02-PLAN-VisibleErrors.md`, following #194:
the three known gaps that PR left open, plus §4.4, §4.1/§4.2 and §5. Each stream
owned a disjoint path set; two ran in isolated worktrees.

| § | Commit | What |
|---|---|---|
| 4b.2–3 | `25f06fd` | Recalibrate the credential-exchange rate limits |
| 4b.3, 4b.5 | `6a80f72` | Name the failure kind in client/kiosk; pace 429 retries |
| 4b.1 | `40ff983` | A rate-limited operator isn't told their password is wrong |
| 4.4 + 4.1/4.2 | `083e234` | Mark frozen telemetry; render node diagnostics |
| 5 + 10.1 | `c4c6809` | Stop rendering empty when the load failed |
| — | `8f6df31` | Wire the rate limits into compose (v16) |

## Three briefs were wrong, and the corrections are the interesting part

**admin-server was not the mirror image of session-manager.** The plan said it
was the one place where adding 429 to `STANDARD_ERROR_REPLIES` was right, on
the grounds that its limiter is `global: true`. In fact
`grep -rl STANDARD_ERROR_REPLIES apps/admin-server` returns **zero**: it is a
BFF with its own `{ok, error}` envelope that declares no `response` map at all,
and `admin-webapp` does not use `createEndpointClient`. All 46 spread sites are
in session-manager and node-server, both `global: false`. The change would have
added an unreachable arm to 46 schemas and done nothing for admin. **No schema
change**; the real defect was a 429 rendering the server's log-facing string at
`error` severity, in the same red slot as "Invalid credentials."

**A tidy two-way error split would have mislabelled the commonest outage.**
nginx's `location /api/session-manager/` sets no `proxy_intercept_errors`, so
when the upstream is down its own 502/503/504 arrive as *undeclared* statuses
and short-circuit to a plain `UnexpectedResponseError` — which under the
proposed rule would have told users "your app is out of date, reload" while the
service was simply down. Gateway statuses are folded in with
`InvalidResponseBodyError` instead.

**The rate limit's ceiling was never the limiter.** `HASH_SALT_ROUNDS = 12`
puts one ~154 ms bcrypt compare on every refresh against a 4-thread libuv pool,
so capacity is ~25 calls/s **globally** and no per-IP number moves it. That is
why refresh was raised rather than exempted. Separately: nginx's
`set_real_ip_from` is commented out by default, so behind an unconfigured LB
"per-IP" is silently deployment-wide.

Two more, from §5 and §4.1: the plan's cited example (`"No devices assigned to
this room."`) is unreachable from a failed load — but the `!detail` fallback one
frame up said **"Room not found."** for a network drop, a dead session-manager
or a bad API key, which is a stronger false claim. And the browser's
`NodeSnapshot` mirror had drifted from its producer, with two published fields
entirely untyped.

## Merge resolution worth reviewing

Four page files conflicted between the two admin-webapp streams.
`audit-page`/`sessions-overview` took the inline `<ErrorState>` over the toast
(a 5-second auto-hiding toast losing to a permanent inline error is the point of
§5). `devices-list`/`kiosk-wizard` took **both** sides — their *load-failure*
toasts became `<ErrorState>`, but their *mutation* toasts (register device,
create room) are the right shape for a failed action and kept the `showApiError`
conversion.

One duplicate no file-level conflict would have surfaced: both streams landed an
`errorMessage(err, fallback)` and they were **not equivalent** — one was
rate-limit aware, one wasn't. A page importing the wrong one would silently lose
the 429 wording. Now one implementation, with a comment saying why.

## Test plan

Whole-repo, on the merged branch:

- [x] `npm run build` — exit 0
- [x] `npm run test:unit` — 2,409 passed across 22 packages, exit 0
- [x] `npm run test:integration` — 775 passed across 6 packages, exit 0
- [x] `npm run lint` — exit 0 (3 pre-existing warnings in untouched `session-detail-page.tsx`)
- [x] compose v16 guard + re-pinned hash green
- [ ] Live verification against a running stack

## Deployment

`compose.yml` v16 — six new `SESSION_AUTH_RATE_LIMIT_*` passthroughs, all
defaulted. Operators copy the new compose and `docker compose up -d`; nothing
else is required. `UPGRADING.md` carries the reasoning and the load-balancer
warning.

## Still open

Tracked in `2026-08-01-02-NEXTSTEPS-VisibleErrors.md`: the failed-exchange block
is a log line with no metric, so guessing is invisible in Grafana; rate-limit
state is per-replica (in-memory store); `useAsyncData`'s old shape still exists
for callers that don't opt into `state`; four `errorMessage` copies remain in
files these streams didn't own; and `<ErrorState>` is not yet adopted on
`device-detail-page`/`session-detail-page`, which still carry the same
"not found" shape that was just fixed on room-detail.
