### PR TITLE
fix(admin-server): Config Check catches the misconfigurations that were passing green

### DIFF
--- a/.changeset/config-check-credentials-and-origin.md
+++ b/.changeset/config-check-credentials-and-origin.md
@@ -1,0 +1,47 @@
+---
+'@scribear/admin-server': minor
+---
+
+Config Check grades the local admin password, proves the test-audio key works,
+and flags a public origin nobody outside the building can reach.
+
+**A one-character admin password used to pass every check green.**
+`ADMIN_LOCAL_CREDENTIALS` had no length or entropy check at all, unlike
+`ADMIN_SESSION_SECRET`. It is a `"<username> <password>"` pair split on the
+*first* space — so the password may contain spaces, and measuring the raw
+variable would have measured the username too. The parse now mirrors
+`LocalAuthService` exactly, and applies an 8-character floor (NIST SP 800-63B /
+OWASP ASVS L1), deliberately **not** the 32-character bar used for
+`ADMIN_SESSION_SECRET`: that is a machine-generated token, this is a
+human-memorised password, and holding them to one standard would be the wrong
+kind of consistency.
+
+Working out that format turned up a second gap worth its own finding: a value
+with no space, an empty username, or an empty password causes `LocalAuthService`
+to **silently disable local login at boot**, while the existing
+`localLoginEnabled` flag — a bare `.trim() !== ''` — cannot see it. A deployment
+could have no working login method and no finding saying so.
+
+**`TEST_AUDIO_SERVICE_KEY` is now live-probed**, as `GRAFANA_ADMIN_PASSWORD`
+already was. A key that is present but *wrong* was indistinguishable from one
+that works. The probe reuses the existing gateway and calls `listDevices()` — a
+cheap `GET`, no audio job triggered — and keeps three outcomes distinct:
+`401`/`403` is a mismatch (critical outside development); unreachable,
+unparseable or an unexpected status collapse into a `probe-unavailable` warning
+that is **never** critical and never reads as a pass; `2xx` is silence. It skips
+entirely when the key is still a placeholder, so that finding is not buried, and
+so two sides sharing the same placeholder cannot read as "verified".
+
+**The public-origin check says what it cannot know.** There is no
+`PUBLIC_ORIGIN`-style variable anywhere in this stack — nginx's `server_name` is
+the wildcard `_`, and `join-url.ts` / `kiosk-url.ts` build every join link and QR
+code from `window.location.origin` in the operator's own browser. The only place
+that origin is visible to admin-server is the `Host` header of the request
+asking for the report, so this check is necessarily **request-scoped, not
+deployment-scoped**, and it is deliberately one-directional: it flags origins
+that certainly will not work off-host — loopback, RFC1918, link-local, `.local`,
+a bare single-label hostname — and stays silent on anything else. A normal
+looking FQDN is reported as *not ruled out*, never asserted reachable, because
+admin-server sits inside the backend network and an in-cluster fetch would prove
+almost nothing. The finding's own text states that limit rather than implying a
+confidence it does not have.

--- a/.changeset/config-check-empty-secrets-and-key-agreement.md
+++ b/.changeset/config-check-empty-secrets-and-key-agreement.md
@@ -1,0 +1,74 @@
+---
+'@scribear/admin-server': minor
+---
+
+Config Check reports secrets that are unset (not merely placeholder), proves
+two cross-service keys actually agree, and names a down monitoring sidecar as
+its own fault.
+
+**Unset secrets were invisible.** `isPlaceholder('')` is `false` and the
+placeholder loop skipped everything that was not a placeholder, so an empty
+`ADMIN_API_KEY` or `DB_PASSWORD` produced no finding at all — silence
+indistinguishable from a well-configured deployment. `describeSecret` had
+carried a `'not set'` branch that nothing could reach. Both now have their own
+findings, kept separate from the placeholder table because "not set" and "still
+the example value" have different consequences and want different sentences.
+`ADMIN_SESSION_SECRET` is excluded: it already had a dedicated missing-check
+saying something more specific. `TEST_AUDIO_SERVICE_KEY` is excluded too, on
+the grounds that its peer fails closed and names the variable itself, and that
+whether the two agree is answerable by calling the generator rather than by
+comparing a string here.
+
+**Two non-placeholder keys that simply differ used to read green.** Nothing
+verified that two services holding the same shared secret hold the _same_
+value, and a placeholder audit cannot see this class of fault at all — it is
+what a container recreated after an `.env` change, next to one that was not,
+looks like. Two pairs are now proved, by the only mechanism the deployment
+actually has: a party holding one copy presents it to the party holding the
+other, and the rejection is the proof.
+
+- `node-server-service-key-mismatch` — the sidecar polls node-server's
+  `/status` every interval with its `NODE_SERVER_SERVICE_API_KEY`, and a 401
+  becomes the `unauthorized` poll reason that `/config-audit` already relayed.
+  That string was previously reported as one more way of _not knowing_, when it
+  is the opposite: a proof about two configuration values. A rejection really
+  is proof rather than a guess, because both other explanations are closed off
+  — node-server refuses to construct with an empty or `CHANGEME` inbound key,
+  and the sidecar does not poll at all with an empty one.
+- `session-manager-admin-key-mismatch` — admin-server already presents
+  `SESSION_MANAGER_API_KEY` to session-manager on every page of the console, so
+  asking an admin-key-protected route and reading the status _is_ the
+  comparison. Its own check rather than a branch of the schema-version read
+  that makes the same call, because that one runs only after `dbClient.ping()`
+  succeeds — a deployment with both faults is exactly the one that needs to be
+  told they are separate. Silent when the key is unset (`admin-api-key-missing`
+  is the better sentence) and when session-manager does not answer at all
+  (`services-unreachable` already says so; only an actual 401/403 is evidence
+  about a key).
+
+No secret is moved to make either comparison, and no service is handed a
+credential it did not already hold.
+
+**`TRANSCRIPTION_API_KEY`, `NODE_SERVER_KEY` and `JWT_SECRET` remain
+unverifiable at config time, deliberately and not by oversight.** Each is held
+only by the two services that use it; neither exercises it until a real session
+starts; and none reports the outcome when it does — a rejected
+`TRANSCRIPTION_API_KEY` closes the upstream socket 1008 "Authentication Failed"
+and node-server records only a generic upstream flap. Closing that gap needs a
+new self-report from node-server, not another check here, and it is not faked
+with an inference this page cannot stand behind. The class docblock says so
+where the next reader will look.
+
+**A down monitoring sidecar is now its own finding.** It was previously
+inferable only as a side effect of `secret-placeholder-audit-unavailable`,
+which named the wrong subject — an operator read "could not check
+node-server-held secrets" and went to look at node-server, which was fine. The
+sidecar is a core service that nothing else on this page covers (it is
+deliberately absent from the health rollup's probe targets), and when it is
+down the console's alerts panel goes blank at the same moment for the same
+reason. `monitoring-sidecar-unreachable` enumerates what went _unchecked_
+rather than leaving it implied — including the `NODE_SERVER_SERVICE_KEY` pair
+above, which it is the sole source of evidence for. Sidecar down must never
+read as "the keys agree". A sidecar that answers with a body Config Check
+cannot parse or does not recognise keeps the existing
+`secret-placeholder-audit-unavailable`: that is version skew, not an outage.

--- a/apps/admin-server/src/server/features/config-check/config-check.controller.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.controller.ts
@@ -23,9 +23,14 @@ export class ConfigCheckController {
    *
    * The response contains no secret values — only classifications and lengths.
    * See `describeSecret`.
+   *
+   * `req.hostname` — the Host header nginx forwarded unchanged — is passed
+   * through so `evaluatePublicOriginCheck` can tell whether the address this
+   * very request reached admin-server on could ever work in a QR code. See
+   * that function's doc for why this is the only place that fact is visible.
    */
-  async configCheck(_req: BaseFastifyRequest, res: BaseFastifyReply) {
-    const report = await this._configCheckService.check();
+  async configCheck(req: BaseFastifyRequest, res: BaseFastifyReply) {
+    const report = await this._configCheckService.check(req.hostname);
     res.code(200).send(okEnvelope(report));
   }
 }

--- a/apps/admin-server/src/server/features/config-check/config-check.controller.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.controller.ts
@@ -30,7 +30,7 @@ export class ConfigCheckController {
    * that function's doc for why this is the only place that fact is visible.
    */
   async configCheck(req: BaseFastifyRequest, res: BaseFastifyReply) {
-    const report = await this._configCheckService.check(req.hostname);
+    const report = await this._configCheckService.check(req.hostname, req.log);
     res.code(200).send(okEnvelope(report));
   }
 }

--- a/apps/admin-server/src/server/features/config-check/config-check.service.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.service.ts
@@ -163,6 +163,19 @@ export interface ConfigCheckReport {
  * never leave this process: every finding reports a classification, and
  * `describeSecret` is the only thing that turns a secret into prose.
  */
+/**
+ * The one logging call this service makes, narrowed to what it needs.
+ *
+ * Passed into `check()` rather than injected, deliberately: `configCheckService`
+ * is a SINGLETON and the useful logger here is the *request-scoped* one (it
+ * carries `reqId`), so injecting it would pin whichever request happened to
+ * build the singleton first. The controller already threads `req.hostname`
+ * through for the same reason, and `req.log` rides along with it.
+ */
+export interface CheckLogger {
+  debug: (obj: Record<string, unknown>, msg: string) => void;
+}
+
 export interface ConfigCheckConfig {
   declaredEnv: string;
   /** True when the server was started with `--dev`. */
@@ -847,28 +860,46 @@ export function evaluateStaticChecks(
  * confidence is exactly the failure mode this check exists to avoid; see
  * `evaluatePublicOriginCheck`'s doc.
  */
+/**
+ * Whether a dotted-quad IPv4 address is one that cannot be reached from
+ * outside the network that handed it out. Split out so the IPv4-mapped IPv6
+ * form (`::ffff:10.1.2.3`) is judged by exactly the same rules rather than by
+ * a second, drifting copy of them.
+ */
+function isUnroutableIPv4(host: string): boolean {
+  const [a, b] = host.split('.').map(Number);
+  if (a === undefined || b === undefined) return false;
+  return (
+    a === 127 || // loopback
+    a === 10 || // RFC1918
+    (a === 172 && b >= 16 && b <= 31) || // RFC1918
+    (a === 192 && b === 168) || // RFC1918
+    (a === 169 && b === 254) || // link-local
+    a === 0 // "this network"
+  );
+}
+
 function looksUnreachableExternally(host: string): boolean {
   const h = host.toLowerCase();
   if (h === 'localhost' || h.endsWith('.localhost')) return true;
   if (h.endsWith('.local')) return true;
 
-  if (isIPv4(h)) {
-    const octets = h.split('.').map(Number);
-    const [a, b] = octets;
-    if (a === undefined || b === undefined) return false;
-    return (
-      a === 127 || // loopback
-      a === 10 || // RFC1918
-      (a === 172 && b >= 16 && b <= 31) || // RFC1918
-      (a === 192 && b === 168) || // RFC1918
-      (a === 169 && b === 254) || // link-local
-      a === 0 // "this network"
-    );
-  }
+  if (isIPv4(h)) return isUnroutableIPv4(h);
 
   if (isIPv6(h)) {
+    // An IPv4-mapped address (`::ffff:127.0.0.1`) is IPv6 by syntax and IPv4 by
+    // reach, and none of the prefix tests below match one — so without this it
+    // would fall through as "not ruled out" while being literally loopback.
+    // Node hands these out for a v4 peer on a dual-stack socket, so it is a
+    // plausible Host header, not a curiosity.
+    const mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/.exec(h);
+    if (mapped?.[1] !== undefined && isIPv4(mapped[1])) {
+      return isUnroutableIPv4(mapped[1]);
+    }
+
     return (
       h === '::1' || // loopback
+      h === '::' || // unspecified
       h.startsWith('fc') || // unique-local fc00::/7
       h.startsWith('fd') ||
       h.startsWith('fe8') || // link-local fe80::/10
@@ -1052,7 +1083,10 @@ export class ConfigCheckService {
    * existing direct caller of `.check()` — the great majority of this file's
    * own unit tests — is unaffected; only the HTTP route passes a real value.
    */
-  async check(requestHostname = ''): Promise<ConfigCheckReport> {
+  async check(
+    requestHostname = '',
+    log?: CheckLogger,
+  ): Promise<ConfigCheckReport> {
     const { environment, environmentSource, declaredButInvalid } =
       resolveEnvironment(this._config);
 
@@ -1071,7 +1105,7 @@ export class ConfigCheckService {
       this._checkDatabase(environment),
       this._checkMonitoring(environment),
       this._checkSecretPlaceholders(environment),
-      this._checkSessionManagerKey(environment),
+      this._checkSessionManagerKey(environment, log),
       this._checkBackup(environment),
       this._checkTestAudioServiceKey(environment),
     ]);
@@ -1818,7 +1852,7 @@ export class ConfigCheckService {
           title: 'The monitoring sidecar is not answering',
           detail: `monitoring-sidecar's /api/monitoring/v1/config-audit ${probeFailure(response, this._config.upstreamTimeoutMs)}. While it is down this console cannot show alerts, and three things go unchecked rather than confirmed: node-server's classification of JWT_SECRET, NODE_SERVER_KEY, NODE_SERVER_SERVICE_KEY and TRANSCRIPTION_API_KEY; whether the sidecar and node-server agree on NODE_SERVER_SERVICE_KEY; and every fleet metric Prometheus scrapes from it.`,
           remediation:
-            'Check `docker compose ps monitoring-sidecar` and `docker compose logs monitoring-sidecar`, and that ADMIN_MONITORING_SIDECAR_BASE_URL points at it on the backend network (monitoring-sidecar:80 by default).',
+            'Check `docker compose ps monitoring-sidecar` and `docker compose logs monitoring-sidecar`, and that MONITORING_SIDECAR_BASE_URL points at it on the backend network (http://monitoring-sidecar:80 by default).',
           docUrl: DOC.monitoring,
         },
         { development: 'advisory', staging: 'warning', production: 'warning' },
@@ -1896,6 +1930,7 @@ export class ConfigCheckService {
    */
   private async _checkSessionManagerKey(
     env: DeploymentEnv,
+    log?: CheckLogger,
   ): Promise<ConfigFinding[]> {
     if (this._config.adminApiKey === '') return [];
 
@@ -1906,9 +1941,20 @@ export class ConfigCheckService {
           signal: AbortSignal.timeout(this._config.upstreamTimeoutMs),
         });
       status = response?.status;
-    } catch {
+    } catch (err: unknown) {
       // Unreachable, timed out, or an unreadable body. Not evidence about the
-      // key, and already reported by the health rollup.
+      // key, and already reported by the health rollup — so this stays silent
+      // on the page rather than guessing.
+      //
+      // It is logged, though, because this catch is deliberately broad: it also
+      // absorbs a genuine defect in `getSchemaStatus` (an unexpected response
+      // shape, a bad timeout signal), and the health rollup probes a *different*
+      // endpoint, so nothing else would necessarily surface that. Silent on the
+      // page, never silent in the logs.
+      log?.debug(
+        { err },
+        'config-check: session-manager key probe could not run; reporting nothing about SESSION_MANAGER_API_KEY',
+      );
       return [];
     }
 

--- a/apps/admin-server/src/server/features/config-check/config-check.service.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.service.ts
@@ -121,6 +121,20 @@ const CONFIG_AUDIT_RESPONSE_SCHEMA = Type.Object({
 
 type ConfigAuditResponse = Static<typeof CONFIG_AUDIT_RESPONSE_SCHEMA>;
 
+/**
+ * The one value of `nodeServer.reason` that reports a *disagreement* rather
+ * than an outage: `AbsoluteStatusPoller`'s `POLL_ERROR_REASONS.UNAUTHORIZED`,
+ * which the sidecar sets when node-server answered its status poll 401 or 403.
+ *
+ * Restated here as a bare string for the same reason the response schema above
+ * is restated: the sidecar exports no package for admin-server to import, and
+ * `reason` crosses a version boundary as an open `Type.String()`. An older or
+ * newer sidecar that renamed the reason therefore degrades to the generic
+ * "could not check" finding rather than to a wrong claim — which is the safe
+ * direction for a string this file cannot typecheck against its producer.
+ */
+const SIDECAR_POLL_UNAUTHORIZED = 'unauthorized';
+
 export interface ConfigCheckReport {
   environment: DeploymentEnv;
   /**
@@ -376,6 +390,82 @@ export function evaluateStaticChecks(
           staging: 'critical',
           production: 'critical',
         },
+        env,
+      ),
+    );
+  }
+
+  // ---- secrets that are not set at all ----
+  // `isPlaceholder('')` is false and the loop above skips everything that is
+  // not a placeholder, so an *unset* secret used to produce no finding
+  // whatsoever — the quieter half of the same mistake, and the likelier one:
+  // compose substitutes a blank string for a variable an operator never set,
+  // renamed, or deleted, and nothing complains until the first request fails
+  // somewhere else. Kept as its own table rather than folded into the one
+  // above because "not set" and "still the example value" have different
+  // consequences and want different sentences; `describeSecret`'s 'not set'
+  // branch is finally reachable from here.
+  //
+  // Two deliberate absences. `ADMIN_SESSION_SECRET` has its own
+  // `admin-session-secret-missing` below, which says something more specific
+  // (admin-server mints an ephemeral secret rather than failing).
+  // `TEST_AUDIO_SERVICE_KEY` is left out because a static check is the weakest
+  // available evidence about it: it is the one key on this list whose peer
+  // fails closed and says so itself — test-audio-generator exits naming the
+  // variable — and whose agreement admin-server can establish by simply
+  // calling the generator, which is a separate check to make rather than a
+  // string comparison to add here.
+  const missingSecretChecks: {
+    id: string;
+    title: string;
+    value: string;
+    variable: string;
+    consequence: string;
+    severities: SeverityByEnv;
+  }[] = [
+    {
+      id: 'admin-api-key-missing',
+      title: 'ADMIN_API_KEY is not set',
+      value: config.adminApiKey,
+      variable: 'SESSION_MANAGER_API_KEY',
+      consequence:
+        'admin-server presents `Authorization: Bearer ` with nothing after it on every call to session-manager, which rejects it 401. This console answers 502 BACKEND_MISCONFIGURATION on every page that lists rooms, devices or sessions.',
+      severities: {
+        development: 'critical',
+        staging: 'critical',
+        production: 'critical',
+      },
+    },
+    {
+      id: 'db-password-missing',
+      title: 'DB_PASSWORD is not set',
+      value: config.dbPassword,
+      variable: 'DB_PASSWORD',
+      consequence:
+        'admin-server connects to Postgres with no password. That works only where the database is configured to trust the connection without one, which no deployed Postgres should be; otherwise the audit log and the admin session store are both unavailable.',
+      // Warning rather than critical in development because a throwaway dev
+      // Postgres on `trust` authentication genuinely works this way, and a
+      // developer who chose that has not misconfigured anything.
+      severities: {
+        development: 'warning',
+        staging: 'critical',
+        production: 'critical',
+      },
+    },
+  ];
+
+  for (const check of missingSecretChecks) {
+    if (check.value !== '') continue;
+    findings.push(
+      finding(
+        {
+          id: check.id,
+          category: 'secrets',
+          title: check.title,
+          detail: `${describeSecret(check.value)}. ${check.consequence}`,
+          remediation: `Set ${check.variable} in deployment/.env to a high-entropy secret, e.g. \`openssl rand -hex 32\`, and recreate the containers that read it.`,
+        },
+        check.severities,
         env,
       ),
     );
@@ -697,6 +787,27 @@ function redisUrlHasPlaceholderPassword(rawUrl: string): boolean {
  * behaviour for everything else. The inferences are deliberately phrased as
  * what was observed ("nothing is publishing") rather than as a conclusion about
  * a variable this process cannot see, because the observation is what is true.
+ *
+ * **How agreement between two services is established, and where it stops.**
+ * Nothing in this deployment exchanges digests of secrets, and nothing should
+ * start: the sidecar's `/config-audit` is unauthenticated on the backend
+ * network, so a fingerprint published there would be a slower way of
+ * disclosing a low-entropy secret to anything that can reach it. The only
+ * mechanism available is the one the sidecar's status poll already uses — a
+ * party holding one copy of a key presents it to the party holding the other,
+ * and the rejection is the proof. That covers exactly the pairs where a
+ * mutually-trusted party holds one side: sidecar↔node-server
+ * (`_nodeServerServiceKeyMismatch`) and admin-server↔session-manager
+ * (`_checkSessionManagerKey`).
+ *
+ * It does **not** cover `TRANSCRIPTION_API_KEY`, `NODE_SERVER_KEY` or
+ * `JWT_SECRET`. Each of those is held only by the two services that use it,
+ * neither of which exercises it until a real session starts, and none of them
+ * reports the outcome when it does — a rejected `TRANSCRIPTION_API_KEY` closes
+ * the upstream socket 1008 "Authentication Failed" and node-server records
+ * only a generic upstream flap. Closing that gap needs a new self-report from
+ * node-server, not a new check here, and it is deliberately not faked with an
+ * inference this page cannot stand behind.
  */
 export class ConfigCheckService {
   private _config: ConfigCheckConfig;
@@ -732,6 +843,7 @@ export class ConfigCheckService {
       database,
       monitoring,
       secretPlaceholders,
+      sessionManagerKey,
       backup,
     ] = await Promise.all([
       this._checkTelemetryBackplane(environment),
@@ -739,6 +851,7 @@ export class ConfigCheckService {
       this._checkDatabase(environment),
       this._checkMonitoring(environment),
       this._checkSecretPlaceholders(environment),
+      this._checkSessionManagerKey(environment),
       this._checkBackup(environment),
     ]);
 
@@ -749,6 +862,7 @@ export class ConfigCheckService {
       ...services,
       ...monitoring,
       ...secretPlaceholders,
+      ...sessionManagerKey,
       ...backup,
     ];
 
@@ -1208,6 +1322,17 @@ export class ConfigCheckService {
    * Unlike the Grafana/Prometheus checks above, this is never gated on an
    * optional profile: the sidecar is a core service, and all four secrets are
    * live in every deployment regardless of whether `monitoring` is on.
+   *
+   * Three outcomes, deliberately distinct, because collapsing them is how a
+   * console ends up implying a clean deployment it never managed to inspect:
+   *
+   * - the **sidecar** did not answer → `monitoring-sidecar-unreachable`. The
+   *   sidecar is the failure, not node-server, and it is the failure for the
+   *   alerts panel too;
+   * - the sidecar answered that **it** cannot currently vouch for node-server
+   *   → `secret-placeholder-audit-unavailable`, except for the one reason
+   *   that is not an outage at all (see `node-server-service-key-mismatch`);
+   * - the sidecar answered with a classification → the per-secret findings.
    */
   private async _checkSecretPlaceholders(
     env: DeploymentEnv,
@@ -1232,7 +1357,7 @@ export class ConfigCheckService {
           // before it can ever self-report on that specific key. Named here
           // so an operator does not have to discover it by reading logs.
           remediation:
-            "Check that monitoring-sidecar is running and reachable at monitoring-sidecar:80, and that its NODE_SERVER_SERVICE_API_KEY matches node-server's. If node-server is otherwise healthy, this can also mean NODE_SERVER_SERVICE_KEY itself is still the deployment/.env.example placeholder — node-server refuses to serve /status at all in that case, which this check cannot distinguish from an unrelated outage.",
+            'Check `docker compose logs node-server`. A node-server that refuses to start is the usual cause: it fails closed when NODE_SERVER_SERVICE_KEY is empty or still the deployment/.env.example placeholder, so it can never self-report on that particular key — which this check cannot distinguish from an unrelated outage.',
           docUrl: DOC.deployment,
         },
         { development: 'advisory', staging: 'warning', production: 'warning' },
@@ -1240,11 +1365,7 @@ export class ConfigCheckService {
       ),
     ];
 
-    if (!response?.ok) {
-      return unavailable(
-        `monitoring-sidecar's /api/monitoring/v1/config-audit ${probeFailure(response, this._config.upstreamTimeoutMs)}. JWT_SECRET, NODE_SERVER_KEY, NODE_SERVER_SERVICE_KEY and TRANSCRIPTION_API_KEY could not be checked.`,
-      );
-    }
+    if (!response?.ok) return this._sidecarUnreachable(response, env);
 
     // Parsing and shape-validating are both failures of the same kind from a
     // caller's point of view — "the sidecar cannot currently vouch for this" —
@@ -1274,6 +1395,13 @@ export class ConfigCheckService {
     const body: ConfigAuditResponse = parsed;
 
     if (body.nodeServer.status !== 'ok') {
+      // `unauthorized` is the one reason that is not an outage: node-server
+      // answered, and refused the key. That is a *proof* about two
+      // configuration values, not an inability to check one — see
+      // `_nodeServerServiceKeyMismatch`.
+      if (body.nodeServer.reason === SIDECAR_POLL_UNAUTHORIZED) {
+        return this._nodeServerServiceKeyMismatch(env);
+      }
       return unavailable(
         `monitoring-sidecar reports node-server status "${body.nodeServer.reason}" — JWT_SECRET, NODE_SERVER_KEY, NODE_SERVER_SERVICE_KEY and TRANSCRIPTION_API_KEY could not be checked.`,
       );
@@ -1335,6 +1463,155 @@ export class ConfigCheckService {
           env,
         ),
       );
+  }
+
+  /**
+   * The monitoring sidecar itself did not answer.
+   *
+   * First-class rather than a shade of "could not check node-server's
+   * secrets", which is how it used to be reported and which named the wrong
+   * subject: the sidecar is a core service that nothing else on this page
+   * covers — it is deliberately absent from `HealthCheckerService`'s probe
+   * targets, so `services-unreachable` never mentions it — and when it is
+   * down the console's alerts panel goes blank at the same moment, for the
+   * same reason. An operator reading "could not check node-server-held
+   * secrets" went looking at node-server, which was fine.
+   *
+   * The detail enumerates what is now *unknown* rather than leaving it
+   * implied. This is the same discipline the alerts panel adopted ("no alerts
+   * firing" and "we could not ask" are different sentences), and it matters
+   * more here because this check is the only thing that would have reported
+   * `node-server-service-key-mismatch`: if the sidecar is down, that pair is
+   * unverified, and saying nothing would read as agreement.
+   */
+  private _sidecarUnreachable(
+    response: Response | null,
+    env: DeploymentEnv,
+  ): ConfigFinding[] {
+    return [
+      finding(
+        {
+          id: 'monitoring-sidecar-unreachable',
+          category: 'monitoring',
+          title: 'The monitoring sidecar is not answering',
+          detail: `monitoring-sidecar's /api/monitoring/v1/config-audit ${probeFailure(response, this._config.upstreamTimeoutMs)}. While it is down this console cannot show alerts, and three things go unchecked rather than confirmed: node-server's classification of JWT_SECRET, NODE_SERVER_KEY, NODE_SERVER_SERVICE_KEY and TRANSCRIPTION_API_KEY; whether the sidecar and node-server agree on NODE_SERVER_SERVICE_KEY; and every fleet metric Prometheus scrapes from it.`,
+          remediation:
+            'Check `docker compose ps monitoring-sidecar` and `docker compose logs monitoring-sidecar`, and that ADMIN_MONITORING_SIDECAR_BASE_URL points at it on the backend network (monitoring-sidecar:80 by default).',
+          docUrl: DOC.monitoring,
+        },
+        { development: 'advisory', staging: 'warning', production: 'warning' },
+        env,
+      ),
+    ];
+  }
+
+  /**
+   * node-server refused the sidecar's key: the two copies of
+   * `NODE_SERVER_SERVICE_KEY` are different.
+   *
+   * This is the one *agreement* fact the deployment can already prove without
+   * anyone moving a secret, and it is proved the only way agreement is ever
+   * provable here — by a party that holds one copy presenting it to the party
+   * that holds the other, and reporting what came back. The sidecar polls
+   * node-server's `/status` with its `NODE_SERVER_SERVICE_API_KEY` every
+   * `NODE_STATUS_INTERVAL_SEC`; a 401 or 403 becomes the `unauthorized` poll
+   * reason, which `/config-audit` relays verbatim. Config Check reads it and
+   * says which two things disagree, rather than reporting the same string as
+   * one more way of not knowing.
+   *
+   * A rejection really is proof and not a guess, because both other
+   * explanations are closed off: node-server's `ServiceAuthService` refuses to
+   * construct when its own inbound key is empty or still `CHANGEME`, so a
+   * node-server that answers at all has a usable key, and the sidecar does not
+   * poll at all when its own copy is empty (it reports `disabled` instead).
+   * What remains is two different non-empty values — which is exactly the
+   * class of fault a placeholder check can never see.
+   */
+  private _nodeServerServiceKeyMismatch(env: DeploymentEnv): ConfigFinding[] {
+    return [
+      finding(
+        {
+          id: 'node-server-service-key-mismatch',
+          category: 'secrets',
+          title:
+            'monitoring-sidecar and node-server disagree on NODE_SERVER_SERVICE_KEY',
+          detail:
+            "node-server rejected the sidecar's status poll as unauthorized, so the two containers hold different values for NODE_SERVER_SERVICE_KEY — usually one of them was recreated after the .env changed and the other was not. Both values are real secrets rather than placeholders, so nothing else on this page reports them. While they disagree the sidecar publishes no node-server telemetry at all: the fleet dashboard's connection, upstream, auth and latency series stay empty, every alert rule built on them can never fire, and the secret classification above cannot be read.",
+          remediation:
+            'Set one NODE_SERVER_SERVICE_KEY in deployment/.env, then recreate both containers together: `docker compose up -d node-server monitoring-sidecar`. Restarting only one leaves them disagreeing.',
+          docUrl: DOC.deployment,
+        },
+        { development: 'advisory', staging: 'warning', production: 'critical' },
+        env,
+      ),
+    ];
+  }
+
+  /**
+   * Does session-manager accept the admin key this console presents?
+   *
+   * The second pair the deployment can prove today, and by the same mechanism
+   * as `_nodeServerServiceKeyMismatch`: admin-server holds one copy of
+   * `SESSION_MANAGER_API_KEY` and session-manager holds the other, so asking
+   * an admin-key-protected route and reading the status *is* the comparison.
+   * No secret is moved and no new credential is needed — this is the key the
+   * gateway already presents on every page of the console.
+   *
+   * Its own check rather than a branch of `_checkSharedSchemaVersion`, which
+   * makes the same call: that one is reached only after `dbClient.ping()`
+   * succeeds, so on a deployment whose Postgres is also down — the case where
+   * an operator most needs to know which faults are separate — a rejected
+   * admin key would go unmentioned. It costs one extra `GET` on a page that
+   * already makes several, and the endpoint is the cheapest authenticated
+   * read session-manager has.
+   *
+   * Deliberately silent in two cases. An empty `ADMIN_API_KEY` is reported by
+   * `admin-api-key-missing` instead, which is the better sentence for it (and
+   * would otherwise produce two findings for one mistake). A session-manager
+   * that does not answer at all is reported by `services-unreachable`; only an
+   * actual 401/403 — session-manager answering, and refusing — is evidence
+   * about the key.
+   */
+  private async _checkSessionManagerKey(
+    env: DeploymentEnv,
+  ): Promise<ConfigFinding[]> {
+    if (this._config.adminApiKey === '') return [];
+
+    let status: number | undefined;
+    try {
+      const [response] =
+        await this._sessionManagerGatewayService.getSchemaStatus({
+          signal: AbortSignal.timeout(this._config.upstreamTimeoutMs),
+        });
+      status = response?.status;
+    } catch {
+      // Unreachable, timed out, or an unreadable body. Not evidence about the
+      // key, and already reported by the health rollup.
+      return [];
+    }
+
+    if (status !== 401 && status !== 403) return [];
+
+    return [
+      finding(
+        {
+          id: 'session-manager-admin-key-mismatch',
+          category: 'secrets',
+          title:
+            'admin-server and session-manager disagree on SESSION_MANAGER_API_KEY',
+          detail: `session-manager answered HTTP ${String(status)} to this console's admin key, so the two containers hold different values for SESSION_MANAGER_API_KEY (admin-server reads it as ADMIN_API_KEY). session-manager refuses to start when its own copy is empty or still the CHANGEME placeholder, so both values are real secrets that simply differ — usually one container was recreated after the .env changed and the other was not. Until they match, every page of this console that lists or edits rooms, devices, schedules or sessions answers 502 BACKEND_MISCONFIGURATION.`,
+          remediation:
+            'Set one SESSION_MANAGER_API_KEY in deployment/.env, then recreate both containers together: `docker compose up -d admin-server session-manager`. Restarting only one leaves them disagreeing.',
+          docUrl: DOC.deployment,
+        },
+        {
+          development: 'critical',
+          staging: 'critical',
+          production: 'critical',
+        },
+        env,
+      ),
+    ];
   }
 
   /**

--- a/apps/admin-server/src/server/features/config-check/config-check.service.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.service.ts
@@ -1,3 +1,4 @@
+import { isIPv4, isIPv6 } from 'node:net';
 import { Type } from 'typebox';
 import type { Static } from 'typebox';
 import { Value } from 'typebox/value';
@@ -215,6 +216,9 @@ export interface ConfigCheckConfig {
   upstreamTimeoutMs: number;
 }
 
+/** See `evaluateStaticChecks`'s "local admin password strength" section. */
+const MIN_LOCAL_PASSWORD_LENGTH = 8;
+
 const PLACEHOLDER_MARKER = 'CHANGEME';
 
 /** Matches the stub marker as a substring — see `assertNotPlaceholderKey`. */
@@ -285,6 +289,26 @@ export function resolveEnvironment(config: ConfigCheckConfig): {
     environmentSource: 'inferred',
     declaredButInvalid: declared !== '',
   };
+}
+
+/**
+ * Splits `ADMIN_LOCAL_CREDENTIALS` into its password half, mirroring
+ * `LocalAuthService`'s own parse rule exactly — split on the FIRST space
+ * only, so the password may itself contain spaces — so this check and
+ * boot-time parsing can never disagree about what the password actually is.
+ * Deliberately duplicated rather than imported: `LocalAuthService`'s parse is
+ * private to its constructor, and re-deriving three characters of `indexOf`
+ * logic here is cheaper and lower-risk than exporting it and coupling the two
+ * files together for a one-line rule.
+ *
+ * Returns `null` for anything `LocalAuthService` itself treats as malformed —
+ * no space, an empty username, or an empty password — which is reported as
+ * its own finding rather than measured as a (nonexistent) password.
+ */
+function parseLocalCredentialsPassword(raw: string): string | null {
+  const spaceIdx = raw.indexOf(' ');
+  if (spaceIdx <= 0 || spaceIdx === raw.length - 1) return null;
+  return raw.slice(spaceIdx + 1);
 }
 
 /**
@@ -607,6 +631,81 @@ export function evaluateStaticChecks(
     );
   }
 
+  // ---- local admin password strength ----
+  // Guarded on `!isPlaceholder` for the same reason the session-secret length
+  // check is: a placeholder value is already reported once, above, and
+  // reporting it a second time here (as "too short") would be a second
+  // finding for one cause. `ADMIN_LOCAL_CREDENTIALS` is not itself the
+  // secret — it is `"<username> <password>"`, parsed by `LocalAuthService`
+  // (split on the FIRST space only, so the password may contain spaces) — so
+  // measuring `config.adminLocalCredentials.length` directly would be
+  // measuring the username too, and would never fall to zero even for a
+  // one-character password. `parseLocalCredentialsPassword` mirrors that
+  // parse rule exactly so this check and boot-time parsing can never
+  // disagree about what the password actually is.
+  if (localLoginEnabled && !isPlaceholder(config.adminLocalCredentials)) {
+    const parsedPassword = parseLocalCredentialsPassword(
+      config.adminLocalCredentials,
+    );
+
+    if (parsedPassword === null) {
+      // No space, an empty username, or an empty password:
+      // `LocalAuthService` treats this as malformed and disables local login
+      // entirely (with a warn-level log), which `localLoginEnabled` above
+      // does not know — it is only `.trim() !== ''`. Worth its own finding
+      // rather than folding into `no-login-method` below: that check already
+      // has its own SSO-completeness reasoning, and conflating "local login
+      // is configured but broken" with "local login was never configured"
+      // would point the operator at the wrong fix (configure SSO) instead of
+      // the actual one (fix the format).
+      findings.push(
+        finding(
+          {
+            id: 'admin-local-credentials-malformed',
+            category: 'access',
+            title: 'ADMIN_LOCAL_CREDENTIALS is set but malformed',
+            detail:
+              'The value has no space separating a username from a password (or an empty username/password), so LocalAuthService disables local login entirely at boot. The admin console silently falls back to SSO only, with nothing on the sign-in page saying why.',
+            remediation:
+              'Set ADMIN_LOCAL_CREDENTIALS in deployment/.env to "<username> <password>" (one space between the two), or clear it entirely to disable local login on purpose.',
+          },
+          {
+            development: 'advisory',
+            staging: 'critical',
+            production: 'critical',
+          },
+          env,
+        ),
+      );
+    } else if (parsedPassword.length < MIN_LOCAL_PASSWORD_LENGTH) {
+      // The bar here is deliberately not the 32-character random-secret
+      // minimum `ADMIN_SESSION_SECRET` gets above: that value is generated
+      // once and never typed by a human, so asking for high entropy costs
+      // nothing. This one is a memorized password behind a login form, where
+      // NIST SP 800-63B's guidance is a length floor rather than a forced
+      // high-entropy string — 8 characters, the same floor OWASP ASVS L1
+      // uses. Below that, a password is guessable in a practical number of
+      // attempts even behind the login route's own rate limit.
+      findings.push(
+        finding(
+          {
+            id: 'admin-local-credentials-weak',
+            category: 'access',
+            title: `The local admin password is shorter than ${String(MIN_LOCAL_PASSWORD_LENGTH)} characters`,
+            detail: `${describeSecret(parsedPassword)}, below the ${String(MIN_LOCAL_PASSWORD_LENGTH)}-character minimum (NIST SP 800-63B / OWASP ASVS L1) for a password protecting full read-write admin access.`,
+            remediation: `Set ADMIN_LOCAL_CREDENTIALS in deployment/.env to "<username> <password>" with a password of at least ${String(MIN_LOCAL_PASSWORD_LENGTH)} characters — a short passphrase of a few random words is both easy to remember and long enough.`,
+          },
+          {
+            development: 'advisory',
+            staging: 'warning',
+            production: 'critical',
+          },
+          env,
+        ),
+      );
+    }
+  }
+
   if (!localLoginEnabled && !ssoFullyConfigured) {
     // Not a hardening nit: nobody can sign in at all. Checks the same
     // 5-var completeness as `isEnabled()`, not the looser `ssoConfigured` —
@@ -733,6 +832,115 @@ export function evaluateStaticChecks(
 }
 
 /**
+ * True when `host` (a Host-header hostname — no port, no brackets) certainly
+ * cannot be resolved by a device outside this host/network: loopback,
+ * RFC1918/link-local IPv4, loopback/unique-local/link-local IPv6, `.local`
+ * mDNS, or a bare single-label name — the shape of a Docker Compose service
+ * name or a LAN machine's own hostname, which resolves only on that specific
+ * network's DNS.
+ *
+ * Deliberately one-directional. A host that passes this (has a dot, isn't a
+ * private/loopback IP) is merely *not ruled out* — admin-server sits inside
+ * the backend network and has no way to dial out and confirm anything
+ * resolves from a device that isn't itself, so a normal-looking public FQDN
+ * is reported as "nothing to say", never as "reachable". Overstating that
+ * confidence is exactly the failure mode this check exists to avoid; see
+ * `evaluatePublicOriginCheck`'s doc.
+ */
+function looksUnreachableExternally(host: string): boolean {
+  const h = host.toLowerCase();
+  if (h === 'localhost' || h.endsWith('.localhost')) return true;
+  if (h.endsWith('.local')) return true;
+
+  if (isIPv4(h)) {
+    const octets = h.split('.').map(Number);
+    const [a, b] = octets;
+    if (a === undefined || b === undefined) return false;
+    return (
+      a === 127 || // loopback
+      a === 10 || // RFC1918
+      (a === 172 && b >= 16 && b <= 31) || // RFC1918
+      (a === 192 && b === 168) || // RFC1918
+      (a === 169 && b === 254) || // link-local
+      a === 0 // "this network"
+    );
+  }
+
+  if (isIPv6(h)) {
+    return (
+      h === '::1' || // loopback
+      h.startsWith('fc') || // unique-local fc00::/7
+      h.startsWith('fd') ||
+      h.startsWith('fe8') || // link-local fe80::/10
+      h.startsWith('fe9') ||
+      h.startsWith('fea') ||
+      h.startsWith('feb')
+    );
+  }
+
+  // No dot at all: not a real FQDN, so it can only be a bare label — a
+  // Compose service name (`admin-server`), an unqualified LAN hostname, or
+  // similar. None of those resolve outside the network that hands them out.
+  return !h.includes('.');
+}
+
+/**
+ * Is the address this request reached admin-server on one that certainly
+ * will not resolve for the audience a QR code is meant for?
+ *
+ * There is no `PUBLIC_ORIGIN` (or equivalent) variable anywhere in this
+ * deployment for admin-server to read and check — confirmed by reading
+ * `deployment/compose.yml` and `infra/scribear-nginx/nginx.conf`: nginx's own
+ * `server_name` is the wildcard `_` (matches any Host), and the one `ORIGIN`
+ * value in `deployment/.env.example` is read only by the demo curl scripts
+ * (`deployment/create-room.sh` and siblings), never by nginx or any service.
+ * `apps/admin-webapp/src/lib/join-url.ts` and `kiosk-url.ts` build every join
+ * link and kiosk QR code from `window.location.origin` — literally whatever
+ * host the operator's own browser used to reach the admin console — so the
+ * *only* place this fact exists is the Host header of the request that
+ * asked for this very report, forwarded unchanged by nginx
+ * (`proxy_set_header Host $host;`).
+ *
+ * That makes this check necessarily request-scoped, not deployment-scoped: it
+ * says "the address you reached this page on", not "the deployment's public
+ * origin" — a different admin, or the same admin through a different tunnel,
+ * could get a different answer from the same deployment. And it can only
+ * rule addresses *out*: admin-server sits inside the backend network with no
+ * way to dial out from a device that isn't itself, so a normal-looking public
+ * hostname is reported as nothing (silence, like every other check on this
+ * page that found no problem) rather than as verified-reachable — see
+ * `looksUnreachableExternally`'s doc for why overclaiming here would be worse
+ * than staying silent.
+ */
+export function evaluatePublicOriginCheck(
+  requestHostname: string,
+  env: DeploymentEnv,
+): ConfigFinding[] {
+  const host = requestHostname.trim();
+  // Should not happen over HTTP/1.1+ (Host is mandatory), and there is
+  // nothing to check without one — not worth its own finding.
+  if (host === '') return [];
+
+  if (!looksUnreachableExternally(host)) return [];
+
+  return [
+    finding(
+      {
+        id: 'public-origin-not-externally-resolvable',
+        category: 'access',
+        title:
+          'The address used to reach this console will not resolve outside this host/network',
+        detail: `This request reached admin-server as "${host}" — a loopback, private-network, or container-local address. join-url.ts and kiosk-url.ts build every join link and kiosk QR code from exactly this address (the browser's own window.location.origin), so a QR code generated by an operator reaching the console this way will not resolve for anyone outside this host or network — invisible until a room fails in front of an audience. admin-server cannot confirm the opposite (that a normal-looking public hostname actually resolves off-host) from inside the backend network, so this check only catches addresses that certainly will not work.`,
+        remediation:
+          'Reach the admin console through the same public DNS name your audience will use to scan the QR code (e.g. https://scribear.example.edu), not a loopback address, private IP, VPN-only alias, or bare container/service name. If a load balancer or reverse proxy sits in front of this nginx, verify it forwards the public Host header rather than an internal one.',
+      },
+      { development: 'advisory', staging: 'critical', production: 'critical' },
+      env,
+    ),
+  ];
+}
+
+/**
  * Why a `_probe` call did not produce a usable answer, as a clause to drop
  * into a finding's detail.
  *
@@ -816,6 +1024,7 @@ export class ConfigCheckService {
   private _dbClient: AppDependencies['dbClient'];
   private _sessionManagerGatewayService: AppDependencies['sessionManagerGatewayService'];
   private _backupDirectoryService: AppDependencies['backupDirectoryService'];
+  private _testAudioGatewayService: AppDependencies['testAudioGatewayService'];
 
   constructor(
     configCheckConfig: ConfigCheckConfig,
@@ -824,6 +1033,7 @@ export class ConfigCheckService {
     dbClient: AppDependencies['dbClient'],
     sessionManagerGatewayService: AppDependencies['sessionManagerGatewayService'],
     backupDirectoryService: AppDependencies['backupDirectoryService'],
+    testAudioGatewayService: AppDependencies['testAudioGatewayService'],
   ) {
     this._config = configCheckConfig;
     this._fleetTelemetryService = fleetTelemetryService;
@@ -831,9 +1041,18 @@ export class ConfigCheckService {
     this._dbClient = dbClient;
     this._sessionManagerGatewayService = sessionManagerGatewayService;
     this._backupDirectoryService = backupDirectoryService;
+    this._testAudioGatewayService = testAudioGatewayService;
   }
 
-  async check(): Promise<ConfigCheckReport> {
+  /**
+   * @param requestHostname The Host header of the request that asked for
+   * this report (no port), used only by `evaluatePublicOriginCheck` — see
+   * its doc for why this one check is necessarily request-scoped rather than
+   * a property of `ConfigCheckConfig`. Defaults to `''` (no finding) so every
+   * existing direct caller of `.check()` — the great majority of this file's
+   * own unit tests — is unaffected; only the HTTP route passes a real value.
+   */
+  async check(requestHostname = ''): Promise<ConfigCheckReport> {
     const { environment, environmentSource, declaredButInvalid } =
       resolveEnvironment(this._config);
 
@@ -845,6 +1064,7 @@ export class ConfigCheckService {
       secretPlaceholders,
       sessionManagerKey,
       backup,
+      testAudioServiceKey,
     ] = await Promise.all([
       this._checkTelemetryBackplane(environment),
       this._checkServiceReachability(environment),
@@ -853,10 +1073,12 @@ export class ConfigCheckService {
       this._checkSecretPlaceholders(environment),
       this._checkSessionManagerKey(environment),
       this._checkBackup(environment),
+      this._checkTestAudioServiceKey(environment),
     ]);
 
     const findings = [
       ...evaluateStaticChecks(this._config, environment, declaredButInvalid),
+      ...evaluatePublicOriginCheck(requestHostname, environment),
       ...database,
       ...telemetry,
       ...services,
@@ -864,6 +1086,7 @@ export class ConfigCheckService {
       ...secretPlaceholders,
       ...sessionManagerKey,
       ...backup,
+      ...testAudioServiceKey,
     ];
 
     const summary: Record<CheckSeverity, number> = {
@@ -1173,6 +1396,105 @@ export class ConfigCheckService {
     }
 
     return findings;
+  }
+
+  /**
+   * Is `TEST_AUDIO_SERVICE_KEY` actually the key `test-audio-generator` is
+   * running with — not just "not the example placeholder" (the static check
+   * above), but *live-verified* against the service it authenticates to.
+   *
+   * A key that is present, non-placeholder, and simply wrong — the operator
+   * copied the wrong value, or only one of the two `.env` copies was updated
+   * on a redeploy — is invisible to every check that inspects
+   * `TEST_AUDIO_SERVICE_KEY` alone; today it reads identically to a correct
+   * key right up until an operator presses "Send test audio" on a room and
+   * it fails. Shaped like `_checkGrafana`'s password check for the same
+   * reason: probe with the gateway already used for real traffic
+   * (`TestAudioGatewayService`, injected — the same "the value never leaves
+   * the process it authenticates from" discipline `_checkGrafana`'s doc
+   * describes) rather than re-deriving the URL/header here, and keep the
+   * three outcomes — verified, verified-wrong, and could-not-verify —
+   * distinct, the same distinction `probeFailure` exists to preserve for
+   * Grafana/Prometheus: a probe that could not run must not read as a pass.
+   *
+   * `listDevices()` (`GET /devices`) is the cheapest authenticated route the
+   * generator exposes — a read, not a job start — so this never triggers an
+   * actual test-audio stream just to check a key.
+   *
+   * Gated on `!isPlaceholder`, same as the local-password check above: a
+   * placeholder key is already reported by `secretChecks`, and a placeholder
+   * key that happens to be identical on both sides (an operator who copied
+   * the *same* placeholder into both `.env` files) would otherwise probe as
+   * "verified" and bury the far more important placeholder finding under a
+   * reassuring green result.
+   */
+  private async _checkTestAudioServiceKey(
+    env: DeploymentEnv,
+  ): Promise<ConfigFinding[]> {
+    if (!this._testAudioGatewayService.enabled) return [];
+    if (isPlaceholder(this._config.testAudioServiceKey)) return [];
+
+    const result = await this._testAudioGatewayService.listDevices();
+
+    const couldNotVerify = (detail: string): ConfigFinding[] => [
+      finding(
+        {
+          id: 'test-audio-service-key-probe-unavailable',
+          category: 'secrets',
+          title:
+            'Could not verify TEST_AUDIO_SERVICE_KEY against the test audio generator',
+          detail,
+          remediation:
+            'Check that test-audio-generator is running and reachable at TEST_AUDIO_BASE_URL, then re-check.',
+        },
+        { development: 'advisory', staging: 'warning', production: 'warning' },
+        env,
+      ),
+    ];
+
+    if (result.kind === 'unreachable') {
+      return couldNotVerify(
+        'TEST_AUDIO_BASE_URL is set and test-audio-generator did not answer GET /devices. TEST_AUDIO_SERVICE_KEY could not be checked either way — this is not a pass.',
+      );
+    }
+
+    if (result.kind === 'unparseable') {
+      return couldNotVerify(
+        `test-audio-generator answered GET /devices with HTTP ${String(result.status)} and a body Config Check could not parse. TEST_AUDIO_SERVICE_KEY could not be checked either way — this is not a pass.`,
+      );
+    }
+
+    if (result.status === 401 || result.status === 403) {
+      return [
+        finding(
+          {
+            id: 'test-audio-service-key-mismatch',
+            category: 'secrets',
+            title:
+              'TEST_AUDIO_SERVICE_KEY is rejected by the test audio generator',
+            detail: `GET /devices answered HTTP ${String(result.status)}. TEST_AUDIO_SERVICE_KEY is set and is not the example placeholder, but does not match test-audio-generator's own copy — every "Send test audio" attempt for a room will fail, indistinguishable from the room page alone from the generator being down.`,
+            remediation:
+              "Set TEST_AUDIO_SERVICE_KEY in deployment/.env to match test-audio-generator's own TEST_AUDIO_SERVICE_KEY (its inbound key), then recreate both containers.",
+          },
+          {
+            development: 'warning',
+            staging: 'critical',
+            production: 'critical',
+          },
+          env,
+        ),
+      ];
+    }
+
+    if (result.status >= 200 && result.status < 300) return [];
+
+    // Any other status the generator could actually answer with (5xx, an
+    // unexpected 4xx) is a service that answered but not usably — same
+    // "could not verify" bucket as unreachable/unparseable, not a pass and
+    // not a confirmed mismatch either.
+    return couldNotVerify(
+      `test-audio-generator answered GET /devices with HTTP ${String(result.status)}, neither the 200 a valid key produces nor the 401/403 a rejected one would. TEST_AUDIO_SERVICE_KEY could not be checked either way — this is not a pass.`,
+    );
   }
 
   /**

--- a/apps/admin-server/src/server/features/config-check/config-check.service.ts
+++ b/apps/admin-server/src/server/features/config-check/config-check.service.ts
@@ -156,14 +156,6 @@ export interface ConfigCheckReport {
 }
 
 /**
- * Everything the check inspects, gathered by `AppConfig` so this service never
- * reads `process.env` itself and can be tested by construction.
- *
- * Secret *values* are passed in because classifying them requires them. They
- * never leave this process: every finding reports a classification, and
- * `describeSecret` is the only thing that turns a secret into prose.
- */
-/**
  * The one logging call this service makes, narrowed to what it needs.
  *
  * Passed into `check()` rather than injected, deliberately: `configCheckService`
@@ -176,6 +168,14 @@ export interface CheckLogger {
   debug: (obj: Record<string, unknown>, msg: string) => void;
 }
 
+/**
+ * Everything the check inspects, gathered by `AppConfig` so this service never
+ * reads `process.env` itself and can be tested by construction.
+ *
+ * Secret *values* are passed in because classifying them requires them. They
+ * never leave this process: every finding reports a classification, and
+ * `describeSecret` is the only thing that turns a secret into prose.
+ */
 export interface ConfigCheckConfig {
   declaredEnv: string;
   /** True when the server was started with `--dev`. */
@@ -845,22 +845,6 @@ export function evaluateStaticChecks(
 }
 
 /**
- * True when `host` (a Host-header hostname — no port, no brackets) certainly
- * cannot be resolved by a device outside this host/network: loopback,
- * RFC1918/link-local IPv4, loopback/unique-local/link-local IPv6, `.local`
- * mDNS, or a bare single-label name — the shape of a Docker Compose service
- * name or a LAN machine's own hostname, which resolves only on that specific
- * network's DNS.
- *
- * Deliberately one-directional. A host that passes this (has a dot, isn't a
- * private/loopback IP) is merely *not ruled out* — admin-server sits inside
- * the backend network and has no way to dial out and confirm anything
- * resolves from a device that isn't itself, so a normal-looking public FQDN
- * is reported as "nothing to say", never as "reachable". Overstating that
- * confidence is exactly the failure mode this check exists to avoid; see
- * `evaluatePublicOriginCheck`'s doc.
- */
-/**
  * Whether a dotted-quad IPv4 address is one that cannot be reached from
  * outside the network that handed it out. Split out so the IPv4-mapped IPv6
  * form (`::ffff:10.1.2.3`) is judged by exactly the same rules rather than by
@@ -879,6 +863,22 @@ function isUnroutableIPv4(host: string): boolean {
   );
 }
 
+/**
+ * True when `host` (a Host-header hostname — no port, no brackets) certainly
+ * cannot be resolved by a device outside this host/network: loopback,
+ * RFC1918/link-local IPv4, loopback/unique-local/link-local IPv6, `.local`
+ * mDNS, or a bare single-label name — the shape of a Docker Compose service
+ * name or a LAN machine's own hostname, which resolves only on that specific
+ * network's DNS.
+ *
+ * Deliberately one-directional. A host that passes this (has a dot, isn't a
+ * private/loopback IP) is merely *not ruled out* — admin-server sits inside
+ * the backend network and has no way to dial out and confirm anything
+ * resolves from a device that isn't itself, so a normal-looking public FQDN
+ * is reported as "nothing to say", never as "reachable". Overstating that
+ * confidence is exactly the failure mode this check exists to avoid; see
+ * `evaluatePublicOriginCheck`'s doc.
+ */
 function looksUnreachableExternally(host: string): boolean {
   const h = host.toLowerCase();
   if (h === 'localhost' || h.endsWith('.localhost')) return true;

--- a/apps/admin-server/tests/integration/config-check.routes.test.ts
+++ b/apps/admin-server/tests/integration/config-check.routes.test.ts
@@ -240,7 +240,7 @@ describe('Config check route', () => {
       expect(data.blockingForProduction).toBeGreaterThanOrEqual(1);
     });
 
-    it('reports unavailable rather than silence when the sidecar cannot answer', async () => {
+    it('names the sidecar, not node-server, when the sidecar cannot answer', async () => {
       vi.stubGlobal('fetch', (url: string) => {
         if (url.startsWith(CONFIG_AUDIT_URL)) {
           return Promise.reject(new Error('connect ECONNREFUSED'));
@@ -259,9 +259,11 @@ describe('Config check route', () => {
         headers: { cookie },
       });
 
-      expect(
-        res.json<ConfigCheckBody>().data.findings.map((f) => f.id),
-      ).toContain('secret-placeholder-audit-unavailable');
+      const ids = res.json<ConfigCheckBody>().data.findings.map((f) => f.id);
+      expect(ids).toContain('monitoring-sidecar-unreachable');
+      // Never silence, and never a clean bill of health for the secrets it
+      // could not read.
+      expect(ids.some((id) => id.endsWith('-placeholder'))).toBe(false);
     });
   });
 });

--- a/apps/admin-server/tests/integration/config-check.routes.test.ts
+++ b/apps/admin-server/tests/integration/config-check.routes.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, vi } from 'vitest';
 
 import type { ConfigCheckReport } from '#src/server/features/config-check/config-check.service.js';
 import {
+  TEST_AUDIO_BASE_URL,
   TEST_MONITORING_SIDECAR_BASE_URL,
   TEST_NODE_BASE_URL,
   TEST_SM_BASE_URL,
@@ -113,7 +114,13 @@ describe('Config check route', () => {
       const res = await server.fastify.inject({
         method: 'GET',
         url: URL,
-        headers: { cookie },
+        // `light-my-request` defaults the Host header to `localhost` when
+        // none is given — exactly the address `public-origin-not-
+        // externally-resolvable` (config-check.service.test.ts) exists to
+        // flag, and unrelated to what this test is asserting. A normal-
+        // looking public host keeps this list to the five findings the test
+        // name promises.
+        headers: { cookie, host: 'admin.example.edu' },
       });
 
       expect(
@@ -156,6 +163,36 @@ describe('Config check route', () => {
       expect(
         res.json<ConfigCheckBody>().data.findings.map((f) => f.id),
       ).not.toContain('schema-version-skew');
+    });
+  });
+
+  // End-to-end coverage for the `req.hostname` wiring itself
+  // (`config-check.controller.ts`) - `evaluatePublicOriginCheck`'s own logic
+  // is exhaustively unit-tested; this only proves the Host header a real
+  // request carries actually reaches it.
+  describe('the public origin', (it) => {
+    it('flags the address reached when no Host header looks public (light-my-request defaults to "localhost")', async () => {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: URL,
+        headers: { cookie },
+      });
+
+      expect(
+        res.json<ConfigCheckBody>().data.findings.map((f) => f.id),
+      ).toContain('public-origin-not-externally-resolvable');
+    });
+
+    it('reports nothing when reached on a normal-looking public host', async () => {
+      const res = await server.fastify.inject({
+        method: 'GET',
+        url: URL,
+        headers: { cookie, host: 'scribear.example.edu' },
+      });
+
+      expect(
+        res.json<ConfigCheckBody>().data.findings.map((f) => f.id),
+      ).not.toContain('public-origin-not-externally-resolvable');
     });
   });
 
@@ -265,5 +302,156 @@ describe('Config check route', () => {
       // could not read.
       expect(ids.some((id) => id.endsWith('-placeholder'))).toBe(false);
     });
+  });
+});
+
+// A separate server, not a describe block inside the one above: this is the
+// only fixture in the file with `testAudioConfig.baseUrl` set at all (every
+// other test's is the default `''`, i.e. the feature turned off), so the
+// live probe exists to be end-to-end tested. `TestAudioGatewayService`
+// itself is unit-tested directly; this only proves the DI wiring — the new
+// constructor parameter and the `Promise.all` member in `check()` — actually
+// runs it.
+describe('Config check route - the test audio service key probe', (it) => {
+  const TEST_AUDIO_DEVICES_URL = `${TEST_AUDIO_BASE_URL}/api/test-audio/v1/devices`;
+
+  const server = useServer({
+    configCheckConfig: { redisUrl: '' },
+    testAudioConfig: { baseUrl: TEST_AUDIO_BASE_URL },
+  });
+  let cookie = '';
+
+  beforeAll(async () => {
+    cookie = (await login(server.fastify)).cookie;
+  });
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', (url: string) => {
+      if (
+        url.startsWith(
+          `${TEST_MONITORING_SIDECAR_BASE_URL}/api/monitoring/v1/config-audit`,
+        )
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              nodeServer: {
+                status: 'ok',
+                secretPlaceholders: {
+                  sessionTokenSigningKeyIsPlaceholder: false,
+                  sessionManagerServiceApiKeyIsPlaceholder: false,
+                  nodeServerServiceApiKeyIsPlaceholder: false,
+                  transcriptionServiceApiKeyIsPlaceholder: false,
+                },
+              },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        );
+      }
+      const known = [TEST_SM_BASE_URL, TEST_NODE_BASE_URL, TEST_TS_BASE_URL];
+      if (!known.some((base) => url.startsWith(base))) {
+        return Promise.reject(new Error('connect ECONNREFUSED'));
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ status: 'ok' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reports nothing when the generator accepts the key', async () => {
+    vi.stubGlobal('fetch', (url: string) => {
+      if (url.startsWith(TEST_AUDIO_DEVICES_URL)) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ devices: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ status: 'ok' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    });
+
+    const res = await server.fastify.inject({
+      method: 'GET',
+      url: URL,
+      headers: { cookie, host: 'scribear.example.edu' },
+    });
+
+    expect(
+      res.json<ConfigCheckBody>().data.findings.map((f) => f.id),
+    ).not.toContain('test-audio-service-key-mismatch');
+  });
+
+  it('flags a rejected key as a mismatch, not a silent pass', async () => {
+    vi.stubGlobal('fetch', (url: string) => {
+      if (url.startsWith(TEST_AUDIO_DEVICES_URL)) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ code: 'UNAUTHORIZED' }), {
+            status: 401,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ status: 'ok' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    });
+
+    const res = await server.fastify.inject({
+      method: 'GET',
+      url: URL,
+      headers: { cookie, host: 'scribear.example.edu' },
+    });
+
+    const { data } = res.json<ConfigCheckBody>();
+    const found = data.findings.find(
+      (f) => f.id === 'test-audio-service-key-mismatch',
+    );
+    expect(found?.severity).toBe('critical');
+    expect(data.blockingForProduction).toBeGreaterThanOrEqual(1);
+  });
+
+  it('reports "could not verify", not a pass, when the generator does not answer', async () => {
+    vi.stubGlobal('fetch', (url: string) => {
+      if (url.startsWith(TEST_AUDIO_DEVICES_URL)) {
+        return Promise.reject(new Error('connect ECONNREFUSED'));
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ status: 'ok' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    });
+
+    const res = await server.fastify.inject({
+      method: 'GET',
+      url: URL,
+      headers: { cookie, host: 'scribear.example.edu' },
+    });
+
+    const findings = res.json<ConfigCheckBody>().data.findings;
+    expect(findings.map((f) => f.id)).toContain(
+      'test-audio-service-key-probe-unavailable',
+    );
+    expect(findings.map((f) => f.id)).not.toContain(
+      'test-audio-service-key-mismatch',
+    );
   });
 });

--- a/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
+++ b/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
@@ -9,6 +9,7 @@ import {
 import type { ConfigCheckConfig } from '#src/server/features/config-check/config-check.service.js';
 import {
   ConfigCheckService,
+  evaluatePublicOriginCheck,
   evaluateStaticChecks,
   resolveEnvironment,
 } from '#src/server/features/config-check/config-check.service.js';
@@ -109,6 +110,22 @@ const REACHABLE_DB: DbClientLike = {
 const FRESH_BACKUP = { newestDumpAgeMs: () => Promise.resolve(0) };
 
 /**
+ * A `TestAudioGatewayService` stand-in that reports the feature as unset —
+ * `TEST_AUDIO_BASE_URL` empty, matching `CLEAN`'s implicit default — so
+ * `_checkTestAudioServiceKey` short-circuits before ever calling
+ * `listDevices()`. Every helper below except the dedicated `testAudioService`
+ * describe block uses this, the same way they pass `{ enabled: false }` for
+ * the monitoring gateways they are not testing.
+ */
+const TEST_AUDIO_GATEWAY_DISABLED = {
+  enabled: false,
+  listDevices: () =>
+    Promise.reject(
+      new Error('listDevices() should not be called while disabled'),
+    ),
+};
+
+/**
  * A `ConfigCheckService` whose only live dependency is the database: fleet
  * telemetry is off, every probed service answers, and session-manager reports the
  * same schema version this build expects, so the findings from `check()` are
@@ -130,6 +147,7 @@ function dbService(
     dbClient as unknown as Args[3],
     gateway(reportedLatest) as unknown as Args[4],
     FRESH_BACKUP as unknown as Args[5],
+    TEST_AUDIO_GATEWAY_DISABLED as unknown as Args[6],
   );
 }
 
@@ -234,6 +252,7 @@ function healthService(components: HealthComponentLike[]): ConfigCheckService {
     REACHABLE_DB as unknown as Args[3],
     gateway(LATEST_MIGRATION) as unknown as Args[4],
     FRESH_BACKUP as unknown as Args[5],
+    TEST_AUDIO_GATEWAY_DISABLED as unknown as Args[6],
   );
 }
 
@@ -351,6 +370,7 @@ function monitoringService(
     REACHABLE_DB as unknown as Args[3],
     gateway(LATEST_MIGRATION) as unknown as Args[4],
     FRESH_BACKUP as unknown as Args[5],
+    TEST_AUDIO_GATEWAY_DISABLED as unknown as Args[6],
   );
 }
 
@@ -383,6 +403,7 @@ function backupService(
     REACHABLE_DB as unknown as Args[3],
     gateway(LATEST_MIGRATION) as unknown as Args[4],
     backupDirectory as unknown as Args[5],
+    TEST_AUDIO_GATEWAY_DISABLED as unknown as Args[6],
   );
 }
 
@@ -632,6 +653,83 @@ describe('evaluateStaticChecks', () => {
     });
   });
 
+  describe('the local admin password', (it) => {
+    // CLEAN's own `adminLocalCredentials` password half is 16 characters —
+    // "healthy" for every test in this block that does not override it.
+    it('accepts a password at or above the 8-character minimum', () => {
+      const found = ids({ adminLocalCredentials: 'engrit 8charmin' });
+      expect(found).not.toContain('admin-local-credentials-weak');
+      expect(found).not.toContain('admin-local-credentials-malformed');
+    });
+
+    it('flags a password shorter than 8 characters', () => {
+      expect(ids({ adminLocalCredentials: 'engrit 1234567' })).toContain(
+        'admin-local-credentials-weak',
+      );
+    });
+
+    it('flags the one-character password the placeholder check alone would pass', () => {
+      // The motivating case: `x` contains no placeholder marker, so
+      // `admin-local-credentials-placeholder` stays quiet on its own.
+      const found = ids({ adminLocalCredentials: 'engrit x' });
+      expect(found).not.toContain('admin-local-credentials-placeholder');
+      expect(found).toContain('admin-local-credentials-weak');
+    });
+
+    it('does not flag a password of exactly 8 characters', () => {
+      expect(ids({ adminLocalCredentials: 'engrit exactly8' })).not.toContain(
+        'admin-local-credentials-weak',
+      );
+    });
+
+    it('is a warning in staging but blocks production, like the session secret', () => {
+      const [found] = check({
+        declaredEnv: 'staging',
+        adminLocalCredentials: 'engrit short',
+      }).filter((f) => f.id === 'admin-local-credentials-weak');
+
+      expect(found?.severity).toBe('warning');
+      expect(found?.productionSeverity).toBe('critical');
+    });
+
+    it('flags a value with no space as malformed, not as a zero-length password', () => {
+      const found = ids({ adminLocalCredentials: 'nopasswordhere' });
+      expect(found).toContain('admin-local-credentials-malformed');
+      expect(found).not.toContain('admin-local-credentials-weak');
+    });
+
+    it('flags a trailing space (empty password) as malformed', () => {
+      expect(ids({ adminLocalCredentials: 'engrit ' })).toContain(
+        'admin-local-credentials-malformed',
+      );
+    });
+
+    it('flags a leading space (empty username) as malformed', () => {
+      expect(ids({ adminLocalCredentials: ' engritpassword' })).toContain(
+        'admin-local-credentials-malformed',
+      );
+    });
+
+    it('does not flag an absent (login disabled) credential', () => {
+      const found = ids({
+        adminLocalCredentials: '',
+        // CLEAN's Azure vars are already all set, so this stays a clean
+        // SSO-only deployment rather than also tripping no-login-method.
+      });
+      expect(found).not.toContain('admin-local-credentials-weak');
+      expect(found).not.toContain('admin-local-credentials-malformed');
+    });
+
+    // One mistake, one finding: a value that already reads as the example
+    // placeholder is reported once, by the placeholder check, not a second
+    // time here as "too short" — mirrors the session-secret guard above.
+    it('does not also flag a placeholder value as weak, even when the parsed password is short', () => {
+      const found = ids({ adminLocalCredentials: 'CHANGEMEuser yz' });
+      expect(found).toContain('admin-local-credentials-placeholder');
+      expect(found).not.toContain('admin-local-credentials-weak');
+    });
+  });
+
   describe('login configuration', (it) => {
     it('flags a deployment nobody can sign in to', () => {
       expect(
@@ -853,6 +951,97 @@ describe('evaluateStaticChecks', () => {
         ).toBeTruthy();
       }
     });
+  });
+});
+
+describe('evaluatePublicOriginCheck', (it) => {
+  const idsFor = (host: string): string[] =>
+    evaluatePublicOriginCheck(host, 'production').map((f) => f.id);
+
+  it('flags localhost', () => {
+    expect(idsFor('localhost')).toContain(
+      'public-origin-not-externally-resolvable',
+    );
+  });
+
+  it('flags a loopback IPv4 literal', () => {
+    expect(idsFor('127.0.0.1')).toContain(
+      'public-origin-not-externally-resolvable',
+    );
+  });
+
+  it.each(['10.1.2.3', '172.16.0.5', '172.31.255.255', '192.168.1.1'])(
+    'flags the private IPv4 address %s',
+    (host) => {
+      expect(idsFor(host)).toContain('public-origin-not-externally-resolvable');
+    },
+  );
+
+  it('does not flag a public-looking IPv4 address', () => {
+    // 172.32.x is outside the 172.16/12 RFC1918 block by one - a real
+    // boundary check, not just "starts with 172".
+    expect(idsFor('172.32.0.1')).toEqual([]);
+  });
+
+  it('flags a link-local IPv4 address', () => {
+    expect(idsFor('169.254.1.1')).toContain(
+      'public-origin-not-externally-resolvable',
+    );
+  });
+
+  it('flags an IPv6 loopback literal', () => {
+    expect(idsFor('::1')).toContain('public-origin-not-externally-resolvable');
+  });
+
+  it('flags an IPv6 unique-local address', () => {
+    expect(idsFor('fd12:3456:789a::1')).toContain(
+      'public-origin-not-externally-resolvable',
+    );
+  });
+
+  it('flags a bare single-label hostname (Compose service name shape)', () => {
+    expect(idsFor('admin-server')).toContain(
+      'public-origin-not-externally-resolvable',
+    );
+  });
+
+  it('flags a .local mDNS name', () => {
+    expect(idsFor('my-laptop.local')).toContain(
+      'public-origin-not-externally-resolvable',
+    );
+  });
+
+  it('does not flag a normal-looking public FQDN', () => {
+    // Cannot be *confirmed* reachable from admin-server's position (see the
+    // function's own doc) - only "not ruled out", which is silence.
+    expect(idsFor('scribear.example.edu')).toEqual([]);
+  });
+
+  it('does not flag a public IPv4 address', () => {
+    expect(idsFor('8.8.8.8')).toEqual([]);
+  });
+
+  it('reports nothing for an empty hostname', () => {
+    expect(idsFor('')).toEqual([]);
+  });
+
+  it('is advisory in development but blocks production', () => {
+    const [found] = evaluatePublicOriginCheck('localhost', 'staging').filter(
+      (f) => f.id === 'public-origin-not-externally-resolvable',
+    );
+    expect(found?.severity).toBe('critical');
+    expect(found?.productionSeverity).toBe('critical');
+
+    const [devFound] = evaluatePublicOriginCheck(
+      'localhost',
+      'development',
+    ).filter((f) => f.id === 'public-origin-not-externally-resolvable');
+    expect(devFound?.severity).toBe('advisory');
+  });
+
+  it('names the offending host in the detail', () => {
+    const [found] = evaluatePublicOriginCheck('localhost', 'production');
+    expect(found?.detail).toContain('localhost');
   });
 });
 
@@ -1392,6 +1581,160 @@ describe('the monitoring probes', () => {
         false,
       );
     });
+  });
+});
+
+/** What `TestAudioGatewayService.listDevices()` can resolve to. */
+type TestAudioResultLike =
+  | { kind: 'response'; status: number; body?: unknown }
+  | { kind: 'unparseable'; status: number }
+  | { kind: 'unreachable'; err: unknown };
+
+/**
+ * A `ConfigCheckService` with a stand-in `TestAudioGatewayService`: `enabled`
+ * mirrors `TEST_AUDIO_BASE_URL` being set, and `listDevices()` resolves to
+ * `result` exactly once — every other dependency is healthy, so `check()`'s
+ * findings are exactly what `_checkTestAudioServiceKey` made of `result`.
+ */
+function testAudioService(
+  enabled: boolean,
+  result: TestAudioResultLike,
+  overrides: Partial<ConfigCheckConfig> = {},
+): ConfigCheckService {
+  type Args = ConstructorParameters<typeof ConfigCheckService>;
+  const gatewayStub = {
+    enabled,
+    listDevices: () => Promise.resolve(result),
+  };
+  return new ConfigCheckService(
+    { ...CLEAN, ...overrides },
+    { enabled: false } as unknown as Args[1],
+    { check: () => Promise.resolve([]) } as unknown as Args[2],
+    REACHABLE_DB as unknown as Args[3],
+    gateway(LATEST_MIGRATION) as unknown as Args[4],
+    FRESH_BACKUP as unknown as Args[5],
+    gatewayStub as unknown as Args[6],
+  );
+}
+
+async function testAudioIds(
+  enabled: boolean,
+  result: TestAudioResultLike,
+  overrides: Partial<ConfigCheckConfig> = {},
+): Promise<string[]> {
+  const report = await testAudioService(enabled, result, overrides).check();
+  return report.findings.map((f) => f.id);
+}
+
+describe('the test audio service key probe', (it) => {
+  it('does not probe at all when TEST_AUDIO_BASE_URL is unset', async () => {
+    // `enabled: false` here stands for "TEST_AUDIO_BASE_URL is empty" -
+    // `listDevices()` on this stub would reject if ever called, so a passing
+    // test also proves the probe was skipped, not merely that its result
+    // produced no finding.
+    const found = await testAudioIds(false, {
+      kind: 'unreachable',
+      err: new Error('should not be called'),
+    });
+    expect(found.some((id) => id.startsWith('test-audio-service-key-'))).toBe(
+      false,
+    );
+  });
+
+  it('reports nothing when the key is accepted', async () => {
+    const found = await testAudioIds(true, {
+      kind: 'response',
+      status: 200,
+      body: { devices: [] },
+    });
+    expect(found.some((id) => id.startsWith('test-audio-service-key-'))).toBe(
+      false,
+    );
+  });
+
+  it('flags a rejected key (wrong, not placeholder) as a mismatch, not a pass', async () => {
+    const found = await testAudioIds(true, {
+      kind: 'response',
+      status: 401,
+      body: {},
+    });
+    expect(found).toContain('test-audio-service-key-mismatch');
+  });
+
+  it('also flags a 403 as a mismatch', async () => {
+    const found = await testAudioIds(true, {
+      kind: 'response',
+      status: 403,
+      body: {},
+    });
+    expect(found).toContain('test-audio-service-key-mismatch');
+  });
+
+  it('is critical in staging and production, unlike a probe that could not run', async () => {
+    const [found] = (
+      await testAudioService(true, {
+        kind: 'response',
+        status: 401,
+        body: {},
+      }).check()
+    ).findings.filter((f) => f.id === 'test-audio-service-key-mismatch');
+    expect(found?.severity).toBe('critical');
+  });
+
+  it('reports "could not verify" - not a pass - when the generator is unreachable', async () => {
+    const found = await testAudioIds(true, {
+      kind: 'unreachable',
+      err: new Error('connect ECONNREFUSED'),
+    });
+    expect(found).toContain('test-audio-service-key-probe-unavailable');
+    expect(found).not.toContain('test-audio-service-key-mismatch');
+  });
+
+  it('reports "could not verify" when the response body is unparseable', async () => {
+    const found = await testAudioIds(true, {
+      kind: 'unparseable',
+      status: 200,
+    });
+    expect(found).toContain('test-audio-service-key-probe-unavailable');
+  });
+
+  it('reports "could not verify" on an unexpected status, not a pass', async () => {
+    const found = await testAudioIds(true, {
+      kind: 'response',
+      status: 500,
+      body: {},
+    });
+    expect(found).toContain('test-audio-service-key-probe-unavailable');
+  });
+
+  it('the "could not verify" finding is only a warning, never critical', async () => {
+    const [found] = (
+      await testAudioService(true, {
+        kind: 'unreachable',
+        err: new Error('timeout'),
+      }).check()
+    ).findings.filter(
+      (f) => f.id === 'test-audio-service-key-probe-unavailable',
+    );
+    expect(found?.severity).toBe('warning');
+    expect(found?.productionSeverity).toBe('warning');
+  });
+
+  it('does not probe when the key is still the example placeholder', async () => {
+    // Already reported by the static placeholder check - probing would
+    // either bury it under a second finding or, worse, read as "verified"
+    // if the generator happens to hold the same placeholder.
+    const found = await testAudioIds(
+      true,
+      { kind: 'unreachable', err: new Error('should not be called') },
+      { testAudioServiceKey: 'CHANGEME' },
+    );
+    expect(found).toContain('test-audio-service-key-placeholder');
+    expect(found.some((id) => id.startsWith('test-audio-service-key-'))).toBe(
+      true, // only the placeholder finding, none of the probe's own ids
+    );
+    expect(found).not.toContain('test-audio-service-key-mismatch');
+    expect(found).not.toContain('test-audio-service-key-probe-unavailable');
   });
 });
 

--- a/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
+++ b/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
@@ -1003,6 +1003,28 @@ describe('evaluatePublicOriginCheck', (it) => {
     );
   });
 
+  // An IPv4-mapped address is IPv6 by syntax and IPv4 by reach. Node hands
+  // these out for a v4 peer on a dual-stack socket, so it is a plausible Host
+  // header — and every IPv6 prefix test misses it, so before this it passed
+  // through as "not ruled out" while being literally loopback.
+  it('flags an IPv4-mapped IPv6 loopback', () => {
+    expect(idsFor('::ffff:127.0.0.1')).toContain(
+      'public-origin-not-externally-resolvable',
+    );
+  });
+
+  it('flags an IPv4-mapped IPv6 RFC1918 address', () => {
+    expect(idsFor('::ffff:10.1.2.3')).toContain(
+      'public-origin-not-externally-resolvable',
+    );
+  });
+
+  it('stays quiet for an IPv4-mapped IPv6 public address', () => {
+    expect(idsFor('::ffff:93.184.216.34')).not.toContain(
+      'public-origin-not-externally-resolvable',
+    );
+  });
+
   it('flags a bare single-label hostname (Compose service name shape)', () => {
     expect(idsFor('admin-server')).toContain(
       'public-origin-not-externally-resolvable',
@@ -2271,6 +2293,32 @@ describe('cross-service key agreement', () => {
     it('stays quiet when the gateway throws', async () => {
       const found = await keyIds({
         getSchemaStatus: () => Promise.reject(new Error('timed out')),
+      });
+
+      expect(found).not.toContain('session-manager-admin-key-mismatch');
+    });
+
+    // Silent on the page is right — a probe that could not run is not evidence
+    // about the key. Silent in the logs is not: this catch is broad enough to
+    // absorb a real defect in `getSchemaStatus`, and the health rollup probes a
+    // different endpoint, so nothing else would necessarily surface it.
+    it('logs the reason it could not run, even though it reports nothing', async () => {
+      const err = new Error('timed out');
+      const debug = vi.fn();
+
+      await keyService({
+        getSchemaStatus: () => Promise.reject(err),
+      }).check('', { debug });
+
+      expect(debug).toHaveBeenCalledWith(
+        { err },
+        expect.stringContaining('SESSION_MANAGER_API_KEY'),
+      );
+    });
+
+    it('does not require a logger', async () => {
+      const found = await keyIds({
+        getSchemaStatus: () => Promise.reject(new Error('boom')),
       });
 
       expect(found).not.toContain('session-manager-admin-key-mismatch');

--- a/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
+++ b/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
@@ -218,6 +218,10 @@ function keyService(
     dbClient as unknown as Args[3],
     gw as unknown as Args[4],
     FRESH_BACKUP as unknown as Args[5],
+    // Disabled so the test-audio key probe stays out of these findings — these
+    // cases are about cross-service key *agreement*, and the probe has its own
+    // suite.
+    { enabled: false } as unknown as Args[6],
   );
 }
 

--- a/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
+++ b/apps/admin-server/tests/unit/features/config-check/config-check.service.test.ts
@@ -158,6 +158,60 @@ async function dbIds(
   return report.findings.map((f) => f.id);
 }
 
+/** The one gateway method the Config Check calls. */
+interface GatewayLike {
+  getSchemaStatus: () => Promise<unknown>;
+}
+
+/**
+ * A Session Manager that answers, and refuses this console's admin key —
+ * the only evidence `_checkSessionManagerKey` treats as proof. 401 is what
+ * the shared `INVALID_ADMIN_KEY_REPLY_SCHEMA` declares; 403 is covered too
+ * because a proxy in front of it may answer that instead.
+ */
+function rejectingGateway(status: number): GatewayLike {
+  return {
+    getSchemaStatus: () =>
+      Promise.resolve([{ status, data: { code: 'INVALID_ADMIN_KEY' } }, null]),
+  };
+}
+
+/** A Postgres that is not answering, so `_checkDatabase` short-circuits. */
+const UNREACHABLE_DB: DbClientLike = {
+  ping: () => Promise.reject(new Error('ECONNREFUSED')),
+  hasAdminSchema: () => Promise.resolve(true),
+  scribearSchemaState: () => Promise.resolve(CURRENT_SCHEMA),
+};
+
+/**
+ * A `ConfigCheckService` whose Session Manager gateway is `gw`, so `check()`'s
+ * findings include exactly what `_checkSessionManagerKey` made of it.
+ */
+function keyService(
+  gw: GatewayLike,
+  overrides: Partial<ConfigCheckConfig> = {},
+  dbClient: DbClientLike = REACHABLE_DB,
+): ConfigCheckService {
+  type Args = ConstructorParameters<typeof ConfigCheckService>;
+  return new ConfigCheckService(
+    { ...CLEAN, ...overrides },
+    { enabled: false } as unknown as Args[1],
+    { check: () => Promise.resolve([]) } as unknown as Args[2],
+    dbClient as unknown as Args[3],
+    gw as unknown as Args[4],
+    FRESH_BACKUP as unknown as Args[5],
+  );
+}
+
+async function keyIds(
+  gw: GatewayLike,
+  overrides: Partial<ConfigCheckConfig> = {},
+  dbClient: DbClientLike = REACHABLE_DB,
+): Promise<string[]> {
+  const report = await keyService(gw, overrides, dbClient).check();
+  return report.findings.map((f) => f.id);
+}
+
 /** One row of the health rollup, as `HealthCheckerService.check()` returns. */
 interface HealthComponentLike {
   name: string;
@@ -451,6 +505,89 @@ describe('evaluateStaticChecks', () => {
 
       expect(found?.severity).toBe('advisory');
       expect(found?.productionSeverity).toBe('critical');
+    });
+  });
+
+  // `isPlaceholder('')` is false, and the placeholder loop skips everything
+  // that is not a placeholder, so an unset secret used to produce no finding
+  // at all — silence indistinguishable from a well-configured deployment.
+  describe('secrets that are not set at all', (it) => {
+    it.each([
+      ['adminApiKey', 'admin-api-key-missing'],
+      ['dbPassword', 'db-password-missing'],
+    ] as const)('are caught for %s', (field, expectedId) => {
+      expect(ids({ [field]: '' })).toContain(expectedId);
+    });
+
+    it('says "not set", never "still the placeholder"', () => {
+      const [found] = check({ adminApiKey: '' }).filter(
+        (f) => f.id === 'admin-api-key-missing',
+      );
+
+      expect(found?.detail).toContain('not set');
+      expect(found?.detail).not.toContain('placeholder');
+    });
+
+    // The two mistakes are different mistakes, and each gets exactly one
+    // finding: an empty secret must not also be reported as a placeholder,
+    // and a placeholder must not also be reported as missing.
+    it.each([
+      ['', 'admin-api-key-missing', 'admin-api-key-placeholder'],
+      ['CHANGEME', 'admin-api-key-placeholder', 'admin-api-key-missing'],
+    ] as const)(
+      'reports %s as %s and not as %s',
+      (value, expectedId, notExpectedId) => {
+        const found = ids({ adminApiKey: value });
+
+        expect(found).toContain(expectedId);
+        expect(found).not.toContain(notExpectedId);
+      },
+    );
+
+    it('is critical for ADMIN_API_KEY in every environment', () => {
+      const [found] = check({
+        declaredEnv: 'development',
+        isDevelopment: true,
+        adminApiKey: '',
+      }).filter((f) => f.id === 'admin-api-key-missing');
+
+      // A console that cannot reach session-manager is equally broken on a
+      // laptop; unlike a weak secret, this is not a hardening nit that a dev
+      // box gets to ignore.
+      expect(found?.severity).toBe('critical');
+      expect(found?.productionSeverity).toBe('critical');
+    });
+
+    // A dev Postgres on `trust` authentication genuinely works with no
+    // password, so this one is graded down in development and not elsewhere.
+    it('is only a warning for DB_PASSWORD in development', () => {
+      const [found] = check({
+        declaredEnv: 'development',
+        isDevelopment: true,
+        dbPassword: '',
+      }).filter((f) => f.id === 'db-password-missing');
+
+      expect(found?.severity).toBe('warning');
+      expect(found?.productionSeverity).toBe('critical');
+    });
+
+    // Deliberate absences, pinned so a later edit has to argue with a test
+    // rather than quietly add a finding that fires on healthy deployments.
+    it('says nothing statically about an empty TEST_AUDIO_SERVICE_KEY', () => {
+      // Its peer fails closed and names the variable itself, and whether the
+      // two agree is answerable by calling the generator - better evidence
+      // than a string comparison, and a separate check.
+      expect(ids({ testAudioServiceKey: '' })).toStrictEqual([]);
+    });
+
+    it('reports an empty ADMIN_SESSION_SECRET once, by its own finding', () => {
+      const found = ids({ adminSessionSecret: '' });
+
+      expect(found).toStrictEqual(['admin-session-secret-missing']);
+    });
+
+    it('reports nothing when every secret is set', () => {
+      expect(ids()).toStrictEqual([]);
     });
   });
 
@@ -1459,14 +1596,6 @@ describe('secret placeholders (PLAN-ConfigCheck-Coverage Phase 2)', (it) => {
     expect(found?.productionSeverity).toBe('critical');
   });
 
-  it('reports unavailable, not silence, when the sidecar cannot be reached', async () => {
-    stubProbes({ [CONFIG_AUDIT_URL]: 'network-error' });
-
-    const found = await monitoringIds();
-
-    expect(found).toContain('secret-placeholder-audit-unavailable');
-  });
-
   it('reports unavailable when the sidecar answers with a body Config Check cannot parse', async () => {
     vi.stubGlobal('fetch', () =>
       Promise.resolve(new Response('not json at all', { status: 200 })),
@@ -1554,30 +1683,7 @@ describe('secret placeholders (PLAN-ConfigCheck-Coverage Phase 2)', (it) => {
     expect(found).not.toContain('secret-placeholder-audit-unavailable');
   });
 
-  it('says the sidecar answered with an error, not that it timed out, on a non-2xx', async () => {
-    stubProbes({ [CONFIG_AUDIT_URL]: { status: 503 } });
-
-    const report = await monitoringService().check();
-    const found = report.findings.find(
-      (f) => f.id === 'secret-placeholder-audit-unavailable',
-    );
-
-    expect(found?.detail).toContain('answered HTTP 503');
-    expect(found?.detail).not.toContain('did not answer');
-  });
-
-  it('says it timed out when the sidecar does not answer at all', async () => {
-    stubProbes({ [CONFIG_AUDIT_URL]: 'network-error' });
-
-    const report = await monitoringService().check();
-    const found = report.findings.find(
-      (f) => f.id === 'secret-placeholder-audit-unavailable',
-    );
-
-    expect(found?.detail).toContain('did not answer within');
-  });
-
-  it.each(['disabled', 'unauthorized', 'not-yet-polled'] as const)(
+  it.each(['disabled', 'not-yet-polled', 'unreachable'] as const)(
     'reports unavailable, not a clean bill of health, when node-server status is %s',
     async (reason) => {
       stubProbes({
@@ -1597,7 +1703,12 @@ describe('secret placeholders (PLAN-ConfigCheck-Coverage Phase 2)', (it) => {
   it('is only a warning, never critical, when the audit itself is unavailable', async () => {
     // A missing report is a sidecar/network problem, not proof of a bad
     // secret - it must not read as worse than "cannot currently check".
-    stubProbes({ [CONFIG_AUDIT_URL]: 'network-error' });
+    stubProbes({
+      [CONFIG_AUDIT_URL]: {
+        status: 200,
+        body: { nodeServer: { status: 'unavailable', reason: 'unreachable' } },
+      },
+    });
 
     const report = await monitoringService().check();
     const found = report.findings.find(
@@ -1606,5 +1717,235 @@ describe('secret placeholders (PLAN-ConfigCheck-Coverage Phase 2)', (it) => {
 
     expect(found?.severity).toBe('warning');
     expect(found?.productionSeverity).toBe('warning');
+  });
+});
+
+// PLAN-VisibleErrors §7.2.5. Previously inferable only as a side effect of
+// `secret-placeholder-audit-unavailable`, which named node-server - the wrong
+// subject - for a fault in a service the health rollup does not probe at all.
+describe('the monitoring sidecar being down', (it) => {
+  it('is its own finding, not a shade of the secret audit', async () => {
+    stubProbes({ [CONFIG_AUDIT_URL]: 'network-error' });
+
+    const found = await monitoringIds();
+
+    expect(found).toContain('monitoring-sidecar-unreachable');
+    expect(found).not.toContain('secret-placeholder-audit-unavailable');
+  });
+
+  it('never reads as "the secrets are fine"', async () => {
+    // The discipline the alerts panel adopted: "nothing to report" and "we
+    // could not ask" must not be the same answer.
+    stubProbes({ [CONFIG_AUDIT_URL]: 'network-error' });
+
+    const found = await monitoringIds();
+
+    expect(found.some((id) => id.endsWith('-placeholder'))).toBe(false);
+    expect(found).not.toContain('node-server-service-key-mismatch');
+  });
+
+  it('says what went unchecked, including the key-agreement pair', async () => {
+    stubProbes({ [CONFIG_AUDIT_URL]: 'network-error' });
+
+    const report = await monitoringService().check();
+    const found = report.findings.find(
+      (f) => f.id === 'monitoring-sidecar-unreachable',
+    );
+
+    expect(found?.detail).toContain('NODE_SERVER_SERVICE_KEY');
+    expect(found?.detail).toContain('alerts');
+  });
+
+  it('says it timed out when the sidecar does not answer at all', async () => {
+    stubProbes({ [CONFIG_AUDIT_URL]: 'network-error' });
+
+    const report = await monitoringService().check();
+    const found = report.findings.find(
+      (f) => f.id === 'monitoring-sidecar-unreachable',
+    );
+
+    expect(found?.detail).toContain('did not answer within');
+  });
+
+  it('says the sidecar answered with an error, not that it timed out, on a non-2xx', async () => {
+    stubProbes({ [CONFIG_AUDIT_URL]: { status: 503 } });
+
+    const report = await monitoringService().check();
+    const found = report.findings.find(
+      (f) => f.id === 'monitoring-sidecar-unreachable',
+    );
+
+    expect(found?.detail).toContain('answered HTTP 503');
+    expect(found?.detail).not.toContain('did not answer');
+  });
+
+  it('is a warning, never critical: it is an outage, not proof of a bad secret', async () => {
+    stubProbes({ [CONFIG_AUDIT_URL]: 'network-error' });
+
+    const report = await monitoringService().check();
+    const found = report.findings.find(
+      (f) => f.id === 'monitoring-sidecar-unreachable',
+    );
+
+    expect(found?.severity).toBe('warning');
+    expect(found?.productionSeverity).toBe('warning');
+  });
+
+  it('stays quiet when the sidecar answers', async () => {
+    const found = await monitoringIds();
+
+    expect(found).not.toContain('monitoring-sidecar-unreachable');
+  });
+});
+
+// PLAN-VisibleErrors §7.2.3. Two non-placeholder keys that simply differ are
+// invisible to every placeholder check in this file, and produce a deployment
+// that looks green and does not work.
+describe('cross-service key agreement', () => {
+  describe('monitoring-sidecar and node-server (NODE_SERVER_SERVICE_KEY)', (it) => {
+    /** node-server answered the sidecar's poll 401/403. */
+    const REJECTED = {
+      status: 200,
+      body: { nodeServer: { status: 'unavailable', reason: 'unauthorized' } },
+    };
+
+    it('names the pair when node-server rejects the sidecar', async () => {
+      stubProbes({ [CONFIG_AUDIT_URL]: REJECTED });
+
+      const found = await monitoringIds();
+
+      expect(found).toContain('node-server-service-key-mismatch');
+    });
+
+    // The whole point of the finding: `unauthorized` used to be reported as
+    // one more way of not knowing, when it is the opposite - a proof about
+    // two configuration values.
+    it('does not also report the audit as merely unavailable', async () => {
+      stubProbes({ [CONFIG_AUDIT_URL]: REJECTED });
+
+      const found = await monitoringIds();
+
+      expect(found).not.toContain('secret-placeholder-audit-unavailable');
+    });
+
+    it('names both containers and the exact variable', async () => {
+      stubProbes({ [CONFIG_AUDIT_URL]: REJECTED });
+
+      const report = await monitoringService().check();
+      const found = report.findings.find(
+        (f) => f.id === 'node-server-service-key-mismatch',
+      );
+
+      expect(found?.title).toContain('NODE_SERVER_SERVICE_KEY');
+      expect(found?.title).toContain('monitoring-sidecar');
+      expect(found?.title).toContain('node-server');
+      // The next action has to name both containers: recreating one is what
+      // leaves them disagreeing.
+      expect(found?.remediation).toContain('node-server monitoring-sidecar');
+    });
+
+    it('blocks promotion to production without being critical in a dev box', async () => {
+      stubProbes({ [CONFIG_AUDIT_URL]: REJECTED });
+
+      const report = await monitoringService({
+        declaredEnv: 'development',
+      }).check();
+      const found = report.findings.find(
+        (f) => f.id === 'node-server-service-key-mismatch',
+      );
+
+      expect(found?.severity).toBe('advisory');
+      expect(found?.productionSeverity).toBe('critical');
+    });
+
+    it('stays quiet when the poll succeeds', async () => {
+      const found = await monitoringIds();
+
+      expect(found).not.toContain('node-server-service-key-mismatch');
+    });
+
+    // An unreachable sidecar cannot vouch for this pair either way, and the
+    // silence must not read as agreement - `monitoring-sidecar-unreachable`
+    // is what says so.
+    it('is neither claimed nor denied when the sidecar is unreachable', async () => {
+      stubProbes({ [CONFIG_AUDIT_URL]: 'network-error' });
+
+      const found = await monitoringIds();
+
+      expect(found).not.toContain('node-server-service-key-mismatch');
+      expect(found).toContain('monitoring-sidecar-unreachable');
+    });
+  });
+
+  describe('admin-server and session-manager (SESSION_MANAGER_API_KEY)', (it) => {
+    it.each([401, 403])(
+      'names the pair when session-manager answers %i',
+      async (status) => {
+        const found = await keyIds(rejectingGateway(status));
+
+        expect(found).toContain('session-manager-admin-key-mismatch');
+      },
+    );
+
+    it('names both containers, the variable, and what an operator sees', async () => {
+      const report = await keyService(rejectingGateway(401)).check();
+      const found = report.findings.find(
+        (f) => f.id === 'session-manager-admin-key-mismatch',
+      );
+
+      expect(found?.title).toContain('SESSION_MANAGER_API_KEY');
+      expect(found?.title).toContain('admin-server');
+      expect(found?.title).toContain('session-manager');
+      expect(found?.detail).toContain('BACKEND_MISCONFIGURATION');
+      expect(found?.remediation).toContain('admin-server session-manager');
+      expect(found?.severity).toBe('critical');
+      // The one secret this finding is about is one admin-server actually
+      // holds, so the disclosure rule is checked against the value itself
+      // rather than against a shape.
+      expect(found?.detail).not.toContain(CLEAN.adminApiKey);
+      expect(found?.remediation).not.toContain(CLEAN.adminApiKey);
+    });
+
+    it('stays quiet when session-manager accepts the key', async () => {
+      const found = await keyIds(gateway(LATEST_MIGRATION));
+
+      expect(found).not.toContain('session-manager-admin-key-mismatch');
+    });
+
+    // A service that did not answer is not evidence about a key, and
+    // `services-unreachable` already reports it. Two findings for one cause
+    // is the pattern this page avoids.
+    it('stays quiet when session-manager did not answer at all', async () => {
+      const found = await keyIds(gateway(null));
+
+      expect(found).not.toContain('session-manager-admin-key-mismatch');
+    });
+
+    it('stays quiet when the gateway throws', async () => {
+      const found = await keyIds({
+        getSchemaStatus: () => Promise.reject(new Error('timed out')),
+      });
+
+      expect(found).not.toContain('session-manager-admin-key-mismatch');
+    });
+
+    // An unset key is a different sentence with a different fix, and
+    // `admin-api-key-missing` already says it.
+    it('defers to admin-api-key-missing when the key is not set at all', async () => {
+      const found = await keyIds(rejectingGateway(401), { adminApiKey: '' });
+
+      expect(found).toContain('admin-api-key-missing');
+      expect(found).not.toContain('session-manager-admin-key-mismatch');
+    });
+
+    // Not folded into `_checkSharedSchemaVersion`, which makes the same call
+    // but only after `dbClient.ping()` succeeds: a deployment with both
+    // faults most needs to be told they are separate.
+    it('is reported even when Postgres is down', async () => {
+      const found = await keyIds(rejectingGateway(401), {}, UNREACHABLE_DB);
+
+      expect(found).toContain('database-unreachable');
+      expect(found).toContain('session-manager-admin-key-mismatch');
+    });
   });
 });


### PR DESCRIPTION
## Summary

PLAN-VisibleErrors §7 — the Config Check gaps (P4). Branched off `staging`
rather than stacked on #195, since this is admin-server only.

Two streams on disjoint §7 items, both landing in `config-check.service.ts`.

| § | What was green that shouldn't have been |
|---|---|
| 7.1 | An **empty** `ADMIN_API_KEY` or `DB_PASSWORD` produced no finding at all |
| 7.2.2 | A **one-character** admin password passed every check |
| 7.2.3 | Two services holding **different** non-placeholder keys read as healthy |
| 7.2.4 | A `TEST_AUDIO_SERVICE_KEY` that was present but **wrong** was indistinguishable from one that works |
| 7.2.5 | "The sidecar is down" was only inferable as a side effect |
| 7.2.6 | A public origin nobody outside the building can reach was unreported |

## Two premises in the plan were wrong

**There is no fingerprint mechanism, and the sidecar does not hold every key.**
§7.2.3 was scoped assuming a digest comparison via the monitoring sidecar. Neither
holds up: every HMAC use in this codebase is token signing or a `timingSafeEqual`
and is never serialized, and `compose.yml` gives the sidecar exactly three keys —
never `JWT_SECRET`, `NODE_SERVER_KEY`, `SESSION_MANAGER_API_KEY` or
`TRANSCRIPTION_API_KEY`. Publishing fingerprints would also have been a
disclosure: `/api/monitoring/v1/config-audit` is **unauthenticated** on the
backend network.

What does exist is that a party presents the key and **the rejection is the
proof** — and the sidecar's poller already classifies 401/403 as `UNAUTHORIZED`,
a signal Config Check was relaying as *"could not check"*, i.e. as ignorance,
when it was evidence. Two pairs are provable today and both were silent:
sidecar↔node-server on `NODE_SERVER_SERVICE_KEY`, and
admin-server↔session-manager on `SESSION_MANAGER_API_KEY`.

**The three pairs the plan names are not provable at config time, and are not
faked.** `TRANSCRIPTION_API_KEY`, `NODE_SERVER_KEY` and
`SESSION_TOKEN_SIGNING_KEY` are each held only by their two users; node-server
never exercises an outbound key until a real session starts, and none reports the
outcome. The class docblock says so where the next reader will look.

**Boot-time fail-closed checks already exist** for every inbound service key —
session-manager, node-server, transcription-service and test-audio-generator all
reject empty *and* placeholder. The one service without such a guard is
**admin-server itself**. So the plan's "no equivalent boot-time check exists"
framing is inaccurate, Config Check is the right home for exactly the two
variables covered here, and no boot check was added (that can strand a running
deployment and is not this PR's call).

## Checks that state their own limits

`7.2.5` matters because the sidecar *performs* one of the comparisons: unreachable
must not read as "keys agree". It is now a first-class finding that enumerates
what went unchecked, including the pair it is sole evidence for — the same
"none firing" vs "could not ask" distinction the alerts panel draws.

`7.2.6` is deliberately one-directional. There is no `PUBLIC_ORIGIN` variable
anywhere; nginx's `server_name` is `_` and join/kiosk URLs are built from
`window.location.origin` in the operator's browser, so the only origin visible to
admin-server is the request's `Host` header. It flags what certainly cannot work
off-host (loopback, RFC1918, link-local, `.local`, bare single-label) and stays
silent otherwise — a normal FQDN is *not ruled out*, never asserted reachable.
A finding that overstates its confidence is the defect this whole plan exists to
remove.

## Findings added

`admin-api-key-missing` · `db-password-missing` · `admin-local-credentials-weak` ·
`admin-local-credentials-malformed` · `node-server-service-key-mismatch` ·
`session-manager-admin-key-mismatch` · `test-audio-service-key-mismatch` ·
`test-audio-service-key-probe-unavailable` · `monitoring-sidecar-unreachable` ·
public-origin unusable.

## Test plan

- [x] `admin-server` unit — **300 passed** (14 files)
- [x] `admin-server` integration — **133 passed** (12 files)
- [x] `tsc --build`, `eslint`, `prettier --check` — clean
- [x] whole-repo `npm run build` — exit 0
- [ ] Live verification against a running stack

## Found here, fixed elsewhere — two real bugs, not Config Check issues

Both are logged in `2026-08-01-02-NEXTSTEPS-VisibleErrors.md`:

1. **A `NODE_SERVER_KEY` mismatch is laundered into a false symptom.**
   session-manager answers 401, but 401 is a *declared* status on that route, so
   `createEndpointClient` returns it as a normal response — and
   `LongPollClient._run` treats any non-null, non-204 result as success (its
   comment says `status === 200`; it never checks). It emits the error body as a
   `Session`, `transcriptionProviderId` is `undefined`, node-server dials
   `.../transcription_stream/undefined`, and the operator chases an
   **`invalid-request`** provider-key problem that does not exist. That path has
   no test. Verified independently.
2. **node-server's own `isPlaceholder` has the identical §7.1 bug**
   (`app-config.ts`), so an empty `JWT_SECRET` self-reports as "not a
   placeholder" and Config Check relays it as green — the same hole, one hop
   upstream, in a workspace this PR does not touch.
