### PR TITLE
fix: a key mismatch no longer disguises itself as a provider-config error

### DIFF
--- a/.changeset/long-poll-declared-error-status.md
+++ b/.changeset/long-poll-declared-error-status.md
@@ -1,0 +1,58 @@
+---
+'@scribear/base-long-poll-client': minor
+'@scribear/kiosk-webapp': patch
+---
+
+The long-poll client no longer emits a declared error body as if it were poll
+data.
+
+`_run()` carried the comment `// status === 200` and checked nothing. It
+skipped 204 and treated *everything else* in the response slot as a payload.
+That slot is fuller than it looks: `createEndpointClient` returns a declared
+status as a typed **response** with a null error, on purpose, so a 401
+`INVALID_DEVICE_TOKEN` or a 404 `DEVICE_NOT_IN_ROOM` — both declared by
+`my-schedule`, as 401 `INVALID_SERVICE_KEY` and 404 `SESSION_NOT_FOUND` are by
+`session-config-stream` — arrived with `err === null` and went straight out the
+`data` event as `{ code, message }`.
+
+The consequence was not a missing update; it was a *misleading* one. node-server
+read `transcriptionProviderId` off a 401 body, got `undefined`, and dialed
+`.../transcription_stream/undefined`; the transcription service refused the
+request and the operator was shown `invalid-request` — sending them to hunt for
+a provider-key misconfiguration that did not exist, when the actual fault was a
+`NODE_SERVER_KEY` mismatch between node-server and session-manager. Two
+unrelated causes collapsed into one wrong answer. On the kiosk the same path
+threw inside the `data` listener (`for (const session of undefined)`), which,
+because the poll loop is a `void`-ed async method, escaped the `while` and left
+the client in `POLLING` with no request in flight and no retry armed:
+permanently silent while `state` still read healthy.
+
+Any response that is not 200 or 204 is now a failure. It surfaces as
+`LongPollResponseError`, a **subclass** of `UnexpectedResponseError` (the same
+relationship `InvalidResponseBodyError` has), so every existing `instanceof
+UnexpectedResponseError` branch and `.status` read keeps working; the subclass
+adds `.code` and `.body` so a consumer can name the cause. Both consumers
+already had `error` handlers that report to a human, so the cause now reaches
+one instead of being laundered.
+
+No status is treated as terminal, 401 included. Nothing in the fleet re-mints a
+credential on demand — the kiosk's `DEVICE_TOKEN` is replaced only by a human
+re-activating the device, and node-server's service key only by a redeploy — but
+both of those happen *while the client is running*, and a poll that had stopped
+for good would not notice. Backoff caps the cost of waiting at one request per
+30s. Relatedly, `_attempt` is now reset only after a genuine 200/204: resetting
+it before the status check pinned a permanently-failing status (a wrong key
+answering 401 forever) at `initialMs`, so backoff never grew and the client
+retried a hopeless request once a second indefinitely.
+
+Two adjacent hazards on the same path are closed. A 200 whose body has no
+numeric `versionResponseKey` field now fails into backoff rather than emitting
+with an unmoved cursor — the server answers 200 to that same cursor
+immediately, so the old behaviour was a hot loop with no delay between
+requests. And an exception thrown by a `data` listener is contained and
+re-emitted on `error` instead of killing the poll loop.
+
+The kiosk now names the two device-specific statuses on the wall banner —
+"Re-activate the device from the admin console" for a 401, "Assign it to a room"
+for a 404 — instead of the generic "The schedule service is failing (HTTP …)",
+which blames the server for a device problem.

--- a/.changeset/node-server-unset-secret-reported.md
+++ b/.changeset/node-server-unset-secret-reported.md
@@ -1,0 +1,34 @@
+---
+'@scribear/node-server': patch
+'@scribear/node-server-schema': patch
+---
+
+An unset node-server secret no longer self-reports as healthy.
+
+`isPlaceholder('')` was `false`, and that function feeds `secretPlaceholders` on
+`GET /status` — the endpoint monitoring-sidecar polls and relays to
+admin-server's Config Check. So an empty `SESSION_TOKEN_SIGNING_KEY`,
+`SESSION_MANAGER_SERVICE_API_KEY` or `TRANSCRIPTION_SERVICE_API_KEY` was
+rendered green on the page whose entire job is to notice exactly that. The env
+schema declares them as bare `Type.String()` with no `minLength`, so an empty
+value boots fine and the false-green was reachable rather than theoretical.
+
+The fix is a deletion. `isPlaceholderSecret` in `utils/constant-time-equal.ts`
+already treated empty as a placeholder — it was exported, never called, and
+sitting a few files from a local duplicate that had drifted away from it. The
+bug was the copy, not a missing capability.
+
+Reporting empty *as* a placeholder, rather than adding a distinct "missing"
+signal, is deliberate. admin-server keeps the two apart because there they have
+different remediations — an empty `ADMIN_SESSION_SECRET` falls back to a random
+per-boot value, which is a different failure from a shared `CHANGEME`. None of
+these four has any such fallback: two are presented directly as bearer
+credentials and one is used directly as an HMAC key, so empty and `CHANGEME`
+are equally guessable and take the identical fix. A tri-state signal would have
+required a new optional field across `node-server-schema`, the sidecar relay and
+Config Check's consumption of it, plus the rolling-upgrade fallback — to tell an
+operator something that does not change what they do.
+
+The schema change is documentation only: the four field descriptions now say
+"or unset". No shape change, so there is nothing to coordinate on a rolling
+upgrade.

--- a/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
+++ b/apps/kiosk-webapp/src/features/kiosk-provider/services/kiosk-service.ts
@@ -6,7 +6,10 @@ import {
   NetworkError,
   UnexpectedResponseError,
 } from '@scribear/base-api-client';
-import { type LongPollClient } from '@scribear/base-long-poll-client';
+import {
+  type LongPollClient,
+  LongPollResponseError,
+} from '@scribear/base-long-poll-client';
 import {
   type WebSocketClient,
   SchemaValidationError as WsSchemaValidationError,
@@ -806,6 +809,20 @@ export class KioskService extends EventEmitter<KioskServiceEvents> {
       'Scheduled sessions may not start or end on time on this kiosk.';
     if (err instanceof NetworkError) {
       return `Cannot reach the ScribeAR schedule service. ${consequence}`;
+    }
+    // Checked before `UnexpectedResponseError`, which it extends. These are
+    // statuses the route *declares*, so the server is up and answering - the
+    // problem is this device, and only a human can fix it. Before the
+    // long-poll client learned to treat a declared non-200 as a failure, these
+    // bodies were emitted as if they were the schedule payload and the kiosk
+    // showed nothing at all.
+    if (err instanceof LongPollResponseError) {
+      if (err.status === 401) {
+        return `This kiosk's registration is no longer valid, so it has stopped receiving schedule updates. Re-activate the device from the admin console.`;
+      }
+      if (err.status === 404) {
+        return `This kiosk is not assigned to a room, so it has no schedule. Assign it to a room from the admin console.`;
+      }
     }
     if (err instanceof UnexpectedResponseError) {
       return `The schedule service is failing (HTTP ${err.status.toString()}). ${consequence}`;

--- a/apps/kiosk-webapp/tests/features/kiosk-provider/services/kiosk-service.test.ts
+++ b/apps/kiosk-webapp/tests/features/kiosk-provider/services/kiosk-service.test.ts
@@ -6,6 +6,7 @@ import {
   NetworkError,
   UnexpectedResponseError,
 } from '@scribear/base-api-client';
+import { LongPollResponseError } from '@scribear/base-long-poll-client';
 import { SchemaValidationError as WsSchemaValidationError } from '@scribear/base-websocket-client';
 import type { MicrophoneService } from '@scribear/microphone-store';
 import type { NodeServerClient } from '@scribear/node-server-client';
@@ -940,6 +941,67 @@ describe('KioskService schedule long-poll health (2.5)', () => {
 
     for (let i = 0; i < 3; i++) {
       fakePoll.emit('error', new UnexpectedResponseError(500));
+    }
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(scheduleFaults.at(-1)?.message).toMatch(/HTTP 500/);
+  });
+
+  it('names a revoked device token rather than blaming the schedule service', async () => {
+    const service = await bringToIdle();
+    const { scheduleFaults } = observe(service);
+
+    // A declared 401 used to reach `poll.on('data')` as if it were the
+    // schedule payload, because `createEndpointClient` returns declared
+    // statuses in the response slot. Nothing was said, and `payload.sessions`
+    // was `undefined`.
+    for (let i = 0; i < 3; i++) {
+      fakePoll.emit(
+        'error',
+        new LongPollResponseError(401, {
+          code: 'INVALID_DEVICE_TOKEN',
+          message: 'The DEVICE_TOKEN cookie is missing, expired, or revoked.',
+        }),
+      );
+    }
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(scheduleFaults.at(-1)?.message).toMatch(/Re-activate the device/);
+    expect(scheduleFaults.at(-1)?.message).not.toMatch(/HTTP 401/);
+  });
+
+  it('names an unassigned device on a 404 rather than blaming the schedule service', async () => {
+    const service = await bringToIdle();
+    const { scheduleFaults } = observe(service);
+
+    for (let i = 0; i < 3; i++) {
+      fakePoll.emit(
+        'error',
+        new LongPollResponseError(404, {
+          code: 'DEVICE_NOT_IN_ROOM',
+          message: 'Device is not assigned to a room.',
+        }),
+      );
+    }
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(scheduleFaults.at(-1)?.message).toMatch(/not assigned to a room/);
+  });
+
+  it('falls back to the HTTP-status wording for a declared 500', async () => {
+    const service = await bringToIdle();
+    const { scheduleFaults } = observe(service);
+
+    // `LongPollResponseError` extends `UnexpectedResponseError`, so a status
+    // with no device-specific meaning keeps the pre-existing wording.
+    for (let i = 0; i < 3; i++) {
+      fakePoll.emit(
+        'error',
+        new LongPollResponseError(500, {
+          code: 'INTERNAL_ERROR',
+          message: 'boom',
+        }),
+      );
     }
     await vi.advanceTimersByTimeAsync(0);
 

--- a/apps/node-server/src/app-config/app-config.ts
+++ b/apps/node-server/src/app-config/app-config.ts
@@ -9,6 +9,7 @@ import type { SecretPlaceholders } from '@scribear/node-server-schema';
 import { DEFAULT_DEMO_SESSION_UID } from '#src/server/features/demo-room/demo-room.constants.js';
 import type { ServiceAuthConfig } from '#src/server/shared/services/service-auth.service.js';
 import type { SessionTokenConfig } from '#src/server/shared/services/session-token.service.js';
+import { isPlaceholderSecret } from '#src/server/utils/constant-time-equal.js';
 
 const CONFIG_SCHEMA = Type.Object({
   LOG_LEVEL: Type.Enum(LogLevel),
@@ -60,19 +61,6 @@ export interface DemoRoomConfig {
   enabled: boolean;
   /** Session UID captions are published for; matches the seeded session. */
   sessionUid: string;
-}
-
-/**
- * Matches the `deployment/.env.example` stub marker as a substring — the same
- * check `config-check.service.ts` on the Admin Server makes of its own
- * secrets. Duplicated rather than shared: this codebase restates rather than
- * shares this kind of check across services (see e.g. transcription-service's
- * Python side restating the status schema rather than importing it), and it
- * is three lines.
- */
-const PLACEHOLDER_MARKER = 'CHANGEME';
-function isPlaceholder(value: string): boolean {
-  return value.toUpperCase().includes(PLACEHOLDER_MARKER);
 }
 
 export interface TelemetryPublisherConfig {
@@ -143,19 +131,55 @@ export class AppConfig {
    * value (PLAN-ConfigCheck-Coverage Phase 2) — reported on `GET /status`,
    * the endpoint the monitoring sidecar already polls, and from there relayed
    * to Config Check on the Admin Server.
+   *
+   * Uses `isPlaceholderSecret`, not a local restatement of the `CHANGEME`
+   * substring match: `config-check.service.ts` on the Admin Server *does*
+   * restate this check for its own secrets rather than importing this
+   * service's copy, and that cross-service duplication is deliberate (see
+   * e.g. transcription-service's Python side restating the status schema
+   * rather than importing it) — but `isPlaceholderSecret` is already this
+   * service's one definition of "unusable", the same one
+   * `assertNotPlaceholderKey` builds its boot guard on, and reusing it here
+   * keeps that true instead of growing a second, driftable copy inside this
+   * file.
+   *
+   * `isPlaceholderSecret` treats an empty string as a placeholder too, so an
+   * unset secret is flagged the same as one still reading `CHANGEME`. That is
+   * deliberately not the same distinction the Admin Server's own
+   * `describeSecret`/`admin-session-secret-missing` draws between "not set"
+   * and "placeholder": that distinction exists there because
+   * `ADMIN_SESSION_SECRET` has a fallback — unset, it signs cookies with a
+   * random secret minted per boot, a materially different failure with a
+   * different remediation than a known, public secret. None of the four
+   * secrets classified here have any such fallback: each is used directly, as
+   * an HMAC key or a presented bearer credential, so empty and `CHANGEME` are
+   * equally guessable and share one remediation ("set a real high-entropy
+   * secret"). Collapsing them into one flag per secret is what that equal
+   * consequence justifies.
+   *
+   * One of the four is additionally unobservable as "empty" here in
+   * practice: `NODE_SERVER_SERVICE_API_KEY`'s `ServiceAuthService` constructor
+   * calls `assertNotPlaceholderKey`, which throws for both empty and
+   * `CHANGEME`, and it is resolved from the DI container inside
+   * `serviceApiKeyHook` on every request that requires the service key —
+   * including `/status` itself. That is a fail-closed *guard*, not a
+   * boot-time check: this process starts fine either way, and the throw
+   * happens on the first request that needs the key. So a deployment with
+   * that one key empty or placeholder fails every service-key-guarded
+   * request rather than ever reaching this getter with a false-green answer.
    */
   get secretPlaceholders(): SecretPlaceholders {
     return {
-      sessionTokenSigningKeyIsPlaceholder: isPlaceholder(
+      sessionTokenSigningKeyIsPlaceholder: isPlaceholderSecret(
         this._env.SESSION_TOKEN_SIGNING_KEY,
       ),
-      sessionManagerServiceApiKeyIsPlaceholder: isPlaceholder(
+      sessionManagerServiceApiKeyIsPlaceholder: isPlaceholderSecret(
         this._env.SESSION_MANAGER_SERVICE_API_KEY,
       ),
-      nodeServerServiceApiKeyIsPlaceholder: isPlaceholder(
+      nodeServerServiceApiKeyIsPlaceholder: isPlaceholderSecret(
         this._env.NODE_SERVER_SERVICE_API_KEY,
       ),
-      transcriptionServiceApiKeyIsPlaceholder: isPlaceholder(
+      transcriptionServiceApiKeyIsPlaceholder: isPlaceholderSecret(
         this._env.TRANSCRIPTION_SERVICE_API_KEY,
       ),
     };

--- a/apps/node-server/tests/unit/app-config/app-config.test.ts
+++ b/apps/node-server/tests/unit/app-config/app-config.test.ts
@@ -278,6 +278,74 @@ describe('AppConfig', () => {
         config.secretPlaceholders.sessionTokenSigningKeyIsPlaceholder,
       ).toBe(true);
     });
+
+    // Regression test: `isPlaceholder('')` used to be false, so an operator
+    // who never set a secret (rather than leaving the .env.example CHANGEME
+    // stub in place) self-reported as fine on Config Check. None of these four
+    // secrets has a fallback for "unset" that would make it a different
+    // situation from "still the stub" - each is used directly, so empty is
+    // exactly as guessable and shares the same remediation.
+    it('flags a secret that is empty, not just one that still reads CHANGEME', () => {
+      // Arrange - env-schema requires these to be present but does not
+      // enforce a minimum length, so an empty string is a valid, bootable
+      // configuration; this is the state an .env with the line present but
+      // no value (or COMPOSE_PROFILES substituting a blank) produces.
+      process.env['SESSION_MANAGER_SERVICE_API_KEY'] = '';
+
+      // Act
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert
+      expect(config.secretPlaceholders).toStrictEqual({
+        sessionTokenSigningKeyIsPlaceholder: false,
+        sessionManagerServiceApiKeyIsPlaceholder: true,
+        nodeServerServiceApiKeyIsPlaceholder: false,
+        transcriptionServiceApiKeyIsPlaceholder: false,
+      });
+    });
+
+    it('flags a placeholder regardless of case', () => {
+      // Arrange - env-schema does not normalize case, so an operator who
+      // typed the stub in lowercase or mixed case must still be caught.
+      process.env['NODE_SERVER_SERVICE_API_KEY'] = 'ChangeMe';
+
+      // Act
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert
+      expect(
+        config.secretPlaceholders.nodeServerServiceApiKeyIsPlaceholder,
+      ).toBe(true);
+    });
+
+    it('does not flag whitespace-only as a placeholder', () => {
+      // Arrange - a real (if odd) high-entropy-looking value is not this
+      // check's job to reject; whitespace-only is neither empty nor CHANGEME,
+      // so it is deliberately left alone here, the same restraint
+      // `isPlaceholderSecret` already applies (equality/substring only, no
+      // trimming or strength rule).
+      process.env['TRANSCRIPTION_SERVICE_API_KEY'] = '   ';
+
+      // Act
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert
+      expect(
+        config.secretPlaceholders.transcriptionServiceApiKeyIsPlaceholder,
+      ).toBe(false);
+    });
+
+    it('does not flag a healthy, real-looking secret', () => {
+      // Act - VALID_ENV's secrets are already real-looking; this test just
+      // makes the "healthy" case explicit rather than leaving it implied by
+      // the fully-populated-environment test above.
+      const config = new AppConfig(NO_DOTENV_FILE);
+
+      // Assert
+      expect(
+        config.secretPlaceholders.sessionManagerServiceApiKeyIsPlaceholder,
+      ).toBe(false);
+    });
   });
 
   describe('schema validation', (it) => {

--- a/apps/node-server/tests/unit/utils/constant-time-equal.test.ts
+++ b/apps/node-server/tests/unit/utils/constant-time-equal.test.ts
@@ -3,6 +3,7 @@ import { describe, expect } from 'vitest';
 import {
   assertNotPlaceholderKey,
   constantTimeEqual,
+  isPlaceholderSecret,
 } from '#src/server/utils/constant-time-equal.js';
 
 describe('constantTimeEqual', (it) => {
@@ -66,5 +67,36 @@ describe('assertNotPlaceholderKey', (it) => {
         'NODE_SERVER_SERVICE_API_KEY',
       );
     }).not.toThrow();
+  });
+});
+
+// Newly load-bearing (AppConfig.secretPlaceholders now calls this directly)
+// though the empty/CHANGEME logic itself predates that caller.
+describe('isPlaceholderSecret', (it) => {
+  it('is true for an empty string', () => {
+    expect(isPlaceholderSecret('')).toBe(true);
+  });
+
+  it('is true for the literal placeholder, case-insensitively', () => {
+    expect(isPlaceholderSecret('CHANGEME')).toBe(true);
+    expect(isPlaceholderSecret('changeme')).toBe(true);
+    expect(isPlaceholderSecret('ChangeMe')).toBe(true);
+  });
+
+  it('is true when the placeholder is only a substring', () => {
+    expect(isPlaceholderSecret('prefix-CHANGEME-suffix')).toBe(true);
+    expect(
+      isPlaceholderSecret('CHANGEME-JWT-must-be-at-least-32-characters-long'),
+    ).toBe(true);
+  });
+
+  it('is false for whitespace-only', () => {
+    // Not empty and not the marker - left alone deliberately, the same
+    // restraint the rest of this check applies (no trimming, no strength rule).
+    expect(isPlaceholderSecret('   ')).toBe(false);
+  });
+
+  it('is false for a real, non-placeholder secret', () => {
+    expect(isPlaceholderSecret('a-real-high-entropy-secret')).toBe(false);
   });
 });

--- a/libs/clients/base-long-poll-client/src/errors.ts
+++ b/libs/clients/base-long-poll-client/src/errors.ts
@@ -1,0 +1,83 @@
+import { UnexpectedResponseError } from '@scribear/base-api-client';
+
+/**
+ * A long-poll route answered with a status it *declares*, but which carries no
+ * poll payload - anything other than 200 (new data) or 204 (no change).
+ *
+ * This exists because "declared" and "successful" are not the same thing, and
+ * conflating them is actively dangerous here. `createEndpointClient` puts every
+ * declared status in the *response* slot with a null error, on purpose: a 401
+ * `INVALID_DEVICE_TOKEN` body is part of the contract, so callers get it typed
+ * rather than as an opaque failure. The long-poll loop then only had to
+ * distinguish 204 from "everything else", and treated a 401/404/500 body as if
+ * it were the 200 payload - emitting `{ code, message }` on the `data` event.
+ *
+ * Downstream that was worse than a plain failure. node-server read
+ * `transcriptionProviderId` off a 401 body, got `undefined`, and dialed
+ * `.../transcription_stream/undefined`; the transcription service refused it and
+ * the operator was shown `invalid-request` - sending them to hunt for a provider
+ * misconfiguration that did not exist, when the real cause was a
+ * `NODE_SERVER_KEY` mismatch. The kiosk read `sessions` off a 404
+ * `DEVICE_NOT_IN_ROOM` body, got `undefined`, and threw inside the `data`
+ * listener.
+ *
+ * A **subclass** of {@link UnexpectedResponseError} rather than a sibling, for
+ * the same reason `InvalidResponseBodyError` is: both consumers already branch
+ * on `instanceof UnexpectedResponseError` and read `.status`, and those branches
+ * keep working unchanged and say something sane. Consumers that want to
+ * distinguish "the service answered a contract error" from "the response was
+ * off-contract entirely" test for this subclass and get {@link body} and
+ * {@link code} with it.
+ */
+class LongPollResponseError extends UnexpectedResponseError {
+  /** The declared, schema-validated response body for {@link status}. */
+  readonly body: unknown;
+  /**
+   * The `code` field of the error body (`INVALID_DEVICE_TOKEN`,
+   * `DEVICE_NOT_IN_ROOM`, `INTERNAL_ERROR`, ...) when the body carries one, or
+   * `null`. This is the field that names the *cause*, so it is lifted out of
+   * the body and into the message rather than left for each consumer to dig
+   * for.
+   */
+  readonly code: string | null;
+
+  /**
+   * @param status Declared HTTP status that is neither 200 nor 204.
+   * @param body Schema-validated response body for that status.
+   */
+  constructor(status: number, body: unknown) {
+    const { code, detail } = describeBody(body);
+    super(
+      status,
+      `Long-poll responded with status ${status.toString()}${
+        code !== null ? ` (${code})` : ''
+      }, which carries no poll payload.${detail !== null ? ` ${detail}` : ''}`,
+    );
+    this.name = 'LongPollResponseError';
+    this.body = body;
+    this.code = code;
+  }
+}
+
+/**
+ * Pull the canonical `{ code, message }` pair out of an error body, if it has
+ * one. Every error body in the repo is `ErrorReply`-shaped, but nothing
+ * guarantees a given route's is, so both fields are optional here.
+ */
+function describeBody(body: unknown): {
+  code: string | null;
+  detail: string | null;
+} {
+  if (typeof body !== 'object' || body === null) {
+    return { code: null, detail: null };
+  }
+  const record = body as Record<string, unknown>;
+  const code = record['code'];
+  const message = record['message'];
+  return {
+    code: typeof code === 'string' ? code : null,
+    detail: typeof message === 'string' ? message : null,
+  };
+}
+
+export { LongPollResponseError };

--- a/libs/clients/base-long-poll-client/src/index.ts
+++ b/libs/clients/base-long-poll-client/src/index.ts
@@ -1,5 +1,6 @@
 export { LongPollClient } from './long-poll-client.js';
 export { createLongPollClient } from './create-long-poll-client.js';
+export { LongPollResponseError } from './errors.js';
 export {
   NetworkError,
   UnexpectedResponseError,

--- a/libs/clients/base-long-poll-client/src/long-poll-client.ts
+++ b/libs/clients/base-long-poll-client/src/long-poll-client.ts
@@ -11,6 +11,8 @@ import type {
   BaseRouteDefinition,
 } from '@scribear/base-schema';
 
+import { LongPollResponseError } from './errors.js';
+
 function isAbortError(err: unknown): boolean {
   return err instanceof Error && err.name === 'AbortError';
 }
@@ -89,6 +91,14 @@ interface LongPollClientEvents<S extends BaseLongPollRouteSchema> {
       ? Static<S['response'][200]>
       : never,
   ) => void;
+  /**
+   * Fires on every failed poll, before the retry is scheduled. Carries a
+   * {@link NetworkError} (unreachable), a {@link LongPollResponseError} (the
+   * route answered a declared non-200/204 status - read `.status`, `.code` and
+   * `.body` for the cause), or a plain {@link UnexpectedResponseError}
+   * (off-contract response). Also fires, without a retry, if a `data` listener
+   * throws.
+   */
   error: (err: NetworkError | UnexpectedResponseError | Error) => void;
   /**
    * Fires on stop (explicit `close()` or unrecoverable error).
@@ -103,13 +113,16 @@ interface LongPollClientEvents<S extends BaseLongPollRouteSchema> {
  *
  * Each poll appends the current version cursor to the URL. The server
  * responds with 200 + payload (cursor advances), 204 (no change, re-poll
- * immediately), or an error (triggers backoff retry).
+ * immediately), or anything else (triggers backoff retry). "Anything else"
+ * includes statuses the route *declares* - a 401 or 404 error body is a
+ * failure for this loop, not data; see {@link LongPollResponseError}.
  *
  * State machine:
  * ```
  *   IDLE -> POLLING (start())
  *   POLLING -> POLLING (200 or 204 - re-polls immediately)
- *   POLLING -> WAITING_RETRY (network error or non-2xx response)
+ *   POLLING -> WAITING_RETRY (network error, or any response that is not
+ *              200/204, declared or not)
  *   POLLING -> CLOSED (close() called)
  *   WAITING_RETRY -> POLLING (retry timer fires)
  *   * -> CLOSED (close())
@@ -229,6 +242,34 @@ export class LongPollClient<
         return;
       }
 
+      // A status the route declares but which is not a poll result (401, 404,
+      // 500, ...) arrives here in the *response* slot with a null error,
+      // because `createEndpointClient` treats "declared" as "on contract"
+      // regardless of status. It is still a failure for this loop, and one
+      // whose cause must reach the consumer rather than be laundered into a
+      // payload - see `LongPollResponseError`.
+      //
+      // Deliberately routed through `_handleFailure` (emit + backoff retry)
+      // rather than being made terminal for any status, including 401. Nothing
+      // in the fleet re-mints a credential on demand: the kiosk's DEVICE_TOKEN
+      // is replaced only by a human re-activating the device, and
+      // node-server's service key only by a redeploy. Both of those *do*
+      // happen while the client is running, and a poll that stopped for good
+      // would not notice - the kiosk would sit on a stale schedule until
+      // someone power-cycled the display. Backoff caps the cost of waiting at
+      // one request per 30s, and the consumer is told every time.
+      if (result !== null && result.status !== 200 && result.status !== 204) {
+        this._handleFailure(
+          new LongPollResponseError(result.status, result.data),
+        );
+        return;
+      }
+
+      // Reset only once the response is known to be a real poll result.
+      // Resetting before the status check let a permanently-failing status
+      // (a wrong API key answering 401 forever) hold `_attempt` at 0, so
+      // backoff never grew past `initialMs` and the client retried a hopeless
+      // request once a second indefinitely.
       this._attempt = 0;
 
       if (result === null || result.status === 204) continue;
@@ -237,8 +278,47 @@ export class LongPollClient<
       const newVersion = (result.data as Record<string, unknown>)[
         this._versionResponseKey
       ];
-      if (typeof newVersion === 'number') this._currentVersion = newVersion;
-      this._emit('data', result.data);
+      if (typeof newVersion !== 'number') {
+        // The body already passed the 200 schema, so this is not contract
+        // drift - it means `versionResponseKey` does not name a numeric field
+        // in that schema, i.e. the client was constructed wrong. Emitting the
+        // payload anyway would leave the cursor unmoved, and the server
+        // answers 200 to the same cursor immediately: a hot loop with no
+        // delay between requests. Fail into backoff instead, so the
+        // misconfiguration is visible and bounded.
+        this._handleFailure(
+          new UnexpectedResponseError(
+            200,
+            `200 response body has no numeric '${this._versionResponseKey}' field; cannot advance the long-poll cursor.`,
+          ),
+        );
+        return;
+      }
+      this._currentVersion = newVersion;
+      this._emitData(result.data);
+    }
+  }
+
+  /**
+   * Emit `data`, containing any exception a listener throws.
+   *
+   * Without this a throwing listener escapes the `while` loop of a `void`-ed
+   * async method: the client is left in `POLLING` with no request in flight
+   * and no retry armed - permanently silent, while `state` still reads
+   * healthy - and the exception surfaces only as an unhandled rejection. That
+   * is how the 404-emitted-as-data bug actually manifested on the kiosk, whose
+   * listener iterates `payload.sessions`.
+   */
+  private _emitData(payload: unknown): void {
+    try {
+      this._emit('data', payload);
+    } catch (cause: unknown) {
+      this._emit(
+        'error',
+        cause instanceof Error
+          ? cause
+          : new Error('long-poll data listener threw', { cause }),
+      );
     }
   }
 

--- a/libs/clients/base-long-poll-client/tests/unit/long-poll-client.test.ts
+++ b/libs/clients/base-long-poll-client/tests/unit/long-poll-client.test.ts
@@ -10,6 +10,7 @@ import type {
   BaseRouteDefinition,
 } from '@scribear/base-schema';
 
+import { LongPollResponseError } from '#src/errors.js';
 import { LongPollClient } from '#src/long-poll-client.js';
 
 const mockEndpointFn = vi.hoisted(() => vi.fn());
@@ -27,6 +28,15 @@ const SCHEMA = {
   response: {
     200: Type.Object({ versionKey: Type.Integer(), payload: Type.String() }),
     204: Type.Null(),
+    // Declared error statuses, mirroring the real routes: `my-schedule`
+    // declares 401 INVALID_DEVICE_TOKEN, 404 DEVICE_NOT_IN_ROOM and
+    // STANDARD_ERROR_REPLIES (which includes 500). Declared statuses are the
+    // dangerous ones - `createEndpointClient` returns them in the *response*
+    // slot with a null error, so they reach the poll loop looking exactly like
+    // a payload.
+    401: Type.Object({ code: Type.String(), message: Type.String() }),
+    404: Type.Object({ code: Type.String(), message: Type.String() }),
+    500: Type.Object({ code: Type.String(), message: Type.String() }),
   },
 } satisfies BaseLongPollRouteSchema;
 
@@ -253,6 +263,294 @@ describe('LongPollClient', () => {
       });
 
       // Assert
+      expect(client.state).toBe('POLLING');
+    });
+  });
+
+  describe('declared non-200/204 responses', () => {
+    /**
+     * The regression test for the `invalid-request` laundering chain.
+     *
+     * A declared 401 comes back in the *response* slot (`err === null`), so
+     * the loop's old `status === 204 ? continue : emit data` shape published
+     * the error body as if it were the payload. node-server then read
+     * `transcriptionProviderId` off `{ code, message }`, got `undefined`, and
+     * dialed `.../transcription_stream/undefined`, which the transcription
+     * service refused - so a `NODE_SERVER_KEY` mismatch was shown to the
+     * operator as `invalid-request`, pointing at a provider misconfiguration
+     * that did not exist.
+     */
+    it('does not emit a declared 401 error body as data', async () => {
+      // Arrange
+      mockEndpointFn
+        .mockResolvedValueOnce([
+          {
+            status: 401,
+            data: { code: 'INVALID_DEVICE_TOKEN', message: 'nope' },
+          },
+          null,
+        ])
+        .mockReturnValue(HANG);
+      const dataSpy = vi.fn();
+      const errorSpy = vi.fn();
+      client.on('data', dataSpy);
+      client.on('error', errorSpy);
+
+      // Act
+      client.start();
+      await vi.waitFor(() => {
+        expect(errorSpy).toHaveBeenCalled();
+      });
+
+      // Assert
+      expect(dataSpy).not.toHaveBeenCalled();
+    });
+
+    it('reports a declared 401 as a LongPollResponseError carrying status, code and body', async () => {
+      // Arrange
+      const body = { code: 'INVALID_DEVICE_TOKEN', message: 'token revoked' };
+      mockEndpointFn
+        .mockResolvedValueOnce([{ status: 401, data: body }, null])
+        .mockReturnValue(HANG);
+      const errorSpy = vi.fn();
+      client.on('error', errorSpy);
+
+      // Act
+      client.start();
+      await vi.waitFor(() => {
+        expect(errorSpy).toHaveBeenCalled();
+      });
+
+      // Assert - the cause has to be legible to a consumer that reports faults
+      // to a human, so status/code/body all survive the trip.
+      const err = errorSpy.mock.calls[0]?.[0] as LongPollResponseError;
+      expect(err).toBeInstanceOf(LongPollResponseError);
+      expect(err.status).toBe(401);
+      expect(err.code).toBe('INVALID_DEVICE_TOKEN');
+      expect(err.body).toEqual(body);
+      expect(err.message).toContain('401');
+      expect(err.message).toContain('INVALID_DEVICE_TOKEN');
+      expect(err.message).toContain('token revoked');
+    });
+
+    it('is an UnexpectedResponseError, so existing consumer branches still match', async () => {
+      // Arrange
+      mockEndpointFn
+        .mockResolvedValueOnce([
+          { status: 401, data: { code: 'INVALID_DEVICE_TOKEN', message: 'x' } },
+          null,
+        ])
+        .mockReturnValue(HANG);
+      const errorSpy = vi.fn();
+      client.on('error', errorSpy);
+
+      // Act
+      client.start();
+      await vi.waitFor(() => {
+        expect(errorSpy).toHaveBeenCalled();
+      });
+
+      // Assert
+      expect(errorSpy.mock.calls[0]?.[0]).toBeInstanceOf(
+        UnexpectedResponseError,
+      );
+    });
+
+    it('does not emit a declared 404 error body as data', async () => {
+      // Arrange
+      mockEndpointFn
+        .mockResolvedValueOnce([
+          {
+            status: 404,
+            data: { code: 'DEVICE_NOT_IN_ROOM', message: 'unassigned' },
+          },
+          null,
+        ])
+        .mockReturnValue(HANG);
+      const dataSpy = vi.fn();
+      const errorSpy = vi.fn();
+      client.on('data', dataSpy);
+      client.on('error', errorSpy);
+
+      // Act
+      client.start();
+      await vi.waitFor(() => {
+        expect(errorSpy).toHaveBeenCalled();
+      });
+
+      // Assert
+      expect(dataSpy).not.toHaveBeenCalled();
+      expect((errorSpy.mock.calls[0]?.[0] as LongPollResponseError).code).toBe(
+        'DEVICE_NOT_IN_ROOM',
+      );
+    });
+
+    it('does not emit a declared 500 error body as data', async () => {
+      // Arrange
+      mockEndpointFn
+        .mockResolvedValueOnce([
+          { status: 500, data: { code: 'INTERNAL_ERROR', message: 'boom' } },
+          null,
+        ])
+        .mockReturnValue(HANG);
+      const dataSpy = vi.fn();
+      const errorSpy = vi.fn();
+      client.on('data', dataSpy);
+      client.on('error', errorSpy);
+
+      // Act
+      client.start();
+      await vi.waitFor(() => {
+        expect(errorSpy).toHaveBeenCalled();
+      });
+
+      // Assert
+      expect(dataSpy).not.toHaveBeenCalled();
+      expect(
+        (errorSpy.mock.calls[0]?.[0] as LongPollResponseError).status,
+      ).toBe(500);
+    });
+
+    it('does not advance the version cursor on a declared error status', async () => {
+      // Arrange
+      mockEndpointFn
+        .mockResolvedValueOnce([
+          {
+            status: 401,
+            // A `versionKey` on an error body must not move the cursor: the
+            // cursor is only meaningful for payloads we actually delivered.
+            data: {
+              code: 'INVALID_DEVICE_TOKEN',
+              message: 'x',
+              versionKey: 99,
+            },
+          },
+          null,
+        ])
+        .mockReturnValue(HANG);
+      const errorSpy = vi.fn();
+      client.on('error', errorSpy);
+
+      // Act
+      client.start();
+      await vi.waitFor(() => {
+        expect(errorSpy).toHaveBeenCalled();
+      });
+      client.close();
+      mockEndpointFn.mockClear();
+      mockEndpointFn.mockReturnValue(HANG);
+      client.start();
+
+      // Assert
+      expect(mockEndpointFn).toHaveBeenCalledWith(
+        expect.objectContaining({ querystring: { sinceVersion: 0 } }),
+        expect.anything(),
+      );
+    });
+
+    it('retries a declared error status with backoff rather than stopping', async () => {
+      // Arrange
+      mockEndpointFn
+        .mockResolvedValueOnce([
+          { status: 401, data: { code: 'INVALID_DEVICE_TOKEN', message: 'x' } },
+          null,
+        ])
+        .mockReturnValue(HANG);
+      const closeSpy = vi.fn();
+      client.on('close', closeSpy);
+
+      // Act - a revoked token is fixed by a human re-activating the device
+      // while this client is still running, so the poll must still be alive to
+      // notice.
+      client.start();
+      await vi.waitFor(() => {
+        expect(client.state).toBe('WAITING_RETRY');
+      });
+
+      // Assert
+      expect(closeSpy).toHaveBeenCalledWith(expect.any(Number));
+    });
+
+    it('grows backoff across consecutive declared error statuses', async () => {
+      // Arrange - a wrong service key answers 401 forever. Resetting `attempt`
+      // before the status check pinned the delay at `initialMs`, hammering a
+      // hopeless request once a second indefinitely.
+      vi.useFakeTimers();
+      mockEndpointFn.mockResolvedValue([
+        { status: 401, data: { code: 'INVALID_SERVICE_KEY', message: 'x' } },
+        null,
+      ]);
+
+      // Act
+      client.start();
+      await Promise.resolve(); // first 401
+      vi.runAllTimers(); // retry
+      await Promise.resolve(); // second 401
+
+      // Assert
+      expect(client.attempt).toBe(2);
+      vi.useRealTimers();
+    });
+  });
+
+  describe('cursor integrity', () => {
+    it('fails rather than emitting a 200 whose body has no numeric version key', async () => {
+      // Arrange - `versionResponseKey` naming a field the 200 schema does not
+      // have. Emitting anyway would leave the cursor at 0, and the server
+      // answers 200 to that same cursor immediately: a hot loop with no delay.
+      mockEndpointFn.mockResolvedValue([
+        { status: 200, data: { payload: 'a' } },
+        null,
+      ]);
+      const dataSpy = vi.fn();
+      const errorSpy = vi.fn();
+      client.on('data', dataSpy);
+      client.on('error', errorSpy);
+
+      // Act
+      client.start();
+      await vi.waitFor(() => {
+        expect(errorSpy).toHaveBeenCalled();
+      });
+
+      // Assert
+      expect(dataSpy).not.toHaveBeenCalled();
+      expect(errorSpy.mock.calls[0]?.[0]).toBeInstanceOf(
+        UnexpectedResponseError,
+      );
+      expect((errorSpy.mock.calls[0]?.[0] as Error).message).toContain(
+        'versionKey',
+      );
+      expect(client.state).toBe('WAITING_RETRY');
+    });
+  });
+
+  describe('data listener failures', () => {
+    it('keeps polling and reports when a data listener throws', async () => {
+      // Arrange - a throwing listener used to escape the `void`-ed async poll
+      // loop, leaving the client in POLLING with no request in flight and no
+      // retry armed: permanently silent while `state` still read healthy.
+      mockEndpointFn
+        .mockResolvedValueOnce([
+          { status: 200, data: { versionKey: 1, payload: 'a' } },
+          null,
+        ])
+        .mockReturnValue(HANG);
+      const boom = new Error('listener blew up');
+      client.on('data', () => {
+        throw boom;
+      });
+      const errorSpy = vi.fn();
+      client.on('error', errorSpy);
+
+      // Act
+      client.start();
+      await vi.waitFor(() => {
+        expect(mockEndpointFn).toHaveBeenCalledTimes(2);
+      });
+
+      // Assert
+      expect(errorSpy).toHaveBeenCalledWith(boom);
       expect(client.state).toBe('POLLING');
     });
   });

--- a/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
+++ b/libs/schemas/node-server-schema/src/status/routes/status.schema.ts
@@ -279,10 +279,20 @@ export const STATUS_PROCESS_SCHEMA = Type.Object({
 export type StatusProcess = Static<typeof STATUS_PROCESS_SCHEMA>;
 
 /**
- * Whether each secret this process holds is still the
- * `deployment/.env.example` `CHANGEME` placeholder — never the value itself,
- * matching the discipline `describeSecret()` already applies on the Admin
- * Server (PLAN-ConfigCheck-Coverage Phase 2).
+ * Whether each secret this process holds is unusable — still the
+ * `deployment/.env.example` `CHANGEME` placeholder, or empty — never the
+ * value itself, matching the discipline `describeSecret()` already applies on
+ * the Admin Server (PLAN-ConfigCheck-Coverage Phase 2).
+ *
+ * Empty counts the same as `CHANGEME` here: `AppConfig.secretPlaceholders`
+ * classifies with `isPlaceholderSecret`, which treats the two the same
+ * because none of these four secrets has a fallback that would make "unset"
+ * a different situation from "still the stub" - each is used directly as a
+ * signing key or a presented credential, so an empty value is exactly as
+ * guessable. That is a deliberate difference from `describeSecret` on the
+ * Admin Server, which *does* keep "not set" distinct from "placeholder" for
+ * secrets that have a fallback (`ADMIN_SESSION_SECRET`, unset, signs cookies
+ * with a random per-boot value instead).
  *
  * A sibling of `sessions`/`sessionsTruncated` on the route response rather
  * than a member of {@link STATUS_PROCESS_SCHEMA}: that schema's properties
@@ -298,19 +308,19 @@ export type StatusProcess = Static<typeof STATUS_PROCESS_SCHEMA>;
 export const SECRET_PLACEHOLDERS_SCHEMA = Type.Object({
   sessionTokenSigningKeyIsPlaceholder: Type.Boolean({
     description:
-      'True if SESSION_TOKEN_SIGNING_KEY (deployment JWT_SECRET) is still the deployment/.env.example placeholder. Every session token would be forgeable.',
+      'True if SESSION_TOKEN_SIGNING_KEY (deployment JWT_SECRET) is still the deployment/.env.example placeholder, or unset. Every session token would be forgeable.',
   }),
   sessionManagerServiceApiKeyIsPlaceholder: Type.Boolean({
     description:
-      'True if SESSION_MANAGER_SERVICE_API_KEY (deployment NODE_SERVER_KEY) is still the deployment/.env.example placeholder. The outbound key this process presents to Session Manager would be public.',
+      'True if SESSION_MANAGER_SERVICE_API_KEY (deployment NODE_SERVER_KEY) is still the deployment/.env.example placeholder, or unset. The outbound key this process presents to Session Manager would be public.',
   }),
   nodeServerServiceApiKeyIsPlaceholder: Type.Boolean({
     description:
-      'True if NODE_SERVER_SERVICE_API_KEY (deployment NODE_SERVER_SERVICE_KEY, the key that guards this very endpoint) is still the deployment/.env.example placeholder.',
+      'True if NODE_SERVER_SERVICE_API_KEY (deployment NODE_SERVER_SERVICE_KEY, the key that guards this very endpoint) is still the deployment/.env.example placeholder, or unset. In practice this process refuses to serve any service-key-guarded request, including this one, once that key is empty or a placeholder, so this flag is never observed true from a live poll - see ServiceAuthService.',
   }),
   transcriptionServiceApiKeyIsPlaceholder: Type.Boolean({
     description:
-      'True if TRANSCRIPTION_SERVICE_API_KEY (deployment TRANSCRIPTION_API_KEY) is still the deployment/.env.example placeholder. The shared key this process and Transcription Service present to each other would be public.',
+      'True if TRANSCRIPTION_SERVICE_API_KEY (deployment TRANSCRIPTION_API_KEY) is still the deployment/.env.example placeholder, or unset. The shared key this process and Transcription Service present to each other would be public.',
   }),
 });
 


### PR DESCRIPTION
## Summary

Two real bugs found while doing §7 Config Check (PR #197), neither of which is a
Config Check issue. On their own branch off `staging` so #197 stays reviewable.

Both are the same shape: **a credential fault presented as something else entirely.**

## 1. A long poll emitted a declared error status as poll data (`6a6d782`)

`LongPollClient._run` checked for a null error slot and a 204, then fell through
to a `// status === 200` comment with **nothing enforcing it**. Any other status
the route *declares* arrives in the response slot with a null error — because
`createEndpointClient` treats "declared" as "on contract" regardless of status —
so its error body was handed to consumers as a poll payload.

On `session-config-stream`, whose `200` body *is* a `Session`: when
`NODE_SERVER_KEY` disagrees between node-server and session-manager,
session-manager answers `401 INVALID_SERVICE_KEY`, that body was emitted as a
`Session`, `transcriptionProviderId` came out `undefined`, node-server dialled
`.../transcription_stream/undefined`, and the operator saw **`invalid-request`** —
and went hunting for a provider-key misconfiguration that does not exist.
`my-schedule` was vulnerable the same way via its own declared 401/404; one
change fixes both.

**Two further faults on that same path, both worse than the one this started
from:**

- **A permanent silent stall.** `_emit('data')` was unguarded and `_run` is
  `void`ed. A consumer listener that throws on a malformed payload — the kiosk's
  does, it iterates `payload.sessions` — threw straight out of the `while` loop,
  leaving the client in state `POLLING` with **no request in flight and no retry
  armed**. Permanently silent, every health readout still green, plus an
  unhandled rejection.
- **Backoff that never grew.** `this._attempt = 0` ran *before* the status check,
  so a permanently-failing declared status pinned the counter at zero — a
  hopeless 401 retried roughly once a second, forever.

Non-200/204 is now `LongPollResponseError`, a **subclass** of
`UnexpectedResponseError` so existing consumer branches still match, carrying
status, code and body. Retried with backoff rather than made terminal, including
for 401: nothing re-mints a credential on demand, but a kiosk re-activation and a
node-server redeploy both happen *while the client is running*, and a poll that
stopped for good would not notice — a wall-mounted kiosk would sit on a stale
schedule until someone power-cycled it.

A 200 whose body carries no numeric version cursor now fails too. It used to be
skipped silently, leaving the cursor unmoved — and since a long-poll server
returns 200 whenever `version > sinceVersion`, that is an unthrottled request
loop against session-manager caused by a typo in `versionResponseKey`.

node-server needed no change: both its handlers already did the right thing once
given an error instead of a fabricated payload.

## 2. An unset node-server secret self-reported as healthy (`464eddb`)

`isPlaceholder('')` was `false`, and that function feeds `secretPlaceholders` on
`GET /status` → monitoring-sidecar → Config Check. An empty
`SESSION_TOKEN_SIGNING_KEY`, `SESSION_MANAGER_SERVICE_API_KEY` or
`TRANSCRIPTION_SERVICE_API_KEY` rendered **green on the page whose whole job is
to notice that**. Reachable, not theoretical: the env schema declares them as
bare `Type.String()` with no `minLength`.

The fix is a deletion — `isPlaceholderSecret` in `utils/constant-time-equal.ts`
already handled empty, exported and never called, a few files from a local
duplicate that had drifted from it.

Empty is reported *as* a placeholder rather than as a distinct "missing" signal,
deliberately: none of these four has a fallback that makes unset a different
failure from `CHANGEME` (two are bearer credentials, one is an HMAC key), so the
remediation is identical. A tri-state signal would have meant a new optional
field across `node-server-schema`, the sidecar relay and Config Check, plus the
rolling-upgrade fallback, to tell an operator something that does not change
what they do.

## Test plan

- [x] whole-repo `npm run build` — exit 0
- [x] whole-repo `npm run test:unit` — **2,315 passed** across 22 packages
- [x] whole-repo `npm run test:integration` — **766 passed** across 6 packages
- [x] whole-repo `npm run lint` — exit 0 (3 pre-existing warnings in untouched code)
- [ ] Live verification against a running stack

## A correction to #197's commit message

#197 states that boot-time fail-closed checks already exist for every inbound
service key. For node-server that is **imprecise**: `serviceAuthService` is a
lazily-resolved Awilix singleton reached through `serviceApiKeyHook`, so the
process starts fine with an empty key and the guard fires on the *first request*
that needs it, not at boot. `assertNotPlaceholderKey`'s own comment saying the
service "refuses to start" is wrong for the same reason. The conclusion in #197
is unaffected — that key still cannot reach `/status` with a false-green answer —
and the code comment here now says what actually happens.

## Noted, not fixed

- A server returning 200 with a **non-increasing** version produces the same hot
  loop as the missing-cursor case. No route in this repo can currently do it, and
  a strict monotonicity check could break a legitimate server — flagged rather
  than guessed at.
- The kiosk reports 401/404 at `warning`; both are arguably `error`, and a 401
  arguably ought to drop it straight to the activation form as `getMyDevice`
  does. Left as out-of-scope consumer behaviour.
- node-server has no operator-facing counter for "session-config poll refused",
  so a persistent 401 there is visible only in logs and as 1011 closes.
