### PR TITLE
fix(python-cd): publish latest and v<version> for the transcription images

### DIFF
--- a/.github/workflows/python-cd.yml
+++ b/.github/workflows/python-cd.yml
@@ -21,18 +21,66 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      transcription_service: ${{ steps.filter.outputs.transcription_service }}
+      build_images: ${{ steps.decide.outputs.build_images }}
       image_matrix: ${{ steps.image_matrix.outputs.matrix }}
       build_matrix: ${{ steps.image_matrix.outputs.build_matrix }}
     steps:
+      # fetch-depth: 0 for the same reason node-cd needs it: the base commit
+      # below has to be in the local history for the diff to resolve, and the
+      # default shallow checkout does not contain it.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@v3
         with:
+          # Pinned to the pre-push commit, matching what detect-changes does in
+          # node-cd.yml. Left unset, paths-filter diffs against the repository
+          # default branch - which here is `staging`, so on a staging -> main
+          # merge it compares main against the very commits main just absorbed,
+          # finds nothing, and skips the build. That is why no transcription
+          # image ever received a `latest` or `v<version>` tag.
+          #
+          # The zero SHA (branch created by this push) falls back to the default
+          # base rather than failing to resolve; main force-builds below anyway.
+          base: ${{ github.event.before != '0000000000000000000000000000000000000000' && github.event.before || '' }}
           filters: |
+            # `.github/**` is global here for the same reason detect-changes
+            # treats it as global in node-cd: a change to build-container,
+            # resolve-container-tags or the tag policy otherwise reaches the
+            # node images on the next staging push but sits dormant for these
+            # three until someone happens to touch Python source. Rebuilding
+            # costs ~3 minutes on a warm cache - the BUILD_* args are the last
+            # layers in both Dockerfiles - and only bites on staging, since
+            # main and workflow_dispatch build unconditionally below.
             transcription_service:
               - 'transcription_service/**'
+              - '.github/**'
+
+      # A push to main is a release: every production image must come out of it
+      # carrying `latest` and `v<version>`, whether or not its source moved
+      # since the last one, so the path filter only gates staging builds. A
+      # manual dispatch builds everything too - same rule detect-changes applies
+      # in node-cd.yml, where an empty base means "run all workspaces".
+      - name: Decide whether to build images
+        id: decide
+        shell: bash
+        env:
+          TRANSCRIPTION_CHANGED: ${{ steps.filter.outputs.transcription_service }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+        run: |
+          if [ "$TRANSCRIPTION_CHANGED" = "true" ] \
+            || [ "$REF" = "refs/heads/main" ] \
+            || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            build_images=true
+          else
+            build_images=false
+          fi
+          echo "build_images=${build_images}" >> "$GITHUB_OUTPUT"
+          echo "transcription_service changed: ${TRANSCRIPTION_CHANGED:-unknown}, build_images: ${build_images}"
 
       - name: Resolve transcription image matrix
         id: image_matrix
@@ -47,7 +95,7 @@ jobs:
   # Mirrors the shape in node-cd.yml.
   docker-build:
     needs: [changes]
-    if: needs.changes.outputs.transcription_service == 'true'
+    if: needs.changes.outputs.build_images == 'true'
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.changes.outputs.build_matrix) }}
@@ -85,7 +133,7 @@ jobs:
   # multi-arch index. Mirrors docker-merge in node-cd.yml.
   docker-merge:
     needs: [changes, docker-build]
-    if: needs.changes.outputs.transcription_service == 'true'
+    if: needs.changes.outputs.build_images == 'true'
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.changes.outputs.image_matrix) }}


### PR DESCRIPTION
## The bug

Merging staging → main publishes `latest` and `v<version>` for the 12 Node/infra images, but never for the three transcription images:

```
scribear-db … admin-webapp        latest, v0.2.0     ✅ (Node.js CD)
transcription-service-cpu         *** none ***       ❌
transcription-service-cuda        *** none ***       ❌
transcription-service-cuda128     *** none ***       ❌
```

Python CD for the #201 promotion finished in 13s with both docker jobs skipped; the #120 promotion skipped the same way in 7s. From that run's log:

```
Changes will be detected between staging and main
git merge-base refs/remotes/origin/staging refs/remotes/origin/main
Filter transcription_service = false
```

`dorny/paths-filter` defaults its base to the repository default branch, which here is `staging`. On a staging → main merge, `merge-base(staging, main)` **is** the staging tip that was just merged, so the diff is empty by construction and `transcription_service` is always `false`. Node CD is unaffected because it uses `.github/actions/detect-changes`, which diffs `github.event.before..HEAD` — the previous *main* tip.

`workflow_dispatch` hit the same trap (`github.event.before` is empty → default base), so re-running Python CD on main could not fix it either.

## The fix

- **Pin the diff base** to `github.event.before`, with the all-zero SHA falling back to the default so a recreated branch can't fail to resolve. `fetch-depth: 0` on the changes checkout so that commit is in local history, same as node-cd.
- **Force a build on main and on `workflow_dispatch`** via a new `build_images` output. A release push publishes every production image whether or not its source moved; a dispatch builds everything, matching the "empty base means run all workspaces" rule detect-changes already applies.
- **Make `.github/**` global to the filter**, as python-ci and detect-changes already do. A change to `build-container` or `resolve-container-tags` otherwise reaches the node images on the next staging push but sits dormant for these three until someone touches Python source — the same drift that hid this bug.

| Event | Before | After |
|---|---|---|
| push → main (release) | always skipped | always builds; `latest` + `v<version>` |
| push → staging | only on `transcription_service/**` | also on `.github/**` |
| workflow_dispatch | skipped | builds everything |

## Cost of the `.github/**` widening

Over the last 40 staging merges, 9 touched `.github/**` and 5 of those touched nothing under `transcription_service/` — so ~1 in 8 staging pushes gains a build. A warm build of all three images is ~3 min wall / ~7 runner-min (run `30768928324`), and the `BUILD_*` args are the last layers in both Dockerfiles, so the CUDA layers stay cached and the push is mostly "already exists". Free runners and free GHCR storage on a public repo. The visible cost is ~12% faster growth of the `staging-<sha>` tag lists.

## After merging

`workflow_dispatch` Python CD against `main` to publish the missing `latest` / `v0.2.0` with correct provenance. Retagging `production-pr201` would also work content-wise, but those images are stamped `BUILD_TAGS=production-pr201`, so the admin console's Deployment Check would report them as PR images.

## Verification

Not run yet — the `base:` behaviour is only proven by the first real run, and no local actionlint was available. The YAML parses and both job conditions resolve to `needs.changes.outputs.build_images == 'true'`. The Python CD run on this PR is a no-op (it's `push`-triggered only); the first live exercise is this branch landing on staging, which the `.github/**` filter change now makes build.
