### PR TITLE
feat(nginx): the site root opens the client webapp; redirects keep their origin

### DIFF
--- a/.changeset/nginx-root-redirects-to-client.md
+++ b/.changeset/nginx-root-redirects-to-client.md
@@ -1,0 +1,43 @@
+---
+'@scribear/scribear-nginx': minor
+---
+
+The site root now opens the client webapp instead of 404ing.
+
+`nginx.conf` routed `/client/`, `/kiosk/`, `/standalone/`, `/admin/`,
+`/grafana/` and the `/api/...` prefixes, and nothing at all at `/` — there is no
+`location /` in the TLS server, so the bare hostname returned nginx's own 404.
+That is the URL a person types by hand into a lecture-room browser, and it was
+the one URL in the deployment that led nowhere.
+
+`location = /` now returns a 302: to `/client/` for an onsite visitor, and to
+`/extlanding` for a gated one — the same landing page every other frontend
+surface already redirects to, so the onsite gate's behavior for an outside
+visitor is unchanged. Exact match, so `/` alone is affected and every other
+unrouted path still 404s.
+
+**302, not 301/308.** What `/` resolves to depends on which network the visitor
+is on, so a permanent redirect would be cached by the browser and replayed for
+the same person after they leave campus — exactly the distinction this location
+exists to make.
+
+**`Cache-Control: no-store` as a literal, not the `$onsite_no_cache` map.** The
+map is empty on the allowed path because the gated locations *proxy* there, and
+an upstream's own `Cache-Control` on hash-versioned assets must be left alone.
+Here both branches are IP-dependent redirects, so neither may be stored.
+
+**`absolute_redirect off`.** nginx otherwise expands a relative redirect against
+`$host`, which drops a non-default port: on the dev/iso stack published at
+`:8443` the browser was sent to `https://<host>/client/` on port 443 — a
+different stack on the same machine. Observed against a real container, not
+theorised. The neighbouring `/client` and `/grafana` 308s share the quirk and
+are deliberately left alone here rather than widening this change.
+
+Verified end-to-end against `ghcr.io/scribear/scribear-nginx` with the shipped
+config and both a permissive and a `default 0` allowlist: onsite `/` → 302
+`/client/` (relative, port preserved) → 200 from the client webapp; gated `/` →
+302 `/extlanding` with `X-Onsite-Gate: denied` → 200 landing page; `/healthz`
+200, an unrouted path 404, and an API still 403 off-campus. `onsite-gate.test.ts`
+now covers the root as an eleventh gated location — including the two ways it
+legitimately differs from the others (no `proxy_pass` to run ahead of, and the
+literal `no-store`), so neither can be quietly dropped.

--- a/.changeset/nginx-root-redirects-to-client.md
+++ b/.changeset/nginx-root-redirects-to-client.md
@@ -26,18 +26,33 @@ map is empty on the allowed path because the gated locations *proxy* there, and
 an upstream's own `Cache-Control` on hash-versioned assets must be left alone.
 Here both branches are IP-dependent redirects, so neither may be stored.
 
-**`absolute_redirect off`.** nginx otherwise expands a relative redirect against
-`$host`, which drops a non-default port: on the dev/iso stack published at
-`:8443` the browser was sent to `https://<host>/client/` on port 443 — a
-different stack on the same machine. Observed against a real container, not
-theorised. The neighbouring `/client` and `/grafana` 308s share the quirk and
-are deliberately left alone here rather than widening this change.
+**`absolute_redirect off`, on the whole TLS server.** nginx expands a redirect
+written as a path into an absolute URL built from `$host`, which carries no
+port: on the dev/iso stack published at `:8443` the browser was sent to
+`https://<host>/client/` on port 443 — a different stack on the same machine.
+Observed against a real container, not theorised. This was found while adding
+the root redirect but affects every redirect nginx generates here, so the
+directive sits on the server: the `/client` and `/grafana` trailing-slash 308s
+and all seven of the onsite gate's `/extlanding` 302s now stay on the origin the
+client actually reached. Production, served on 443, is byte-identical either
+way — which is exactly why this could not be caught there, and why
+`tests/unit/relative-redirects.test.ts` now pins both the directive and the
+path-style targets it governs.
+
+Untouched: the plain-HTTP listener's `return 301 https://$host$request_uri`,
+which is an absolute URL by construction and could not be fixed here anyway —
+it crosses schemes, and the TLS port is not derivable from the HTTP one. And
+upstream-generated `Location` headers, which are `proxy_redirect`'s business;
+no location sets one.
 
 Verified end-to-end against `ghcr.io/scribear/scribear-nginx` with the shipped
 config and both a permissive and a `default 0` allowlist: onsite `/` → 302
 `/client/` (relative, port preserved) → 200 from the client webapp; gated `/` →
-302 `/extlanding` with `X-Onsite-Gate: denied` → 200 landing page; `/healthz`
-200, an unrouted path 404, and an API still 403 off-campus. `onsite-gate.test.ts`
+302 `/extlanding` with `X-Onsite-Gate: denied` → 200 landing page; every one of
+`/`, `/client`, `/grafana`, `/client/`, `/kiosk/`, `/standalone/`, `/admin/` and
+`/grafana/` emitting a bare-path `Location` on both sides of the gate;
+`/healthz` 200, an unrouted path 404, and an API still 403 off-campus.
+`onsite-gate.test.ts`
 now covers the root as an eleventh gated location — including the two ways it
 legitimately differs from the others (no `proxy_pass` to run ahead of, and the
 literal `no-store`), so neither can be quietly dropped.

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -34,6 +34,18 @@ page `/` means depends on where the visitor is, so it must not be cached and
 replayed for the same person on a different network. Every other unrouted path
 still 404s, and `/healthz` is unaffected.
 
+**Redirects now name a path instead of a full URL.** `Location: /client/`
+rather than `Location: https://<host>/client/`, for every redirect nginx
+generates itself — the root, the `/client` and `/grafana` trailing-slash
+redirects, and the onsite gate's redirects to `/extlanding`. On a deployment
+served from the standard port 443 this changes nothing observable. It matters
+if you publish the stack on any other port: the old form was built from the
+`Host` header with the port stripped, so a stack on `:8443` redirected visitors
+to port 443 of the same machine. If you have a proxy, CDN, or test harness in
+front of nginx that assumes an absolute `Location`, this is the release to
+check it against — a relative one has been valid since RFC 7231 and every
+browser accepts it.
+
 ---
 
 ## Unreleased — session-auth rate limits are tunable and recalibrated (`compose.yml` v16)

--- a/deployment/UPGRADING.md
+++ b/deployment/UPGRADING.md
@@ -12,6 +12,30 @@ lists every key the current `compose.yml` understands.
 
 ---
 
+## Unreleased — the site root now opens the client webapp
+
+**Image-only change: pull the new `scribear-nginx` image and
+`docker compose up -d`.** No `compose.yml` or `.env` change.
+
+`https://<your-host>/` used to return a bare 404 — the reverse proxy routed
+`/client/`, `/kiosk/`, `/admin/` and the rest, but nothing at all at the root,
+so typing the hostname into a lecture-room browser gave a blank error page with
+nothing to click. It now answers with a temporary redirect (302):
+
+- **Onsite** (or on any stack that has not set `ONSITE_ALLOWLIST_PATH` to a
+  real allowlist, which is every stock deployment) → `/client/`, the live
+  captions webapp.
+- **Off-campus**, when a real allowlist is in force → `/extlanding`, the same
+  landing page every other gated frontend route already redirects to. Nothing
+  about the gate's behavior changes for an outside visitor.
+
+The redirect is deliberately temporary and `Cache-Control: no-store`: which
+page `/` means depends on where the visitor is, so it must not be cached and
+replayed for the same person on a different network. Every other unrouted path
+still 404s, and `/healthz` is unaffected.
+
+---
+
 ## Unreleased — session-auth rate limits are tunable and recalibrated (`compose.yml` v16)
 
 **Copy the new [`compose.yml`](compose.yml)** and `docker compose up -d`. A

--- a/infra/scribear-nginx/nginx.conf
+++ b/infra/scribear-nginx/nginx.conf
@@ -253,8 +253,12 @@ http {
 
         # Container healthcheck target. Self-contained (no upstream) so it
         # reports nginx's own liveness, and an exact match so it never shadows a
-        # proxied route. The root "/" has no location and returns 404, which a
-        # healthcheck would read as failure — hence a dedicated endpoint.
+        # proxied route. "/" is not a substitute: it used to 404, and now 302s
+        # to /client/ (see `location = /` below), which the Dockerfile's
+        # busybox `wget -qO-` would follow into client-webapp — making this
+        # container's health depend on a different container's, and on which
+        # side of the onsite gate the healthcheck itself lands. Hence a
+        # dedicated endpoint that answers for nginx and nothing else.
         location = /healthz {
             access_log off;
             add_header Content-Type text/plain;
@@ -442,6 +446,50 @@ http {
         }
 
         # -- Frontend Webapps --
+
+        # The site root. Onsite, "/" means the client webapp - that is what
+        # someone typing the bare hostname into a lecture-room browser is
+        # after, and until now they got a bare 404 with nothing to click.
+        # Off-campus it behaves like every other frontend surface and shows
+        # the landing page, so the gate's story is unchanged for anyone
+        # outside the allowlist.
+        #
+        # 302 (temporary), not 301/308: what "/" resolves to depends on where
+        # the visitor is, so it must stay re-resolvable. A permanent redirect
+        # would be cached by the browser itself and replayed for the same
+        # person on a different network, which is precisely the case this
+        # location exists to distinguish.
+        #
+        # `Cache-Control: no-store` as a literal, NOT $onsite_no_cache: both
+        # branches here are redirects chosen by the client's network location,
+        # so neither may be stored - unlike the proxying locations below,
+        # where the allowed path carries the upstream's own Cache-Control for
+        # hash-versioned assets and must be left untouched (the reason that
+        # map is empty on the allowed path - see where it is defined).
+        #
+        # Exact match, so it governs "/" and nothing else: there is still no
+        # `location /`, so every other unrouted path 404s exactly as before.
+        #
+        # `absolute_redirect off` emits `Location: /client/` rather than
+        # letting nginx expand it against $host, which drops any non-default
+        # port: on the dev/iso stack (published on 8443) the expanded form
+        # sends the browser to https://<host>/client/ - port 443, a different
+        # stack entirely on the same machine, or nothing at all. Observed, not
+        # theorised. The bare hostname is the URL a person is most likely to
+        # type by hand with a port, which is why it matters here first; the
+        # neighbouring 308s share the quirk and are left alone rather than
+        # widened into this change.
+        location = / {
+            absolute_redirect off;
+
+            if ($onsite = 0) {
+                return 302 /extlanding;
+            }
+            add_header X-Onsite-Gate $onsite_gate_status always;
+            add_header Cache-Control "no-store" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            return 302 /client/;
+        }
 
         # The client webapp is served under /client/ (trailing slash). A bare
         # /client would otherwise 404, since there is no server-level root. The

--- a/infra/scribear-nginx/nginx.conf
+++ b/infra/scribear-nginx/nginx.conf
@@ -251,6 +251,38 @@ http {
 
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
+        # Every redirect this server generates itself - the /client and
+        # /grafana trailing-slash 308s, the onsite gate's 302s to /extlanding,
+        # and the site root below - is written as a path, and nginx would
+        # otherwise expand each one into an absolute URL built from $host.
+        # $host carries no port, so on any origin not served on 443 the
+        # expansion silently rewrites which server the browser goes to next:
+        # on the dev/iso stack (published at :8443) a gated /client/ answered
+        # `Location: https://localhost/extlanding`, sending the browser to
+        # port 443 - a different stack on the same machine. Observed against
+        # real containers, not theorised.
+        #
+        # Emitting the path as written keeps the client on the origin it
+        # already reached, whatever port that was. A relative Location has
+        # been explicitly valid since RFC 7231 §7.1.2 (which replaced RFC
+        # 2616's absolute-URI requirement); every browser has accepted one for
+        # far longer.
+        #
+        # This does NOT affect the plain-HTTP listener's `return 301
+        # https://$host$request_uri`, which is an absolute URL by construction
+        # and so is left as nginx wrote it - and could not be fixed here
+        # anyway: that redirect crosses schemes, and the TLS port is not
+        # derivable from the HTTP one (the iso stack maps 8080->80 and
+        # 8443->443, which no variable in this config relates).
+        #
+        # Nor does it touch Location headers that come back from an upstream:
+        # those are proxy_redirect's business, and no location here sets one.
+        #
+        # `tests/unit/relative-redirects.test.ts` pins this: dropping the
+        # directive breaks nothing in production, where everything is on 443,
+        # and quietly misroutes every dev stack.
+        absolute_redirect off;
+
         # Container healthcheck target. Self-contained (no upstream) so it
         # reports nginx's own liveness, and an exact match so it never shadows a
         # proxied route. "/" is not a substitute: it used to 404, and now 302s
@@ -470,18 +502,11 @@ http {
         # Exact match, so it governs "/" and nothing else: there is still no
         # `location /`, so every other unrouted path 404s exactly as before.
         #
-        # `absolute_redirect off` emits `Location: /client/` rather than
-        # letting nginx expand it against $host, which drops any non-default
-        # port: on the dev/iso stack (published on 8443) the expanded form
-        # sends the browser to https://<host>/client/ - port 443, a different
-        # stack entirely on the same machine, or nothing at all. Observed, not
-        # theorised. The bare hostname is the URL a person is most likely to
-        # type by hand with a port, which is why it matters here first; the
-        # neighbouring 308s share the quirk and are left alone rather than
-        # widened into this change.
+        # Both branches emit their Location as the bare path written here,
+        # which is the server-level `absolute_redirect off` above doing its
+        # job - it matters most for this location, the URL a person is most
+        # likely to type by hand with a port on it.
         location = / {
-            absolute_redirect off;
-
             if ($onsite = 0) {
                 return 302 /extlanding;
             }

--- a/infra/scribear-nginx/tests/unit/onsite-gate.test.ts
+++ b/infra/scribear-nginx/tests/unit/onsite-gate.test.ts
@@ -48,6 +48,9 @@ const GATED_LOCATIONS: {
     header: 'location /api/node-server/ {',
     denial: 'api',
   },
+  // Redirects rather than proxies on the allowed path too (to /client/), so
+  // it is the one gated block with no proxy_pass - see the assertions below.
+  { name: 'site root', header: 'location = / {', denial: 'frontend' },
   { name: 'client-webapp', header: 'location /client/ {', denial: 'frontend' },
   { name: 'kiosk-webapp', header: 'location /kiosk/ {', denial: 'frontend' },
   {
@@ -127,11 +130,15 @@ describe('nginx onsite-only access gate', (it) => {
         ifIndex,
         `${name}'s location block is missing the "if ($onsite = 0) { ... }" gate.`,
       ).toBeGreaterThanOrEqual(0);
-      expect(
-        ifIndex,
-        `${name}'s $onsite gate must run before proxy_pass, not after - ` +
-          'otherwise the request already reached the upstream before being denied.',
-      ).toBeLessThan(proxyIndex);
+      // The site root has no proxy_pass at all - both of its branches are
+      // redirects - so there is no upstream for the gate to run ahead of.
+      if (proxyIndex >= 0) {
+        expect(
+          ifIndex,
+          `${name}'s $onsite gate must run before proxy_pass, not after - ` +
+            'otherwise the request already reached the upstream before being denied.',
+        ).toBeLessThan(proxyIndex);
+      }
 
       if (denial === 'api') {
         expect(block).toContain(`return 403 "${ONSITE_DENIED_MESSAGE}`);
@@ -140,8 +147,14 @@ describe('nginx onsite-only access gate', (it) => {
         // Stops a stale redirect from being replayed by a caching
         // intermediary after the client actually connects - API 403s don't
         // need this (they aren't redirects a client would "come back to").
-        expect(block).toContain(
-          'add_header Cache-Control $onsite_no_cache always;',
+        //
+        // Either the $onsite_no_cache map (no-store only on the gate's own
+        // 302, so a proxied response keeps the upstream's Cache-Control for
+        // hash-versioned assets) or a literal no-store, which the site root
+        // uses because its allowed path is a redirect too and so is equally
+        // IP-dependent. Anything else - or nothing - is a regression.
+        expect(block).toMatch(
+          /add_header Cache-Control (\$onsite_no_cache|"no-store") always;/,
         );
       }
 

--- a/infra/scribear-nginx/tests/unit/relative-redirects.test.ts
+++ b/infra/scribear-nginx/tests/unit/relative-redirects.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect } from 'vitest';
+
+/**
+ * Pins `absolute_redirect off` on the TLS server, for the same reason
+ * `onsite-gate.test.ts` pins the gate: nginx.conf is the only place this
+ * lives, and its absence is invisible in the one environment anybody
+ * checks.
+ *
+ * nginx expands a redirect written as a path into an absolute URL built
+ * from `$host`, which carries no port. In production, where the stack is
+ * served on 443, the expansion is indistinguishable from the path - so a
+ * deletion of this directive passes every production smoke test. On any
+ * origin published elsewhere (the dev/iso stack at :8443) the expanded
+ * Location moves the browser to port 443 of the same host: a different
+ * stack on the same machine, or nothing listening at all. Observed against
+ * real containers before this was added.
+ */
+const NGINX_CONF_PATH = fileURLToPath(
+  new URL('../../nginx.conf', import.meta.url),
+);
+
+// The `return`s that this directive governs: nginx generates each one
+// itself, and each is written as a path rather than an absolute URL. Every
+// one of these would be rewritten against $host without it.
+const PATH_REDIRECTS = [
+  'return 308 /client/;',
+  'return 308 /grafana/;',
+  'return 302 /client/;',
+  'return 302 /extlanding;',
+];
+
+describe('nginx relative redirects', (it) => {
+  const conf = readFileSync(NGINX_CONF_PATH, 'utf8');
+
+  it('turns off absolute_redirect on the TLS server', () => {
+    // Arrange - scope the search to the 443 server, so the directive cannot
+    // satisfy this test from the plain-HTTP server block, where it would do
+    // nothing (that listener's only redirect is an absolute URL already).
+    const tlsServer = conf.slice(conf.indexOf('listen 443 ssl;'));
+
+    // Assert
+    expect(
+      tlsServer,
+      'nginx.conf no longer sets `absolute_redirect off` on the TLS ' +
+        'server. Without it every path redirect below is rewritten against ' +
+        '$host, which drops a non-default port and sends the client to a ' +
+        'different origin than the one it reached. This is invisible on a ' +
+        'stack served from 443 - do not "verify" its removal there.',
+    ).toContain('absolute_redirect off;');
+  });
+
+  it('still writes every self-generated redirect as a path, not an absolute URL', () => {
+    // Arrange - the directive only has an effect on redirects written as
+    // paths. A future edit that "helpfully" spells one out as
+    // https://$host/... would opt that route back out of the fix without
+    // touching the directive above, so both halves are pinned.
+    const tlsServer = conf.slice(conf.indexOf('listen 443 ssl;'));
+
+    // Assert
+    for (const redirect of PATH_REDIRECTS) {
+      expect(
+        tlsServer,
+        `nginx.conf no longer contains \`${redirect}\`. If that route was ` +
+          'renamed, update this list; if its target was rewritten as an ' +
+          'absolute URL, it has silently opted out of `absolute_redirect ' +
+          'off` and will drop the port again.',
+      ).toContain(redirect);
+    }
+    expect(
+      tlsServer,
+      'A redirect target in the TLS server is now an absolute URL built ' +
+        'from $host. That is exactly what `absolute_redirect off` exists to ' +
+        'avoid here - see the comment on that directive.',
+    ).not.toMatch(/return 30[128] https?:\/\/\$host/);
+  });
+});


### PR DESCRIPTION
Two commits: `/` now redirects to `/client/` (302) for onsite visitors and to the landing page for off-campus ones — and, found while testing that, every redirect nginx generates here now keeps the client on the origin it actually reached.

## 1. The site root

The TLS server routes `/client/`, `/kiosk/`, `/standalone/`, `/admin/`, `/grafana/` and the `/api/...` prefixes, and nothing at all at `/`. There is no `location /`, so the bare hostname returns nginx's own 404 — confirmed against both running stacks (`live GET / -> 404`, `iso GET / -> 404`). That's the URL a person types by hand into a lecture-room browser, and it was the one URL in the deployment that led nowhere.

```nginx
location = / {
    if ($onsite = 0) {
        return 302 /extlanding;
    }
    add_header X-Onsite-Gate $onsite_gate_status always;
    add_header Cache-Control "no-store" always;
    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
    return 302 /client/;
}
```

Exact match, so `/` alone is affected and every other unrouted path still 404s. The `if` is the bare-`return`-only form the rest of the file uses.

- **302, not 301/308.** What `/` resolves to depends on which network the visitor is on, so a permanent redirect would be cached by the browser and replayed for the same person after they leave campus — exactly the distinction this location exists to make.
- **`Cache-Control: no-store` literally, not `$onsite_no_cache`.** That map is empty on the allowed path because the other gated locations *proxy* there, where an upstream's `Cache-Control` on hash-versioned assets must be left alone. Here both branches are IP-dependent redirects, so neither may be stored.

## 2. `absolute_redirect off` on the TLS server

nginx expands a redirect written as a path into an absolute URL built from `$host`, which carries no port. Served from 443 the expansion is indistinguishable from the path — which is why this survived: it is invisible in the only environment anyone checks. On the iso stack at `:8443`, a gated `/client/` answered

```
Location: https://localhost/extlanding
```

sending the browser to port 443 of the same machine — a different stack here, and nothing at all on a developer's laptop.

The directive sits on the server rather than the one location, because it governs every redirect nginx generates: the `/client` and `/grafana` trailing-slash 308s, all seven of the gate's 302s to `/extlanding`, and the new root. Deliberately **not** the plain-HTTP listener's `return 301 https://$host$request_uri` — absolute by construction, and unfixable here anyway, since it crosses schemes and the TLS port is not derivable from the HTTP one (the iso stack maps 8080→80 and 8443→443, which no variable relates). Upstream `Location` headers are `proxy_redirect`'s business and no location sets one.

## Verification

A container running this config on `:9443` with the real SSL/content mounts, under two allowlists:

| Request | `geo default 1` (onsite) | `geo default 0` (off-campus) |
|---|---|---|
| `GET /` | 302 → `/client/`, `no-store`, HSTS | 302 → `/extlanding`, `X-Onsite-Gate: denied`, `no-store`, HSTS |
| `GET /client` `/grafana` | 308 → `/client/` `/grafana/` | 308 (ungated, unchanged) |
| `GET /client/` `/kiosk/` `/standalone/` `/admin/` | 200 | 302 → `/extlanding` |
| `GET /extlanding` | 200 | 200 |
| `GET /healthz` | 200 | 200 |
| `GET /nonexistent` | 404 | 404 |
| `GET /api/admin/v1/...` | — | 403 (unchanged) |

Every redirect above emits a bare-path `Location` and resolves back to `:9443`; before this branch, each of them lost the port. Following `/` end-to-end lands on the client webapp onsite (200) and on the landing page off-campus (200). `nginx -t` passes.

Unit tests: `scribear-nginx` 17/17 across two files, plus the three other suites that parse `nginx.conf` — session-manager 624, node-server 253, monitoring-sidecar 148, all passing.

- `onsite-gate.test.ts` covers the root as an eleventh gated location. Two narrow accommodations, both commented in place: the root block has no `proxy_pass` for the gate to run ahead of, and it uses the literal `no-store` rather than the map. The "count every `$onsite` gate" assertion still holds at exactly the number of listed locations, so nothing can be added or dropped silently.
- `relative-redirects.test.ts` (new) pins `absolute_redirect off` *and* the path-style targets it governs — a redirect respelled as `https://$host/...` would opt back out without touching the directive. Its own file rather than the gate's, because removing the directive breaks no production smoke test; a comment would not have held it.

`deployment/UPGRADING.md` gets an operator-facing section for both changes, including a note to check any front proxy that assumes an absolute `Location`. `scribear-nginx` gets a minor changeset.
