### PR TITLE
fix(node-cd): give every image the release tag, not just the rebuilt ones

### DIFF
--- a/.github/workflows/node-cd.yml
+++ b/.github/workflows/node-cd.yml
@@ -166,6 +166,112 @@ jobs:
           first_tag=$(echo "$TAGS" | head -n1)
           docker buildx imagetools inspect "ghcr.io/${IMAGE_NAME}:${first_tag}"
 
+  # Gives the release's v<version> tag to the images this push did NOT rebuild.
+  #
+  # deployment/compose.yml pins all sixteen services with one ${IMAGE_TAG}, so
+  # `IMAGE_TAG=v0.3.0` only resolves if every image carries that tag. Change
+  # detection means a push to main rebuilds only the images whose workspace it
+  # touched, so an image that did not change gets no release tag at all and
+  # pinning the stack to a version fails on it - not with a useful message,
+  # but with a manifest-unknown pull error on one service. Live proof at the
+  # time of writing: test-audio-generator stopped at v0.1.0 while everything
+  # else reached v0.2.0, so `IMAGE_TAG=v0.2.0` cannot start the stack today.
+  #
+  # A release commit hides this, because bumping every package.json marks every
+  # workspace changed and so rebuilds everything - but that is a side effect of
+  # how versions happen to be bumped, not a guarantee, and it does not survive a
+  # hotfix promoted to main on its own.
+  #
+  # Retag, don't rebuild: `imagetools create` copies the manifest registry-side.
+  # Measured against a real multi-arch image from this registry - source and new
+  # tag report the identical digest (sha256:553e627e...) with linux/amd64 and
+  # linux/arm64 both intact - so the release tag is an alias for the same bits,
+  # not a second build carrying a different provenance stamp. (It re-wraps into
+  # a fresh index only when the source is a single-arch manifest, which nothing
+  # docker-merge publishes ever is.)
+  #
+  # An existing v<version> is never moved, only missing ones are created, so
+  # re-running this can add a tag but can never re-point one.
+  #
+  # main only: the staging tags are `staging` and `staging-<sha>`, and an
+  # unchanged image's `staging` tag already points at its last build, which is
+  # the right answer there. python-cd needs no equivalent - it rebuilds all
+  # three transcription images on every push to main, changed or not.
+  backfill-release-tags:
+    needs: [changes, docker-merge]
+    # Runs whether or not docker-merge had anything to do (no changed images at
+    # all still needs the tags), but never after it failed: a half-published
+    # release must not have the rest of the stack labelled as that version.
+    if: >-
+      !cancelled()
+      && github.ref == 'refs/heads/main'
+      && needs.docker-merge.result != 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Tag every image this push did not rebuild
+        env:
+          # Only the images that were rebuilt; everything else in
+          # node-images.json is what this job is for.
+          IMAGE_MATRIX: ${{ needs.changes.outputs.image_matrix }}
+        run: |
+          node <<'JS' > /tmp/pending.tsv
+          const { readFileSync } = require('fs');
+
+          const images = JSON.parse(
+            readFileSync('.github/node-images.json', 'utf8'),
+          );
+          // Each image's own version file, not one global version: they agree
+          // today because changesets moves the npm packages as a fixed group,
+          // and reading each one keeps this correct if that ever stops.
+          const built = new Set(
+            JSON.parse(process.env.IMAGE_MATRIX || '{"include":[]}').include.map(
+              (image) => image.image_name,
+            ),
+          );
+          for (const image of images) {
+            if (built.has(image.image_name)) continue;
+            const { version } = JSON.parse(
+              readFileSync(image.version_file, 'utf8'),
+            );
+            process.stdout.write(`${image.image_name}\t${version}\n`);
+          }
+          JS
+
+          if [ ! -s /tmp/pending.tsv ]; then
+            echo "This push rebuilt every image; docker-merge already tagged them."
+            exit 0
+          fi
+
+          while IFS=$'\t' read -r image version; do
+            release="ghcr.io/${image}:v${version}"
+            latest="ghcr.io/${image}:latest"
+
+            if docker buildx imagetools inspect "$release" >/dev/null 2>&1; then
+              echo "= ${release} already published - left where it points."
+              continue
+            fi
+
+            if ! docker buildx imagetools inspect "$latest" >/dev/null 2>&1; then
+              echo "! ${latest} does not exist: ${image} has never been released, so there is no manifest to tag. Skipping."
+              continue
+            fi
+
+            echo "+ ${release} -> the manifest currently tagged latest"
+            docker buildx imagetools create -t "$release" "$latest"
+          done < /tmp/pending.tsv
+
   deploy-standalone-webapp:
     needs: [changes, docker-merge]
     if: contains(needs.changes.outputs.workspaces, 'apps/standalone-webapp') && github.ref == 'refs/heads/main'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,13 +42,19 @@ changelogs.
 - Pushes to `staging` build changed containers with the `staging` and `staging-<commit-sha>` tags.
 - Pushes to `main` build changed containers with the `latest` and `v<major>.<minor>.<patch>` tags.
 - "Changed" is per image: a push rebuilds only the images whose workspace it
-  touched, so an unchanged image keeps `latest` pointing at its previous build
-  and gets no `v<version>` tag for that release. A promotion carrying a release
-  commit rebuilds everything anyway — the bump edits every `package.json`, so
-  every workspace counts as changed — which is why the version bump has to ride
-  the promotion rather than follow it. (The transcription images are the one
-  exception to the rule: a push to `main` always rebuilds all three, changed or
-  not.)
+  touched, so an unchanged image keeps `latest` pointing at its previous build.
+  It still gets the release's `v<version>`, though — `node-cd`'s
+  `backfill-release-tags` job gives every image that this push did not rebuild
+  the release tag as an alias of the manifest already tagged `latest`, so
+  `IMAGE_TAG=v<version>` resolves for the whole stack and not just the parts
+  that happened to change. (The transcription images need no backfill: a push
+  to `main` always rebuilds all three.) An existing `v<version>` is never
+  re-pointed, only missing ones are created.
+- Release tags are not immutable. A push to `main` that carries no version bump
+  — a hotfix promoted on its own — republishes `latest` **and** `v<version>`
+  for whichever images it rebuilt, so that version tag moves for those images
+  and stays put for the rest. If you need a fixed reference to exactly what was
+  deployed, use the image digest or `staging-<sha>`, not the version tag.
 
 ## Version sources
 


### PR DESCRIPTION
Gives the release's `v<version>` tag to the images a push to `main` did **not** rebuild, so `IMAGE_TAG=v<version>` resolves for the whole stack.

## The bug

`deployment/compose.yml` pins all sixteen services with a single `${IMAGE_TAG}`. Change detection means a push to `main` rebuilds only the images whose workspace it touched, so anything unchanged gets no release tag — and pinning the stack to a version fails on it, as a manifest-unknown pull error on one service rather than anything that names the cause.

Not hypothetical. `IMAGE_TAG=v0.2.0` cannot start the stack right now:

```
MISSING v0.2.0: test-audio-generator          (has: latest, v0.1.0)
MISSING v0.2.0: transcription-service-cpu     (has: none)
MISSING v0.2.0: transcription-service-cuda    (has: none)
MISSING v0.2.0: transcription-service-cuda128 (has: none)
```

`test-audio-generator` is exactly this bug: it stopped at `v0.1.0` while the other eleven node images reached `v0.2.0`. The three transcription images are the separate cause #204 fixed.

Release commits have been hiding it — bumping every `package.json` marks every workspace changed, so a promotion carrying a release rebuilds everything. That is a side effect of how versions are bumped, not a guarantee, and it does not survive a hotfix promoted to `main` on its own.

## The fix

A `backfill-release-tags` job in `node-cd.yml`, on push to `main` only. For each image in `node-images.json` that this push did not rebuild, it gives the manifest already tagged `latest` the release's `v<version>`.

**Retag, not rebuild.** `imagetools create` copies the manifest registry-side — seconds, no build, and the release tag is an alias for the same bits rather than a second build carrying a different provenance stamp. Rebuilding all twelve images on every push to `main` would cost 24 build legs and move `latest` for code that did not change.

## Verification

Against a throwaway local `registry:2` seeded from real multi-arch images out of GHCR, running the job's own loop verbatim (only `ghcr.io` swapped for the local registry):

| Fixture | Result |
|---|---|
| has `latest`, no release tag | tag created; both report `sha256:553e627e…` with `linux/amd64` + `linux/arm64` intact — a true alias, not a re-wrap |
| release tag exists, pointing elsewhere | left exactly where it points — this can add a tag, never re-point one |
| never released (no `latest`) | logs why and skips, rather than failing the release |
| run a second time | no-op |

The digest equality is the load-bearing check: `imagetools create` *does* build a fresh index when handed a single-arch manifest, which would silently produce a single-arch release tag. Everything `docker-merge` publishes is an index, and for an index the digest is preserved — confirmed above against `client-webapp:latest` straight out of GHCR.

The selection logic was checked against three matrix shapes: nothing changed → all 12 pending; two rebuilt → the other 10, with neither rebuilt image included; everything rebuilt → empty, and the job exits early.

## Notes

- **`main` only.** The staging tags are `staging` and `staging-<sha>`, and an unchanged image's `staging` tag already points at its last build, which is the right answer there.
- **No equivalent in `python-cd`** — it rebuilds all three transcription images on every push to `main`, changed or not.
- **Never runs after a failed `docker-merge`**, so a half-published release cannot get the rest of the stack labelled as that version.
- **Historical gaps are not repaired.** This tags the version in the tree at push time; `v0.2.0` stays missing for `test-audio-generator` unless someone retags it by hand.
- **`RELEASING.md`** is updated in a second commit: the container-tags section said an unchanged image gets no release tag, which this makes untrue. It now also records that release tags are *not* immutable — a hotfix promoted to `main` with no version bump re-points `v<version>` for whichever images it rebuilt. Making them immutable is a separate decision, not taken here.

CI-only change, so no changeset — matching #155, #157, #172 and #176.
